### PR TITLE
Task 01-02: Flyway V1 core tables migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,6 @@ thumb
 sketch
 
 # End of https://www.toptal.com/developers/gitignore/api/python,react
+
+# Git worktrees
+.worktrees/

--- a/backend/src/main/resources/db/migration/V1__core_tables.sql
+++ b/backend/src/main/resources/db/migration/V1__core_tables.sql
@@ -1,0 +1,183 @@
+-- V1__core_tables.sql
+-- Task 01-02: Foundational SLPA tables — users, parcels, auctions, parcel_tags, auction_tags.
+-- Spec: docs/superpowers/specs/2026-04-10-flyway-core-migrations-design.md
+-- See DESIGN.md §7 for the canonical schema definitions.
+
+-- ============================================================================
+-- users
+-- ============================================================================
+CREATE TABLE users (
+    id                       BIGSERIAL PRIMARY KEY,
+    email                    VARCHAR(255) UNIQUE NOT NULL,
+    password_hash            VARCHAR(255) NOT NULL,
+    sl_avatar_uuid           UUID UNIQUE,
+    sl_avatar_name           VARCHAR(255),
+    sl_display_name          VARCHAR(255),
+    sl_username              VARCHAR(255),
+    sl_born_date             DATE,
+    sl_payinfo               INTEGER,
+    display_name             VARCHAR(255),
+    bio                      TEXT,
+    profile_pic_url          TEXT,
+    verified                 BOOLEAN NOT NULL DEFAULT FALSE,
+    verified_at              TIMESTAMPTZ,
+    avg_seller_rating        DECIMAL(3,2),
+    avg_buyer_rating         DECIMAL(3,2),
+    total_seller_reviews     INTEGER NOT NULL DEFAULT 0,
+    total_buyer_reviews      INTEGER NOT NULL DEFAULT 0,
+    completed_sales          INTEGER NOT NULL DEFAULT 0,
+    cancelled_with_bids      INTEGER NOT NULL DEFAULT 0,
+    listing_suspension_until TIMESTAMPTZ,
+    email_verified           BOOLEAN NOT NULL DEFAULT FALSE,
+    notify_email             JSONB DEFAULT '{"bidding":true,"auction_result":true,"escrow":true,"listing_status":true,"reviews":true,"realty_group":true,"marketing":false}',
+    notify_sl_im             JSONB DEFAULT '{"bidding":true,"auction_result":true,"escrow":true,"listing_status":true,"reviews":false,"realty_group":false,"marketing":false}',
+    notify_email_muted       BOOLEAN NOT NULL DEFAULT FALSE,
+    notify_sl_im_muted       BOOLEAN NOT NULL DEFAULT FALSE,
+    sl_im_quiet_start        TIME,
+    sl_im_quiet_end          TIME,
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ============================================================================
+-- parcels
+-- ============================================================================
+CREATE TABLE parcels (
+    id              BIGSERIAL PRIMARY KEY,
+    parcel_uuid     UUID UNIQUE NOT NULL,
+    owner_id        BIGINT REFERENCES users(id),
+    sl_owner_uuid   UUID,
+    owner_type      VARCHAR(10) NOT NULL DEFAULT 'AGENT', -- enum: AGENT | GROUP
+    sl_group_uuid   UUID,
+    parcel_name     VARCHAR(255),
+    region_name     VARCHAR(255),
+    grid_x          INTEGER,
+    grid_y          INTEGER,
+    area_sqm        INTEGER,
+    prim_capacity   INTEGER,
+    maturity        VARCHAR(20),                          -- enum: GENERAL | MODERATE | ADULT
+    estate_type     VARCHAR(50),                          -- from Grid Survey API; e.g. Mainland, Private Estate, Homestead
+    description     TEXT,
+    snapshot_url    TEXT,
+    layout_map_url  TEXT,
+    layout_map_data JSONB,
+    layout_map_at   TIMESTAMPTZ,
+    location        VARCHAR(100),
+    slurl           TEXT,
+    verified        BOOLEAN NOT NULL DEFAULT FALSE,
+    verified_at     TIMESTAMPTZ,
+    last_checked    TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_parcels_grid ON parcels(grid_x, grid_y);
+
+-- ============================================================================
+-- auctions
+-- ============================================================================
+CREATE TABLE auctions (
+    id                  BIGSERIAL PRIMARY KEY,
+    parcel_id           BIGINT NOT NULL REFERENCES parcels(id),
+    seller_id           BIGINT NOT NULL REFERENCES users(id),
+    listing_agent_id    BIGINT REFERENCES users(id),
+    realty_group_id     BIGINT,  -- FK to realty_groups(id) added in Task 01-03 / V2 (table doesn't exist yet)
+    status              VARCHAR(30) NOT NULL DEFAULT 'DRAFT',
+    -- Status values (validated at the application layer, not via CHECK):
+    --   DRAFT, DRAFT_PAID, VERIFICATION_PENDING, VERIFICATION_FAILED,
+    --   ACTIVE, ENDED, ESCROW_PENDING, ESCROW_FUNDED,
+    --   TRANSFER_PENDING, COMPLETED, CANCELLED, EXPIRED, DISPUTED
+    verification_tier   VARCHAR(10),  -- enum: SCRIPT | BOT | HUMAN
+    verification_method VARCHAR(20),  -- enum: UUID_ENTRY | REZZABLE | SALE_TO_BOT
+    assigned_bot_uuid   UUID,
+    sale_sentinel_price BIGINT,
+    last_bot_check_at   TIMESTAMPTZ,
+    bot_check_failures  INTEGER NOT NULL DEFAULT 0,
+    listing_fee_paid    BOOLEAN NOT NULL DEFAULT FALSE,
+    listing_fee_amt     BIGINT,
+    listing_fee_txn     VARCHAR(255),
+    listing_fee_paid_at TIMESTAMPTZ,
+    verified_at         TIMESTAMPTZ,
+    verification_notes  TEXT,
+    starting_bid        BIGINT NOT NULL,
+    reserve_price       BIGINT,
+    buy_now_price       BIGINT,
+    current_bid         BIGINT NOT NULL DEFAULT 0,
+    bid_count           INTEGER NOT NULL DEFAULT 0,
+    winner_id           BIGINT REFERENCES users(id),
+    duration_hours      INTEGER NOT NULL,
+    snipe_protect       BOOLEAN NOT NULL DEFAULT FALSE,
+    snipe_window_min    INTEGER,
+    starts_at           TIMESTAMPTZ,
+    ends_at             TIMESTAMPTZ,
+    original_ends_at    TIMESTAMPTZ,
+    seller_desc         TEXT,
+    commission_rate     DECIMAL(5,4) DEFAULT 0.0500,
+    commission_amt      BIGINT,
+    agent_fee_rate      DECIMAL(5,4) DEFAULT 0.0000,
+    agent_fee_amt       BIGINT,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_auctions_status  ON auctions(status);
+CREATE INDEX idx_auctions_seller  ON auctions(seller_id);
+CREATE INDEX idx_auctions_ends_at ON auctions(ends_at);
+
+-- ============================================================================
+-- parcel_tags
+-- Replaces DESIGN.md's parcel_tag ENUM with a real table so admins can
+-- add/rename/deactivate tags via the UI without writing migrations.
+-- ============================================================================
+CREATE TABLE parcel_tags (
+    id          BIGSERIAL PRIMARY KEY,
+    code        VARCHAR(50)  NOT NULL,
+    label       VARCHAR(100) NOT NULL,
+    category    VARCHAR(50)  NOT NULL,
+    description TEXT,
+    sort_order  INTEGER      NOT NULL DEFAULT 0,
+    active      BOOLEAN      NOT NULL DEFAULT TRUE,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CONSTRAINT parcel_tags_code_unique UNIQUE (code),
+    CONSTRAINT parcel_tags_code_format CHECK (code ~ '^[A-Z][A-Z0-9_]*$')
+);
+
+-- ============================================================================
+-- auction_tags (join table: auction ↔ parcel_tag)
+-- ============================================================================
+CREATE TABLE auction_tags (
+    auction_id BIGINT NOT NULL REFERENCES auctions(id) ON DELETE CASCADE,
+    -- tag_id: RESTRICT because tags are soft-deleted via parcel_tags.active;
+    -- hard DELETE on a tag with attached auctions should fail loudly.
+    tag_id     BIGINT NOT NULL REFERENCES parcel_tags(id) ON DELETE RESTRICT,
+    PRIMARY KEY (auction_id, tag_id)
+);
+CREATE INDEX idx_auction_tags_tag ON auction_tags(tag_id);
+
+-- ============================================================================
+-- Seed data: 25 parcel tags from DESIGN.md §7
+-- ============================================================================
+INSERT INTO parcel_tags (code, label, category, description, sort_order) VALUES
+  ('WATERFRONT',       'Waterfront',       'Terrain / Environment', 'Ocean, lake, or river border',                        1),
+  ('SAILABLE',         'Sailable',         'Terrain / Environment', 'Connected to navigable water (Linden waterways)',     2),
+  ('GRASS',            'Grass',            'Terrain / Environment', 'Grass terrain',                                        3),
+  ('SNOW',             'Snow',             'Terrain / Environment', 'Snow terrain',                                         4),
+  ('SAND',             'Sand',             'Terrain / Environment', 'Sand or beach terrain',                                5),
+  ('MOUNTAIN',         'Mountain',         'Terrain / Environment', 'Elevated or hilly terrain',                            6),
+  ('FOREST',           'Forest',           'Terrain / Environment', 'Wooded area',                                          7),
+  ('FLAT',             'Flat',             'Terrain / Environment', 'Level terrain, good for building',                     8),
+  ('STREETFRONT',      'Streetfront',      'Roads / Access',        'Borders a Linden road',                                9),
+  ('ROADSIDE',         'Roadside',         'Roads / Access',        'Near (but not directly on) a Linden road',            10),
+  ('RAILWAY',          'Railway',          'Roads / Access',        'Near Linden railroad / SLRR',                         11),
+  ('CORNER_LOT',       'Corner Lot',       'Location Features',     'Parcel on a corner (two road or water sides)',        12),
+  ('HILLTOP',          'Hilltop',          'Location Features',     'Elevated with views',                                 13),
+  ('ISLAND',           'Island',           'Location Features',     'Surrounded by water',                                 14),
+  ('PENINSULA',        'Peninsula',        'Location Features',     'Water on three sides',                                15),
+  ('SHELTERED',        'Sheltered',        'Location Features',     'Enclosed or private feeling, surrounded by terrain',  16),
+  ('RESIDENTIAL',      'Residential',      'Neighbors / Context',   'Residential neighborhood',                            17),
+  ('COMMERCIAL',       'Commercial',       'Neighbors / Context',   'Commercial or shopping area',                         18),
+  ('INFOHUB_ADJACENT', 'Infohub Adjacent', 'Neighbors / Context',   'Near a Linden infohub',                               19),
+  ('PROTECTED_LAND',   'Protected Land',   'Neighbors / Context',   'Adjacent to Linden-owned protected land',             20),
+  ('SCENIC',           'Scenic',           'Neighbors / Context',   'Notable views or landscape',                          21),
+  ('DOUBLE_PRIM',      'Double Prim',      'Parcel Features',       'On a double-prim region (Magnum, etc.)',              22),
+  ('HIGH_PRIM',        'High Prim',        'Parcel Features',       'Above-average prim capacity for size',                23),
+  ('LARGE_PARCEL',     'Large Parcel',     'Parcel Features',       '4096+ sqm',                                           24),
+  ('FULL_REGION',      'Full Region',      'Parcel Features',       'Entire region (65536 sqm)',                           25);

--- a/docs/initial-design/DESIGN.md
+++ b/docs/initial-design/DESIGN.md
@@ -1081,28 +1081,28 @@ CREATE TABLE users (
     sl_payinfo      INTEGER,                -- from llRequestAgentData(DATA_PAYINFO)
     display_name    VARCHAR(255),           -- custom display name override on SLPA
     bio             TEXT,                    -- user bio/description
-    profile_pic_url VARCHAR(512),           -- user-uploaded profile picture
-    verified        BOOLEAN DEFAULT FALSE,
-    verified_at     TIMESTAMP,
+    profile_pic_url TEXT,                   -- user-uploaded profile picture
+    verified        BOOLEAN NOT NULL DEFAULT FALSE,
+    verified_at     TIMESTAMPTZ,
     -- Reputation fields (denormalized for fast display)
     avg_seller_rating DECIMAL(3,2),          -- avg rating as seller (1.00-5.00)
     avg_buyer_rating  DECIMAL(3,2),          -- avg rating as buyer
-    total_seller_reviews INTEGER DEFAULT 0,
-    total_buyer_reviews  INTEGER DEFAULT 0,
-    completed_sales   INTEGER DEFAULT 0,
-    cancelled_with_bids INTEGER DEFAULT 0,   -- cancellation counter (admin-visible only)
-    listing_suspension_until TIMESTAMP,      -- NULL if not suspended
+    total_seller_reviews INTEGER NOT NULL DEFAULT 0,
+    total_buyer_reviews  INTEGER NOT NULL DEFAULT 0,
+    completed_sales   INTEGER NOT NULL DEFAULT 0,
+    cancelled_with_bids INTEGER NOT NULL DEFAULT 0,   -- cancellation counter (admin-visible only)
+    listing_suspension_until TIMESTAMPTZ,      -- NULL if not suspended
     -- Notification preferences
     email              VARCHAR(255),           -- for notifications + account recovery
-    email_verified     BOOLEAN DEFAULT FALSE,
+    email_verified     BOOLEAN NOT NULL DEFAULT FALSE,
     notify_email       JSONB DEFAULT '{"bidding":true,"auction_result":true,"escrow":true,"listing_status":true,"reviews":true,"realty_group":true,"marketing":false}',
     notify_sl_im       JSONB DEFAULT '{"bidding":true,"auction_result":true,"escrow":true,"listing_status":true,"reviews":false,"realty_group":false,"marketing":false}',
-    notify_email_muted BOOLEAN DEFAULT FALSE,  -- global email mute
-    notify_sl_im_muted BOOLEAN DEFAULT FALSE,  -- global SL IM mute
+    notify_email_muted BOOLEAN NOT NULL DEFAULT FALSE,  -- global email mute
+    notify_sl_im_muted BOOLEAN NOT NULL DEFAULT FALSE,  -- global SL IM mute
     sl_im_quiet_start  TIME,                   -- quiet hours start (SLT)
     sl_im_quiet_end    TIME,                   -- quiet hours end (SLT)
-    created_at      TIMESTAMP DEFAULT NOW(),
-    updated_at      TIMESTAMP DEFAULT NOW()
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 ```
 
@@ -1172,7 +1172,7 @@ CREATE TABLE parcels (
     parcel_uuid     UUID UNIQUE NOT NULL,
     owner_id        BIGINT REFERENCES users(id),    -- SLPA user who listed it
     sl_owner_uuid   UUID,                           -- SL avatar UUID (individual) or group UUID
-    owner_type      VARCHAR(10) DEFAULT 'AGENT',    -- AGENT or GROUP
+    owner_type      VARCHAR(10) NOT NULL DEFAULT 'AGENT', -- enum: AGENT | GROUP
     sl_group_uuid   UUID,                           -- group UUID if group-owned (NULL for individual)
     parcel_name     VARCHAR(255),
     region_name     VARCHAR(255),
@@ -1180,19 +1180,19 @@ CREATE TABLE parcels (
     grid_y          INTEGER,                -- region grid Y coordinate (from Map API)
     area_sqm        INTEGER,
     prim_capacity   INTEGER,
-    maturity        VARCHAR(20),
-    estate_type     VARCHAR(50),            -- Mainland, Private Estate, etc. (from Grid Survey)
+    maturity        VARCHAR(20),            -- enum: GENERAL | MODERATE | ADULT
+    estate_type     VARCHAR(50),            -- from Grid Survey API; e.g. Mainland, Private Estate, Homestead
     description     TEXT,
-    snapshot_url     VARCHAR(512),
-    layout_map_url   VARCHAR(512),          -- generated parcel boundary grid image (see 5.5)
-    layout_map_data  JSONB,                 -- raw grid data for interactive tooltip overlay
-    layout_map_at    TIMESTAMP,             -- when layout map was last generated
+    snapshot_url    TEXT,
+    layout_map_url  TEXT,                   -- generated parcel boundary grid image (see 5.5)
+    layout_map_data JSONB,                  -- raw grid data for interactive tooltip overlay
+    layout_map_at   TIMESTAMPTZ,            -- when layout map was last generated
     location        VARCHAR(100),           -- local coordinates within region (e.g. "128,64,25")
-    slurl           VARCHAR(512),           -- generated: secondlife:///Region Name/x/y/z
-    verified        BOOLEAN DEFAULT FALSE,
-    verified_at     TIMESTAMP,
-    last_checked    TIMESTAMP,
-    created_at      TIMESTAMP DEFAULT NOW()
+    slurl           TEXT,                   -- generated: secondlife:///Region Name/x/y/z
+    verified        BOOLEAN NOT NULL DEFAULT FALSE,
+    verified_at     TIMESTAMPTZ,
+    last_checked    TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 CREATE INDEX idx_parcels_grid ON parcels(grid_x, grid_y);
 ```
@@ -1248,45 +1248,45 @@ CREATE INDEX idx_auction_tags_tag ON auction_tags(tag);
 ```sql
 CREATE TABLE auctions (
     id              BIGSERIAL PRIMARY KEY,
-    parcel_id       BIGINT REFERENCES parcels(id),
-    seller_id       BIGINT REFERENCES users(id),      -- parcel owner
-    listing_agent_id BIGINT REFERENCES users(id),      -- agent who created listing (may differ from seller)
-    realty_group_id BIGINT REFERENCES realty_groups(id), -- NULL if individual listing
+    parcel_id       BIGINT NOT NULL REFERENCES parcels(id),
+    seller_id       BIGINT NOT NULL REFERENCES users(id),      -- parcel owner
+    listing_agent_id BIGINT REFERENCES users(id),              -- agent who created listing (may differ from seller)
+    realty_group_id BIGINT REFERENCES realty_groups(id),       -- NULL if individual listing
     status          VARCHAR(30) NOT NULL DEFAULT 'DRAFT',
         -- DRAFT, DRAFT_PAID, VERIFICATION_PENDING, VERIFICATION_FAILED,
         -- ACTIVE, ENDED, ESCROW_PENDING, ESCROW_FUNDED,
         -- TRANSFER_PENDING, COMPLETED, CANCELLED, EXPIRED, DISPUTED
-    verification_tier VARCHAR(10),           -- SCRIPT, BOT, HUMAN (set after verification)
-    verification_method VARCHAR(20),        -- UUID_ENTRY, REZZABLE, SALE_TO_BOT
-    assigned_bot_uuid UUID,                 -- which SLPA bot is assigned for Method C monitoring
-    sale_sentinel_price INTEGER,            -- expected sale price (L$999,999,999) for Method C
-    last_bot_check_at TIMESTAMP,            -- last successful bot monitoring check
-    bot_check_failures INTEGER DEFAULT 0,   -- consecutive failed bot checks
-    listing_fee_paid BOOLEAN DEFAULT FALSE,
-    listing_fee_amt  INTEGER,               -- L$ listing fee paid
-    listing_fee_txn  VARCHAR(255),          -- transaction reference from payment terminal
-    listing_fee_paid_at TIMESTAMP,
-    verified_at     TIMESTAMP,              -- when verification completed
-    verification_notes TEXT,                -- bot/human verification details
-    starting_bid    INTEGER NOT NULL,       -- L$
-    reserve_price   INTEGER,                -- L$ (optional)
-    buy_now_price   INTEGER,                -- L$ (optional)
-    current_bid     INTEGER DEFAULT 0,      -- L$
-    bid_count       INTEGER DEFAULT 0,
+    verification_tier VARCHAR(10),           -- enum: SCRIPT | BOT | HUMAN
+    verification_method VARCHAR(20),         -- enum: UUID_ENTRY | REZZABLE | SALE_TO_BOT
+    assigned_bot_uuid UUID,                  -- which SLPA bot is assigned for Method C monitoring
+    sale_sentinel_price BIGINT,              -- expected sale price (L$999,999,999) for Method C
+    last_bot_check_at TIMESTAMPTZ,           -- last successful bot monitoring check
+    bot_check_failures INTEGER NOT NULL DEFAULT 0,  -- consecutive failed bot checks
+    listing_fee_paid BOOLEAN NOT NULL DEFAULT FALSE,
+    listing_fee_amt  BIGINT,                 -- L$ listing fee paid
+    listing_fee_txn  VARCHAR(255),           -- transaction reference from payment terminal
+    listing_fee_paid_at TIMESTAMPTZ,
+    verified_at     TIMESTAMPTZ,             -- when verification completed
+    verification_notes TEXT,                 -- bot/human verification details
+    starting_bid    BIGINT NOT NULL,         -- L$
+    reserve_price   BIGINT,                  -- L$ (optional)
+    buy_now_price   BIGINT,                  -- L$ (optional)
+    current_bid     BIGINT NOT NULL DEFAULT 0,  -- L$
+    bid_count       INTEGER NOT NULL DEFAULT 0,
     winner_id       BIGINT REFERENCES users(id),
     duration_hours  INTEGER NOT NULL,
-    snipe_protect   BOOLEAN DEFAULT FALSE,  -- seller opt-in
+    snipe_protect   BOOLEAN NOT NULL DEFAULT FALSE,  -- seller opt-in
     snipe_window_min INTEGER,               -- extension window in minutes (5,10,15,30,60)
-    starts_at       TIMESTAMP,
-    ends_at         TIMESTAMP,
-    original_ends_at TIMESTAMP,             -- original end time before any snipe extensions
+    starts_at       TIMESTAMPTZ,
+    ends_at         TIMESTAMPTZ,
+    original_ends_at TIMESTAMPTZ,           -- original end time before any snipe extensions
     seller_desc     TEXT,
     commission_rate DECIMAL(5,4) DEFAULT 0.0500,  -- 5% platform
-    commission_amt  INTEGER,                -- L$ platform commission (calculated at completion)
-    agent_fee_rate  DECIMAL(5,4) DEFAULT 0, -- group agent fee (copied from group at listing time)
-    agent_fee_amt   INTEGER,                -- L$ agent fee (calculated at completion)
-    created_at      TIMESTAMP DEFAULT NOW(),
-    updated_at      TIMESTAMP DEFAULT NOW()
+    commission_amt  BIGINT,                 -- L$ platform commission (calculated at completion)
+    agent_fee_rate  DECIMAL(5,4) DEFAULT 0.0000,  -- group agent fee (copied from group at listing time)
+    agent_fee_amt   BIGINT,                 -- L$ agent fee (calculated at completion)
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 ```
 

--- a/docs/superpowers/plans/2026-04-10-flyway-core-migrations.md
+++ b/docs/superpowers/plans/2026-04-10-flyway-core-migrations.md
@@ -1,0 +1,485 @@
+# Flyway Core Migrations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create a single Flyway migration `V1__core_tables.sql` containing the foundational SLPA schema (`users`, `parcels`, `auctions`, `parcel_tags`, `auction_tags`) plus seed data for the 25 parcel tags from DESIGN.md §7.
+
+**Architecture:** One atomic SQL migration file under `backend/src/main/resources/db/migration/`. Verification piggybacks on the existing `BackendApplicationTests.contextLoads()` test (which runs Flyway against the dev profile's local PostgreSQL with `ddl-auto: validate`) plus a manual psql smoke check.
+
+**Tech Stack:** Spring Boot 4.0.5, Flyway, PostgreSQL, JUnit 5, Maven.
+
+**Spec:** `docs/superpowers/specs/2026-04-10-flyway-core-migrations-design.md`
+
+---
+
+## File Structure
+
+| Action | Path | Purpose |
+|---|---|---|
+| Create | `backend/src/main/resources/db/migration/V1__core_tables.sql` | Single migration: 5 tables, 7 indexes, 25 tag rows |
+| Delete | `backend/src/main/resources/db/migration/.gitkeep` | No longer needed once a real migration file exists |
+
+No new Java sources, no new test files. The `users`, `parcels`, `auctions`, `parcel_tags`, and `auction_tags` tables are created by raw SQL in dependency order; FK constraints in the SQL itself enforce that ordering.
+
+## Important Context for the Implementer
+
+**Why no TDD failing-test-first cycle for this task.** The test we rely on (`BackendApplicationTests.contextLoads()`) already exists and already passes. Without a `V1` file, Flyway has nothing to migrate and the test passes trivially. With a broken `V1` file, the test fails with a Flyway exception. So the natural verification cycle is: build the migration, run the test once at the end, fix any errors, commit. There is no point writing a new test that asserts schema state — the next task (01-04, JPA entities) will exercise every column and constraint via Hibernate's `validate` mode, which is a stronger check than anything we'd write here by hand.
+
+**Why dev DB state matters.** Flyway records every applied migration in `flyway_schema_history` with a checksum. If a previous attempt has already applied a partial or wrong `V1`, you'll get a checksum mismatch on the next run. **Task 1 below resets the dev DB to a clean state before you start writing SQL.** Do not skip it.
+
+**The dev profile config (already in place from Task 01-01):**
+- JDBC URL: `jdbc:postgresql://localhost:5432/slpa`
+- Username: `slpa` / Password: `slpa`
+- `spring.jpa.hibernate.ddl-auto: validate`
+- `spring.flyway.enabled: true`
+- Migration location: classpath default `db/migration`
+
+---
+
+### Task 1: Reset dev database to a clean state
+
+**Files:** none (database state only)
+
+**Why:** Eliminates the possibility of a Flyway checksum mismatch from a previous attempt at this task.
+
+- [ ] **Step 1: Stop any running backend instance**
+
+If `./mvnw spring-boot:run` is running in another terminal, stop it (Ctrl-C). The reset commands below will fail if Spring Boot holds an open connection.
+
+- [ ] **Step 2: Open a psql session against the dev database**
+
+Run:
+```bash
+psql -h localhost -U slpa -d slpa
+```
+
+Password when prompted: `slpa`
+
+Expected: psql prompt `slpa=>`.
+
+If `psql` is not on PATH, use whatever client you prefer (DBeaver, IntelliJ Database tool, `docker exec` into the postgres container, etc.). The SQL commands below are the same regardless of client.
+
+- [ ] **Step 3: Drop and recreate the public schema**
+
+Run inside psql:
+```sql
+DROP SCHEMA public CASCADE;
+CREATE SCHEMA public;
+GRANT ALL ON SCHEMA public TO slpa;
+GRANT ALL ON SCHEMA public TO public;
+```
+
+Expected: four `NOTICE` / command-complete lines, no errors. The `flyway_schema_history` table is dropped along with everything else.
+
+- [ ] **Step 4: Verify the schema is empty**
+
+Run inside psql:
+```sql
+\dt
+```
+
+Expected output: `Did not find any relations.`
+
+- [ ] **Step 5: Exit psql**
+
+Run:
+```sql
+\q
+```
+
+---
+
+### Task 2: Create V1__core_tables.sql, verify, and commit
+
+**Files:**
+- Create: `backend/src/main/resources/db/migration/V1__core_tables.sql`
+- Delete: `backend/src/main/resources/db/migration/.gitkeep`
+
+**Why:** This is the entire migration. Building it as one file in one task respects the spec's "single atomic V1" decision and avoids Flyway checksum churn between sub-steps.
+
+The steps below append to the same file in order. After the last SQL block is appended, run the test once to verify the whole thing.
+
+- [ ] **Step 1: Create the file with a header comment**
+
+Create `backend/src/main/resources/db/migration/V1__core_tables.sql` with these contents:
+
+```sql
+-- V1__core_tables.sql
+-- Task 01-02: Foundational SLPA tables — users, parcels, auctions, parcel_tags, auction_tags.
+-- Spec: docs/superpowers/specs/2026-04-10-flyway-core-migrations-design.md
+-- See DESIGN.md §7 for the canonical schema definitions.
+
+```
+
+- [ ] **Step 2: Append the `users` table**
+
+Append to `V1__core_tables.sql`:
+
+```sql
+-- ============================================================================
+-- users
+-- ============================================================================
+CREATE TABLE users (
+    id                       BIGSERIAL PRIMARY KEY,
+    email                    VARCHAR(255) UNIQUE NOT NULL,
+    password_hash            VARCHAR(255) NOT NULL,
+    sl_avatar_uuid           UUID UNIQUE,
+    sl_avatar_name           VARCHAR(255),
+    sl_display_name          VARCHAR(255),
+    sl_username              VARCHAR(255),
+    sl_born_date             DATE,
+    sl_payinfo               INTEGER,
+    display_name             VARCHAR(255),
+    bio                      TEXT,
+    profile_pic_url          VARCHAR(512),
+    verified                 BOOLEAN DEFAULT FALSE,
+    verified_at              TIMESTAMP,
+    avg_seller_rating        DECIMAL(3,2),
+    avg_buyer_rating         DECIMAL(3,2),
+    total_seller_reviews     INTEGER DEFAULT 0,
+    total_buyer_reviews      INTEGER DEFAULT 0,
+    completed_sales          INTEGER DEFAULT 0,
+    cancelled_with_bids      INTEGER DEFAULT 0,
+    listing_suspension_until TIMESTAMP,
+    email_verified           BOOLEAN DEFAULT FALSE,
+    notify_email             JSONB DEFAULT '{"bidding":true,"auction_result":true,"escrow":true,"listing_status":true,"reviews":true,"realty_group":true,"marketing":false}',
+    notify_sl_im             JSONB DEFAULT '{"bidding":true,"auction_result":true,"escrow":true,"listing_status":true,"reviews":false,"realty_group":false,"marketing":false}',
+    notify_email_muted       BOOLEAN DEFAULT FALSE,
+    notify_sl_im_muted       BOOLEAN DEFAULT FALSE,
+    sl_im_quiet_start        TIME,
+    sl_im_quiet_end          TIME,
+    created_at               TIMESTAMP DEFAULT NOW(),
+    updated_at               TIMESTAMP DEFAULT NOW()
+);
+```
+
+Notes:
+- The DESIGN.md duplicate `email` column is collapsed into the single `UNIQUE NOT NULL` declaration on line 5 of the table.
+- Both JSONB defaults are on a single line (Postgres tolerates whitespace inside the JSON literal but a single line is easier to diff).
+
+- [ ] **Step 3: Append the `parcels` table and its index**
+
+Append to `V1__core_tables.sql`:
+
+```sql
+
+-- ============================================================================
+-- parcels
+-- ============================================================================
+CREATE TABLE parcels (
+    id              BIGSERIAL PRIMARY KEY,
+    parcel_uuid     UUID UNIQUE NOT NULL,
+    owner_id        BIGINT REFERENCES users(id),
+    sl_owner_uuid   UUID,
+    owner_type      VARCHAR(10) DEFAULT 'AGENT',
+    sl_group_uuid   UUID,
+    parcel_name     VARCHAR(255),
+    region_name     VARCHAR(255),
+    grid_x          INTEGER,
+    grid_y          INTEGER,
+    area_sqm        INTEGER,
+    prim_capacity   INTEGER,
+    maturity        VARCHAR(20),
+    estate_type     VARCHAR(50),
+    description     TEXT,
+    snapshot_url    VARCHAR(512),
+    layout_map_url  VARCHAR(512),
+    layout_map_data JSONB,
+    layout_map_at   TIMESTAMP,
+    location        VARCHAR(100),
+    slurl           VARCHAR(512),
+    verified        BOOLEAN DEFAULT FALSE,
+    verified_at     TIMESTAMP,
+    last_checked    TIMESTAMP,
+    created_at      TIMESTAMP DEFAULT NOW()
+);
+CREATE INDEX idx_parcels_grid ON parcels(grid_x, grid_y);
+```
+
+- [ ] **Step 4: Append the `auctions` table and its three indexes**
+
+Append to `V1__core_tables.sql`:
+
+```sql
+
+-- ============================================================================
+-- auctions
+-- ============================================================================
+CREATE TABLE auctions (
+    id                  BIGSERIAL PRIMARY KEY,
+    parcel_id           BIGINT REFERENCES parcels(id),
+    seller_id           BIGINT REFERENCES users(id),
+    listing_agent_id    BIGINT REFERENCES users(id),
+    realty_group_id     BIGINT,  -- FK to realty_groups(id) added in Task 01-03 / V2 (table doesn't exist yet)
+    status              VARCHAR(30) NOT NULL DEFAULT 'DRAFT',
+    -- Status values (validated at the application layer, not via CHECK):
+    --   DRAFT, DRAFT_PAID, VERIFICATION_PENDING, VERIFICATION_FAILED,
+    --   ACTIVE, ENDED, ESCROW_PENDING, ESCROW_FUNDED,
+    --   TRANSFER_PENDING, COMPLETED, CANCELLED, EXPIRED, DISPUTED
+    verification_tier   VARCHAR(10),
+    verification_method VARCHAR(20),
+    assigned_bot_uuid   UUID,
+    sale_sentinel_price INTEGER,
+    last_bot_check_at   TIMESTAMP,
+    bot_check_failures  INTEGER DEFAULT 0,
+    listing_fee_paid    BOOLEAN DEFAULT FALSE,
+    listing_fee_amt     INTEGER,
+    listing_fee_txn     VARCHAR(255),
+    listing_fee_paid_at TIMESTAMP,
+    verified_at         TIMESTAMP,
+    verification_notes  TEXT,
+    starting_bid        INTEGER NOT NULL,
+    reserve_price       INTEGER,
+    buy_now_price       INTEGER,
+    current_bid         INTEGER DEFAULT 0,
+    bid_count           INTEGER DEFAULT 0,
+    winner_id           BIGINT REFERENCES users(id),
+    duration_hours      INTEGER NOT NULL,
+    snipe_protect       BOOLEAN DEFAULT FALSE,
+    snipe_window_min    INTEGER,
+    starts_at           TIMESTAMP,
+    ends_at             TIMESTAMP,
+    original_ends_at    TIMESTAMP,
+    seller_desc         TEXT,
+    commission_rate     DECIMAL(5,4) DEFAULT 0.0500,
+    commission_amt     INTEGER,
+    agent_fee_rate      DECIMAL(5,4) DEFAULT 0,
+    agent_fee_amt       INTEGER,
+    created_at          TIMESTAMP DEFAULT NOW(),
+    updated_at          TIMESTAMP DEFAULT NOW()
+);
+CREATE INDEX idx_auctions_status  ON auctions(status);
+CREATE INDEX idx_auctions_seller  ON auctions(seller_id);
+CREATE INDEX idx_auctions_ends_at ON auctions(ends_at);
+```
+
+Notes:
+- `realty_group_id` is a plain `BIGINT` with no FK — the comment on that line documents why. Task 01-03 (V2) will add the FK via `ALTER TABLE`.
+- No CHECK constraint on `status` — see spec section "auctions Table" for the rationale.
+- The three new indexes (`idx_auctions_status`, `idx_auctions_seller`, `idx_auctions_ends_at`) are deviations from DESIGN.md, justified in the spec's "Deviations" table.
+
+- [ ] **Step 5: Append the `parcel_tags` table**
+
+Append to `V1__core_tables.sql`:
+
+```sql
+
+-- ============================================================================
+-- parcel_tags
+-- Replaces DESIGN.md's parcel_tag ENUM with a real table so admins can
+-- add/rename/deactivate tags via the UI without writing migrations.
+-- ============================================================================
+CREATE TABLE parcel_tags (
+    id          BIGSERIAL PRIMARY KEY,
+    code        VARCHAR(50)  NOT NULL,
+    label       VARCHAR(100) NOT NULL,
+    category    VARCHAR(50)  NOT NULL,
+    description TEXT,
+    sort_order  INTEGER      NOT NULL DEFAULT 0,
+    active      BOOLEAN      NOT NULL DEFAULT TRUE,
+    created_at  TIMESTAMP    NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMP    NOT NULL DEFAULT NOW(),
+    CONSTRAINT parcel_tags_code_unique UNIQUE (code),
+    CONSTRAINT parcel_tags_code_format CHECK (code ~ '^[A-Z][A-Z0-9_]*$')
+);
+```
+
+Notes:
+- The `code` CHECK constraint forbids lowercase or punctuation, preventing case-insensitive duplicate codes.
+- `active` is a soft-delete flag — pairs with the `ON DELETE RESTRICT` on `auction_tags.tag_id` below.
+
+- [ ] **Step 6: Append the `auction_tags` join table and its index**
+
+Append to `V1__core_tables.sql`:
+
+```sql
+
+-- ============================================================================
+-- auction_tags (join table: auction ↔ parcel_tag)
+-- ============================================================================
+CREATE TABLE auction_tags (
+    auction_id BIGINT NOT NULL REFERENCES auctions(id) ON DELETE CASCADE,
+    tag_id     BIGINT NOT NULL REFERENCES parcel_tags(id) ON DELETE RESTRICT,
+    PRIMARY KEY (auction_id, tag_id)
+);
+CREATE INDEX idx_auction_tags_tag ON auction_tags(tag_id);
+```
+
+Notes:
+- `auction_id ON DELETE CASCADE`: deleting an auction removes its tag attachments.
+- `tag_id ON DELETE RESTRICT`: pairs with `parcel_tags.active` soft-delete philosophy — admins must deactivate tags, not delete them.
+- The PK index already covers `(auction_id, tag_id)` lookups; the secondary index serves "what auctions have this tag?" queries (browse-by-tag filter).
+
+- [ ] **Step 7: Append the parcel_tags seed INSERT**
+
+Append to `V1__core_tables.sql`:
+
+```sql
+
+-- ============================================================================
+-- Seed data: 25 parcel tags from DESIGN.md §7
+-- ============================================================================
+INSERT INTO parcel_tags (code, label, category, description, sort_order) VALUES
+  ('WATERFRONT',       'Waterfront',       'Terrain / Environment', 'Ocean, lake, or river border',                        1),
+  ('SAILABLE',         'Sailable',         'Terrain / Environment', 'Connected to navigable water (Linden waterways)',     2),
+  ('GRASS',            'Grass',            'Terrain / Environment', 'Grass terrain',                                        3),
+  ('SNOW',             'Snow',             'Terrain / Environment', 'Snow terrain',                                         4),
+  ('SAND',             'Sand',             'Terrain / Environment', 'Sand or beach terrain',                                5),
+  ('MOUNTAIN',         'Mountain',         'Terrain / Environment', 'Elevated or hilly terrain',                            6),
+  ('FOREST',           'Forest',           'Terrain / Environment', 'Wooded area',                                          7),
+  ('FLAT',             'Flat',             'Terrain / Environment', 'Level terrain, good for building',                     8),
+  ('STREETFRONT',      'Streetfront',      'Roads / Access',        'Borders a Linden road',                                9),
+  ('ROADSIDE',         'Roadside',         'Roads / Access',        'Near (but not directly on) a Linden road',            10),
+  ('RAILWAY',          'Railway',          'Roads / Access',        'Near Linden railroad / SLRR',                         11),
+  ('CORNER_LOT',       'Corner Lot',       'Location Features',     'Parcel on a corner (two road or water sides)',        12),
+  ('HILLTOP',          'Hilltop',          'Location Features',     'Elevated with views',                                 13),
+  ('ISLAND',           'Island',           'Location Features',     'Surrounded by water',                                 14),
+  ('PENINSULA',        'Peninsula',        'Location Features',     'Water on three sides',                                15),
+  ('SHELTERED',        'Sheltered',        'Location Features',     'Enclosed or private feeling, surrounded by terrain',  16),
+  ('RESIDENTIAL',      'Residential',      'Neighbors / Context',   'Residential neighborhood',                            17),
+  ('COMMERCIAL',       'Commercial',       'Neighbors / Context',   'Commercial or shopping area',                         18),
+  ('INFOHUB_ADJACENT', 'Infohub Adjacent', 'Neighbors / Context',   'Near a Linden infohub',                               19),
+  ('PROTECTED_LAND',   'Protected Land',   'Neighbors / Context',   'Adjacent to Linden-owned protected land',             20),
+  ('SCENIC',           'Scenic',           'Neighbors / Context',   'Notable views or landscape',                          21),
+  ('DOUBLE_PRIM',      'Double Prim',      'Parcel Features',       'On a double-prim region (Magnum, etc.)',              22),
+  ('HIGH_PRIM',        'High Prim',        'Parcel Features',       'Above-average prim capacity for size',                23),
+  ('LARGE_PARCEL',     'Large Parcel',     'Parcel Features',       '4096+ sqm',                                           24),
+  ('FULL_REGION',      'Full Region',      'Parcel Features',       'Entire region (65536 sqm)',                           25);
+```
+
+- [ ] **Step 8: Delete `.gitkeep`**
+
+Delete `backend/src/main/resources/db/migration/.gitkeep`. The directory is no longer empty so the placeholder is unneeded.
+
+```bash
+rm backend/src/main/resources/db/migration/.gitkeep
+```
+
+- [ ] **Step 9: Run the test suite**
+
+Run from the repo root:
+```bash
+cd backend && ./mvnw test
+```
+
+Expected: `BUILD SUCCESS`. The test you care about is `BackendApplicationTests.contextLoads`, which spins up the full Spring context against the dev profile's PostgreSQL. Flyway runs `V1__core_tables.sql` during context startup; any SQL syntax error or constraint violation will surface as a `FlywayException` in the test failure trace.
+
+If the test fails:
+1. Read the Flyway error message carefully — it points to the offending SQL line.
+2. Fix the SQL in `V1__core_tables.sql`.
+3. Re-run Task 1's reset steps (the failed migration left a row in `flyway_schema_history` that will block re-application).
+4. Re-run `./mvnw test`.
+
+- [ ] **Step 10: Manual smoke check via psql**
+
+Open a fresh psql session:
+```bash
+psql -h localhost -U slpa -d slpa
+```
+
+Run each query and confirm the expected output:
+
+```sql
+-- Should list exactly: auctions, auction_tags, flyway_schema_history, parcel_tags, parcels, users
+\dt
+```
+
+```sql
+-- Should return 1 row, success = t
+SELECT version, description, success FROM flyway_schema_history;
+```
+
+Expected:
+```
+ version |   description    | success
+---------+------------------+---------
+ 1       | core tables      | t
+```
+
+```sql
+-- Should return 25
+SELECT count(*) FROM parcel_tags;
+```
+
+```sql
+-- Should return 5: 'Terrain / Environment', 'Roads / Access', 'Location Features', 'Neighbors / Context', 'Parcel Features'
+SELECT DISTINCT category FROM parcel_tags ORDER BY category;
+```
+
+```sql
+-- Should reject the insert with: ERROR:  new row for relation "parcel_tags" violates check constraint "parcel_tags_code_format"
+INSERT INTO parcel_tags (code, label, category) VALUES ('lowercase', 'Lowercase', 'Test');
+```
+
+```sql
+-- Should reject the insert with: ERROR:  insert or update on table "auction_tags" violates foreign key constraint
+INSERT INTO auction_tags (auction_id, tag_id) VALUES (999, 999);
+```
+
+```sql
+-- Confirms the three deferred / new indexes exist on auctions
+SELECT indexname FROM pg_indexes WHERE tablename = 'auctions' ORDER BY indexname;
+```
+
+Expected to include: `idx_auctions_ends_at`, `idx_auctions_seller`, `idx_auctions_status`, plus the PK index `auctions_pkey`.
+
+Exit psql:
+```sql
+\q
+```
+
+- [ ] **Step 11: Stage and commit**
+
+Run from repo root:
+```bash
+git add backend/src/main/resources/db/migration/V1__core_tables.sql
+git rm backend/src/main/resources/db/migration/.gitkeep
+git status
+```
+
+Expected `git status`: one new file (`V1__core_tables.sql`), one deleted file (`.gitkeep`). Nothing else.
+
+Then commit:
+```bash
+git commit -m "$(cat <<'EOF'
+feat(db): add V1 core tables migration
+
+Creates users, parcels, auctions, parcel_tags, and auction_tags
+in a single Flyway migration. Tags are a real table (not a Postgres
+enum) so admins can manage them via the UI later. Three extra
+hot-path indexes added on auctions (status, seller_id, ends_at).
+realty_group_id FK deferred to Task 01-03.
+
+Refs: docs/superpowers/specs/2026-04-10-flyway-core-migrations-design.md
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit succeeds. If a pre-commit hook fails, fix the underlying issue, re-stage, and create a NEW commit (do not amend).
+
+---
+
+## Self-Review
+
+**Spec coverage check** — every section of the spec is implemented in this plan:
+
+| Spec section | Implemented in |
+|---|---|
+| Migration File Structure (single V1) | Task 2, Step 1 |
+| `users` table | Task 2, Step 2 |
+| `parcels` table + `idx_parcels_grid` | Task 2, Step 3 |
+| `auctions` table + 3 new indexes + deferred FK | Task 2, Step 4 |
+| `parcel_tags` table + CHECK + soft delete | Task 2, Step 5 |
+| `auction_tags` join table + CASCADE/RESTRICT | Task 2, Step 6 |
+| Seed data (25 tags, single multi-row INSERT) | Task 2, Step 7 |
+| Delete `.gitkeep` | Task 2, Step 8 |
+| Verification via `BackendApplicationTests` | Task 2, Step 9 |
+| Manual smoke check | Task 2, Step 10 |
+| Files Created/Modified table | File Structure section above |
+| Acceptance Criteria | Covered by Steps 9 + 10 |
+
+**Placeholder scan:** None. Every step contains either complete SQL, an exact command, or an exact action.
+
+**Type / name consistency:** Cross-checked column names between tables (`users.id` vs FKs in `parcels.owner_id`, `auctions.seller_id`, `auctions.listing_agent_id`, `auctions.winner_id`; `parcels.id` vs `auctions.parcel_id`; `parcel_tags.id` vs `auction_tags.tag_id`; `auctions.id` vs `auction_tags.auction_id`). All match. Index names consistent. Constraint names consistent.

--- a/docs/superpowers/specs/2026-04-10-flyway-core-migrations-design.md
+++ b/docs/superpowers/specs/2026-04-10-flyway-core-migrations-design.md
@@ -1,0 +1,225 @@
+_April 10, 2026_
+
+# Task 01-02: Flyway Migrations — Core Tables — Design Spec
+
+## Goal
+
+Create the foundational database tables (`users`, `parcels`, `auctions`) plus the supporting `parcel_tags` and `auction_tags` tables, all in a single Flyway migration. After this task, a fresh database can hold a verified user, a parcel they own, an auction listing that parcel, and the tags attached to that listing.
+
+## Approach
+
+Single migration file `V1__core_tables.sql` containing all five tables and the parcel tag seed data, in dependency order. The "split into V1/V2/V3" alternative offered in the task description is rejected — at this size, atomicity outweighs granularity.
+
+Schema follows DESIGN.md §7 verbatim with three deliberate deviations, all called out in the [Deviations from DESIGN.md](#deviations-from-designmd) section below.
+
+## Migration File Structure
+
+**Path:** `backend/src/main/resources/db/migration/V1__core_tables.sql`
+
+**Order of statements** (each section is a top-level comment block in the SQL file):
+
+1. `users` table
+2. `parcels` table + `idx_parcels_grid`
+3. `auctions` table + `idx_auctions_status`, `idx_auctions_seller`, `idx_auctions_ends_at`
+4. `parcel_tags` table
+5. `auction_tags` table + `idx_auction_tags_tag`
+6. Seed data: single multi-row `INSERT` into `parcel_tags` with all 25 tags
+
+This order respects FK dependencies: `parcels.owner_id → users(id)`, `auctions.parcel_id → parcels(id)`, `auctions.seller_id/listing_agent_id/winner_id → users(id)`, `auction_tags.auction_id → auctions(id)`, `auction_tags.tag_id → parcel_tags(id)`.
+
+## `users` Table
+
+Exact column set from DESIGN.md §7. The duplicated `email` field in DESIGN.md (declared in both the main identity block and the notification block) is collapsed to a single `VARCHAR(255) UNIQUE NOT NULL` column. This matches the task description's note.
+
+**FKs out:** none
+**Constraints:** `UNIQUE(email)`, `UNIQUE(sl_avatar_uuid)`
+**Indexes:** none beyond the implicit indexes from PK and UNIQUE constraints
+**Notable defaults:**
+- `notify_email JSONB DEFAULT '{"bidding":true,"auction_result":true,"escrow":true,"listing_status":true,"reviews":true,"realty_group":true,"marketing":false}'`
+- `notify_sl_im JSONB DEFAULT '{"bidding":true,"auction_result":true,"escrow":true,"listing_status":true,"reviews":false,"realty_group":false,"marketing":false}'`
+- `verified BOOLEAN DEFAULT FALSE`
+- `email_verified BOOLEAN DEFAULT FALSE`
+- `notify_email_muted BOOLEAN DEFAULT FALSE`
+- `notify_sl_im_muted BOOLEAN DEFAULT FALSE`
+- `total_seller_reviews / total_buyer_reviews / completed_sales / cancelled_with_bids INTEGER DEFAULT 0`
+- `created_at / updated_at TIMESTAMP DEFAULT NOW()`
+
+## `parcels` Table
+
+Exact column set from DESIGN.md §7.
+
+**FKs out:** `owner_id → users(id)`
+**Constraints:** `UNIQUE(parcel_uuid)`
+**Indexes:**
+- `idx_parcels_grid ON parcels(grid_x, grid_y)` (from DESIGN.md)
+**Notable defaults:**
+- `owner_type VARCHAR(10) DEFAULT 'AGENT'`
+- `verified BOOLEAN DEFAULT FALSE`
+- `created_at TIMESTAMP DEFAULT NOW()`
+
+## `auctions` Table
+
+Exact column set from DESIGN.md §7, with two intentional schema choices:
+
+1. **`status VARCHAR(30) NOT NULL DEFAULT 'DRAFT'` with no CHECK constraint.** The task description explicitly chose VARCHAR over an enum so that adding new statuses doesn't require a migration. A CHECK constraint listing valid values would defeat that goal. Status validation lives at the application layer (Java enum + service-layer guards).
+
+2. **`realty_group_id BIGINT` with no foreign key constraint.** The `realty_groups` table is created in Task 01-03. Adding the FK now would require either pulling realty_groups into this migration (scope creep) or splitting V1 into multiple files. Instead, the column is declared as a plain `BIGINT` with an inline SQL comment: `-- FK to realty_groups(id) added in Task 01-03 / V2`.
+
+**FKs out:**
+- `parcel_id → parcels(id)`
+- `seller_id → users(id)`
+- `listing_agent_id → users(id)`
+- `winner_id → users(id)`
+
+**Indexes added in this migration:**
+- `idx_auctions_status ON auctions(status)` — every browse-listings query filters by status.
+- `idx_auctions_seller ON auctions(seller_id)` — "my listings" dashboard query.
+- `idx_auctions_ends_at ON auctions(ends_at)` — auction expiry sweeper job (Epic 04).
+
+These three are not in DESIGN.md but are obvious hot paths and are added proactively rather than chasing down a separate index migration in a few weeks.
+
+**Notable defaults:**
+- `status VARCHAR(30) NOT NULL DEFAULT 'DRAFT'`
+- `current_bid INTEGER DEFAULT 0`
+- `bid_count INTEGER DEFAULT 0`
+- `listing_fee_paid BOOLEAN DEFAULT FALSE`
+- `snipe_protect BOOLEAN DEFAULT FALSE`
+- `bot_check_failures INTEGER DEFAULT 0`
+- `commission_rate DECIMAL(5,4) DEFAULT 0.0500`
+- `agent_fee_rate DECIMAL(5,4) DEFAULT 0`
+- `created_at / updated_at TIMESTAMP DEFAULT NOW()`
+
+## `parcel_tags` Table
+
+**Replaces** the `parcel_tag` Postgres ENUM from DESIGN.md. Tags become rows in a real table so that admins can add, rename, and deactivate tags through the SLPA admin UI without writing a migration. See [Deviations from DESIGN.md](#deviations-from-designmd).
+
+```sql
+CREATE TABLE parcel_tags (
+    id          BIGSERIAL PRIMARY KEY,
+    code        VARCHAR(50)  NOT NULL,
+    label       VARCHAR(100) NOT NULL,
+    category    VARCHAR(50)  NOT NULL,
+    description TEXT,
+    sort_order  INTEGER      NOT NULL DEFAULT 0,
+    active      BOOLEAN      NOT NULL DEFAULT TRUE,
+    created_at  TIMESTAMP    NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMP    NOT NULL DEFAULT NOW(),
+    CONSTRAINT parcel_tags_code_unique UNIQUE (code),
+    CONSTRAINT parcel_tags_code_format CHECK (code ~ '^[A-Z][A-Z0-9_]*$')
+);
+```
+
+**Design rationale:**
+
+- **`code` is the stable machine identifier**, `label` is the display string. Backend logic and analytics key off `code`. UI rename of "Waterfront" → "Oceanfront" only changes `label`.
+- **`code` CHECK constraint** enforces UPPER_SNAKE_CASE format at the database level. Prevents the eventual "waterfront" / "WATERFRONT" duplicate-tag mess.
+- **`active` flag (soft delete)** rather than hard delete. Once a tag is attached to even one historical auction, hard-deleting it would either cascade-remove `auction_tags` rows (loses listing history) or fail outright. Soft delete lets admins hide a tag from new listings without rewriting history.
+- **`category` as plain VARCHAR**, not a normalized `parcel_tag_categories` table. Five categories, rarely-changing — normalization is overkill at this scale and easy to extract later if it becomes admin-editable.
+- **`sort_order` column** so the UI can present tags in an intentional order rather than alphabetical or insertion order. Lower values render first.
+
+## `auction_tags` Table
+
+Pure join table — no surrogate id.
+
+```sql
+CREATE TABLE auction_tags (
+    auction_id BIGINT NOT NULL REFERENCES auctions(id) ON DELETE CASCADE,
+    tag_id     BIGINT NOT NULL REFERENCES parcel_tags(id) ON DELETE RESTRICT,
+    PRIMARY KEY (auction_id, tag_id)
+);
+CREATE INDEX idx_auction_tags_tag ON auction_tags(tag_id);
+```
+
+**FK delete behavior rationale:**
+
+- `auction_id ... ON DELETE CASCADE` — when an auction is deleted, its tag attachments go with it. Tag attachments have no meaning without the auction.
+- `tag_id ... ON DELETE RESTRICT` — pairs with the soft-delete philosophy on `parcel_tags`. Prevents accidental hard delete of an in-use tag; forces admins to use the `active` flag instead.
+
+**Index rationale:**
+
+- The PK already creates an index on `(auction_id, tag_id)`, which serves "what tags does this auction have?" queries.
+- `idx_auction_tags_tag ON (tag_id)` serves the reverse query "what auctions have this tag?", which is the basis for the browse-by-tag filter on the listings page.
+
+## Seed Data
+
+A single multi-row `INSERT` at the bottom of `V1__core_tables.sql` populates `parcel_tags` with all 25 tags from DESIGN.md §7. Inline rather than a separate `V2__seed_parcel_tags.sql` file: keeps the "fresh install brings up a working tag system" guarantee atomic in one migration.
+
+```sql
+INSERT INTO parcel_tags (code, label, category, description, sort_order) VALUES
+  ('WATERFRONT',       'Waterfront',       'Terrain / Environment', 'Ocean, lake, or river border',                          1),
+  ('SAILABLE',         'Sailable',         'Terrain / Environment', 'Connected to navigable water (Linden waterways)',       2),
+  ('GRASS',            'Grass',            'Terrain / Environment', 'Grass terrain',                                          3),
+  ('SNOW',             'Snow',             'Terrain / Environment', 'Snow terrain',                                           4),
+  ('SAND',             'Sand',             'Terrain / Environment', 'Sand or beach terrain',                                  5),
+  ('MOUNTAIN',         'Mountain',         'Terrain / Environment', 'Elevated or hilly terrain',                              6),
+  ('FOREST',           'Forest',           'Terrain / Environment', 'Wooded area',                                            7),
+  ('FLAT',             'Flat',             'Terrain / Environment', 'Level terrain, good for building',                       8),
+  ('STREETFRONT',      'Streetfront',      'Roads / Access',        'Borders a Linden road',                                  9),
+  ('ROADSIDE',         'Roadside',         'Roads / Access',        'Near (but not directly on) a Linden road',              10),
+  ('RAILWAY',          'Railway',          'Roads / Access',        'Near Linden railroad / SLRR',                           11),
+  ('CORNER_LOT',       'Corner Lot',       'Location Features',     'Parcel on a corner (two road or water sides)',          12),
+  ('HILLTOP',          'Hilltop',          'Location Features',     'Elevated with views',                                   13),
+  ('ISLAND',           'Island',           'Location Features',     'Surrounded by water',                                   14),
+  ('PENINSULA',        'Peninsula',        'Location Features',     'Water on three sides',                                  15),
+  ('SHELTERED',        'Sheltered',        'Location Features',     'Enclosed or private feeling, surrounded by terrain',    16),
+  ('RESIDENTIAL',      'Residential',      'Neighbors / Context',   'Residential neighborhood',                              17),
+  ('COMMERCIAL',       'Commercial',       'Neighbors / Context',   'Commercial or shopping area',                           18),
+  ('INFOHUB_ADJACENT', 'Infohub Adjacent', 'Neighbors / Context',   'Near a Linden infohub',                                 19),
+  ('PROTECTED_LAND',   'Protected Land',   'Neighbors / Context',   'Adjacent to Linden-owned protected land',               20),
+  ('SCENIC',           'Scenic',           'Neighbors / Context',   'Notable views or landscape',                            21),
+  ('DOUBLE_PRIM',      'Double Prim',      'Parcel Features',       'On a double-prim region (Magnum, etc.)',                22),
+  ('HIGH_PRIM',        'High Prim',        'Parcel Features',       'Above-average prim capacity for size',                  23),
+  ('LARGE_PARCEL',     'Large Parcel',     'Parcel Features',       '4096+ sqm',                                             24),
+  ('FULL_REGION',      'Full Region',      'Parcel Features',       'Entire region (65536 sqm)',                             25);
+```
+
+## Deviations from DESIGN.md
+
+These are the deliberate departures from DESIGN.md §7. All have been explicitly approved during brainstorming.
+
+| # | Deviation | Reason |
+|---|---|---|
+| 1 | Tags are a **table** (`parcel_tags`), not a Postgres `ENUM` type. `auction_tags.tag` becomes `auction_tags.tag_id BIGINT REFERENCES parcel_tags(id)`. | Enables admin-editable tags via the SLPA UI without database migrations. |
+| 2 | The seeded tag set has **25 values**, not the "27 values" mentioned in the task description prose. | DESIGN.md §7 (the stated source of truth) actually defines 25 tags: 8 Terrain + 3 Roads + 5 Location + 5 Neighbors + 4 Parcel = 25. The task description's "27" appears to be a counting error. |
+| 3 | Added three indexes not in DESIGN.md: `idx_auctions_status`, `idx_auctions_seller`, `idx_auctions_ends_at`. | All three are obvious hot paths (browse filter, dashboard, expiry sweeper). Adding now is cheaper than discovering them via slow queries later. |
+| 4 | `auctions.realty_group_id` is declared without a foreign key constraint. | The `realty_groups` table is created in Task 01-03. The FK is added there via `ALTER TABLE auctions ADD CONSTRAINT`. Tracked by an inline SQL comment on the column. |
+| 5 | Added `CHECK (code ~ '^[A-Z][A-Z0-9_]*$')` to `parcel_tags.code`. | Prevents case-insensitive duplicate codes (e.g., `waterfront` vs `WATERFRONT`) at the database level. Cheap insurance against admin UI bugs. |
+| 6 | The duplicated `email` column in DESIGN.md's `users` definition is collapsed to one column. | Per the task description note. |
+
+## Verification
+
+This task does not add new test files. Verification relies on existing infrastructure:
+
+1. **`BackendApplicationTests.contextLoads()`** — already runs against the `dev` profile's local PostgreSQL with `ddl-auto: validate`. Flyway runs at startup; if `V1__core_tables.sql` has any SQL syntax error, the test fails. (No JPA entities exist yet, so `validate` has nothing to check beyond migration success.)
+
+2. **Manual smoke check (one-time, during task execution):**
+   - `cd backend && ./mvnw spring-boot:run`
+   - Confirm the application starts without errors.
+   - Connect to the local Postgres and verify:
+     - `SELECT * FROM flyway_schema_history;` — one row for V1, `success = true`.
+     - `\dt` — five new tables exist: `users`, `parcels`, `auctions`, `parcel_tags`, `auction_tags`.
+     - `SELECT count(*) FROM parcel_tags;` — returns 25.
+
+3. **Schema-vs-entity validation lands in Task 01-04**, which adds the JPA entities. At that point `ddl-auto: validate` will catch any column-type mismatch between this migration and the entity classes.
+
+## Files Created/Modified
+
+| Action | Path (relative to repo root) |
+|---|---|
+| Create | `backend/src/main/resources/db/migration/V1__core_tables.sql` |
+| Delete | `backend/src/main/resources/db/migration/.gitkeep` |
+
+The `.gitkeep` is no longer needed once a real migration file exists in the directory.
+
+## Acceptance Criteria
+
+- `V1__core_tables.sql` exists at `backend/src/main/resources/db/migration/V1__core_tables.sql`.
+- Running `./mvnw test` succeeds — `BackendApplicationTests.contextLoads()` passes against the dev profile's PostgreSQL with V1 applied.
+- After startup against a fresh database:
+  - All five tables exist: `users`, `parcels`, `auctions`, `parcel_tags`, `auction_tags`.
+  - All foreign key relationships in [the relevant sections above](#auctions-table) are present, except `auctions.realty_group_id`, which is intentionally a plain `BIGINT` until Task 01-03.
+  - The `parcel_tags` table contains exactly 25 rows.
+  - The `parcel_tags.code` CHECK constraint rejects a row with `code = 'waterfront'` and accepts a row with `code = 'TEST_TAG'`.
+  - All indexes from the [migration file structure](#migration-file-structure) section exist (verifiable via `\d auctions`, `\d parcels`, `\d auction_tags`).
+  - `flyway_schema_history` has one row for V1 with `success = true`.
+- The `auction_tags` join table accepts an insert linking a real auction id to a real tag id, and rejects an insert referencing a nonexistent tag id.


### PR DESCRIPTION
## Summary

- Single Flyway migration `V1__core_tables.sql` creating `users`, `parcels`, `auctions`, `parcel_tags`, `auction_tags` with 7 indexes and 25 seed tag rows
- Tags are a real table (not a Postgres enum) so admins can add/rename/deactivate via the UI later without migrations
- Three extra hot-path indexes on `auctions` (`status`, `seller_id`, `ends_at`) added proactively
- Code-review-driven schema tightening: `TIMESTAMPTZ` everywhere, `BIGINT` for L\$ money columns, `TEXT` for URL columns, `NOT NULL` on FKs/counters/timestamps/booleans with defaults, inline enum comments
- `DESIGN.md` section 7 updated to match the migration for the type/nullability changes

## Design decisions

- `auctions.realty_group_id` is a plain `BIGINT` with no FK constraint — the `realty_groups` table is created in Task 01-03, which will add the FK via `ALTER TABLE`
- `auctions.status` is `VARCHAR(30)` with no `CHECK` constraint — intentional so new status values can be added without migrations; validation lives at the application layer
- `parcel_tags.code` has a `CHECK (code ~ '^[A-Z][A-Z0-9_]*$')` constraint to prevent case-insensitive duplicate codes
- `auction_tags.tag_id` is `ON DELETE RESTRICT` to pair with `parcel_tags.active` soft delete; admins deactivate, never hard-delete

## Test Plan

- [x] ``./mvnw test`` — BUILD SUCCESS, 5 tests pass, `BackendApplicationTests.contextLoads` exercises Flyway against real PostgreSQL
- [x] Manual psql smoke check: 6 relations present, 25 parcel_tags rows, 5 distinct categories, CHECK constraint rejects lowercase codes, FK constraint rejects orphan `auction_tags` rows, all 4 expected indexes on `auctions`
- [x] Verified all timestamps are ``timestamp with time zone``, money columns are ``bigint``, URL columns are ``text``, and NOT NULL constraints are in place where added

## Spec and plan

- Spec: ``docs/superpowers/specs/2026-04-10-flyway-core-migrations-design.md``
- Plan: ``docs/superpowers/plans/2026-04-10-flyway-core-migrations.md``