### PR TITLE
feat(ws): Task 01-09 - WebSocket STOMP infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ The frontend dev server runs at `http://localhost:3000`. Component primitives li
 
 The frontend has three auth pages (`/register`, `/login`, `/forgot-password`) wired to the backend JWT auth endpoints from Task 01-07. Forms use react-hook-form + zod with backend ProblemDetail error mapping. Tests run against MSW mocks; the canary `lib/api.401-interceptor.test.tsx` proves the API client's auto-refresh-and-retry behavior. See [`docs/superpowers/specs/2026-04-12-task-01-08-frontend-auth-design.md`](docs/superpowers/specs/2026-04-12-task-01-08-frontend-auth-design.md) for the full design.
 
+Task 01-09 wires the real-time pipe end-to-end. The backend exposes a STOMP-over-WebSocket endpoint at `/ws` with SockJS fallback, authenticated at the STOMP `CONNECT` frame by `JwtChannelInterceptor` (the HTTP upgrade itself is `permitAll` — browsers cannot send custom headers on a WebSocket handshake). A dev/test-only broadcast endpoint `POST /api/ws-test/broadcast` fans messages out to `/topic/ws-test`. The frontend ships a singleton STOMP client in `lib/ws/client.ts` with a reusable `ensureFreshAccessToken` stampede guard shared with the HTTP 401 interceptor, plus `useConnectionState` / `useStompSubscription` hooks, and a development-only verification harness page at [`/dev/ws-test`](http://localhost:3000/dev/ws-test) (404s in production builds).
+
 ## Running tests
 
 ```bash

--- a/backend/src/main/java/com/slparcelauctions/backend/auth/JwtChannelInterceptor.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auth/JwtChannelInterceptor.java
@@ -1,0 +1,72 @@
+package com.slparcelauctions.backend.auth;
+
+import com.slparcelauctions.backend.auth.exception.TokenExpiredException;
+import com.slparcelauctions.backend.auth.exception.TokenInvalidException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+/**
+ * STOMP CONNECT-frame authentication gate. Reads the {@code Authorization}
+ * native header from the first {@link StompCommand#CONNECT} frame, parses it
+ * via {@link JwtService}, and attaches a {@link StompAuthenticationToken} to
+ * the session. Subsequent frames (SUBSCRIBE, SEND, DISCONNECT) pass through
+ * unchanged — the principal set here lives on the session for their lifetime.
+ *
+ * <p><strong>Why CONNECT-only:</strong> Task 01-09 spec §3 (Q3c-i). Matching
+ * the HTTP filter's one-check-per-request behavior. Epic 04 may revisit if
+ * sensitive write operations ever flow through {@code @MessageMapping}
+ * handlers.
+ *
+ * <p><strong>Why throw {@link MessagingException}:</strong> Spring's STOMP
+ * infrastructure catches it and sends a STOMP ERROR frame back to the client
+ * before closing the session. The frontend's {@code onStompError} handler
+ * picks it up and surfaces the error via the ConnectionState machine.
+ *
+ * <p><strong>Why {@code getFirstNativeHeader}, not {@code getHeader}:</strong>
+ * STOMP headers arrive as a {@code MultiValueMap<String, String>} under the
+ * key {@code nativeHeaders}. {@code getHeader} looks up Spring-internal
+ * framework headers and returns null for STOMP client headers.
+ * See FOOTGUNS §F.16.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtChannelInterceptor implements ChannelInterceptor {
+
+    private final JwtService jwtService;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor =
+            MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor == null || !StompCommand.CONNECT.equals(accessor.getCommand())) {
+            return message;
+        }
+
+        String authHeader = accessor.getFirstNativeHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            log.debug("STOMP CONNECT rejected: missing or non-Bearer Authorization header");
+            throw new MessagingException(message, "Missing or invalid Authorization header");
+        }
+
+        String token = authHeader.substring(7);
+        try {
+            AuthPrincipal principal = jwtService.parseAccessToken(token);
+            accessor.setUser(new StompAuthenticationToken(principal));
+            log.debug("STOMP CONNECT authenticated: userId={}", principal.userId());
+            return message;
+        } catch (TokenExpiredException | TokenInvalidException e) {
+            log.debug("STOMP CONNECT rejected: {}", e.getMessage());
+            throw new MessagingException(message, "Invalid or expired access token");
+        }
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/auth/StompAuthenticationToken.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auth/StompAuthenticationToken.java
@@ -1,0 +1,21 @@
+package com.slparcelauctions.backend.auth;
+
+import java.security.Principal;
+
+/**
+ * Minimal {@link Principal} wrapper attached to a STOMP session by
+ * {@link JwtChannelInterceptor} after a successful CONNECT-frame JWT
+ * validation. Spring's {@code SimpMessagingTemplate.convertAndSendToUser}
+ * resolves user-scoped destinations via {@link #getName()}.
+ *
+ * <p>This wrapper exists so Epic 04 can convert and send to specific users
+ * for per-auction notifications. For Task 01-09, only {@link #principal()} is
+ * read (via {@code @AuthenticationPrincipal} on the test controller, which
+ * reaches in through the Spring MVC resolver chain anyway).
+ */
+public record StompAuthenticationToken(AuthPrincipal principal) implements Principal {
+    @Override
+    public String getName() {
+        return String.valueOf(principal.userId());
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
@@ -58,6 +58,12 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/users/me").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/users/{id}").permitAll()
                         .requestMatchers("/api/auth/logout-all").authenticated()
+                        // WebSocket handshake is permitted at the HTTP layer.
+                        // Authentication happens at the STOMP CONNECT frame via
+                        // JwtChannelInterceptor. Do NOT change this to .authenticated() —
+                        // the browser WebSocket API cannot set an Authorization header on
+                        // the HTTP upgrade, so gating it here is impossible. See FOOTGUNS §F.16.
+                        .requestMatchers("/ws/**").permitAll()
                         .requestMatchers("/api/**").authenticated()
                         .anyRequest().denyAll())
                 .exceptionHandling(eh -> eh.authenticationEntryPoint(authenticationEntryPoint))

--- a/backend/src/main/java/com/slparcelauctions/backend/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/config/WebSocketConfig.java
@@ -1,0 +1,61 @@
+package com.slparcelauctions.backend.config;
+
+import com.slparcelauctions.backend.auth.JwtChannelInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+/**
+ * STOMP over WebSocket configuration. Exposes a single endpoint at {@code /ws}
+ * with SockJS fallback, a simple in-memory broker for {@code /topic}
+ * destinations, and the {@link JwtChannelInterceptor} on the client inbound
+ * channel.
+ *
+ * <p><strong>In-memory broker:</strong> sufficient for Phase 1 single-instance
+ * deployments. Epic 04 may swap to a relayed broker (RabbitMQ STOMP plugin)
+ * when cross-instance fanout is needed. Leaving this comment so the Epic 04
+ * implementer does not need to rediscover the rationale.
+ *
+ * <p><strong>{@code /app} application prefix:</strong> unused in Task 01-09
+ * (the test controller uses REST + {@code SimpMessagingTemplate}) but set
+ * here so Epic 04 can add {@code @MessageMapping("/bid")} handlers without
+ * reconfiguring the broker.
+ *
+ * <p><strong>CORS on the endpoint:</strong> Spring's STOMP endpoint CORS is
+ * configured separately from the main {@code HttpSecurity} CORS source.
+ * Without {@code .setAllowedOrigins()} the SockJS handshake XHR fails with a
+ * confusing CORS error even though the main security filter passes.
+ */
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final JwtChannelInterceptor jwtChannelInterceptor;
+
+    @Value("${cors.allowed-origin:http://localhost:3000}")
+    private String allowedOrigin;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+            .setAllowedOrigins(allowedOrigin)
+            .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(jwtChannelInterceptor);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wstest/WsTestController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wstest/WsTestController.java
@@ -1,0 +1,63 @@
+package com.slparcelauctions.backend.wstest;
+
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.wstest.dto.WsTestBroadcastRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Dev/test-only WebSocket verification harness. Broadcasts whatever the caller
+ * POSTs onto {@code /topic/ws-test}, which any authenticated STOMP subscriber
+ * receives in real time.
+ *
+ * <p><strong>Profile gating:</strong> {@code @Profile({"dev", "test"})} means
+ * this bean is absent from the prod application context entirely. There is no
+ * SecurityConfig matcher to maintain because there is no bean to guard.
+ *
+ * <p><strong>Authentication:</strong> the broadcast endpoint falls under the
+ * {@code /api/**} authenticated catch-all in {@code SecurityConfig} — only
+ * logged-in users can trigger a broadcast. The {@code AuthPrincipal} injected
+ * here is the same one the JWT filter attaches in {@code JwtAuthenticationFilter}.
+ *
+ * <p><strong>Wire-type note:</strong> {@code principal.userId()} is a Java
+ * {@code Long}. Jackson serializes it as a JSON number, which lands in
+ * JavaScript as a plain {@code number}. Safe because user IDs are well under
+ * {@code Number.MAX_SAFE_INTEGER} (2^53 - 1). The frontend harness types
+ * {@code senderId} as {@code number} to match.
+ */
+@RestController
+@RequestMapping("/api/ws-test")
+@RequiredArgsConstructor
+@Profile({"dev", "test"})
+@Slf4j
+public class WsTestController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @PostMapping("/broadcast")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void broadcast(
+            @Valid @RequestBody WsTestBroadcastRequest request,
+            @AuthenticationPrincipal AuthPrincipal principal) {
+        log.info("WS test broadcast from userId={}: {}", principal.userId(), request.message());
+        Object payload = Map.of(
+            "message", request.message(),
+            "senderId", principal.userId(),
+            "timestamp", Instant.now().toString()
+        );
+        messagingTemplate.convertAndSend("/topic/ws-test", payload);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wstest/dto/WsTestBroadcastRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wstest/dto/WsTestBroadcastRequest.java
@@ -1,0 +1,8 @@
+package com.slparcelauctions.backend.wstest.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record WsTestBroadcastRequest(
+    @NotBlank @Size(max = 500) String message
+) {}

--- a/backend/src/test/java/com/slparcelauctions/backend/auth/JwtChannelInterceptorTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auth/JwtChannelInterceptorTest.java
@@ -1,0 +1,127 @@
+package com.slparcelauctions.backend.auth;
+
+import com.slparcelauctions.backend.auth.exception.TokenExpiredException;
+import com.slparcelauctions.backend.auth.exception.TokenInvalidException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+
+import java.security.Principal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class JwtChannelInterceptorTest {
+
+    private JwtService jwtService;
+    private JwtChannelInterceptor interceptor;
+    private MessageChannel channel;
+
+    @BeforeEach
+    void setUp() {
+        jwtService = Mockito.mock(JwtService.class);
+        interceptor = new JwtChannelInterceptor(jwtService);
+        channel = Mockito.mock(MessageChannel.class);
+    }
+
+    private Message<byte[]> stompMessage(StompCommand command, String authHeader) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(command);
+        if (authHeader != null) {
+            accessor.setNativeHeader("Authorization", authHeader);
+        }
+        accessor.setLeaveMutable(true);
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+
+    @Test
+    @DisplayName("non-CONNECT frames pass through unchanged")
+    void preSend_nonConnectFrame_passesThrough() {
+        Message<byte[]> msg = stompMessage(StompCommand.SEND, null);
+
+        Message<?> result = interceptor.preSend(msg, channel);
+
+        assertThat(result).isSameAs(msg);
+        Mockito.verifyNoInteractions(jwtService);
+    }
+
+    @Test
+    @DisplayName("CONNECT with missing Authorization header is rejected")
+    void preSend_connectFrame_missingAuthHeader_throws() {
+        Message<byte[]> msg = stompMessage(StompCommand.CONNECT, null);
+
+        assertThatThrownBy(() -> interceptor.preSend(msg, channel))
+            .isInstanceOf(MessagingException.class)
+            .hasMessageContaining("Missing or invalid Authorization header");
+
+        Mockito.verifyNoInteractions(jwtService);
+    }
+
+    @Test
+    @DisplayName("CONNECT with malformed Bearer header is rejected")
+    void preSend_connectFrame_malformedBearer_throws() {
+        Message<byte[]> msg = stompMessage(StompCommand.CONNECT, "NotBearer foo");
+
+        assertThatThrownBy(() -> interceptor.preSend(msg, channel))
+            .isInstanceOf(MessagingException.class)
+            .hasMessageContaining("Missing or invalid Authorization header");
+
+        Mockito.verifyNoInteractions(jwtService);
+    }
+
+    @Test
+    @DisplayName("CONNECT with valid token attaches StompAuthenticationToken principal")
+    void preSend_connectFrame_validToken_attachesPrincipal() {
+        AuthPrincipal authPrincipal = new AuthPrincipal(42L, "test@example.com", 1L);
+        when(jwtService.parseAccessToken("valid-jwt")).thenReturn(authPrincipal);
+
+        Message<byte[]> msg = stompMessage(StompCommand.CONNECT, "Bearer valid-jwt");
+
+        Message<?> result = interceptor.preSend(msg, channel);
+
+        assertThat(result).isNotNull();
+        StompHeaderAccessor resultAccessor =
+            StompHeaderAccessor.wrap(result);
+        Principal user = resultAccessor.getUser();
+        assertThat(user).isInstanceOf(StompAuthenticationToken.class);
+        assertThat(user.getName()).isEqualTo("42");
+        StompAuthenticationToken token = (StompAuthenticationToken) user;
+        assertThat(token.principal().userId()).isEqualTo(42L);
+        assertThat(token.principal().email()).isEqualTo("test@example.com");
+        assertThat(token.principal().tokenVersion()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("CONNECT with expired token is rejected")
+    void preSend_connectFrame_expiredToken_throws() {
+        when(jwtService.parseAccessToken(any()))
+            .thenThrow(new TokenExpiredException("expired"));
+
+        Message<byte[]> msg = stompMessage(StompCommand.CONNECT, "Bearer expired-jwt");
+
+        assertThatThrownBy(() -> interceptor.preSend(msg, channel))
+            .isInstanceOf(MessagingException.class)
+            .hasMessageContaining("Invalid or expired access token");
+    }
+
+    @Test
+    @DisplayName("CONNECT with invalid token is rejected")
+    void preSend_connectFrame_invalidToken_throws() {
+        when(jwtService.parseAccessToken(any()))
+            .thenThrow(new TokenInvalidException("bad token"));
+
+        Message<byte[]> msg = stompMessage(StompCommand.CONNECT, "Bearer bad-jwt");
+
+        assertThatThrownBy(() -> interceptor.preSend(msg, channel))
+            .isInstanceOf(MessagingException.class)
+            .hasMessageContaining("Invalid or expired access token");
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/wstest/WsTestIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/wstest/WsTestIntegrationTest.java
@@ -1,0 +1,230 @@
+package com.slparcelauctions.backend.wstest;
+
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.wstest.dto.WsTestBroadcastRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.Transport;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("dev")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class WsTestIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private JwtService jwtService;
+
+    private WebSocketStompClient stompClient;
+    private BlockingQueue<Map<String, Object>> receivedMessages;
+
+    @BeforeEach
+    void setUp() {
+        List<Transport> transports = List.of(new WebSocketTransport(new StandardWebSocketClient()));
+        SockJsClient sockJsClient = new SockJsClient(transports);
+        stompClient = new WebSocketStompClient(sockJsClient);
+        stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+        receivedMessages = new LinkedBlockingQueue<>();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (stompClient != null) {
+            stompClient.stop();
+        }
+    }
+
+    private String issueAccessTokenForTestUser() {
+        AuthPrincipal principal = new AuthPrincipal(9999L, "wstest@example.com", 1L);
+        return jwtService.issueAccessToken(principal);
+    }
+
+    private String wsUrl() {
+        return "http://localhost:" + port + "/ws";
+    }
+
+    @Test
+    void stompConnectWithValidToken_receivesBroadcast() throws Exception {
+        String token = issueAccessTokenForTestUser();
+
+        StompHeaders connectHeaders = new StompHeaders();
+        connectHeaders.add("Authorization", "Bearer " + token);
+
+        CompletableFuture<StompSession> sessionFuture = new CompletableFuture<>();
+        stompClient.connectAsync(
+            wsUrl(),
+            new WebSocketHttpHeaders(),
+            connectHeaders,
+            new StompSessionHandlerAdapter() {
+                @Override
+                public void afterConnected(StompSession session, StompHeaders headers) {
+                    sessionFuture.complete(session);
+                }
+
+                @Override
+                public void handleException(StompSession session, StompCommand command,
+                                            StompHeaders headers, byte[] payload, Throwable exception) {
+                    sessionFuture.completeExceptionally(exception);
+                }
+
+                @Override
+                public void handleTransportError(StompSession session, Throwable exception) {
+                    if (!sessionFuture.isDone()) {
+                        sessionFuture.completeExceptionally(exception);
+                    }
+                }
+            }
+        );
+
+        StompSession session = sessionFuture.get(5, TimeUnit.SECONDS);
+
+        session.subscribe("/topic/ws-test", new StompFrameHandler() {
+            @Override
+            public Type getPayloadType(StompHeaders headers) {
+                return Map.class;
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public void handleFrame(StompHeaders headers, Object payload) {
+                receivedMessages.offer((Map<String, Object>) payload);
+            }
+        });
+
+        // Tiny pause to let the subscription register before we broadcast.
+        Thread.sleep(200);
+
+        // Trigger the broadcast via the HTTP endpoint.
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setBearerAuth(token);
+        httpHeaders.setContentType(org.springframework.http.MediaType.APPLICATION_JSON);
+        HttpEntity<WsTestBroadcastRequest> request =
+            new HttpEntity<>(new WsTestBroadcastRequest("hello from test"), httpHeaders);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+            "http://localhost:" + port + "/api/ws-test/broadcast",
+            HttpMethod.POST,
+            request,
+            Void.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        Map<String, Object> received = receivedMessages.poll(5, TimeUnit.SECONDS);
+        assertThat(received).isNotNull();
+        assertThat(received.get("message")).isEqualTo("hello from test");
+        assertThat(received.get("senderId")).isEqualTo(9999);
+        assertThat(received.get("timestamp")).isNotNull();
+    }
+
+    @Test
+    void stompConnectWithoutAuthHeader_isRejected() {
+        // No Authorization header in connectHeaders — interceptor throws
+        // MessagingException which surfaces as a connect failure.
+        StompHeaders connectHeaders = new StompHeaders();
+
+        CompletableFuture<StompSession> sessionFuture = new CompletableFuture<>();
+        stompClient.connectAsync(
+            wsUrl(),
+            new WebSocketHttpHeaders(),
+            connectHeaders,
+            new StompSessionHandlerAdapter() {
+                @Override
+                public void afterConnected(StompSession session, StompHeaders headers) {
+                    sessionFuture.complete(session);
+                }
+
+                @Override
+                public void handleException(StompSession session, StompCommand command,
+                                            StompHeaders headers, byte[] payload, Throwable exception) {
+                    sessionFuture.completeExceptionally(exception);
+                }
+
+                @Override
+                public void handleTransportError(StompSession session, Throwable exception) {
+                    if (!sessionFuture.isDone()) {
+                        sessionFuture.completeExceptionally(exception);
+                    }
+                }
+            }
+        );
+
+        assertThatThrownBy(() -> sessionFuture.get(5, TimeUnit.SECONDS))
+            .isInstanceOfAny(ExecutionException.class, TimeoutException.class);
+    }
+
+    @Test
+    void stompConnectWithInvalidToken_isRejected() {
+        StompHeaders connectHeaders = new StompHeaders();
+        connectHeaders.add("Authorization", "Bearer not-a-real-jwt");
+
+        CompletableFuture<StompSession> sessionFuture = new CompletableFuture<>();
+        stompClient.connectAsync(
+            wsUrl(),
+            new WebSocketHttpHeaders(),
+            connectHeaders,
+            new StompSessionHandlerAdapter() {
+                @Override
+                public void afterConnected(StompSession session, StompHeaders headers) {
+                    sessionFuture.complete(session);
+                }
+
+                @Override
+                public void handleException(StompSession session, StompCommand command,
+                                            StompHeaders headers, byte[] payload, Throwable exception) {
+                    sessionFuture.completeExceptionally(exception);
+                }
+
+                @Override
+                public void handleTransportError(StompSession session, Throwable exception) {
+                    if (!sessionFuture.isDone()) {
+                        sessionFuture.completeExceptionally(exception);
+                    }
+                }
+            }
+        );
+
+        assertThatThrownBy(() -> sessionFuture.get(5, TimeUnit.SECONDS))
+            .isInstanceOfAny(ExecutionException.class, TimeoutException.class);
+    }
+}

--- a/docs/implementation/FOOTGUNS.md
+++ b/docs/implementation/FOOTGUNS.md
@@ -955,3 +955,41 @@ Discovered when implementing `mapProblemDetailToForm` tests in Task 01-08. The p
 - A missing import surfaces as `ReferenceError: beforeAll is not defined` at test runtime. The fix is one line.
 
 Discovered during MSW lifecycle wiring in Task 01-08 Task 4.
+
+### F.16 WebSocket handshake is permitted at HTTP, authenticated at STOMP
+
+**Rule:** `SecurityConfig` must list `/ws/**` as `.permitAll()` above the `/api/**` authenticated catch-all. The HTTP-layer WebSocket upgrade does not carry an `Authorization` header from the browser (the WebSocket API has no mechanism to set custom headers on upgrades), so gating the upgrade at the HTTP layer is impossible. Authentication happens in `JwtChannelInterceptor.preSend()` on the first STOMP `CONNECT` frame, before the session is usable for any subscription or send.
+
+**Why:** Task 01-09 locked this model in the brainstorm (spec §3 Q1-A). Matcher order in `SecurityConfig` is first-match-wins (§B.5), so `/ws/**` must appear ABOVE `/api/**`. Moving it below the catch-all silently flips it from permitAll to authenticated and every WebSocket connection starts failing with a bewildering 401 before the STOMP layer even sees the frame.
+
+**How to apply:** when editing `SecurityConfig.authorizeHttpRequests`, verify the `/ws/**` matcher is still above `/api/**`. If code review proposes "tightening" it to `.authenticated()`, reject — browsers cannot send the required header.
+
+### F.17 `ensureFreshAccessToken` stampede guard — `finally` inside the IIFE
+
+**Rule:** In `lib/auth/refresh.ts`, the `inFlightRefresh = null` cleanup MUST live inside the IIFE's `try { ... } finally { inFlightRefresh = null; }`, not after the outer promise chain. The shared promise between HTTP 401 interceptor and STOMP `beforeConnect` depends on this: if the cleanup runs outside the IIFE, every awaiter nulls the ref as they resolve, and a concurrent refresh kicked off during the resolution window sees `null` and fires a second `/api/auth/refresh`, defeating the stampede guard.
+
+**Why:** this is §F.4 restated for the extracted module. Two canary tests pin this behavior:
+- `frontend/src/lib/auth/refresh.test.ts` (three tests, local to the extracted module)
+- `frontend/src/lib/api.401-interceptor.test.tsx` (three tests, HTTP end-to-end via MSW)
+
+If either canary starts failing with "fetch called twice instead of once", the `finally` clause has been moved.
+
+**How to apply:** when touching `lib/auth/refresh.ts`, diff the `finally` placement. If code review ever proposes "flattening the IIFE for readability", reject it — the flattening breaks the contract.
+
+### F.18 `beforeConnect` must not throw — stash errors and let stompjs produce the ERROR frame
+
+**Rule:** In `lib/ws/client.ts`, the `beforeConnect` callback wraps `ensureFreshAccessToken` in try/catch. On `RefreshFailedError`, store the message via `setState({status:"error", detail})` and return normally — do NOT throw from `beforeConnect`. Stompjs treats a thrown `beforeConnect` as a catastrophic failure and either deactivates the client entirely or loops infinitely depending on the version.
+
+**Why:** letting stompjs proceed with no `Authorization` header causes the interceptor to reject the CONNECT frame with an `ERROR` frame, which the client handles gracefully via `onStompError` and our `ConnectionState` machine. Any path that throws from `beforeConnect` hides the error from UI and potentially deadlocks the client.
+
+**How to apply:** when reviewing `beforeConnect` changes, verify that the catch block only stores state, never throws or calls `client.deactivate()`. The setState call path is safe; throw is not.
+
+### F.19 `@stomp/stompjs` `subscribe()` only works when `client.connected === true`
+
+**Rule:** `client.subscribe(destination, callback)` throws if called before the client is connected. Our `lib/ws/client.ts` handles this by deferring the actual `client.subscribe()` call until `onConnect` fires, via an inline `subscribeToConnectionState` listener that unsubscribes itself after one fire.
+
+**Why:** without the deferral, calling `useStompSubscription` during initial page load (before the WS handshake completes) throws a runtime error that crashes the React tree. The deferral is ~6 lines but load-bearing — do not "simplify" it away.
+
+A known edge case lives here (spec §14.7): a rapid `onConnect → onWebSocketClose` sequence can leave the deferred listener waiting mid-cycle. The subscription is not lost — it attaches on the next successful connect — just delayed by one reconnect. Epic 04 may harden this with re-attach-on-every-transition + subscription dedup when auction-room subscriptions need robustness under flaky networks.
+
+**How to apply:** any path that eagerly invokes `client.subscribe` must first check `client.connected`, and if false, defer via the state listener. This rule applies equally to Epic 04's auction-room subscription code.

--- a/docs/superpowers/plans/2026-04-12-task-01-09-websocket-stomp.md
+++ b/docs/superpowers/plans/2026-04-12-task-01-09-websocket-stomp.md
@@ -1,0 +1,2928 @@
+# Task 01-09: WebSocket STOMP Configuration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a JWT-authenticated STOMP-over-WebSocket pipe between the Next.js frontend and Spring Boot backend, with an end-to-end verification harness, so Epic 04's real-time auction features can build on top of it.
+
+**Architecture:** Backend exposes `/ws` as a SockJS-capable STOMP endpoint; authentication happens inside the STOMP `CONNECT` frame via a `ChannelInterceptor` that reads the `Authorization: Bearer <jwt>` header and validates it with the existing `JwtService`. Frontend ships a singleton `@stomp/stompjs` client wrapped in a reference-counted module with observable connection state. A shared `ensureFreshAccessToken()` helper (extracted from `lib/api.ts`) dedupes refresh calls across the HTTP 401 interceptor and the WebSocket `beforeConnect` hook, keeping the single in-flight refresh promise invariant.
+
+**Tech Stack:** Spring Boot 4 + Spring Messaging STOMP + SockJS, `@stomp/stompjs` v7, `sockjs-client`, Next.js 16 App Router, TanStack Query v5, Vitest + MSW, Mockito + JUnit 5, `WebSocketStompClient` (spring-messaging).
+
+---
+
+## Overview
+
+**Spec:** `docs/superpowers/specs/2026-04-12-task-01-09-websocket-stomp-design.md` — the design source of truth. Read its §5 and §6 (backend and frontend detailed design) before starting implementation work.
+
+**Worktree:** This plan executes in `C:/Users/heath/Repos/Personal/slpa-task-01-09`, branched from `dev`. Commit and push to `task/01-09-websocket-stomp`. Final PR targets `dev`, not `main`.
+
+**Phases:**
+
+| Phase | Tasks  | What it proves                                                     |
+|-------|--------|--------------------------------------------------------------------|
+| A     | 1–2    | Refresh stampede guard extracted; HTTP 401 canary still green.     |
+| B     | 3–4    | STOMP broker + JWT `CONNECT` interceptor wired end-to-end.         |
+| C     | 5–6    | Dev-profile broadcast endpoint; full backend E2E smoke test green. |
+| D     | 7–10   | Frontend singleton client + hooks with full unit coverage.         |
+| E     | 11     | Dev-only `/dev/ws-test` harness that exercises the live pipe.      |
+| F     | 12     | FOOTGUNS §F.16–§F.19 and README sweep.                             |
+| G     | 13     | Full verify chain + manual end-to-end smoke.                       |
+
+**Commit discipline:**
+- One atomic commit per task unless the task says otherwise.
+- Commit messages: conventional commits (`feat:`, `fix:`, `test:`, `docs:`, `chore:`).
+- No AI/tool attribution footers. No `Co-Authored-By`. No `--no-verify` on pre-commit hooks — if a hook fails, fix the underlying issue.
+- Push after each task so review can happen continuously.
+
+**Invariants that must NOT drift during execution:**
+1. The `finally { inFlightRefresh = null; }` clause in `lib/auth/refresh.ts` lives **inside the IIFE**, not outside the Promise chain. See spec §F.17 and existing §F.4.
+2. The HTTP 401 canary at `frontend/src/lib/api.401-interceptor.test.tsx` must stay green throughout. It's the security canary for the refresh pipeline.
+3. `SecurityConfig` matchers are first-match-wins. `/ws/**` must appear ABOVE `/api/**` in the matcher list.
+4. `WsTestController` is `@Profile({"dev", "test"})` — it must NOT exist in the prod bean graph.
+5. The `subscribe()` function in `lib/ws/client.ts` defers to `onConnect` when the client isn't connected yet; do not "simplify" the deferral away.
+6. `beforeConnect` in `lib/ws/client.ts` catches errors but NEVER throws — throwing from `beforeConnect` deactivates stompjs in confusing ways.
+
+**Backend test commands:**
+```
+cd backend
+./mvnw test -Dtest=JwtChannelInterceptorTest          # Task 3
+./mvnw test -Dtest=WsTestIntegrationTest              # Task 6
+./mvnw test                                           # All backend tests
+```
+
+**Frontend test commands:**
+```
+cd frontend
+npx vitest run src/lib/auth/refresh.test.ts          # Task 1
+npx vitest run src/lib/api.401-interceptor.test.tsx  # Task 2 (canary)
+npx vitest run src/lib/ws                            # Tasks 9, 10
+npm test                                             # Full frontend suite
+npm run lint
+npm run build
+```
+
+**Docker prerequisites for backend integration tests:**
+- PostgreSQL running at `localhost:5432` (user `slpa`, password `slpa`, db `slpa`)
+- Redis running at `localhost:6379`
+- See memory `dev_containers.md` for exact `docker run` commands.
+
+---
+
+## Phase A — Frontend Refresh Extraction
+
+**Phase goal:** Move the refresh-stampede guard out of `lib/api.ts` into a new shared module that the WebSocket client will also consume. The existing HTTP 401 canary test is the regression gate — it must stay green without any test-code changes.
+
+**Why this phase runs first:** Doing the extraction before any WebSocket code means Phase D's `beforeConnect` can import `ensureFreshAccessToken` from day one. No late-stage refactor. The refactor is also isolated — if something goes wrong, only the HTTP path is affected, and we haven't built anything new on top yet.
+
+---
+
+### Task 1: Create `lib/auth/refresh.ts` with Stampede Canary
+
+**Why:** Extracts the refresh-token deduplication primitive. Adds three unit tests (the "three-test canary" locked in Q7d) to pin behavior: single call, concurrent dedup, failure-and-retry. This task creates the module in isolation — it is not yet consumed by anyone.
+
+**Files:**
+- Create: `frontend/src/lib/auth/refresh.ts`
+- Create: `frontend/src/lib/auth/refresh.test.ts`
+
+---
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/src/lib/auth/refresh.test.ts`:
+
+```typescript
+// frontend/src/lib/auth/refresh.test.ts
+//
+// CANARY — see FOOTGUNS §F.17. This test pins the stampede-dedup contract for
+// the shared refresh helper. Both the HTTP 401 interceptor and the STOMP
+// beforeConnect hook depend on `inFlightRefresh` being nulled inside the IIFE's
+// finally clause. If this canary starts failing with "fetch called twice",
+// someone has moved the finally out of the IIFE.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { QueryClient } from "@tanstack/react-query";
+import { server } from "@/test/msw/server";
+import {
+  RefreshFailedError,
+  configureRefresh,
+  ensureFreshAccessToken,
+  __resetRefreshStateForTests,
+} from "./refresh";
+import { getAccessToken, setAccessToken } from "./session";
+
+describe("ensureFreshAccessToken (stampede canary)", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    configureRefresh(queryClient);
+    setAccessToken("stale-token");
+  });
+
+  afterEach(() => {
+    __resetRefreshStateForTests();
+    setAccessToken(null);
+  });
+
+  it("single call hits /api/auth/refresh once and returns the fresh token", async () => {
+    let refreshCount = 0;
+    server.use(
+      http.post("*/api/auth/refresh", () => {
+        refreshCount++;
+        return HttpResponse.json({
+          accessToken: "fresh-token-A",
+          user: {
+            id: 1,
+            email: "t@example.com",
+            displayName: null,
+            slAvatarUuid: null,
+            verified: false,
+          },
+        });
+      })
+    );
+
+    const token = await ensureFreshAccessToken();
+
+    expect(refreshCount).toBe(1);
+    expect(token).toBe("fresh-token-A");
+    expect(getAccessToken()).toBe("fresh-token-A");
+    expect(queryClient.getQueryData(["auth", "session"])).toMatchObject({
+      id: 1,
+    });
+  });
+
+  it("three concurrent calls hit the backend exactly once and all resolve with the same token", async () => {
+    let refreshCount = 0;
+    server.use(
+      http.post("*/api/auth/refresh", async () => {
+        refreshCount++;
+        // Small delay so the stampede has a window to form.
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return HttpResponse.json({
+          accessToken: "fresh-token-B",
+          user: {
+            id: 2,
+            email: "t2@example.com",
+            displayName: null,
+            slAvatarUuid: null,
+            verified: false,
+          },
+        });
+      })
+    );
+
+    const results = await Promise.all([
+      ensureFreshAccessToken(),
+      ensureFreshAccessToken(),
+      ensureFreshAccessToken(),
+    ]);
+
+    expect(refreshCount).toBe(1);
+    expect(results).toEqual(["fresh-token-B", "fresh-token-B", "fresh-token-B"]);
+    expect(getAccessToken()).toBe("fresh-token-B");
+  });
+
+  it("failed refresh clears session, throws RefreshFailedError, and allows the next call to retry", async () => {
+    let refreshCount = 0;
+    server.use(
+      http.post("*/api/auth/refresh", () => {
+        refreshCount++;
+        if (refreshCount === 1) {
+          return HttpResponse.json(
+            { code: "AUTH_TOKEN_MISSING", status: 401 },
+            { status: 401 }
+          );
+        }
+        return HttpResponse.json({
+          accessToken: "fresh-token-C",
+          user: {
+            id: 3,
+            email: "t3@example.com",
+            displayName: null,
+            slAvatarUuid: null,
+            verified: false,
+          },
+        });
+      })
+    );
+
+    // First call — fails.
+    await expect(ensureFreshAccessToken()).rejects.toThrow(RefreshFailedError);
+    expect(getAccessToken()).toBeNull();
+    expect(queryClient.getQueryData(["auth", "session"])).toBeNull();
+
+    // Second call — proves inFlightRefresh was cleared in the finally block
+    // on the failure path. Fetch is called a SECOND time and resolves fresh.
+    const token = await ensureFreshAccessToken();
+    expect(refreshCount).toBe(2);
+    expect(token).toBe("fresh-token-C");
+    expect(getAccessToken()).toBe("fresh-token-C");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/lib/auth/refresh.test.ts`
+Expected: FAIL with `Cannot find module './refresh'` or similar.
+
+- [ ] **Step 3: Create `lib/auth/refresh.ts`**
+
+Create `frontend/src/lib/auth/refresh.ts`:
+
+```typescript
+// frontend/src/lib/auth/refresh.ts
+//
+// Shared refresh-token stampede guard. Both the HTTP 401 interceptor
+// (lib/api.ts) and the STOMP beforeConnect hook (lib/ws/client.ts) call
+// ensureFreshAccessToken() — a single in-flight promise dedupes concurrent
+// refresh attempts from either source.
+//
+// The finally clause that clears inFlightRefresh MUST live inside the IIFE,
+// not outside the Promise chain. See FOOTGUNS §F.4 and §F.17.
+
+import type { QueryClient } from "@tanstack/react-query";
+import { setAccessToken } from "./session";
+import type { AuthUser } from "./session";
+
+let queryClientRef: QueryClient | null = null;
+let inFlightRefresh: Promise<string> | null = null;
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
+const SESSION_QUERY_KEY = ["auth", "session"] as const;
+
+type RefreshResponse = { accessToken: string; user: AuthUser };
+
+export class RefreshFailedError extends Error {
+  readonly status: number;
+  constructor(status: number) {
+    super(`Refresh failed with status ${status}`);
+    this.name = "RefreshFailedError";
+    this.status = status;
+  }
+}
+
+export function configureRefresh(queryClient: QueryClient): void {
+  queryClientRef = queryClient;
+}
+
+/**
+ * Refreshes the access token, deduping concurrent callers onto a single
+ * in-flight promise. Returns the new access token string. On failure, clears
+ * the in-memory access token and the session query cache, then throws
+ * RefreshFailedError.
+ *
+ * Callers that need redirect-to-login behavior (HTTP 401 interceptor) do so
+ * after catching RefreshFailedError.
+ */
+export async function ensureFreshAccessToken(): Promise<string> {
+  if (inFlightRefresh) return inFlightRefresh;
+
+  inFlightRefresh = (async () => {
+    try {
+      const response = await fetch(`${BASE_URL}/api/auth/refresh`, {
+        method: "POST",
+        credentials: "include",
+      });
+
+      if (!response.ok) {
+        setAccessToken(null);
+        if (queryClientRef) {
+          queryClientRef.setQueryData(SESSION_QUERY_KEY, null);
+        }
+        throw new RefreshFailedError(response.status);
+      }
+
+      const body = (await response.json()) as RefreshResponse;
+      setAccessToken(body.accessToken);
+      if (queryClientRef) {
+        queryClientRef.setQueryData(SESSION_QUERY_KEY, body.user);
+      }
+      return body.accessToken;
+    } finally {
+      inFlightRefresh = null;
+    }
+  })();
+
+  return inFlightRefresh;
+}
+
+// Test-only reset. The ugly name signals "do not call from production code".
+export function __resetRefreshStateForTests(): void {
+  inFlightRefresh = null;
+  queryClientRef = null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/lib/auth/refresh.test.ts`
+Expected: PASS — 3 tests green.
+
+- [ ] **Step 5: Run lint**
+
+Run: `cd frontend && npm run lint`
+Expected: PASS — no lint errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09
+git add frontend/src/lib/auth/refresh.ts frontend/src/lib/auth/refresh.test.ts
+git commit -m "feat(auth): extract ensureFreshAccessToken stampede guard
+
+Create lib/auth/refresh.ts as the shared refresh-token primitive. Both
+the HTTP 401 interceptor (existing) and the STOMP beforeConnect hook
+(Task 01-09 Phase D) will consume this single in-flight promise to
+dedupe concurrent refresh attempts.
+
+Ships with a three-test canary pinning:
+1. single call hits /api/auth/refresh once
+2. three concurrent calls dedupe onto one fetch
+3. failed refresh clears session and allows the next call to retry
+
+The finally clause inside the IIFE is load-bearing — see FOOTGUNS §F.4
+and (incoming) §F.17. Both canary tests and the existing 401 interceptor
+canary depend on it."
+git push
+```
+
+---
+
+### Task 2: Delegate `lib/api.ts` to `ensureFreshAccessToken`
+
+**Why:** Replaces the inlined `handleUnauthorized` IIFE in `lib/api.ts` with a delegating call to the extracted helper. Keeps `configureApiClient` as a one-line passthrough so `providers.tsx` and the existing canary test do not need to change. Verifies the 401 canary stays green.
+
+**Files:**
+- Modify: `frontend/src/lib/api.ts`
+- Test: `frontend/src/lib/api.401-interceptor.test.tsx` (unchanged — must still pass)
+
+---
+
+- [ ] **Step 1: Rewrite `lib/api.ts` to delegate**
+
+Replace the file content with:
+
+```typescript
+import type { QueryClient } from "@tanstack/react-query";
+import { getAccessToken } from "@/lib/auth/session";
+import {
+  ensureFreshAccessToken,
+  configureRefresh,
+  RefreshFailedError,
+} from "@/lib/auth/refresh";
+
+/**
+ * Wires the API client to the app's QueryClient. Called once at app mount from
+ * `app/providers.tsx`. Kept as a passthrough to `configureRefresh` so existing
+ * call sites (providers.tsx, api.401-interceptor.test.tsx) do not need to
+ * change when the refresh primitive moved into `lib/auth/refresh.ts`.
+ */
+export function configureApiClient(queryClient: QueryClient): void {
+  configureRefresh(queryClient);
+}
+
+/**
+ * RFC 7807 Problem Details. Matches the shape that
+ * backend/src/main/java/.../common/GlobalExceptionHandler.java emits.
+ *
+ * `errors` is a SLPA extension for validation failures —
+ * { fieldName: "must not be blank", ... } — populated by the
+ * MethodArgumentNotValidException handler.
+ */
+export type ProblemDetail = {
+  type?: string;
+  title?: string;
+  status: number;
+  detail?: string;
+  instance?: string;
+  errors?: Record<string, string>;
+  [key: string]: unknown;
+};
+
+/**
+ * Thrown by every non-2xx response. Callers `try { } catch (e)` and
+ * either rethrow, narrow with `isApiError(e)`, or read the normalized
+ * `e.problem` to render field-level error messages.
+ */
+export class ApiError extends Error {
+  readonly status: number;
+  readonly problem: ProblemDetail;
+
+  constructor(problem: ProblemDetail) {
+    super(problem.detail ?? problem.title ?? `HTTP ${problem.status}`);
+    this.name = "ApiError";
+    this.status = problem.status;
+    this.problem = problem;
+  }
+}
+
+/**
+ * Type guard. Prefer this over `instanceof ApiError` across module
+ * boundaries — bundler edge cases in RSC + client splits can produce
+ * duplicate class identities, breaking instanceof checks.
+ */
+export function isApiError(e: unknown): e is ApiError {
+  return e instanceof ApiError;
+}
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
+
+type RequestOptions = Omit<RequestInit, "body"> & {
+  body?: unknown;
+  params?: Record<string, string | number | boolean | undefined>;
+};
+
+function buildPath(
+  path: string,
+  params?: RequestOptions["params"]
+): string {
+  if (!params) return path;
+  const sp = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) continue;
+    sp.append(key, String(value));
+  }
+  const qs = sp.toString();
+  return qs ? `${path}?${qs}` : path;
+}
+
+/**
+ * Handles a 401 response from a non-auth path by delegating to the shared
+ * `ensureFreshAccessToken` helper and retrying the original request. On
+ * refresh failure, performs the redirect-to-login side effect.
+ *
+ * The stampede-dedup logic lives in `lib/auth/refresh.ts` — see FOOTGUNS §F.4
+ * and §F.17 for why the finally clause must live inside the IIFE there.
+ */
+async function handleUnauthorized<T>(
+  path: string,
+  options: RequestOptions
+): Promise<T> {
+  try {
+    await ensureFreshAccessToken();
+  } catch (e) {
+    if (e instanceof RefreshFailedError) {
+      if (typeof window !== "undefined") {
+        const next = encodeURIComponent(
+          window.location.pathname + window.location.search
+        );
+        window.location.href = `/login?next=${next}`;
+      }
+      const problem: ProblemDetail = { status: 401, title: "Session expired" };
+      throw new ApiError(problem);
+    }
+    throw e;
+  }
+  return request<T>(path, options, /* isRetry */ true);
+}
+
+async function request<T>(
+  path: string,
+  { body, headers, params, ...rest }: RequestOptions = {},
+  isRetry = false
+): Promise<T> {
+  const token = getAccessToken();
+  const response = await fetch(`${BASE_URL}${buildPath(path, params)}`, {
+    credentials: "include",
+    ...rest,
+    headers: {
+      Accept: "application/json",
+      ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...headers,
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+
+  if (response.status === 401 && !isRetry && !path.startsWith("/api/auth/")) {
+    return handleUnauthorized<T>(path, { body, headers, params, ...rest });
+  }
+
+  if (!response.ok) {
+    let problem: ProblemDetail;
+    try {
+      problem = (await response.json()) as ProblemDetail;
+    } catch {
+      problem = { status: response.status, title: response.statusText };
+    }
+    throw new ApiError(problem);
+  }
+
+  if (response.status === 204) return undefined as T;
+  return (await response.json()) as T;
+}
+
+export const api = {
+  get: <T>(path: string, options?: RequestOptions) =>
+    request<T>(path, { ...options, method: "GET" }),
+  post: <T>(path: string, body?: unknown, options?: RequestOptions) =>
+    request<T>(path, { ...options, method: "POST", body }),
+  put: <T>(path: string, body?: unknown, options?: RequestOptions) =>
+    request<T>(path, { ...options, method: "PUT", body }),
+  delete: <T>(path: string, options?: RequestOptions) =>
+    request<T>(path, { ...options, method: "DELETE" }),
+};
+```
+
+**What changed compared to the previous `lib/api.ts`:**
+- Removed module-level `queryClientRef` and `inFlightRefresh` — those live in `lib/auth/refresh.ts` now.
+- `configureApiClient` is now a one-line passthrough to `configureRefresh`.
+- `handleUnauthorized` now calls `ensureFreshAccessToken()` and handles the `RefreshFailedError` redirect path.
+- Everything else (request/response shapes, ApiError class, path building) is unchanged byte-for-byte.
+
+- [ ] **Step 2: Run the HTTP 401 canary test**
+
+Run: `cd frontend && npx vitest run src/lib/api.401-interceptor.test.tsx`
+Expected: PASS — all 3 canary tests still green. If any fail, STOP and debug before touching anything else — the canary is the regression gate for the refresh pipeline.
+
+- [ ] **Step 3: Run the new refresh canary**
+
+Run: `cd frontend && npx vitest run src/lib/auth/refresh.test.ts`
+Expected: PASS — all 3 canary tests still green.
+
+- [ ] **Step 4: Run the full frontend test suite**
+
+Run: `cd frontend && npm test`
+Expected: PASS — the extracted module should not break any other test. Particularly watch for auth hook tests that may call `bootstrapSession()` through the same refresh path.
+
+- [ ] **Step 5: Run lint and build**
+
+Run: `cd frontend && npm run lint && npm run build`
+Expected: PASS — no lint errors, production build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09
+git add frontend/src/lib/api.ts
+git commit -m "refactor(api): delegate 401 refresh to shared ensureFreshAccessToken
+
+Replace the inlined handleUnauthorized IIFE with a call to
+ensureFreshAccessToken from lib/auth/refresh. The HTTP 401 canary at
+lib/api.401-interceptor.test.tsx is unchanged and still passes — its
+contract is preserved because the stampede-dedup and failure-redirect
+behaviors are identical, just moved.
+
+configureApiClient is kept as a one-line passthrough to configureRefresh
+so app/providers.tsx and the canary test imports do not need updating."
+git push
+```
+
+---
+
+## Phase B — Backend WebSocket Infrastructure
+
+**Phase goal:** Wire up the STOMP broker, the CONNECT-time JWT validator, and the `/ws/**` security permit rule. At the end of this phase, a STOMP client can connect to `/ws` with a valid JWT and have its principal attached to the session. No broadcasting yet — that's Phase C.
+
+---
+
+### Task 3: `JwtChannelInterceptor` with Unit Tests
+
+**Why:** Creates the STOMP CONNECT-frame authentication gate. The interceptor reads the `Authorization: Bearer <jwt>` header from the first CONNECT frame, validates it with the existing `JwtService`, and either attaches a `Principal` to the session or throws `MessagingException` to reject. Six unit tests pin every branch.
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/auth/StompAuthenticationToken.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/auth/JwtChannelInterceptor.java`
+- Create: `backend/src/test/java/com/slparcelauctions/backend/auth/JwtChannelInterceptorTest.java`
+
+---
+
+- [ ] **Step 1: Create `StompAuthenticationToken`**
+
+Create `backend/src/main/java/com/slparcelauctions/backend/auth/StompAuthenticationToken.java`:
+
+```java
+package com.slparcelauctions.backend.auth;
+
+import java.security.Principal;
+
+/**
+ * Minimal {@link Principal} wrapper attached to a STOMP session by
+ * {@link JwtChannelInterceptor} after a successful CONNECT-frame JWT
+ * validation. Spring's {@code SimpMessagingTemplate.convertAndSendToUser}
+ * resolves user-scoped destinations via {@link #getName()}.
+ *
+ * <p>This wrapper exists so Epic 04 can convert and send to specific users
+ * for per-auction notifications. For Task 01-09, only {@link #principal()} is
+ * read (via {@code @AuthenticationPrincipal} on the test controller, which
+ * reaches in through the Spring MVC resolver chain anyway).
+ */
+public record StompAuthenticationToken(AuthPrincipal principal) implements Principal {
+    @Override
+    public String getName() {
+        return String.valueOf(principal.userId());
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing interceptor tests**
+
+Create `backend/src/test/java/com/slparcelauctions/backend/auth/JwtChannelInterceptorTest.java`:
+
+```java
+package com.slparcelauctions.backend.auth;
+
+import com.slparcelauctions.backend.auth.exception.TokenExpiredException;
+import com.slparcelauctions.backend.auth.exception.TokenInvalidException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+
+import java.security.Principal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class JwtChannelInterceptorTest {
+
+    private JwtService jwtService;
+    private JwtChannelInterceptor interceptor;
+    private MessageChannel channel;
+
+    @BeforeEach
+    void setUp() {
+        jwtService = Mockito.mock(JwtService.class);
+        interceptor = new JwtChannelInterceptor(jwtService);
+        channel = Mockito.mock(MessageChannel.class);
+    }
+
+    private Message<byte[]> stompMessage(StompCommand command, String authHeader) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(command);
+        if (authHeader != null) {
+            accessor.setNativeHeader("Authorization", authHeader);
+        }
+        accessor.setLeaveMutable(true);
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+
+    @Test
+    @DisplayName("non-CONNECT frames pass through unchanged")
+    void preSend_nonConnectFrame_passesThrough() {
+        Message<byte[]> msg = stompMessage(StompCommand.SEND, null);
+
+        Message<?> result = interceptor.preSend(msg, channel);
+
+        assertThat(result).isSameAs(msg);
+        Mockito.verifyNoInteractions(jwtService);
+    }
+
+    @Test
+    @DisplayName("CONNECT with missing Authorization header is rejected")
+    void preSend_connectFrame_missingAuthHeader_throws() {
+        Message<byte[]> msg = stompMessage(StompCommand.CONNECT, null);
+
+        assertThatThrownBy(() -> interceptor.preSend(msg, channel))
+            .isInstanceOf(MessagingException.class)
+            .hasMessageContaining("Missing or invalid Authorization header");
+
+        Mockito.verifyNoInteractions(jwtService);
+    }
+
+    @Test
+    @DisplayName("CONNECT with malformed Bearer header is rejected")
+    void preSend_connectFrame_malformedBearer_throws() {
+        Message<byte[]> msg = stompMessage(StompCommand.CONNECT, "NotBearer foo");
+
+        assertThatThrownBy(() -> interceptor.preSend(msg, channel))
+            .isInstanceOf(MessagingException.class)
+            .hasMessageContaining("Missing or invalid Authorization header");
+
+        Mockito.verifyNoInteractions(jwtService);
+    }
+
+    @Test
+    @DisplayName("CONNECT with valid token attaches StompAuthenticationToken principal")
+    void preSend_connectFrame_validToken_attachesPrincipal() {
+        AuthPrincipal authPrincipal = new AuthPrincipal(42L, "test@example.com", 1L);
+        when(jwtService.parseAccessToken("valid-jwt")).thenReturn(authPrincipal);
+
+        Message<byte[]> msg = stompMessage(StompCommand.CONNECT, "Bearer valid-jwt");
+
+        Message<?> result = interceptor.preSend(msg, channel);
+
+        assertThat(result).isNotNull();
+        StompHeaderAccessor resultAccessor =
+            StompHeaderAccessor.wrap(result);
+        Principal user = resultAccessor.getUser();
+        assertThat(user).isInstanceOf(StompAuthenticationToken.class);
+        assertThat(user.getName()).isEqualTo("42");
+        StompAuthenticationToken token = (StompAuthenticationToken) user;
+        assertThat(token.principal().userId()).isEqualTo(42L);
+        assertThat(token.principal().email()).isEqualTo("test@example.com");
+        assertThat(token.principal().tokenVersion()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("CONNECT with expired token is rejected")
+    void preSend_connectFrame_expiredToken_throws() {
+        when(jwtService.parseAccessToken(any()))
+            .thenThrow(new TokenExpiredException("expired"));
+
+        Message<byte[]> msg = stompMessage(StompCommand.CONNECT, "Bearer expired-jwt");
+
+        assertThatThrownBy(() -> interceptor.preSend(msg, channel))
+            .isInstanceOf(MessagingException.class)
+            .hasMessageContaining("Invalid or expired access token");
+    }
+
+    @Test
+    @DisplayName("CONNECT with invalid token is rejected")
+    void preSend_connectFrame_invalidToken_throws() {
+        when(jwtService.parseAccessToken(any()))
+            .thenThrow(new TokenInvalidException("bad token"));
+
+        Message<byte[]> msg = stompMessage(StompCommand.CONNECT, "Bearer bad-jwt");
+
+        assertThatThrownBy(() -> interceptor.preSend(msg, channel))
+            .isInstanceOf(MessagingException.class)
+            .hasMessageContaining("Invalid or expired access token");
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd backend && ./mvnw test -Dtest=JwtChannelInterceptorTest`
+Expected: FAIL — `JwtChannelInterceptor` class does not exist yet. Compilation error, or the test class won't even run.
+
+- [ ] **Step 4: Implement `JwtChannelInterceptor`**
+
+Create `backend/src/main/java/com/slparcelauctions/backend/auth/JwtChannelInterceptor.java`:
+
+```java
+package com.slparcelauctions.backend.auth;
+
+import com.slparcelauctions.backend.auth.exception.TokenExpiredException;
+import com.slparcelauctions.backend.auth.exception.TokenInvalidException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+/**
+ * STOMP CONNECT-frame authentication gate. Reads the {@code Authorization}
+ * native header from the first {@link StompCommand#CONNECT} frame, parses it
+ * via {@link JwtService}, and attaches a {@link StompAuthenticationToken} to
+ * the session. Subsequent frames (SUBSCRIBE, SEND, DISCONNECT) pass through
+ * unchanged — the principal set here lives on the session for their lifetime.
+ *
+ * <p><strong>Why CONNECT-only:</strong> Task 01-09 spec §3 (Q3c-i). Matching
+ * the HTTP filter's one-check-per-request behavior. Epic 04 may revisit if
+ * sensitive write operations ever flow through {@code @MessageMapping}
+ * handlers.
+ *
+ * <p><strong>Why throw {@link MessagingException}:</strong> Spring's STOMP
+ * infrastructure catches it and sends a STOMP ERROR frame back to the client
+ * before closing the session. The frontend's {@code onStompError} handler
+ * picks it up and surfaces the error via the ConnectionState machine.
+ *
+ * <p><strong>Why {@code getFirstNativeHeader}, not {@code getHeader}:</strong>
+ * STOMP headers arrive as a {@code MultiValueMap<String, String>} under the
+ * key {@code nativeHeaders}. {@code getHeader} looks up Spring-internal
+ * framework headers and returns null for STOMP client headers.
+ * See FOOTGUNS §F.16.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtChannelInterceptor implements ChannelInterceptor {
+
+    private final JwtService jwtService;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor =
+            MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor == null || !StompCommand.CONNECT.equals(accessor.getCommand())) {
+            return message;
+        }
+
+        String authHeader = accessor.getFirstNativeHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            log.debug("STOMP CONNECT rejected: missing or non-Bearer Authorization header");
+            throw new MessagingException(message, "Missing or invalid Authorization header");
+        }
+
+        String token = authHeader.substring(7);
+        try {
+            AuthPrincipal principal = jwtService.parseAccessToken(token);
+            accessor.setUser(new StompAuthenticationToken(principal));
+            log.debug("STOMP CONNECT authenticated: userId={}", principal.userId());
+            return message;
+        } catch (TokenExpiredException | TokenInvalidException e) {
+            log.debug("STOMP CONNECT rejected: {}", e.getMessage());
+            throw new MessagingException(message, "Invalid or expired access token");
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && ./mvnw test -Dtest=JwtChannelInterceptorTest`
+Expected: PASS — all 6 tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09
+git add backend/src/main/java/com/slparcelauctions/backend/auth/StompAuthenticationToken.java \
+        backend/src/main/java/com/slparcelauctions/backend/auth/JwtChannelInterceptor.java \
+        backend/src/test/java/com/slparcelauctions/backend/auth/JwtChannelInterceptorTest.java
+git commit -m "feat(auth): add JwtChannelInterceptor for STOMP CONNECT auth
+
+Authenticate the first STOMP CONNECT frame by reading the
+Authorization: Bearer <jwt> header and delegating to the existing
+JwtService.parseAccessToken. On success, attach a StompAuthenticationToken
+to the session via accessor.setUser. On any failure (missing header,
+malformed bearer, expired token, invalid token), throw MessagingException
+which Spring translates to a STOMP ERROR frame.
+
+Subsequent frames (SUBSCRIBE, SEND, DISCONNECT) pass through unchanged.
+Matches the HTTP filter's one-check-per-request behavior — see spec §3
+Q3c-i.
+
+Ships with 6 unit tests covering:
+- non-CONNECT frame passthrough
+- CONNECT with missing Authorization header
+- CONNECT with malformed Bearer prefix
+- CONNECT with valid token (principal attached)
+- CONNECT with expired token
+- CONNECT with invalid token"
+git push
+```
+
+---
+
+### Task 4: `WebSocketConfig` + SecurityConfig `/ws/**` Permit
+
+**Why:** Wires up the STOMP broker (`/topic` destinations, SockJS `/ws` endpoint, `/app` application prefix) and injects the `JwtChannelInterceptor` into the client inbound channel. Also updates `SecurityConfig` to permit the raw HTTP WebSocket upgrade on `/ws/**` — authentication happens at the STOMP layer, not the HTTP layer, so the HTTP matcher must be `permitAll`.
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/config/WebSocketConfig.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java`
+
+---
+
+- [ ] **Step 1: Create `WebSocketConfig`**
+
+Create `backend/src/main/java/com/slparcelauctions/backend/config/WebSocketConfig.java`:
+
+```java
+package com.slparcelauctions.backend.config;
+
+import com.slparcelauctions.backend.auth.JwtChannelInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+/**
+ * STOMP over WebSocket configuration. Exposes a single endpoint at {@code /ws}
+ * with SockJS fallback, a simple in-memory broker for {@code /topic}
+ * destinations, and the {@link JwtChannelInterceptor} on the client inbound
+ * channel.
+ *
+ * <p><strong>In-memory broker:</strong> sufficient for Phase 1 single-instance
+ * deployments. Epic 04 may swap to a relayed broker (RabbitMQ STOMP plugin)
+ * when cross-instance fanout is needed. Leaving this comment so the Epic 04
+ * implementer does not need to rediscover the rationale.
+ *
+ * <p><strong>{@code /app} application prefix:</strong> unused in Task 01-09
+ * (the test controller uses REST + {@code SimpMessagingTemplate}) but set
+ * here so Epic 04 can add {@code @MessageMapping("/bid")} handlers without
+ * reconfiguring the broker.
+ *
+ * <p><strong>CORS on the endpoint:</strong> Spring's STOMP endpoint CORS is
+ * configured separately from the main {@code HttpSecurity} CORS source.
+ * Without {@code .setAllowedOrigins()} the SockJS handshake XHR fails with a
+ * confusing CORS error even though the main security filter passes.
+ */
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final JwtChannelInterceptor jwtChannelInterceptor;
+
+    @Value("${cors.allowed-origin:http://localhost:3000}")
+    private String allowedOrigin;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+            .setAllowedOrigins(allowedOrigin)
+            .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(jwtChannelInterceptor);
+    }
+}
+```
+
+- [ ] **Step 2: Update `SecurityConfig` to permit `/ws/**`**
+
+Open `backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java` and add a new matcher above `/api/**`:
+
+Replace the `.authorizeHttpRequests(...)` block with:
+
+```java
+.authorizeHttpRequests(auth -> auth
+        .requestMatchers(HttpMethod.GET, "/api/health").permitAll()
+        .requestMatchers(
+                "/api/auth/register",
+                "/api/auth/login",
+                "/api/auth/refresh",
+                "/api/auth/logout"
+        ).permitAll()
+        .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
+        .requestMatchers(HttpMethod.GET, "/api/users/me").authenticated()
+        .requestMatchers(HttpMethod.GET, "/api/users/{id}").permitAll()
+        .requestMatchers("/api/auth/logout-all").authenticated()
+        // WebSocket handshake is permitted at the HTTP layer.
+        // Authentication happens at the STOMP CONNECT frame via
+        // JwtChannelInterceptor. Do NOT change this to .authenticated() —
+        // the browser WebSocket API cannot set an Authorization header on
+        // the HTTP upgrade, so gating it here is impossible. See FOOTGUNS §F.16.
+        .requestMatchers("/ws/**").permitAll()
+        .requestMatchers("/api/**").authenticated()
+        .anyRequest().denyAll())
+```
+
+Everything else in `SecurityConfig` (imports, fields, CORS config, the `@Bean` definitions) stays the same.
+
+- [ ] **Step 3: Run the full backend test suite**
+
+Run: `cd backend && ./mvnw test`
+Expected: PASS — no tests should break. `JwtChannelInterceptorTest` from Task 3 still passes; no new integration tests yet.
+
+- [ ] **Step 4: Verify the app starts**
+
+Run: `cd backend && ./mvnw spring-boot:run`
+
+In another terminal, verify the `/ws/info` SockJS endpoint responds:
+
+```bash
+curl -s http://localhost:8080/ws/info
+```
+
+Expected: JSON response containing `"websocket":true` and a `"origins"` array. This is SockJS's "is this endpoint alive?" check — if it 404s, the endpoint is not registered.
+
+Stop the backend with Ctrl+C.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09
+git add backend/src/main/java/com/slparcelauctions/backend/config/WebSocketConfig.java \
+        backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
+git commit -m "feat(ws): configure STOMP broker and permit /ws/** at HTTP layer
+
+- WebSocketConfig: simple in-memory broker on /topic, /app application
+  prefix (unused now, ready for Epic 04's @MessageMapping handlers),
+  SockJS endpoint at /ws with explicit setAllowedOrigins for the CORS
+  handshake, JwtChannelInterceptor on clientInboundChannel.
+- SecurityConfig: permit /ws/** above the /api/** authenticated catch-all.
+  Authentication happens at the STOMP CONNECT frame layer, not the HTTP
+  upgrade — browsers cannot set an Authorization header on WebSocket
+  upgrades, so HTTP-layer auth is impossible."
+git push
+```
+
+---
+
+## Phase C — Backend Test Harness
+
+**Phase goal:** Ship a dev/test profile-gated REST endpoint that proves the broker wiring works end-to-end. A real STOMP client connecting to the backend can subscribe to `/topic/ws-test`, receive a broadcast triggered via `POST /api/ws-test/broadcast`, and reject unauthenticated connects.
+
+---
+
+### Task 5: `WsTestController` + `WsTestBroadcastRequest` DTO
+
+**Why:** Creates the HTTP-triggered broadcast endpoint. Profile-gated to `dev` and `test` so it's entirely absent from the prod bean graph. The controller is trivial — POST a message, shove it onto `/topic/ws-test` via `SimpMessagingTemplate`.
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wstest/dto/WsTestBroadcastRequest.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wstest/WsTestController.java`
+
+---
+
+- [ ] **Step 1: Create the request DTO**
+
+Create `backend/src/main/java/com/slparcelauctions/backend/wstest/dto/WsTestBroadcastRequest.java`:
+
+```java
+package com.slparcelauctions.backend.wstest.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record WsTestBroadcastRequest(
+    @NotBlank @Size(max = 500) String message
+) {}
+```
+
+- [ ] **Step 2: Create the controller**
+
+Create `backend/src/main/java/com/slparcelauctions/backend/wstest/WsTestController.java`:
+
+```java
+package com.slparcelauctions.backend.wstest;
+
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.wstest.dto.WsTestBroadcastRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Dev/test-only WebSocket verification harness. Broadcasts whatever the caller
+ * POSTs onto {@code /topic/ws-test}, which any authenticated STOMP subscriber
+ * receives in real time.
+ *
+ * <p><strong>Profile gating:</strong> {@code @Profile({"dev", "test"})} means
+ * this bean is absent from the prod application context entirely. There is no
+ * SecurityConfig matcher to maintain because there is no bean to guard.
+ *
+ * <p><strong>Authentication:</strong> the broadcast endpoint falls under the
+ * {@code /api/**} authenticated catch-all in {@code SecurityConfig} — only
+ * logged-in users can trigger a broadcast. The {@code AuthPrincipal} injected
+ * here is the same one the JWT filter attaches in {@code JwtAuthenticationFilter}.
+ *
+ * <p><strong>Wire-type note:</strong> {@code principal.userId()} is a Java
+ * {@code Long}. Jackson serializes it as a JSON number, which lands in
+ * JavaScript as a plain {@code number}. Safe because user IDs are well under
+ * {@code Number.MAX_SAFE_INTEGER} (2^53 - 1). The frontend harness types
+ * {@code senderId} as {@code number} to match.
+ */
+@RestController
+@RequestMapping("/api/ws-test")
+@RequiredArgsConstructor
+@Profile({"dev", "test"})
+@Slf4j
+public class WsTestController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @PostMapping("/broadcast")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void broadcast(
+            @Valid @RequestBody WsTestBroadcastRequest request,
+            @AuthenticationPrincipal AuthPrincipal principal) {
+        log.info("WS test broadcast from userId={}: {}", principal.userId(), request.message());
+        messagingTemplate.convertAndSend("/topic/ws-test",
+            Map.of(
+                "message", request.message(),
+                "senderId", principal.userId(),
+                "timestamp", Instant.now().toString()
+            ));
+    }
+}
+```
+
+- [ ] **Step 3: Run the full backend test suite**
+
+Run: `cd backend && ./mvnw test`
+Expected: PASS — no tests break. The new controller has no tests yet (those come in Task 6 as an integration test).
+
+- [ ] **Step 4: Manual verification (optional but recommended)**
+
+Run: `cd backend && ./mvnw spring-boot:run`
+
+In another terminal, get an access token by registering and logging in, then POST to the broadcast endpoint:
+
+```bash
+# Register a dev user (or use an existing one)
+curl -s -c /tmp/slpa-cookies.txt \
+  -H "Content-Type: application/json" \
+  -d '{"email":"wstest@example.com","password":"Testpass123!","displayName":null}' \
+  http://localhost:8080/api/auth/register | jq .
+
+# Copy the accessToken from the response. Then:
+export TOKEN="<paste-access-token>"
+
+curl -v -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"message":"hello"}' \
+  http://localhost:8080/api/ws-test/broadcast
+```
+
+Expected: `204 No Content`. Log line in the backend console like `WS test broadcast from userId=1: hello`. No STOMP subscribers yet, so nothing receives the message — but the endpoint fires cleanly.
+
+Stop the backend with Ctrl+C.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09
+git add backend/src/main/java/com/slparcelauctions/backend/wstest/dto/WsTestBroadcastRequest.java \
+        backend/src/main/java/com/slparcelauctions/backend/wstest/WsTestController.java
+git commit -m "feat(wstest): add dev/test profile-gated broadcast endpoint
+
+POST /api/ws-test/broadcast pushes the provided message onto
+/topic/ws-test via SimpMessagingTemplate. Authenticated via the existing
+JWT filter; the endpoint is @Profile({\"dev\", \"test\"}) so it is
+entirely absent from the prod bean graph.
+
+Ships alongside WsTestBroadcastRequest DTO with @NotBlank + @Size(500)
+validation."
+git push
+```
+
+---
+
+### Task 6: `WsTestIntegrationTest` — End-to-End Smoke Test
+
+**Why:** The single load-bearing backend test. Proves the entire pipe works: STOMP client connects with a JWT, interceptor validates and attaches the principal, subscription to `/topic/ws-test` is accepted, POST to broadcast endpoint triggers a message that the STOMP client actually receives. Also covers the two rejection paths (missing header, invalid token).
+
+**Files:**
+- Create: `backend/src/test/java/com/slparcelauctions/backend/wstest/WsTestIntegrationTest.java`
+
+---
+
+- [ ] **Step 1: Write the integration test**
+
+Create `backend/src/test/java/com/slparcelauctions/backend/wstest/WsTestIntegrationTest.java`:
+
+```java
+package com.slparcelauctions.backend.wstest;
+
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.wstest.dto.WsTestBroadcastRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.Transport;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class WsTestIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private JwtService jwtService;
+
+    private WebSocketStompClient stompClient;
+    private BlockingQueue<Map<String, Object>> receivedMessages;
+
+    @BeforeEach
+    void setUp() {
+        List<Transport> transports = List.of(new WebSocketTransport(new StandardWebSocketClient()));
+        SockJsClient sockJsClient = new SockJsClient(transports);
+        stompClient = new WebSocketStompClient(sockJsClient);
+        stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+        receivedMessages = new LinkedBlockingQueue<>();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (stompClient != null) {
+            stompClient.stop();
+        }
+    }
+
+    private String issueAccessTokenForTestUser() {
+        AuthPrincipal principal = new AuthPrincipal(9999L, "wstest@example.com", 1L);
+        return jwtService.issueAccessToken(principal);
+    }
+
+    private String wsUrl() {
+        return "http://localhost:" + port + "/ws";
+    }
+
+    @Test
+    void stompConnectWithValidToken_receivesBroadcast() throws Exception {
+        String token = issueAccessTokenForTestUser();
+
+        StompHeaders connectHeaders = new StompHeaders();
+        connectHeaders.add("Authorization", "Bearer " + token);
+
+        CompletableFuture<StompSession> sessionFuture = new CompletableFuture<>();
+        stompClient.connectAsync(
+            wsUrl(),
+            new WebSocketHttpHeaders(),
+            connectHeaders,
+            new StompSessionHandlerAdapter() {
+                @Override
+                public void afterConnected(StompSession session, StompHeaders headers) {
+                    sessionFuture.complete(session);
+                }
+
+                @Override
+                public void handleException(StompSession session, StompCommand command,
+                                            StompHeaders headers, byte[] payload, Throwable exception) {
+                    sessionFuture.completeExceptionally(exception);
+                }
+
+                @Override
+                public void handleTransportError(StompSession session, Throwable exception) {
+                    if (!sessionFuture.isDone()) {
+                        sessionFuture.completeExceptionally(exception);
+                    }
+                }
+            }
+        );
+
+        StompSession session = sessionFuture.get(5, TimeUnit.SECONDS);
+
+        session.subscribe("/topic/ws-test", new StompFrameHandler() {
+            @Override
+            public Type getPayloadType(StompHeaders headers) {
+                return Map.class;
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public void handleFrame(StompHeaders headers, Object payload) {
+                receivedMessages.offer((Map<String, Object>) payload);
+            }
+        });
+
+        // Tiny pause to let the subscription register before we broadcast.
+        Thread.sleep(200);
+
+        // Trigger the broadcast via the HTTP endpoint.
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setBearerAuth(token);
+        httpHeaders.setContentType(org.springframework.http.MediaType.APPLICATION_JSON);
+        HttpEntity<WsTestBroadcastRequest> request =
+            new HttpEntity<>(new WsTestBroadcastRequest("hello from test"), httpHeaders);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+            "http://localhost:" + port + "/api/ws-test/broadcast",
+            HttpMethod.POST,
+            request,
+            Void.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        Map<String, Object> received = receivedMessages.poll(5, TimeUnit.SECONDS);
+        assertThat(received).isNotNull();
+        assertThat(received.get("message")).isEqualTo("hello from test");
+        assertThat(received.get("senderId")).isEqualTo(9999);
+        assertThat(received.get("timestamp")).isNotNull();
+    }
+
+    @Test
+    void stompConnectWithoutAuthHeader_isRejected() {
+        // No Authorization header in connectHeaders — interceptor throws
+        // MessagingException which surfaces as a connect failure.
+        StompHeaders connectHeaders = new StompHeaders();
+
+        CompletableFuture<StompSession> sessionFuture = new CompletableFuture<>();
+        stompClient.connectAsync(
+            wsUrl(),
+            new WebSocketHttpHeaders(),
+            connectHeaders,
+            new StompSessionHandlerAdapter() {
+                @Override
+                public void afterConnected(StompSession session, StompHeaders headers) {
+                    sessionFuture.complete(session);
+                }
+
+                @Override
+                public void handleException(StompSession session, StompCommand command,
+                                            StompHeaders headers, byte[] payload, Throwable exception) {
+                    sessionFuture.completeExceptionally(exception);
+                }
+
+                @Override
+                public void handleTransportError(StompSession session, Throwable exception) {
+                    if (!sessionFuture.isDone()) {
+                        sessionFuture.completeExceptionally(exception);
+                    }
+                }
+            }
+        );
+
+        assertThatThrownBy(() -> sessionFuture.get(5, TimeUnit.SECONDS))
+            .isInstanceOfAny(ExecutionException.class, TimeoutException.class);
+    }
+
+    @Test
+    void stompConnectWithInvalidToken_isRejected() {
+        StompHeaders connectHeaders = new StompHeaders();
+        connectHeaders.add("Authorization", "Bearer not-a-real-jwt");
+
+        CompletableFuture<StompSession> sessionFuture = new CompletableFuture<>();
+        stompClient.connectAsync(
+            wsUrl(),
+            new WebSocketHttpHeaders(),
+            connectHeaders,
+            new StompSessionHandlerAdapter() {
+                @Override
+                public void afterConnected(StompSession session, StompHeaders headers) {
+                    sessionFuture.complete(session);
+                }
+
+                @Override
+                public void handleException(StompSession session, StompCommand command,
+                                            StompHeaders headers, byte[] payload, Throwable exception) {
+                    sessionFuture.completeExceptionally(exception);
+                }
+
+                @Override
+                public void handleTransportError(StompSession session, Throwable exception) {
+                    if (!sessionFuture.isDone()) {
+                        sessionFuture.completeExceptionally(exception);
+                    }
+                }
+            }
+        );
+
+        assertThatThrownBy(() -> sessionFuture.get(5, TimeUnit.SECONDS))
+            .isInstanceOfAny(ExecutionException.class, TimeoutException.class);
+    }
+}
+```
+
+**Why `@DirtiesContext(AFTER_CLASS)`:** the STOMP broker holds background threads (message scheduler, heartbeat). Without dirtying the context, a second integration test class in the same JVM may leak sessions. Cheap insurance.
+
+**Why `@ActiveProfiles("test")`:** activates `WsTestController`'s `@Profile({"dev", "test"})` gate. Without this, the bean is absent and the broadcast POST returns 404.
+
+**Why `Thread.sleep(200)` before broadcasting:** STOMP `subscribe()` is sent asynchronously. Without the pause, the broadcast sometimes fires before the server registers the subscription and the test flakes. 200ms is comfortable.
+
+- [ ] **Step 2: Run the integration test**
+
+**Prerequisite:** Postgres and Redis containers must be running (see memory `dev_containers.md`).
+
+Run: `cd backend && ./mvnw test -Dtest=WsTestIntegrationTest`
+Expected: PASS — all 3 tests green. Test 1 completes within ~1s after the sleep; tests 2 and 3 complete within the 5s timeout.
+
+If test 1 flakes on the broadcast receipt (poll returns null), try raising the poll timeout from 5s to 10s — CI machines are slower than dev boxes.
+
+- [ ] **Step 3: Run the full backend test suite**
+
+Run: `cd backend && ./mvnw test`
+Expected: PASS — everything green including the new integration test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09
+git add backend/src/test/java/com/slparcelauctions/backend/wstest/WsTestIntegrationTest.java
+git commit -m "test(ws): end-to-end STOMP integration smoke test
+
+Single load-bearing integration test covering the full WebSocket pipe:
+- STOMP client connects to /ws with a freshly-issued JWT
+- JwtChannelInterceptor validates, attaches the principal
+- Subscription to /topic/ws-test accepted
+- POST /api/ws-test/broadcast triggers a message
+- The subscriber receives it within the timeout
+
+Also covers the two rejection paths: missing Authorization header on
+connect, and malformed JWT on connect.
+
+@ActiveProfiles(\"test\") activates WsTestController via its
+@Profile({\"dev\",\"test\"}) gate. @DirtiesContext(AFTER_CLASS) cleans
+up the broker threads between test classes."
+git push
+```
+
+---
+
+## Phase D — Frontend WebSocket Client
+
+**Phase goal:** Ship the singleton, reference-counted, observable-state STOMP client plus the React hooks that wrap it. At the end of Phase D, any component can call `useStompSubscription("/topic/foo", cb)` and `useConnectionState()` to participate in the WebSocket pipe.
+
+---
+
+### Task 7: Install Frontend Dependencies
+
+**Why:** Pulls in `@stomp/stompjs` v7 (the STOMP client library), `sockjs-client` (the SockJS transport), and `@types/sockjs-client` (the TypeScript definitions). Version pinning notes in the spec §6.1.
+
+**Files:**
+- Modify: `frontend/package.json`
+- Modify: `frontend/package-lock.json` (auto-generated)
+
+---
+
+- [ ] **Step 1: Install the runtime dependencies**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09/frontend
+npm install @stomp/stompjs@^7.1.1 sockjs-client@^1.6.1
+```
+
+- [ ] **Step 2: Install the type definitions as a dev dependency**
+
+```bash
+npm install -D @types/sockjs-client@^1.5.4
+```
+
+- [ ] **Step 3: Verify the installation**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09/frontend
+node -e "console.log(require('@stomp/stompjs/package.json').version)"
+node -e "console.log(require('sockjs-client/package.json').version)"
+```
+
+Expected: prints `7.1.1` (or `7.x.y` where y >= 1) and `1.6.1` (or higher).
+
+- [ ] **Step 4: Verify the build still works**
+
+Run: `cd frontend && npm run build`
+Expected: PASS — production build succeeds. The deps are not yet used by any code, so they're just available.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09
+git add frontend/package.json frontend/package-lock.json
+git commit -m "chore(deps): add @stomp/stompjs, sockjs-client for WebSocket client
+
+- @stomp/stompjs ^7.1.1 — browser STOMP client with fully-awaited
+  beforeConnect hook (v7.1+ guarantees async await in the connect
+  sequence, which our shared ensureFreshAccessToken depends on).
+- sockjs-client ^1.6.1 — SockJS fallback transport for proxies that
+  strip WebSocket upgrades.
+- @types/sockjs-client ^1.5.4 — type definitions.
+
+Not yet consumed by any code; lib/ws/client.ts in the next task will
+import them."
+git push
+```
+
+---
+
+### Task 8: `lib/ws/types.ts`
+
+**Why:** Small type-only module carrying the discriminated-union `ConnectionState` and the `Unsubscribe` alias. Lives separately from `client.ts` so tests can import the types without triggering the client's module-level state.
+
+**Files:**
+- Create: `frontend/src/lib/ws/types.ts`
+
+---
+
+- [ ] **Step 1: Create `lib/ws/types.ts`**
+
+Create `frontend/src/lib/ws/types.ts`:
+
+```typescript
+// frontend/src/lib/ws/types.ts
+//
+// Type-only module for the WebSocket layer. Separate from client.ts so tests
+// can import the types without pulling in client.ts's module-level state.
+
+/**
+ * Discriminated union of the five states the WebSocket connection can be in.
+ * Consumers branch on `status` and TypeScript narrows the shape.
+ *
+ *   disconnected  — initial state, or after the last subscriber unsubscribed
+ *                   past the grace window.
+ *   connecting    — beforeConnect has fired; awaiting STOMP CONNECTED.
+ *   connected     — STOMP session is live, subscriptions can flow.
+ *   reconnecting  — WebSocket closed unexpectedly and stompjs is retrying.
+ *   error         — a STOMP ERROR frame arrived or auth refresh failed.
+ */
+export type ConnectionState =
+  | { status: "disconnected" }
+  | { status: "connecting" }
+  | { status: "connected" }
+  | { status: "reconnecting" }
+  | { status: "error"; detail: string };
+
+/**
+ * Unsubscribe handle returned by `subscribe()` and `subscribeToConnectionState()`.
+ * Calling the handle removes the subscription; idempotent.
+ */
+export type Unsubscribe = () => void;
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: PASS — no type errors. (If `tsc --noEmit` isn't set up, `npm run build` also works.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09
+git add frontend/src/lib/ws/types.ts
+git commit -m "feat(ws): add ConnectionState and Unsubscribe types
+
+Type-only module for the WebSocket layer, separate from client.ts so
+tests can import the types without triggering client.ts's module-level
+state. Discriminated union with five states: disconnected, connecting,
+connected, reconnecting, error."
+git push
+```
+
+---
+
+### Task 9: `lib/ws/client.ts` — Singleton Client with Unit Tests
+
+**Why:** The heart of the frontend WebSocket layer. Singleton module-level `@stomp/stompjs` client with reference counting, 5-second disconnect grace period, observable connection state, and a `subscribe<T>(destination, onMessage)` primitive with generic JSON-parse wrapping. Nine unit tests pin every public-API branch and state transition.
+
+**Files:**
+- Create: `frontend/src/lib/ws/client.ts`
+- Create: `frontend/src/lib/ws/client.test.ts`
+
+---
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/src/lib/ws/client.test.ts`:
+
+```typescript
+// frontend/src/lib/ws/client.test.ts
+//
+// Unit tests for lib/ws/client.ts. Mocks @stomp/stompjs so tests run without
+// a real WebSocket — the captured callbacks on the mock Client instance let
+// us simulate onConnect, onWebSocketClose, onStompError etc. manually.
+
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+// The mocked Client class. Captured callbacks and flags live on the instance
+// so tests can trigger lifecycle events on demand.
+type MockStompClient = {
+  activate: Mock;
+  deactivate: Mock;
+  subscribe: Mock;
+  connected: boolean;
+  active: boolean;
+  connectHeaders: Record<string, string>;
+  beforeConnect?: () => void | Promise<void>;
+  onConnect?: () => void;
+  onWebSocketClose?: () => void;
+  onStompError?: (frame: { headers: Record<string, string> }) => void;
+};
+
+let mockClientInstance: MockStompClient | null = null;
+
+vi.mock("@stomp/stompjs", () => {
+  return {
+    Client: vi.fn().mockImplementation((config: Partial<MockStompClient>) => {
+      const instance: MockStompClient = {
+        activate: vi.fn(() => {
+          instance.active = true;
+        }),
+        deactivate: vi.fn(() => {
+          instance.active = false;
+          instance.connected = false;
+        }),
+        subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })),
+        connected: false,
+        active: false,
+        connectHeaders: {},
+        beforeConnect: config.beforeConnect,
+        onConnect: config.onConnect,
+        onWebSocketClose: config.onWebSocketClose,
+        onStompError: config.onStompError,
+      };
+      mockClientInstance = instance;
+      return instance;
+    }),
+  };
+});
+
+vi.mock("sockjs-client", () => ({
+  default: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock("@/lib/auth/refresh", () => ({
+  ensureFreshAccessToken: vi.fn(async () => "mock-access-token"),
+  RefreshFailedError: class extends Error {
+    readonly status: number;
+    constructor(status: number) {
+      super(`Refresh failed ${status}`);
+      this.status = status;
+    }
+  },
+}));
+
+// Import UNDER TEST after the mocks are declared.
+import {
+  __devForceDisconnect,
+  __devForceReconnect,
+  __resetWsClientForTests,
+  getConnectionState,
+  subscribe,
+  subscribeToConnectionState,
+} from "./client";
+import { ensureFreshAccessToken } from "@/lib/auth/refresh";
+
+describe("lib/ws/client", () => {
+  beforeEach(() => {
+    __resetWsClientForTests();
+    mockClientInstance = null;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    __resetWsClientForTests();
+  });
+
+  it("first subscribe activates the client", () => {
+    subscribe<unknown>("/topic/foo", () => {});
+
+    expect(mockClientInstance).not.toBeNull();
+    expect(mockClientInstance!.activate).toHaveBeenCalledTimes(1);
+  });
+
+  it("second subscribe reuses the existing client (single activate)", () => {
+    subscribe<unknown>("/topic/foo", () => {});
+    subscribe<unknown>("/topic/bar", () => {});
+
+    expect(mockClientInstance!.activate).toHaveBeenCalledTimes(1);
+  });
+
+  it("last unsubscribe schedules disconnect with 5s grace period", () => {
+    vi.useFakeTimers();
+    try {
+      const unsub = subscribe<unknown>("/topic/foo", () => {});
+
+      unsub();
+      // Not yet — grace period.
+      expect(mockClientInstance!.deactivate).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(5_000);
+      expect(mockClientInstance!.deactivate).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resubscribe within grace window cancels the scheduled teardown", () => {
+    vi.useFakeTimers();
+    try {
+      const unsub1 = subscribe<unknown>("/topic/foo", () => {});
+
+      unsub1();
+      vi.advanceTimersByTime(4_000);
+      // Second subscribe within grace — teardown should cancel.
+      subscribe<unknown>("/topic/bar", () => {});
+      vi.advanceTimersByTime(5_000);
+
+      expect(mockClientInstance!.deactivate).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("beforeConnect calls ensureFreshAccessToken and sets Authorization header", async () => {
+    subscribe<unknown>("/topic/foo", () => {});
+
+    // Invoke the captured beforeConnect callback.
+    await mockClientInstance!.beforeConnect!();
+
+    expect(ensureFreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(mockClientInstance!.connectHeaders.Authorization).toBe("Bearer mock-access-token");
+  });
+
+  it("onConnect transitions ConnectionState to connected", () => {
+    const states: string[] = [];
+    subscribeToConnectionState((s) => states.push(s.status));
+
+    subscribe<unknown>("/topic/foo", () => {});
+    // Simulate the captured onConnect firing.
+    mockClientInstance!.onConnect!();
+
+    expect(getConnectionState().status).toBe("connected");
+    expect(states).toContain("connected");
+  });
+
+  it("onWebSocketClose while active transitions ConnectionState to reconnecting", () => {
+    subscribe<unknown>("/topic/foo", () => {});
+    mockClientInstance!.active = true;
+
+    mockClientInstance!.onWebSocketClose!();
+
+    expect(getConnectionState().status).toBe("reconnecting");
+  });
+
+  it("onStompError transitions ConnectionState to error with the frame detail", () => {
+    subscribe<unknown>("/topic/foo", () => {});
+
+    mockClientInstance!.onStompError!({ headers: { message: "Auth failed" } });
+
+    const state = getConnectionState();
+    expect(state.status).toBe("error");
+    if (state.status === "error") {
+      expect(state.detail).toBe("Auth failed");
+    }
+  });
+
+  it("subscribe before connected defers the stompjs subscribe until onConnect", () => {
+    const handler = vi.fn();
+    subscribe<{ msg: string }>("/topic/foo", handler);
+
+    // Client is not connected yet.
+    mockClientInstance!.connected = false;
+    expect(mockClientInstance!.subscribe).not.toHaveBeenCalled();
+
+    // Now connect — the deferred attach should fire.
+    mockClientInstance!.connected = true;
+    mockClientInstance!.onConnect!();
+
+    expect(mockClientInstance!.subscribe).toHaveBeenCalledTimes(1);
+    expect(mockClientInstance!.subscribe.mock.calls[0][0]).toBe("/topic/foo");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/lib/ws/client.test.ts`
+Expected: FAIL — module `./client` not found.
+
+- [ ] **Step 3: Create `lib/ws/client.ts`**
+
+Create `frontend/src/lib/ws/client.ts`:
+
+```typescript
+// frontend/src/lib/ws/client.ts
+"use client";
+
+import { Client, type IMessage, type StompSubscription } from "@stomp/stompjs";
+import SockJS from "sockjs-client";
+import { ensureFreshAccessToken, RefreshFailedError } from "@/lib/auth/refresh";
+import type { ConnectionState, Unsubscribe } from "./types";
+
+const WS_URL = process.env.NEXT_PUBLIC_WS_URL ?? "http://localhost:8080/ws";
+const DISCONNECT_GRACE_MS = 5_000;
+
+let client: Client | null = null;
+let subscriberCount = 0;
+let disconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let connectionState: ConnectionState = { status: "disconnected" };
+const stateListeners = new Set<(state: ConnectionState) => void>();
+
+function setState(next: ConnectionState): void {
+  connectionState = next;
+  for (const listener of stateListeners) listener(next);
+}
+
+export function getConnectionState(): ConnectionState {
+  return connectionState;
+}
+
+export function subscribeToConnectionState(
+  listener: (state: ConnectionState) => void
+): Unsubscribe {
+  stateListeners.add(listener);
+  // Fire immediately with current state so consumers have something to render.
+  listener(connectionState);
+  return () => {
+    stateListeners.delete(listener);
+  };
+}
+
+function getOrCreateClient(): Client {
+  if (client) return client;
+
+  client = new Client({
+    webSocketFactory: () => new SockJS(WS_URL),
+    reconnectDelay: 5_000,
+    heartbeatIncoming: 10_000,
+    heartbeatOutgoing: 10_000,
+    beforeConnect: async () => {
+      if (!client) return;
+      setState({ status: "connecting" });
+      try {
+        const token = await ensureFreshAccessToken();
+        client.connectHeaders = { Authorization: `Bearer ${token}` };
+      } catch (e) {
+        // Do NOT throw from beforeConnect — stompjs handles a thrown
+        // beforeConnect as a catastrophic failure. Instead, let stompjs
+        // proceed without an Authorization header; the interceptor will
+        // reject the CONNECT frame, onStompError will fire, and the
+        // ConnectionState machine will surface the error.
+        //
+        // See FOOTGUNS §F.18.
+        if (e instanceof RefreshFailedError) {
+          setState({
+            status: "error",
+            detail: "Session expired — please sign in again",
+          });
+        } else {
+          setState({
+            status: "error",
+            detail: "Could not refresh access token",
+          });
+        }
+      }
+    },
+    onConnect: () => {
+      setState({ status: "connected" });
+    },
+    onWebSocketClose: () => {
+      if (client?.active) {
+        setState({ status: "reconnecting" });
+      } else {
+        setState({ status: "disconnected" });
+      }
+    },
+    onStompError: (frame) => {
+      const detail = frame.headers["message"] ?? "STOMP error";
+      setState({ status: "error", detail });
+    },
+  });
+
+  return client;
+}
+
+/**
+ * Subscribe to a STOMP destination. Returns an unsubscribe closure. The
+ * callback receives the JSON-parsed message payload typed as `T`. Malformed
+ * JSON is logged via `console.error` and the subscription stays alive.
+ *
+ * Reference counting: the first subscribe activates the singleton client;
+ * the last unsubscribe schedules a `DISCONNECT_GRACE_MS` deactivation. A new
+ * subscribe inside the grace window cancels the teardown.
+ *
+ * Deferral: if the client is not yet connected, the actual `client.subscribe`
+ * call is deferred until `onConnect` fires. See FOOTGUNS §F.19.
+ */
+export function subscribe<T>(
+  destination: string,
+  onMessage: (payload: T) => void
+): Unsubscribe {
+  const c = getOrCreateClient();
+  subscriberCount += 1;
+
+  if (disconnectTimer) {
+    clearTimeout(disconnectTimer);
+    disconnectTimer = null;
+  }
+
+  if (!c.active) {
+    c.activate();
+  }
+
+  let stompSub: StompSubscription | null = null;
+
+  const attach = () => {
+    stompSub = c.subscribe(destination, (frame: IMessage) => {
+      try {
+        const parsed = JSON.parse(frame.body) as T;
+        onMessage(parsed);
+      } catch (err) {
+        console.error(
+          `[ws] Failed to parse message body on ${destination}:`,
+          err,
+          frame.body
+        );
+      }
+    });
+  };
+
+  if (c.connected) {
+    attach();
+  } else {
+    // KNOWN RACE (Epic 04 hardening followup, spec §14.7):
+    //   If onConnect → onWebSocketClose fires in rapid succession, the
+    //   listener sees "reconnecting" mid-cycle and keeps waiting through the
+    //   reconnect. On the next successful connect the listener fires and
+    //   attach() runs — subscription not lost, just delayed by one reconnect
+    //   cycle. Acceptable for 01-09; Epic 04 will want a more robust
+    //   re-attach strategy.
+    const stateUnsub = subscribeToConnectionState((state) => {
+      if (state.status === "connected") {
+        attach();
+        stateUnsub();
+      }
+    });
+  }
+
+  return () => {
+    if (stompSub) stompSub.unsubscribe();
+    subscriberCount = Math.max(0, subscriberCount - 1);
+    if (subscriberCount === 0) {
+      scheduleTeardown();
+    }
+  };
+}
+
+function scheduleTeardown(): void {
+  if (disconnectTimer) return;
+  disconnectTimer = setTimeout(() => {
+    disconnectTimer = null;
+    if (subscriberCount === 0 && client) {
+      client.deactivate();
+      setState({ status: "disconnected" });
+    }
+  }, DISCONNECT_GRACE_MS);
+}
+
+// Manual controls for the /dev/ws-test page's Disconnect / Reconnect buttons.
+// Consumers should NOT use these in production code — they bypass reference
+// counting and can leave other subscribers stranded.
+export function __devForceDisconnect(): void {
+  if (client?.active) client.deactivate();
+  setState({ status: "disconnected" });
+}
+
+export function __devForceReconnect(): void {
+  const c = getOrCreateClient();
+  if (!c.active) c.activate();
+}
+
+// Test-only reset. Clears all module state so each test starts from scratch.
+export function __resetWsClientForTests(): void {
+  if (client) {
+    try {
+      client.deactivate();
+    } catch {
+      // Ignore — mocked client may not implement deactivate cleanly.
+    }
+  }
+  client = null;
+  subscriberCount = 0;
+  if (disconnectTimer) {
+    clearTimeout(disconnectTimer);
+    disconnectTimer = null;
+  }
+  stateListeners.clear();
+  connectionState = { status: "disconnected" };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/lib/ws/client.test.ts`
+Expected: PASS — all 9 tests green.
+
+If test 6 (`onConnect transitions state to connected`) fails because the listener was already registered when the state was `"connecting"`, check that the test uses `subscribeToConnectionState` BEFORE calling `subscribe`. The listener fires immediately with the current state when registered.
+
+- [ ] **Step 5: Run the full frontend test suite**
+
+Run: `cd frontend && npm test`
+Expected: PASS — no regressions in any existing tests.
+
+- [ ] **Step 6: Run lint and build**
+
+Run: `cd frontend && npm run lint && npm run build`
+Expected: PASS — no lint errors, production build succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09
+git add frontend/src/lib/ws/client.ts frontend/src/lib/ws/client.test.ts
+git commit -m "feat(ws): singleton STOMP client with reference counting
+
+lib/ws/client.ts is the module-level @stomp/stompjs client wrapped in a
+reference-counted API. First subscribe activates the client; last
+unsubscribe schedules a DISCONNECT_GRACE_MS (5s) deactivation; a new
+subscribe inside the grace window cancels the teardown.
+
+Key contract:
+- beforeConnect calls ensureFreshAccessToken and sets the Authorization
+  header; catches RefreshFailedError and stores it in ConnectionState
+  without throwing (stompjs handles thrown beforeConnect badly).
+- onConnect / onWebSocketClose / onStompError drive the ConnectionState
+  discriminated union; consumers subscribe via subscribeToConnectionState.
+- subscribe<T>() defers the actual client.subscribe until onConnect if
+  the client is not yet connected — see spec §14.7 for the known race.
+- JSON.parse is wrapped in try/catch so malformed frames don't kill the
+  subscription.
+
+Ships with 9 unit tests via mocked @stomp/stompjs covering all public
+API branches and state transitions."
+git push
+```
+
+---
+
+### Task 10: `lib/ws/hooks.ts` — React Hook Wrappers
+
+**Why:** Thin React hooks around the module primitives. `useConnectionState` subscribes via `subscribeToConnectionState`; `useStompSubscription` wraps `subscribe()` in a `useEffect` with a stable-callback ref so re-renders don't resubscribe. Three tests cover the React integration.
+
+**Files:**
+- Create: `frontend/src/lib/ws/hooks.ts`
+- Create: `frontend/src/lib/ws/hooks.test.tsx`
+
+---
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/src/lib/ws/hooks.test.tsx`:
+
+```typescript
+// frontend/src/lib/ws/hooks.test.tsx
+
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { render, renderHook, act } from "@testing-library/react";
+
+// Track calls to the module primitives without pulling in stompjs.
+const subscribeMock = vi.fn();
+const subscribeToConnectionStateMock = vi.fn();
+const getConnectionStateMock = vi.fn(() => ({ status: "disconnected" as const }));
+
+vi.mock("./client", () => ({
+  subscribe: (...args: unknown[]) => {
+    subscribeMock(...args);
+    return () => {
+      // Unsubscribe closure is tracked via subscribeMock.mock.results.
+    };
+  },
+  subscribeToConnectionState: (
+    listener: (state: { status: string }) => void
+  ) => {
+    subscribeToConnectionStateMock(listener);
+    // Fire immediately with current state, like the real impl.
+    listener(getConnectionStateMock());
+    return () => {};
+  },
+  getConnectionState: getConnectionStateMock,
+}));
+
+import { useConnectionState, useStompSubscription } from "./hooks";
+
+describe("lib/ws/hooks", () => {
+  beforeEach(() => {
+    subscribeMock.mockReset();
+    (subscribeMock as unknown as Mock).mockImplementation(() => () => {});
+    subscribeToConnectionStateMock.mockReset();
+    getConnectionStateMock.mockReset();
+    getConnectionStateMock.mockReturnValue({ status: "disconnected" });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("useConnectionState renders the current state and reacts to updates", () => {
+    let capturedListener: ((s: { status: string }) => void) | null = null;
+    subscribeToConnectionStateMock.mockImplementation((listener) => {
+      capturedListener = listener;
+      listener({ status: "disconnected" });
+      return () => {};
+    });
+
+    const { result } = renderHook(() => useConnectionState());
+    expect(result.current.status).toBe("disconnected");
+
+    act(() => {
+      capturedListener!({ status: "connected" });
+    });
+
+    expect(result.current.status).toBe("connected");
+  });
+
+  it("useStompSubscription subscribes on mount and unsubscribes on unmount", () => {
+    const unsubscribeMock = vi.fn();
+    subscribeMock.mockImplementation(() => unsubscribeMock);
+
+    function Probe() {
+      useStompSubscription<{ msg: string }>("/topic/foo", () => {});
+      return null;
+    }
+
+    const { unmount } = render(<Probe />);
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
+    expect(subscribeMock.mock.calls[0][0]).toBe("/topic/foo");
+
+    unmount();
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("useStompSubscription does not re-subscribe when the callback identity changes", () => {
+    const unsubscribeMock = vi.fn();
+    subscribeMock.mockImplementation(() => unsubscribeMock);
+
+    let renderCount = 0;
+    function Probe() {
+      renderCount++;
+      // Inline arrow creates a new function identity on every render.
+      useStompSubscription<{ msg: string }>("/topic/foo", () => {
+        // noop
+      });
+      return null;
+    }
+
+    const { rerender } = render(<Probe />);
+    rerender(<Probe />);
+    rerender(<Probe />);
+
+    expect(renderCount).toBe(3);
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/lib/ws/hooks.test.tsx`
+Expected: FAIL — module `./hooks` not found.
+
+- [ ] **Step 3: Create `lib/ws/hooks.ts`**
+
+Create `frontend/src/lib/ws/hooks.ts`:
+
+```typescript
+// frontend/src/lib/ws/hooks.ts
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  getConnectionState,
+  subscribe,
+  subscribeToConnectionState,
+} from "./client";
+import type { ConnectionState } from "./types";
+
+/**
+ * React-friendly accessor for the module-level ConnectionState. Re-renders
+ * whenever the underlying state changes. Fires immediately on mount with the
+ * current state (the listener is invoked synchronously inside
+ * `subscribeToConnectionState`).
+ */
+export function useConnectionState(): ConnectionState {
+  const [state, setState] = useState<ConnectionState>(() => getConnectionState());
+  useEffect(() => {
+    return subscribeToConnectionState(setState);
+  }, []);
+  return state;
+}
+
+/**
+ * React-friendly wrapper around `subscribe()`. The callback is held in a ref
+ * so re-renders with a new inline function identity do not re-subscribe; only
+ * a change to the `destination` string triggers a new subscription.
+ */
+export function useStompSubscription<T>(
+  destination: string,
+  onMessage: (payload: T) => void
+): void {
+  const callbackRef = useRef(onMessage);
+  callbackRef.current = onMessage;
+
+  useEffect(() => {
+    const unsubscribe = subscribe<T>(destination, (payload) => {
+      callbackRef.current(payload);
+    });
+    return unsubscribe;
+  }, [destination]);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/lib/ws/hooks.test.tsx`
+Expected: PASS — all 3 tests green.
+
+- [ ] **Step 5: Run lint**
+
+Run: `cd frontend && npm run lint`
+Expected: PASS. If the React compiler complains about the ref pattern, add an `// eslint-disable-next-line` comment on the `callbackRef.current = onMessage;` line with a note that this is intentional stable-callback pattern.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09
+git add frontend/src/lib/ws/hooks.ts frontend/src/lib/ws/hooks.test.tsx
+git commit -m "feat(ws): useConnectionState and useStompSubscription hooks
+
+Thin React hooks around the module primitives from lib/ws/client.ts.
+
+useConnectionState:
+- subscribes via subscribeToConnectionState; re-renders on state change.
+- initial value comes from getConnectionState() so the first render has
+  the correct state without waiting for the first effect.
+
+useStompSubscription:
+- holds the callback in a ref so re-renders with new inline functions
+  do not re-subscribe (classic stable-callback pattern).
+- [destination] dep array — a destination change triggers a new sub.
+
+Ships with 3 tests covering state rendering/updates, mount/unmount
+subscribe lifecycle, and callback-identity stability."
+git push
+```
+
+---
+
+## Phase E — Frontend Test Harness
+
+**Phase goal:** Ship the `/dev/ws-test` page and its `WsTestHarness` component. This is the browser-based verification surface that proves the full pipe works end-to-end when a human clicks through it. Also adds the `NEXT_PUBLIC_WS_URL` env var example.
+
+---
+
+### Task 11: `WsTestHarness` Component + `/dev/ws-test` Page + `.env.local.example`
+
+**Why:** Bundled task because the page, the component, and the env var all ship together as the "dev harness" unit and have no independent value. The page is a thin server component that 404s in production and renders `WsTestHarness` in development. The harness has four zones: connection status, manual controls, broadcast form, received messages log.
+
+**Files:**
+- Create: `frontend/src/components/dev/WsTestHarness.tsx`
+- Create: `frontend/src/app/dev/ws-test/page.tsx`
+- Create: `frontend/.env.local.example`
+
+---
+
+- [ ] **Step 1: Create `WsTestHarness` component**
+
+Create `frontend/src/components/dev/WsTestHarness.tsx`:
+
+```tsx
+// frontend/src/components/dev/WsTestHarness.tsx
+"use client";
+
+import { useState } from "react";
+import { api } from "@/lib/api";
+import { __devForceDisconnect, __devForceReconnect } from "@/lib/ws/client";
+import { useConnectionState, useStompSubscription } from "@/lib/ws/hooks";
+import type { ConnectionState } from "@/lib/ws/types";
+
+// senderId is a Java Long on the backend, serialized as a JSON number, which
+// parses to a plain JS number here. User IDs are well under 2^53 - 1. See
+// spec §5.4 for the wire-type note.
+type WsTestMessage = {
+  message: string;
+  senderId: number;
+  timestamp: string;
+};
+
+const MAX_MESSAGES = 50;
+
+export function WsTestHarness() {
+  const state = useConnectionState();
+  const [messages, setMessages] = useState<WsTestMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+
+  useStompSubscription<WsTestMessage>("/topic/ws-test", (payload) => {
+    setMessages((prev) => [payload, ...prev].slice(0, MAX_MESSAGES));
+  });
+
+  const sendBroadcast = async () => {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    setSending(true);
+    setSendError(null);
+    try {
+      await api.post("/api/ws-test/broadcast", { message: trimmed });
+      setInput("");
+    } catch (err) {
+      setSendError(err instanceof Error ? err.message : "Failed to send");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto max-w-3xl p-8">
+      <h1 className="text-2xl font-semibold text-on-surface">
+        WebSocket Test Harness
+      </h1>
+      <p className="mt-2 text-on-surface-variant">
+        Dev-only page for verifying the STOMP pipe. Returns 404 in production
+        builds.
+      </p>
+
+      <div className="mt-6">
+        <ConnectionBadge state={state} />
+      </div>
+
+      <div className="mt-4 flex gap-2">
+        <button
+          type="button"
+          onClick={__devForceDisconnect}
+          className="rounded-md bg-surface-container px-3 py-2 text-sm text-on-surface hover:bg-surface-container-high"
+        >
+          Force Disconnect
+        </button>
+        <button
+          type="button"
+          onClick={__devForceReconnect}
+          className="rounded-md bg-surface-container px-3 py-2 text-sm text-on-surface hover:bg-surface-container-high"
+        >
+          Force Reconnect
+        </button>
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          void sendBroadcast();
+        }}
+        className="mt-8"
+      >
+        <label
+          htmlFor="ws-test-input"
+          className="block text-sm font-medium text-on-surface"
+        >
+          Send test message
+        </label>
+        <div className="mt-2 flex gap-2">
+          <input
+            id="ws-test-input"
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Type a message"
+            className="flex-1 rounded-md bg-surface-container px-3 py-2 text-on-surface placeholder:text-on-surface-variant"
+          />
+          <button
+            type="submit"
+            disabled={sending || !input.trim()}
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-on-primary disabled:opacity-50"
+          >
+            {sending ? "Sending..." : "Send"}
+          </button>
+        </div>
+        {sendError ? (
+          <p className="mt-2 text-sm text-error">{sendError}</p>
+        ) : null}
+      </form>
+
+      <section className="mt-8">
+        <h2 className="text-lg font-medium text-on-surface">
+          Received ({messages.length})
+        </h2>
+        <ol className="mt-2 space-y-2">
+          {messages.map((m, i) => (
+            <li
+              key={`${m.timestamp}-${i}`}
+              className="rounded-md bg-surface-container p-3"
+            >
+              <div className="flex items-baseline justify-between">
+                <span className="text-on-surface">{m.message}</span>
+                <span className="font-mono text-xs text-on-surface-variant">
+                  {m.timestamp}
+                </span>
+              </div>
+              <div className="mt-1 text-xs text-on-surface-variant">
+                from userId {m.senderId}
+              </div>
+            </li>
+          ))}
+          {messages.length === 0 ? (
+            <li className="rounded-md bg-surface-container p-3 text-sm text-on-surface-variant">
+              No messages yet. Send one or trigger a broadcast from another
+              tab / curl.
+            </li>
+          ) : null}
+        </ol>
+      </section>
+    </main>
+  );
+}
+
+function ConnectionBadge({ state }: { state: ConnectionState }) {
+  const label = {
+    disconnected: "Disconnected",
+    connecting: "Connecting...",
+    connected: "Connected",
+    reconnecting: "Reconnecting...",
+    error: "Error",
+  }[state.status];
+
+  const tone = {
+    disconnected: "bg-surface-container text-on-surface-variant",
+    connecting: "bg-tertiary-container text-on-tertiary-container",
+    connected: "bg-primary-container text-on-primary-container",
+    reconnecting: "bg-tertiary-container text-on-tertiary-container",
+    error: "bg-error-container text-on-error-container",
+  }[state.status];
+
+  return (
+    <div className={`inline-flex flex-col rounded-md px-3 py-2 text-sm ${tone}`}>
+      <span className="font-medium">{label}</span>
+      {state.status === "error" ? (
+        <span className="mt-1 text-xs">{state.detail}</span>
+      ) : null}
+    </div>
+  );
+}
+```
+
+**Design-system notes:**
+- All colors use semantic tokens from the Tailwind config (`text-on-surface`, `bg-surface-container`, `bg-primary-container`, etc.). No hex values. No inline styles. The harness is a dev tool but still has to pass `npm run verify:no-hex-colors` and `npm run verify:no-inline-styles`.
+- No `border-*` classes. DESIGN.md §2 "No-Line Rule" applies everywhere.
+- If your project's Tailwind config doesn't have an `bg-tertiary-container` token, check `frontend/tailwind.config.ts` or `frontend/src/app/globals.css` for the actual available tokens and pick the closest. The lint-verify scripts are authoritative.
+
+- [ ] **Step 2: Create the page file**
+
+Create `frontend/src/app/dev/ws-test/page.tsx`:
+
+```tsx
+// frontend/src/app/dev/ws-test/page.tsx
+import { notFound } from "next/navigation";
+import { WsTestHarness } from "@/components/dev/WsTestHarness";
+
+export default function WsTestPage() {
+  // Route 404s in production — /dev/** is a development-only surface.
+  if (process.env.NODE_ENV === "production") {
+    notFound();
+  }
+  return <WsTestHarness />;
+}
+```
+
+- [ ] **Step 3: Create `.env.local.example`**
+
+Create `frontend/.env.local.example` (if one doesn't already exist — check with `ls frontend/.env*` first and only create it if absent):
+
+```
+# Copy to .env.local for local development. Never commit .env.local.
+
+NEXT_PUBLIC_API_URL=http://localhost:8080
+NEXT_PUBLIC_WS_URL=http://localhost:8080/ws
+```
+
+If the file already exists, append the `NEXT_PUBLIC_WS_URL` line instead.
+
+- [ ] **Step 4: Run lint**
+
+Run: `cd frontend && npm run lint`
+Expected: PASS. If the ESLint React-compiler or react/no-unescaped-entities rule complains, address the specific warning — do not blanket-disable.
+
+- [ ] **Step 5: Run the full frontend test suite**
+
+Run: `cd frontend && npm test`
+Expected: PASS — no regressions. The harness and page have no direct unit tests (they're manually verified in Task 13), but importing them must not break existing tests.
+
+- [ ] **Step 6: Run the verify chain**
+
+Run: `cd frontend && npm run verify`
+Expected: PASS — no-dark-variants, no-hex-colors, no-inline-styles, and coverage scripts all pass.
+
+- [ ] **Step 7: Run the production build**
+
+Run: `cd frontend && npm run build`
+Expected: PASS. Specifically watch for:
+- Next.js static-generation errors on `/dev/ws-test`. The `notFound()` call in a Server Component during SSG returns a 404 page, which is fine — the build should succeed.
+- `"use client"` boundary errors. `WsTestHarness` is a client component imported from a server-component page; that's the correct pattern.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09
+git add frontend/src/components/dev/WsTestHarness.tsx \
+        frontend/src/app/dev/ws-test/page.tsx \
+        frontend/.env.local.example
+git commit -m "feat(dev): /dev/ws-test harness with four verification zones
+
+Browser-based WebSocket verification surface. Renders in development
+and 404s in production via a NODE_ENV check in the server-component
+page wrapper.
+
+Four zones in WsTestHarness:
+1. Connection status badge (driven by useConnectionState).
+2. Force Disconnect / Force Reconnect manual controls (exercise the
+   reconnect path without killing the backend).
+3. Send test message form (POST /api/ws-test/broadcast).
+4. Received messages log (last 50, subscribed via useStompSubscription).
+
+Adds NEXT_PUBLIC_WS_URL to .env.local.example so contributors know to
+set it alongside NEXT_PUBLIC_API_URL."
+git push
+```
+
+---
+
+## Phase F — Documentation
+
+**Phase goal:** Ship the FOOTGUNS additions locked in the spec §13 and update the root README.md with a one-liner about the new dev harness and WebSocket infrastructure. Per the auto-memory `feedback_update_readme_each_task.md`, the README sweep is mandatory for every task.
+
+---
+
+### Task 12: FOOTGUNS §F.16–§F.19 + README Sweep
+
+**Why:** Encode the four WebSocket-related invariants into the permanent FOOTGUNS ledger so future contributors can't accidentally unwind them. Also update the README to mention the new `/dev/ws-test` harness and the WebSocket pipe.
+
+**Files:**
+- Modify: `docs/implementation/FOOTGUNS.md`
+- Modify: `README.md`
+
+---
+
+- [ ] **Step 1: Open `FOOTGUNS.md` and locate the end of §F**
+
+Find the `§F.15` block (the last existing frontend entry). Append the four new entries after it.
+
+- [ ] **Step 2: Add §F.16 — WebSocket HTTP permit rule**
+
+Append to `docs/implementation/FOOTGUNS.md`:
+
+```markdown
+### F.16 WebSocket handshake is permitted at HTTP, authenticated at STOMP
+
+**Rule:** `SecurityConfig` must list `/ws/**` as `.permitAll()` above the `/api/**` authenticated catch-all. The HTTP-layer WebSocket upgrade does not carry an `Authorization` header from the browser (the WebSocket API has no mechanism to set custom headers on upgrades), so gating the upgrade at the HTTP layer is impossible. Authentication happens in `JwtChannelInterceptor.preSend()` on the first STOMP `CONNECT` frame, before the session is usable for any subscription or send.
+
+**Why:** Task 01-09 locked this model in the brainstorm (spec §3 Q1-A). Matcher order in `SecurityConfig` is first-match-wins (§B.5), so `/ws/**` must appear ABOVE `/api/**`. Moving it below the catch-all silently flips it from permitAll to authenticated and every WebSocket connection starts failing with a bewildering 401 before the STOMP layer even sees the frame.
+
+**How to apply:** when editing `SecurityConfig.authorizeHttpRequests`, verify the `/ws/**` matcher is still above `/api/**`. If code review proposes "tightening" it to `.authenticated()`, reject — browsers cannot send the required header.
+```
+
+- [ ] **Step 3: Add §F.17 — Extracted stampede guard's finally-in-IIFE invariant**
+
+Append:
+
+```markdown
+### F.17 `ensureFreshAccessToken` stampede guard — `finally` inside the IIFE
+
+**Rule:** In `lib/auth/refresh.ts`, the `inFlightRefresh = null` cleanup MUST live inside the IIFE's `try { ... } finally { inFlightRefresh = null; }`, not after the outer promise chain. The shared promise between HTTP 401 interceptor and STOMP `beforeConnect` depends on this: if the cleanup runs outside the IIFE, every awaiter nulls the ref as they resolve, and a concurrent refresh kicked off during the resolution window sees `null` and fires a second `/api/auth/refresh`, defeating the stampede guard.
+
+**Why:** this is §F.4 restated for the extracted module. Two canary tests pin this behavior:
+- `frontend/src/lib/auth/refresh.test.ts` (three tests, local to the extracted module)
+- `frontend/src/lib/api.401-interceptor.test.tsx` (three tests, HTTP end-to-end via MSW)
+
+If either canary starts failing with "fetch called twice instead of once", the `finally` clause has been moved.
+
+**How to apply:** when touching `lib/auth/refresh.ts`, diff the `finally` placement. If code review ever proposes "flattening the IIFE for readability", reject it — the flattening breaks the contract.
+```
+
+- [ ] **Step 4: Add §F.18 — `beforeConnect` must not throw**
+
+Append:
+
+```markdown
+### F.18 `beforeConnect` must not throw — stash errors and let stompjs produce the ERROR frame
+
+**Rule:** In `lib/ws/client.ts`, the `beforeConnect` callback wraps `ensureFreshAccessToken` in try/catch. On `RefreshFailedError`, store the message via `setState({status:"error", detail})` and return normally — do NOT throw from `beforeConnect`. Stompjs treats a thrown `beforeConnect` as a catastrophic failure and either deactivates the client entirely or loops infinitely depending on the version.
+
+**Why:** letting stompjs proceed with no `Authorization` header causes the interceptor to reject the CONNECT frame with an `ERROR` frame, which the client handles gracefully via `onStompError` and our `ConnectionState` machine. Any path that throws from `beforeConnect` hides the error from UI and potentially deadlocks the client.
+
+**How to apply:** when reviewing `beforeConnect` changes, verify that the catch block only stores state, never throws or calls `client.deactivate()`. The setState call path is safe; throw is not.
+```
+
+- [ ] **Step 5: Add §F.19 — stompjs `subscribe()` requires connected**
+
+Append:
+
+```markdown
+### F.19 `@stomp/stompjs` `subscribe()` only works when `client.connected === true`
+
+**Rule:** `client.subscribe(destination, callback)` throws if called before the client is connected. Our `lib/ws/client.ts` handles this by deferring the actual `client.subscribe()` call until `onConnect` fires, via an inline `subscribeToConnectionState` listener that unsubscribes itself after one fire.
+
+**Why:** without the deferral, calling `useStompSubscription` during initial page load (before the WS handshake completes) throws a runtime error that crashes the React tree. The deferral is ~6 lines but load-bearing — do not "simplify" it away.
+
+A known edge case lives here (spec §14.7): a rapid `onConnect → onWebSocketClose` sequence can leave the deferred listener waiting mid-cycle. The subscription is not lost — it attaches on the next successful connect — just delayed by one reconnect. Epic 04 may harden this with re-attach-on-every-transition + subscription dedup when auction-room subscriptions need robustness under flaky networks.
+
+**How to apply:** any path that eagerly invokes `client.subscribe` must first check `client.connected`, and if false, defer via the state listener. This rule applies equally to Epic 04's auction-room subscription code.
+```
+
+- [ ] **Step 6: Update `README.md`**
+
+Open `README.md` at the project root. Find the section that describes the frontend features (should mention the auth pages from Task 01-08) and the backend services. Add a one-liner under each:
+
+In the frontend section, append near the existing auth pages list:
+```markdown
+- `/dev/ws-test` — development-only WebSocket verification harness (404s in production)
+```
+
+In the backend section, append near the existing auth endpoints:
+```markdown
+- **WebSocket**: STOMP over `/ws` with SockJS fallback; JWT-authenticated at the CONNECT frame via `JwtChannelInterceptor`. Dev-only broadcast endpoint at `POST /api/ws-test/broadcast`.
+```
+
+If the README doesn't have explicit "frontend pages" or "backend endpoints" subsections, find a reasonable equivalent location and add a short paragraph mentioning the WebSocket pipe and the dev harness page. The specific wording is less important than the README not being stale.
+
+- [ ] **Step 7: Run the verify chain**
+
+Run: `cd frontend && npm run verify` (verifies the dev harness doesn't introduce hex colors etc.)
+
+Run: `cd backend && ./mvnw test`
+Expected: PASS — nothing touched by this task affects compilation or tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09
+git add docs/implementation/FOOTGUNS.md README.md
+git commit -m "docs: FOOTGUNS F.16-F.19 and README sweep for Task 01-09
+
+Four new entries in the frontend FOOTGUNS section covering the
+WebSocket-specific invariants:
+- F.16: /ws/** must be permitAll at the HTTP layer; auth is at STOMP.
+- F.17: ensureFreshAccessToken finally clause lives inside the IIFE.
+- F.18: beforeConnect must not throw; stash errors in ConnectionState.
+- F.19: stompjs subscribe() requires client.connected; deferral pattern.
+
+README updated to mention the new /dev/ws-test harness page and the
+JWT-authenticated STOMP pipe backend."
+git push
+```
+
+---
+
+## Phase G — Final Verification
+
+**Phase goal:** Prove the full stack works end-to-end in a real browser, not just in tests. Backend + frontend + Postgres + Redis all running; navigate to `/dev/ws-test`, click through the four verification zones, observe messages arrive in real time, exercise the reconnect path.
+
+---
+
+### Task 13: End-to-End Manual Smoke Test + Full Verify Chain
+
+**Why:** Tests prove units work; manual smoke proves the deployed system works. CLAUDE.md's "For UI or frontend changes, start the dev server and use the feature in a browser" rule makes this mandatory for any UI-adjacent work.
+
+**Files:**
+- No file changes. This task is pure verification.
+
+---
+
+- [ ] **Step 1: Start infrastructure containers**
+
+Verify Postgres and Redis are running:
+
+```bash
+docker ps | grep -E "postgres|redis"
+```
+
+Expected: both containers listed. If missing, see memory `dev_containers.md` for the `docker run` commands.
+
+- [ ] **Step 2: Run the full backend test suite**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09/backend
+./mvnw clean test
+```
+
+Expected: ALL tests pass. Specifically verify:
+- `JwtChannelInterceptorTest` — 6 tests.
+- `WsTestIntegrationTest` — 3 tests.
+- Any pre-existing tests from previous tasks (Task 01-07 auth, Task 01-04 user) still pass.
+
+- [ ] **Step 3: Run the full frontend test suite**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09/frontend
+npm test
+```
+
+Expected: ALL tests pass. Specifically:
+- `src/lib/auth/refresh.test.ts` — 3 tests.
+- `src/lib/api.401-interceptor.test.tsx` — 3 tests (unchanged canary).
+- `src/lib/ws/client.test.ts` — 9 tests.
+- `src/lib/ws/hooks.test.tsx` — 3 tests.
+- Any pre-existing tests from Task 01-08 (auth hooks, forms, Header, etc.) still pass.
+
+- [ ] **Step 4: Run frontend lint, verify, and build**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09/frontend
+npm run lint
+npm run verify
+npm run build
+```
+
+Expected: ALL pass. Any failure is a hard stop — do not proceed to manual smoke until the verify chain is green.
+
+- [ ] **Step 5: Start the backend**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09/backend
+./mvnw spring-boot:run
+```
+
+Wait for `Started BackendApplication in X.Xs` in the logs. Expected: no exceptions. Specifically watch for:
+- `WebSocketConfig` bean initialization (look for `Broker` or `stomp` in the startup logs at DEBUG level, if enabled).
+- `WsTestController` registered — should see `Mapped "/api/ws-test/broadcast"` in the mappings output.
+
+- [ ] **Step 6: Start the frontend dev server (in another terminal)**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09/frontend
+npm run dev
+```
+
+Wait for `Ready in X.Xs`. Expected: dev server listens on `http://localhost:3000` with no compile errors.
+
+- [ ] **Step 7: Manual smoke test — register and sign in**
+
+1. Open `http://localhost:3000/register` in a browser.
+2. Register a new user (any valid email + password meeting the validation rules).
+3. After registration, verify the Header shows the authenticated state (user dropdown).
+
+- [ ] **Step 8: Manual smoke test — /dev/ws-test page**
+
+1. Navigate to `http://localhost:3000/dev/ws-test`.
+2. Expected: the harness renders. Connection badge cycles through "Connecting..." → "Connected".
+3. **Zone 1 (connection status):** badge shows green "Connected".
+4. **Zone 3 (send broadcast):** type "hello" in the input, click "Send". Expected:
+   - The input clears.
+   - A new message appears in Zone 4 (received log) within ~100ms with `message: "hello"`, `senderId: <your user id>`, and a timestamp.
+5. Send a few more messages to confirm the log retains up to 50 and prepends new ones.
+
+- [ ] **Step 9: Manual smoke test — reconnection**
+
+1. Still on the `/dev/ws-test` page, click **Force Disconnect**.
+2. Expected: connection badge transitions to "Disconnected".
+3. Click **Force Reconnect**.
+4. Expected: badge transitions "Connecting..." → "Connected" within a few seconds.
+5. Send another test message. Verify it arrives — proves the reconnected session works.
+
+- [ ] **Step 10: Manual smoke test — backend restart reconnect**
+
+1. In the backend terminal, press Ctrl+C to stop Spring Boot.
+2. In the browser, observe the connection badge transition to "Reconnecting..." (stompjs auto-reconnect kicks in every 5 seconds).
+3. Restart the backend: `./mvnw spring-boot:run` in the backend terminal.
+4. Wait for startup.
+5. Expected: the browser's connection badge transitions back to "Connected" automatically within ~5-10 seconds without any user interaction. This proves the `beforeConnect` refresh flow works across a real reconnect cycle.
+6. Send one final test message to confirm post-reconnect subscriptions still work.
+
+- [ ] **Step 11: Manual smoke test — production build 404 verification**
+
+1. Stop the dev server (Ctrl+C).
+2. Build the production bundle: `cd frontend && npm run build`.
+3. Start the production server: `npm run start`.
+4. Navigate to `http://localhost:3000/dev/ws-test`.
+5. Expected: **404 Not Found**. The `NODE_ENV === "production"` guard in `page.tsx` ran `notFound()`.
+6. Navigate to `http://localhost:3000/` (or another valid route) — expected: renders normally. Proves only `/dev/**` is guarded, not the whole app.
+7. Stop the production server.
+
+- [ ] **Step 12: Stop all processes**
+
+Stop the backend (Ctrl+C) and the frontend production server (Ctrl+C). Leave Postgres and Redis running.
+
+- [ ] **Step 13: Final commit check**
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09
+git status
+```
+
+Expected: clean. No uncommitted changes. All Task 01-09 commits are on `task/01-09-websocket-stomp` and pushed to origin.
+
+```bash
+git log --oneline origin/dev..HEAD
+```
+
+Expected: one commit per task (13 commits: spec, refresh extract, api delegate, interceptor, ws config, wstest controller, ws integration test, deps, types, client, hooks, harness, footguns+readme). Plus the spec commit from the brainstorm phase.
+
+If there are no uncommitted changes and the test suites are all green, **Task 01-09 is complete**. The next step is opening a pull request against `dev`:
+
+```bash
+cd C:/Users/heath/Repos/Personal/slpa-task-01-09
+gh pr create --base dev --title "feat(ws): Task 01-09 — WebSocket STOMP infrastructure" --body "$(cat <<'EOF'
+## Summary
+
+Ships the JWT-authenticated STOMP over WebSocket pipe between the Next.js frontend and Spring Boot backend, with an end-to-end verification harness. Infrastructure only — no user-facing auction features (those are Epic 04).
+
+**Backend:**
+- `WebSocketConfig` — simple in-memory broker on /topic, /app application prefix, SockJS endpoint at /ws.
+- `JwtChannelInterceptor` — validates the STOMP CONNECT frame's Authorization header via the existing JwtService and attaches a StompAuthenticationToken principal.
+- `SecurityConfig` — /ws/** permitAll above /api/** (HTTP-layer auth is impossible for WebSocket upgrades).
+- `WsTestController` — dev/test profile-gated REST endpoint that broadcasts to /topic/ws-test.
+
+**Frontend:**
+- `lib/auth/refresh.ts` — extracted stampede guard. Shared by HTTP 401 interceptor and STOMP beforeConnect hook.
+- `lib/api.ts` — delegates 401 handling to ensureFreshAccessToken. HTTP 401 canary still green.
+- `lib/ws/client.ts` — singleton @stomp/stompjs client with reference counting, 5s disconnect grace, observable ConnectionState.
+- `lib/ws/hooks.ts` — useConnectionState + useStompSubscription React wrappers.
+- `/dev/ws-test` — four-zone verification harness; 404s in production.
+
+**Tests:**
+- JwtChannelInterceptorTest — 6 unit tests
+- WsTestIntegrationTest — 3 end-to-end tests with real STOMP client
+- refresh.test.ts — 3 stampede canary tests
+- client.test.ts — 9 unit tests
+- hooks.test.tsx — 3 hook tests
+- api.401-interceptor.test.tsx — unchanged, still green
+
+**FOOTGUNS added:** §F.16 (WebSocket permit rule), §F.17 (finally-in-IIFE), §F.18 (beforeConnect must not throw), §F.19 (subscribe requires connected).
+
+## Test plan
+- [ ] Backend ./mvnw test all green
+- [ ] Frontend npm test all green (all existing tests + new tests)
+- [ ] Frontend npm run lint && npm run verify && npm run build green
+- [ ] Manual smoke: register → /dev/ws-test → connected → send message → received
+- [ ] Manual smoke: Force Disconnect → Force Reconnect → still works
+- [ ] Manual smoke: backend restart → frontend auto-reconnects
+- [ ] Manual smoke: production build → /dev/ws-test returns 404
+
+Spec: docs/superpowers/specs/2026-04-12-task-01-09-websocket-stomp-design.md
+Plan: docs/superpowers/plans/2026-04-12-task-01-09-websocket-stomp.md
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+This section is the plan author's sanity check before handoff. Remove before final commit if policy requires.
+
+**1. Spec coverage check:**
+
+| Spec section | Implemented by |
+|--------------|----------------|
+| §5.1 WebSocketConfig | Task 4 |
+| §5.2 JwtChannelInterceptor + StompAuthenticationToken | Task 3 |
+| §5.3 SecurityConfig /ws/** permit | Task 4 |
+| §5.4 WsTestController + DTO | Task 5 |
+| §6.1 Dependencies | Task 7 |
+| §6.2 lib/auth/refresh.ts | Task 1 |
+| §6.3 lib/api.ts delegation | Task 2 |
+| §6.4 lib/ws/client.ts | Task 9 |
+| §6.5 lib/ws/types.ts | Task 8 |
+| §6.6 lib/ws/hooks.ts | Task 10 |
+| §6.7 /dev/ws-test page + harness | Task 11 |
+| §10.3 .env.local.example | Task 11 |
+| §10.4 providers.tsx update | NOT NEEDED — Task 2 keeps `configureApiClient` as a passthrough, so providers.tsx stays byte-exact |
+| §11.1 JwtChannelInterceptorTest | Task 3 |
+| §11.2 WsTestIntegrationTest | Task 6 |
+| §11.3 client.test.ts | Task 9 |
+| §11.4 refresh.test.ts canary | Task 1 |
+| §11.5 hooks.test.tsx | Task 10 |
+| §13 FOOTGUNS §F.16-§F.19 | Task 12 |
+
+All spec sections mapped.
+
+**2. Placeholder scan:** every step has either exact code, exact commands, or a specific enough instruction (with expected output) for the engineer to execute. No TBDs, no "handle errors appropriately", no "write tests for the above".
+
+**3. Type consistency:** cross-checked the following identifiers across tasks:
+- `ensureFreshAccessToken` — defined Task 1, consumed Task 2 (api.ts), Task 9 (ws/client.ts).
+- `configureRefresh` — defined Task 1, consumed Task 2 (via `configureApiClient` passthrough).
+- `RefreshFailedError` — defined Task 1, caught Task 2 and Task 9.
+- `AuthPrincipal` (existing) — read by Task 3, Task 5.
+- `StompAuthenticationToken` — defined Task 3, used inside the interceptor same task.
+- `ConnectionState` — defined Task 8, consumed Tasks 9, 10, 11.
+- `Unsubscribe` — defined Task 8, consumed Task 9.
+- `useConnectionState`, `useStompSubscription` — defined Task 10, consumed Task 11.
+- `DISCONNECT_GRACE_MS` — defined Task 9, referenced only inside client.ts.
+- `subscribe<T>`, `subscribeToConnectionState`, `getConnectionState`, `__devForceDisconnect`, `__devForceReconnect`, `__resetWsClientForTests` — all defined Task 9, consumed Tasks 10, 11, and Task 9's own tests.
+
+No drift. Every identifier used in a later task is defined in an earlier task (or is pre-existing in the codebase).

--- a/docs/superpowers/specs/2026-04-12-task-01-09-websocket-stomp-design.md
+++ b/docs/superpowers/specs/2026-04-12-task-01-09-websocket-stomp-design.md
@@ -272,6 +272,12 @@ public class WsTestController {
             @Valid @RequestBody WsTestBroadcastRequest request,
             @AuthenticationPrincipal AuthPrincipal principal) {
         log.info("WS test broadcast from userId={}: {}", principal.userId(), request.message());
+        // Wire-type note: principal.userId() is a Java Long. Jackson serializes
+        // it as a JSON number, which lands in JavaScript as a plain `number`.
+        // Safe because user IDs are Long but well under Number.MAX_SAFE_INTEGER
+        // (2^53 - 1). The frontend harness types senderId as `number` to match.
+        // If user IDs ever grow past 2^53 (not going to happen), switch to
+        // serializing as a string and parse on the frontend.
         messagingTemplate.convertAndSend("/topic/ws-test",
             Map.of(
                 "message", request.message(),
@@ -576,6 +582,18 @@ export function subscribe<T>(
     // Defer until onConnect. Stompjs does not auto-subscribe pending callbacks
     // in all paths for v7, so we register an onConnect hook-of-hooks via
     // publish + subscribe on the connection state.
+    //
+    // KNOWN RACE (Epic 04 hardening followup, §14.7):
+    //   If onConnect → onWebSocketClose fires in rapid succession (fast
+    //   backend bounce), the listener may see "reconnecting" mid-cycle and
+    //   keep waiting through the reconnect. On the next successful connect
+    //   the listener fires and attach() runs — so the subscription is not
+    //   lost, just delayed by one reconnect cycle. Acceptable for the 01-09
+    //   dev harness (reconnects are manual or rare). Epic 04's auction-room
+    //   subscriptions will see flaky networks and want a more robust
+    //   re-attach strategy (e.g., re-attach on every connected transition
+    //   with subscription dedup, instead of self-unsubscribing after one
+    //   fire).
     const stateUnsub = subscribeToConnectionState((state) => {
       if (state.status === "connected") {
         attach();
@@ -716,6 +734,8 @@ import { useConnectionState, useStompSubscription } from "@/lib/ws/hooks";
 import { __devForceDisconnect, __devForceReconnect } from "@/lib/ws/client";
 import { api } from "@/lib/api";
 
+// senderId is a Java Long on the backend, serialized as JSON number, which
+// parses to a plain JS number here. See §5.4 for the wire-type explanation.
 type WsTestMessage = { message: string; senderId: number; timestamp: string };
 
 export function WsTestHarness() {
@@ -1062,6 +1082,7 @@ Four entries added to the frontend section at the end of the `§F` block. Number
 4. **Multi-instance STOMP relay** (RabbitMQ / ActiveMQ). Single-instance in-memory broker is sufficient for Phase 1.
 5. **`WsTestController` removal.** The test harness ships with this task. A future task deletes `wstest/` package and `/dev/ws-test` page once Epic 04 auction-room subscriptions are stable enough to serve as the verification surface.
 6. **Frontend WS layer security review for auth redirect UX.** Currently a `RefreshFailedError` during `beforeConnect` surfaces as a generic error badge. Epic 04 may want to redirect to `/login?next=` from the WS layer itself, similar to the HTTP interceptor's current redirect. This task does not block on it because no production surface consumes the WS layer yet.
+7. **`subscribe()` deferral race hardening.** The deferred-attach pattern in §6.4 (`lib/ws/client.ts`) has a known edge case: if `onConnect → onWebSocketClose` fires in rapid succession (fast backend bounce), the state listener may see `"reconnecting"` mid-cycle and keep waiting through the reconnect. The subscription is not lost — it attaches on the next successful connect — but the first message is delayed by one reconnect cycle. Acceptable for this task's dev harness where reconnects are manual or rare. Epic 04's auction-room subscriptions will see flaky networks and should harden the re-attach strategy (e.g., re-attach on every connected transition with subscription dedup, instead of self-unsubscribing the state listener after one fire).
 
 ## 15. Acceptance Criteria Mapping
 

--- a/docs/superpowers/specs/2026-04-12-task-01-09-websocket-stomp-design.md
+++ b/docs/superpowers/specs/2026-04-12-task-01-09-websocket-stomp-design.md
@@ -1,0 +1,1102 @@
+# Task 01-09: WebSocket STOMP Configuration — Design Spec
+
+**Task brief:** `docs/implementation/epic-01/task-09-websocket-setup.md`
+**Date:** 2026-04-12
+**Base branch:** `dev`
+**Author:** brainstorming skill session
+
+---
+
+## 1. Goal
+
+Ship the WebSocket infrastructure — backend STOMP broker with JWT-authenticated handshake, frontend singleton connection manager, and an end-to-end verification harness — so that Epic 04 can immediately build real-time auction rooms on top of it.
+
+This task delivers no user-facing auction feature. Its deliverable is a working, authenticated, reconnectable pipe between browser and backend, plus the tests that prove it stays working.
+
+## 2. Alignment With The Brief
+
+The brief (`epic-01/task-09-websocket-setup.md`) is well-scoped and directly implementable. Two interpretation notes:
+
+- **"Ensure WebSocket handshake works with JWT authentication (validate token on connect)"** — we interpret "handshake" as the STOMP `CONNECT` frame, not the raw HTTP WebSocket upgrade. The upgrade itself is permitted unauthenticated; authentication happens inside the first STOMP frame. See §6.1 for why.
+- **"Test endpoint or scheduled message"** — we ship the test endpoint, not the scheduler. Scheduled background chatter pollutes logs and makes "did my message arrive?" ambiguous. See §7.1.
+
+No other brief corrections needed.
+
+## 3. Architecture Overview
+
+```
+Browser                                          Backend (Spring Boot 4)
+┌─────────────────────────┐                     ┌────────────────────────────┐
+│ lib/ws/client.ts        │                     │ WebSocketConfig            │
+│ (singleton, ref-counted)│                     │  - /ws SockJS endpoint     │
+│                         │ HTTP upgrade        │  - /topic broker           │
+│  ┌──────────────────┐   │ ───────────────────▶│  - /app app prefix         │
+│  │ @stomp/stompjs   │   │                     │                            │
+│  │ Client           │   │ STOMP CONNECT       │                            │
+│  │                  │   │  Authorization:     │ JwtChannelInterceptor      │
+│  │  beforeConnect:  │   │  Bearer <jwt>       │   preSend on CONNECT:      │
+│  │  ensureFresh-    │   │ ───────────────────▶│    - read Authorization    │
+│  │  AccessToken()   │   │                     │    - jwtService.parse      │
+│  └──────────────────┘   │                     │    - accessor.setUser()    │
+│                         │ CONNECTED / ERROR   │   - throw on invalid       │
+│                         │◀────────────────────│                            │
+│                         │                     │                            │
+│                         │ SUBSCRIBE           │                            │
+│                         │ /topic/ws-test      │ SimpMessagingTemplate      │
+│                         │────────────────────▶│  /topic/ws-test            │
+│                         │                     │                            │
+│                         │ MESSAGE             │                            │
+│                         │◀────────────────────│ WsTestController           │
+│                         │                     │  POST /api/ws-test/        │
+│                         │                     │       broadcast            │
+└─────────────────────────┘                     └────────────────────────────┘
+        │                                                    │
+        │ /api/auth/refresh (shared stampede guard)          │
+        │ ensureFreshAccessToken() — lib/auth/refresh.ts     │
+        │────────────────────────────────────────────────────▶
+```
+
+**Key design points captured in the Q&A:**
+
+1. **STOMP-frame authentication** (Q1-A). Raw WS upgrade is unauthenticated; JWT lives in the `CONNECT` frame's `Authorization` header. ChannelInterceptor validates it via existing `JwtService.parseAccessToken`.
+2. **`beforeConnect` always refreshes** (Q2-A). Every connect/reconnect calls `ensureFreshAccessToken()` before handing stompjs the token. Cheap (~100ms), trivially correct.
+3. **Extracted stampede guard** (Q2-A follow-up). The refresh-dedup logic moves from `lib/api.ts` into `lib/auth/refresh.ts`. HTTP 401 interceptor and STOMP `beforeConnect` share one module, one in-flight promise.
+4. **CONNECT-only auth** (Q3c). Subsequent `SUBSCRIBE`/`SEND` frames reuse the `Principal` set on the session by the interceptor.
+5. **`tv` freshness not enforced on WS** (Q3d). Matches the HTTP filter — 15-minute token lifetime is the natural staleness window. Epic 04 will add Redis pub/sub eviction if bids ever flow through STOMP.
+6. **HTTP-triggered broadcast** (Q4a). `POST /api/ws-test/broadcast` → `/topic/ws-test`. No scheduler.
+7. **`@Profile({"dev","test"})` gating** (Q4b). Test controller is bean-graph-absent in prod.
+8. **Reference-counted client with 5s grace period** (Q5b). `DISCONNECT_GRACE_MS = 5_000` named constant.
+9. **Observable ConnectionState** (Q6a). Module-level state + `subscribeToConnectionState()` + `useConnectionState()` hook.
+10. **Four-test suite** (Q7). Interceptor unit tests, STOMP integration smoke, frontend client unit tests, and a dedicated `ensureFreshAccessToken` canary.
+
+## 4. Module Inventory
+
+### 4.1 Backend
+
+```
+backend/src/main/java/com/slparcelauctions/backend/
+├── config/
+│   ├── SecurityConfig.java                          (MODIFY: permit /ws/**)
+│   └── WebSocketConfig.java                         (CREATE)
+├── auth/
+│   └── JwtChannelInterceptor.java                   (CREATE)
+└── wstest/                                          (CREATE — new package, dev/test profile only)
+    ├── WsTestController.java                        (CREATE)
+    └── dto/
+        └── WsTestBroadcastRequest.java              (CREATE — record DTO)
+
+backend/src/test/java/com/slparcelauctions/backend/
+├── auth/
+│   └── JwtChannelInterceptorTest.java               (CREATE — unit)
+└── wstest/
+    └── WsTestIntegrationTest.java                   (CREATE — @SpringBootTest, real STOMP client)
+```
+
+### 4.2 Frontend
+
+```
+frontend/src/
+├── lib/
+│   ├── auth/
+│   │   ├── refresh.ts                               (CREATE — extracted stampede guard)
+│   │   └── refresh.test.ts                          (CREATE — canary: stampede dedup, failure reset)
+│   ├── api.ts                                       (MODIFY: consume lib/auth/refresh)
+│   └── ws/                                          (CREATE — new directory)
+│       ├── client.ts                                (CREATE — singleton Client, ref counting, state machine)
+│       ├── client.test.ts                           (CREATE — unit tests w/ mocked @stomp/stompjs)
+│       ├── hooks.ts                                 (CREATE — useStompSubscription, useConnectionState)
+│       ├── hooks.test.tsx                           (CREATE — hook tests)
+│       └── types.ts                                 (CREATE — ConnectionState, Message<T>)
+└── app/
+    └── dev/
+        └── ws-test/
+            └── page.tsx                             (CREATE — NODE_ENV guard + four-zone harness)
+```
+
+## 5. Backend Detailed Design
+
+### 5.1 `WebSocketConfig`
+
+```java
+package com.slparcelauctions.backend.config;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final JwtChannelInterceptor jwtChannelInterceptor;
+
+    @Value("${cors.allowed-origin:http://localhost:3000}")
+    private String allowedOrigin;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // Simple in-memory broker for /topic (broadcast) destinations.
+        // Epic 04 may swap to a relayed broker (RabbitMQ STOMP plugin) when
+        // we need cross-instance fanout; for now single-instance in-memory is
+        // sufficient.
+        registry.enableSimpleBroker("/topic");
+        // Prefix for messages bound for @MessageMapping handlers. Unused in
+        // 01-09 — the test controller uses REST + SimpMessagingTemplate —
+        // but set here so Epic 04 can @MessageMapping("/bid") without
+        // reconfiguring.
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+            .setAllowedOrigins(allowedOrigin)
+            .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(jwtChannelInterceptor);
+    }
+}
+```
+
+**Why `.setAllowedOrigins()` on the endpoint:** Spring's STOMP endpoint CORS is configured separately from the main `HttpSecurity` CORS source. Forgetting this produces a 403 on the SockJS handshake XHR with a confusing "CORS policy: No 'Access-Control-Allow-Origin' header is present" message even though `SecurityConfig` has CORS set.
+
+**Why in-memory broker instead of a relayed broker:** YAGNI. Single-instance dev and the Phase 1 topology don't need relayed STOMP. Leaving a comment so the Epic 04 implementer doesn't need to rediscover.
+
+### 5.2 `JwtChannelInterceptor`
+
+```java
+package com.slparcelauctions.backend.auth;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtChannelInterceptor implements ChannelInterceptor {
+
+    private final JwtService jwtService;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor =
+            MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor == null || !StompCommand.CONNECT.equals(accessor.getCommand())) {
+            // Only gate CONNECT frames. SUBSCRIBE/SEND/DISCONNECT etc. flow
+            // through unchanged — the user is already attached to the session
+            // via accessor.setUser() from the earlier CONNECT.
+            return message;
+        }
+
+        String authHeader = accessor.getFirstNativeHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            log.debug("STOMP CONNECT rejected: missing or non-Bearer Authorization header");
+            throw new MessagingException(message, "Missing or invalid Authorization header");
+        }
+
+        String token = authHeader.substring(7);
+        try {
+            AuthPrincipal principal = jwtService.parseAccessToken(token);
+            accessor.setUser(new StompAuthenticationToken(principal));
+            log.debug("STOMP CONNECT authenticated: userId={}", principal.userId());
+            return message;
+        } catch (TokenExpiredException | TokenInvalidException e) {
+            log.debug("STOMP CONNECT rejected: {}", e.getMessage());
+            throw new MessagingException(message, "Invalid or expired access token");
+        }
+    }
+}
+```
+
+**The `StompAuthenticationToken`** is a small wrapper implementing `java.security.Principal`:
+
+```java
+package com.slparcelauctions.backend.auth;
+
+public record StompAuthenticationToken(AuthPrincipal principal) implements Principal {
+    @Override
+    public String getName() {
+        return String.valueOf(principal.userId());
+    }
+}
+```
+
+It exists so Spring's `SimpMessagingTemplate.convertAndSendToUser(principal.getName(), ...)` can find user-scoped destinations later. Epic 04 may use this for per-user notifications. For 01-09, it's just the Principal handle.
+
+**Why throw `MessagingException`:** locked in Q3a-i. Spring's STOMP infrastructure catches this and sends an `ERROR` frame back to the client, then closes the session cleanly. The frontend's `onStompError` handler picks up the error and surfaces it.
+
+**Why `getFirstNativeHeader`:** STOMP headers come through as a `MultiValueMap<String, String>`. `getFirstNativeHeader` is the idiomatic single-value read; `getHeader` reads Spring-internal headers, not STOMP client headers, and returns null for `Authorization`. Footgun candidate — see §11.1.
+
+### 5.3 `SecurityConfig` modification
+
+Add one matcher **above** `/api/**`:
+
+```java
+.authorizeHttpRequests(auth -> auth
+    .requestMatchers(HttpMethod.GET, "/api/health").permitAll()
+    .requestMatchers(
+        "/api/auth/register",
+        "/api/auth/login",
+        "/api/auth/refresh",
+        "/api/auth/logout"
+    ).permitAll()
+    .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
+    .requestMatchers(HttpMethod.GET, "/api/users/me").authenticated()
+    .requestMatchers(HttpMethod.GET, "/api/users/{id}").permitAll()
+    .requestMatchers("/api/auth/logout-all").authenticated()
+    // WebSocket handshake is permitted at the HTTP layer.
+    // Authentication happens at the STOMP CONNECT frame via JwtChannelInterceptor.
+    // See FOOTGUNS §F.16 (to be added in this task).
+    .requestMatchers("/ws/**").permitAll()
+    .requestMatchers("/api/**").authenticated()
+    .anyRequest().denyAll())
+```
+
+**CORS update:** the existing `corsConfigurationSource()` uses `setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"))`. SockJS's info endpoint issues OPTIONS preflights, which is already allowed. No CORS change needed beyond the endpoint-level `.setAllowedOrigins()` in `WebSocketConfig`.
+
+### 5.4 `WsTestController` (dev/test profile only)
+
+```java
+package com.slparcelauctions.backend.wstest;
+
+@RestController
+@RequestMapping("/api/ws-test")
+@RequiredArgsConstructor
+@Profile({"dev", "test"})
+@Slf4j
+public class WsTestController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @PostMapping("/broadcast")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void broadcast(
+            @Valid @RequestBody WsTestBroadcastRequest request,
+            @AuthenticationPrincipal AuthPrincipal principal) {
+        log.info("WS test broadcast from userId={}: {}", principal.userId(), request.message());
+        messagingTemplate.convertAndSend("/topic/ws-test",
+            Map.of(
+                "message", request.message(),
+                "senderId", principal.userId(),
+                "timestamp", Instant.now().toString()
+            ));
+    }
+}
+```
+
+**DTO:**
+
+```java
+package com.slparcelauctions.backend.wstest.dto;
+
+public record WsTestBroadcastRequest(
+    @NotBlank @Size(max = 500) String message
+) {}
+```
+
+**Why `@Profile({"dev", "test"})`:** the controller and its package are absent from the prod bean graph. No SecurityConfig matcher needed to block it in prod — there's nothing to block. `dev` covers `application-dev.yml` runs; `test` covers `@SpringBootTest` integration tests (see §11.2).
+
+**Authentication requirement:** the broadcast endpoint is on `/api/ws-test/**`, which falls under the `/api/**` authenticated catch-all in `SecurityConfig`. Only authenticated users can trigger broadcasts, which is what we want — the test harness proves end-to-end auth, not open broadcast.
+
+## 6. Frontend Detailed Design
+
+### 6.1 Dependencies
+
+Add to `frontend/package.json`:
+
+```json
+{
+  "dependencies": {
+    "@stomp/stompjs": "^7.1.1"
+  }
+}
+```
+
+**Why `@stomp/stompjs` v7:** industry-standard STOMP client for browsers. Version 7 dropped the legacy SockJS hard dependency and introduced explicit `webSocketFactory` config, which is what we want — we'll pass a `SockJS` factory explicitly.
+
+Also add SockJS:
+
+```json
+{
+  "dependencies": {
+    "sockjs-client": "^1.6.1"
+  },
+  "devDependencies": {
+    "@types/sockjs-client": "^1.5.4"
+  }
+}
+```
+
+**Why SockJS:** browser native WebSocket is 95%+ supported, but corporate proxies sometimes strip WS upgrades. SockJS falls back to XHR long-polling in that case. The backend config enables `.withSockJS()` regardless; the frontend matches.
+
+### 6.2 `lib/auth/refresh.ts` — Extracted Stampede Guard
+
+**New file** (extracted from `lib/api.ts`):
+
+```typescript
+/**
+ * Shared refresh-token stampede guard. Both the HTTP 401 interceptor
+ * (lib/api.ts) and the STOMP beforeConnect hook (lib/ws/client.ts) call
+ * ensureFreshAccessToken() — a single in-flight promise dedupes concurrent
+ * refresh attempts from either source.
+ *
+ * The finally clause that clears inFlightRefresh MUST live inside the IIFE,
+ * not outside the Promise chain. See FOOTGUNS §F.4 and §F.17.
+ */
+import type { QueryClient } from "@tanstack/react-query";
+import { setAccessToken } from "./session";
+import type { AuthUser } from "./session";
+
+let queryClientRef: QueryClient | null = null;
+let inFlightRefresh: Promise<string> | null = null;
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
+const SESSION_QUERY_KEY = ["auth", "session"] as const;
+
+type RefreshResponse = { accessToken: string; user: AuthUser };
+
+export class RefreshFailedError extends Error {
+  readonly status: number;
+  constructor(status: number) {
+    super(`Refresh failed with status ${status}`);
+    this.name = "RefreshFailedError";
+    this.status = status;
+  }
+}
+
+export function configureRefresh(queryClient: QueryClient): void {
+  queryClientRef = queryClient;
+}
+
+/**
+ * Refreshes the access token, deduping concurrent callers onto a single
+ * in-flight promise. Returns the new access token string. On failure, clears
+ * the in-memory access token and the session query cache, then throws
+ * RefreshFailedError.
+ *
+ * Callers that need to handle redirect-to-login (HTTP 401 interceptor) do so
+ * after catching RefreshFailedError.
+ */
+export async function ensureFreshAccessToken(): Promise<string> {
+  if (inFlightRefresh) return inFlightRefresh;
+
+  inFlightRefresh = (async () => {
+    try {
+      const response = await fetch(`${BASE_URL}/api/auth/refresh`, {
+        method: "POST",
+        credentials: "include",
+      });
+
+      if (!response.ok) {
+        setAccessToken(null);
+        if (queryClientRef) {
+          queryClientRef.setQueryData(SESSION_QUERY_KEY, null);
+        }
+        throw new RefreshFailedError(response.status);
+      }
+
+      const body = (await response.json()) as RefreshResponse;
+      setAccessToken(body.accessToken);
+      if (queryClientRef) {
+        queryClientRef.setQueryData(SESSION_QUERY_KEY, body.user);
+      }
+      return body.accessToken;
+    } finally {
+      inFlightRefresh = null;
+    }
+  })();
+
+  return inFlightRefresh;
+}
+
+// Test-only reset (exported under a deliberately-ugly name so production code
+// doesn't call it). Unit tests reset module state between cases.
+export function __resetRefreshStateForTests(): void {
+  inFlightRefresh = null;
+  queryClientRef = null;
+}
+```
+
+**Design notes:**
+- **Returns the new access token** rather than `void`. The old `lib/api.ts` version didn't need to return anything because the retry read from `getAccessToken()` after the refresh ran. The new version returns the token so STOMP's `beforeConnect` can plug it directly into `connectHeaders.Authorization` without a second `getAccessToken()` call. Small ergonomic win.
+- **`RefreshFailedError`** is a new named exception. The HTTP 401 interceptor catches it, clears session, redirects to `/login?next=...`. STOMP `beforeConnect` catches it and lets stompjs error out (`onStompError` eventually surfaces it via ConnectionState).
+- **`configureRefresh(queryClient)`** replaces the existing `configureApiClient(queryClient)` role. `lib/api.ts` will delegate: `configureApiClient` is kept as a thin wrapper that calls `configureRefresh` for backwards compatibility with `app/providers.tsx`, OR `providers.tsx` is updated to call `configureRefresh` directly. We'll pick the simpler path in the plan — `providers.tsx` updates.
+- **`__resetRefreshStateForTests`** — only consumed by `refresh.test.ts`. The double-underscore prefix signals don't-ship-this-in-consumer-code.
+
+### 6.3 `lib/api.ts` — Consumes The Shared Guard
+
+The existing `handleUnauthorized<T>` IIFE is deleted. In its place:
+
+```typescript
+import { ensureFreshAccessToken, RefreshFailedError } from "@/lib/auth/refresh";
+
+async function handleUnauthorized<T>(path: string, options: RequestOptions): Promise<T> {
+  try {
+    await ensureFreshAccessToken();
+  } catch (e) {
+    if (e instanceof RefreshFailedError) {
+      if (typeof window !== "undefined") {
+        const next = encodeURIComponent(window.location.pathname + window.location.search);
+        window.location.href = `/login?next=${next}`;
+      }
+      const problem: ProblemDetail = { status: 401, title: "Session expired" };
+      throw new ApiError(problem);
+    }
+    throw e;
+  }
+  return request<T>(path, options, /* isRetry */ true);
+}
+```
+
+The `inFlightRefresh` and `queryClientRef` module-level vars in `lib/api.ts` are removed. `configureApiClient(queryClient)` is either deleted or becomes a one-line passthrough to `configureRefresh(queryClient)` — the plan will pick one. The existing `api.401-interceptor.test.tsx` canary still passes because `ensureFreshAccessToken` implements the same contract the inlined IIFE did.
+
+### 6.4 `lib/ws/client.ts` — Singleton Connection Manager
+
+**Full file sketch** (exact code lives in the plan):
+
+```typescript
+"use client";
+
+import { Client, type IMessage, type StompSubscription } from "@stomp/stompjs";
+import SockJS from "sockjs-client";
+import { ensureFreshAccessToken, RefreshFailedError } from "@/lib/auth/refresh";
+import type { ConnectionState, StompMessage, Unsubscribe } from "./types";
+
+const WS_URL = process.env.NEXT_PUBLIC_WS_URL ?? "http://localhost:8080/ws";
+const DISCONNECT_GRACE_MS = 5_000;
+
+let client: Client | null = null;
+let subscriberCount = 0;
+let disconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let connectionState: ConnectionState = { status: "disconnected" };
+const stateListeners = new Set<(state: ConnectionState) => void>();
+let lastError: string | null = null;
+
+function setState(next: ConnectionState): void {
+  connectionState = next;
+  for (const listener of stateListeners) listener(next);
+}
+
+export function getConnectionState(): ConnectionState {
+  return connectionState;
+}
+
+export function subscribeToConnectionState(
+  listener: (state: ConnectionState) => void
+): Unsubscribe {
+  stateListeners.add(listener);
+  // Fire immediately with current state so consumers have something to render.
+  listener(connectionState);
+  return () => {
+    stateListeners.delete(listener);
+  };
+}
+
+function getOrCreateClient(): Client {
+  if (client) return client;
+
+  client = new Client({
+    webSocketFactory: () => new SockJS(WS_URL),
+    reconnectDelay: 5_000,
+    heartbeatIncoming: 10_000,
+    heartbeatOutgoing: 10_000,
+    beforeConnect: async () => {
+      if (!client) return;
+      setState({ status: "connecting" });
+      try {
+        const token = await ensureFreshAccessToken();
+        client.connectHeaders = { Authorization: `Bearer ${token}` };
+      } catch (e) {
+        lastError = e instanceof RefreshFailedError
+          ? "Session expired — please sign in again"
+          : "Could not refresh access token";
+        // Let stompjs continue — it will fail CONNECT with a clear ERROR frame
+        // which we surface via onStompError.
+      }
+    },
+    onConnect: () => {
+      lastError = null;
+      setState({ status: "connected" });
+    },
+    onWebSocketClose: () => {
+      // If auto-reconnect is active (client.active === true), we're about to
+      // retry. Otherwise we've been fully stopped.
+      if (client?.active) {
+        setState({ status: "reconnecting" });
+      } else {
+        setState({ status: "disconnected" });
+      }
+    },
+    onStompError: (frame) => {
+      lastError = frame.headers["message"] ?? "STOMP error";
+      setState({ status: "error", detail: lastError });
+    },
+  });
+
+  return client;
+}
+
+export function subscribe<T>(
+  destination: string,
+  onMessage: (payload: T) => void
+): Unsubscribe {
+  const c = getOrCreateClient();
+  subscriberCount += 1;
+
+  // Cancel any pending teardown — a new subscriber re-activates the connection.
+  if (disconnectTimer) {
+    clearTimeout(disconnectTimer);
+    disconnectTimer = null;
+  }
+
+  if (!c.active) {
+    c.activate();
+  }
+
+  // If the client isn't connected yet, stompjs queues the subscription until
+  // onConnect. No manual deferral needed — the library handles it.
+  let stompSub: StompSubscription | null = null;
+
+  const attach = () => {
+    stompSub = c.subscribe(destination, (frame: IMessage) => {
+      try {
+        const parsed = JSON.parse(frame.body) as T;
+        onMessage(parsed);
+      } catch (err) {
+        console.error(
+          `[ws] Failed to parse message body on ${destination}:`,
+          err,
+          frame.body
+        );
+      }
+    });
+  };
+
+  if (c.connected) {
+    attach();
+  } else {
+    // Defer until onConnect. Stompjs does not auto-subscribe pending callbacks
+    // in all paths for v7, so we register an onConnect hook-of-hooks via
+    // publish + subscribe on the connection state.
+    const stateUnsub = subscribeToConnectionState((state) => {
+      if (state.status === "connected") {
+        attach();
+        stateUnsub();
+      }
+    });
+  }
+
+  return () => {
+    if (stompSub) stompSub.unsubscribe();
+    subscriberCount = Math.max(0, subscriberCount - 1);
+    if (subscriberCount === 0) {
+      scheduleTeardown();
+    }
+  };
+}
+
+function scheduleTeardown(): void {
+  if (disconnectTimer) return;
+  disconnectTimer = setTimeout(() => {
+    disconnectTimer = null;
+    if (subscriberCount === 0 && client) {
+      client.deactivate();
+      setState({ status: "disconnected" });
+    }
+  }, DISCONNECT_GRACE_MS);
+}
+
+// Manual controls for the /dev/ws-test page's "Disconnect" / "Reconnect" buttons.
+// Consumers should NOT use these in production code — they bypass the reference
+// counting and can leave other subscribers stranded.
+export function __devForceDisconnect(): void {
+  if (client?.active) client.deactivate();
+  setState({ status: "disconnected" });
+}
+
+export function __devForceReconnect(): void {
+  const c = getOrCreateClient();
+  if (!c.active) c.activate();
+}
+
+// Test-only reset.
+export function __resetWsClientForTests(): void {
+  if (client) client.deactivate();
+  client = null;
+  subscriberCount = 0;
+  if (disconnectTimer) {
+    clearTimeout(disconnectTimer);
+    disconnectTimer = null;
+  }
+  stateListeners.clear();
+  connectionState = { status: "disconnected" };
+  lastError = null;
+}
+```
+
+**Why the subscribe-before-connected deferral via `subscribeToConnectionState`:** the stompjs `Client.subscribe()` method only works when `client.connected === true`. Calling it before connect throws. Rather than maintaining our own pending-queue, we reuse the ConnectionState observer to fire the subscribe exactly when `onConnect` runs. Self-unsubscribes the state listener to avoid leak.
+
+**`DISCONNECT_GRACE_MS = 5_000`** as a named constant per Q5b.
+
+**Why `__devForce*` exports:** the test page needs manual disconnect/reconnect buttons to exercise reconnection without `kill -9`-ing the backend. Ugly names so Epic 04 implementers don't accidentally reach for them.
+
+### 6.5 `lib/ws/types.ts`
+
+```typescript
+export type ConnectionState =
+  | { status: "disconnected" }
+  | { status: "connecting" }
+  | { status: "connected" }
+  | { status: "reconnecting" }
+  | { status: "error"; detail: string };
+
+export type Unsubscribe = () => void;
+
+// Re-exported for consumers who want to type their payload.
+export type StompMessage<T> = T;
+```
+
+Discriminated union — consumers `switch(state.status)` and TypeScript narrows. The `error` variant carries the detail string.
+
+### 6.6 `lib/ws/hooks.ts`
+
+```typescript
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { subscribe, subscribeToConnectionState, getConnectionState } from "./client";
+import type { ConnectionState, Unsubscribe } from "./types";
+
+export function useConnectionState(): ConnectionState {
+  const [state, setState] = useState<ConnectionState>(() => getConnectionState());
+  useEffect(() => subscribeToConnectionState(setState), []);
+  return state;
+}
+
+export function useStompSubscription<T>(
+  destination: string,
+  onMessage: (payload: T) => void
+): void {
+  // Stable-callback guard via ref — avoids re-subscribing on every render when
+  // consumers pass an inline arrow function. Classic React pattern.
+  const callbackRef = useRef(onMessage);
+  callbackRef.current = onMessage;
+
+  useEffect(() => {
+    const unsubscribe: Unsubscribe = subscribe<T>(destination, (payload) => {
+      callbackRef.current(payload);
+    });
+    return unsubscribe;
+  }, [destination]);
+}
+```
+
+**Why `useRef` for the callback:** passing `onMessage` as a dependency to `useEffect` would re-subscribe every render. Storing the current callback in a ref and reading `callbackRef.current` inside the subscription means the subscription survives re-renders while always dispatching to the latest callback.
+
+### 6.7 `app/dev/ws-test/page.tsx` — Four-Zone Test Harness
+
+```tsx
+import { notFound } from "next/navigation";
+import { WsTestHarness } from "@/components/dev/WsTestHarness";
+
+export default function WsTestPage() {
+  // Route 404s in production — /dev/** is a development-only surface.
+  if (process.env.NODE_ENV === "production") {
+    notFound();
+  }
+  return <WsTestHarness />;
+}
+```
+
+The harness itself lives in `components/dev/WsTestHarness.tsx` (client component) so the page file stays thin:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { useConnectionState, useStompSubscription } from "@/lib/ws/hooks";
+import { __devForceDisconnect, __devForceReconnect } from "@/lib/ws/client";
+import { api } from "@/lib/api";
+
+type WsTestMessage = { message: string; senderId: number; timestamp: string };
+
+export function WsTestHarness() {
+  const state = useConnectionState();
+  const [messages, setMessages] = useState<WsTestMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+
+  useStompSubscription<WsTestMessage>("/topic/ws-test", (payload) => {
+    setMessages((prev) => [payload, ...prev].slice(0, 50));
+  });
+
+  const sendBroadcast = async () => {
+    if (!input.trim()) return;
+    setSending(true);
+    try {
+      await api.post("/api/ws-test/broadcast", { message: input });
+      setInput("");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto max-w-3xl p-8">
+      <h1 className="text-2xl font-semibold text-on-surface">WebSocket Test Harness</h1>
+      <p className="mt-2 text-on-surface-variant">
+        Dev-only page for verifying the STOMP pipe. Will 404 in production builds.
+      </p>
+
+      {/* Zone 1: connection status */}
+      <ConnectionBadge state={state} />
+
+      {/* Zone 4: manual controls */}
+      <div className="mt-4 flex gap-2">
+        <button onClick={__devForceDisconnect} className="...">Force Disconnect</button>
+        <button onClick={__devForceReconnect} className="...">Force Reconnect</button>
+      </div>
+
+      {/* Zone 2: broadcast form */}
+      <form onSubmit={(e) => { e.preventDefault(); sendBroadcast(); }} className="mt-6">
+        <label className="...">Send test message</label>
+        <input value={input} onChange={(e) => setInput(e.target.value)} className="..." />
+        <button type="submit" disabled={sending || !input.trim()}>Send</button>
+      </form>
+
+      {/* Zone 3: received messages log */}
+      <section className="mt-8">
+        <h2 className="text-lg font-medium text-on-surface">Received ({messages.length})</h2>
+        <ol className="mt-2 space-y-2">
+          {messages.map((m, i) => (
+            <li key={`${m.timestamp}-${i}`} className="...">
+              <span className="font-mono text-xs text-on-surface-variant">{m.timestamp}</span>
+              <p className="text-on-surface">{m.message}</p>
+              <span className="text-xs text-on-surface-variant">from userId {m.senderId}</span>
+            </li>
+          ))}
+        </ol>
+      </section>
+    </main>
+  );
+}
+
+function ConnectionBadge({ state }: { state: ConnectionState }) {
+  // Renders a colored badge + label based on state.status.
+  // "error" variant shows state.detail inline.
+  // ...
+}
+```
+
+**DESIGN.md conformance:** the harness is a dev tool, not a user-facing surface, so we relax the strict design-system requirements. It should still use the token-based Tailwind classes (no hex, no inline styles) to stay lint-clean. No `border-t` (No-Line Rule). Plain structure — we're debugging, not shipping.
+
+## 7. STOMP CONNECT Authentication Flow
+
+Sequence for a first-time connection:
+
+```
+Browser                          Backend
+   │                                │
+   │ HTTP POST /ws/info (SockJS)    │
+   │───────────────────────────────▶│
+   │                                │ Spring Security: /ws/** permitAll
+   │◀───────────────────────────────│ (no auth check at HTTP layer)
+   │                                │
+   │ HTTP upgrade /ws/xxx/yyy       │
+   │───────────────────────────────▶│
+   │◀───────────────────────────────│ 101 Switching Protocols
+   │                                │
+   │                                │ --- WS open, client.beforeConnect fires ---
+   │                                │
+   │ beforeConnect:                 │
+   │   ensureFreshAccessToken()     │
+   │ ───────────────────────────────│
+   │ POST /api/auth/refresh         │
+   │ (Cookie: refreshToken=...)     │
+   │───────────────────────────────▶│
+   │◀───────────────────────────────│ 200 { accessToken, user }
+   │                                │
+   │ connectHeaders.Authorization   │
+   │   = "Bearer " + token          │
+   │                                │
+   │ STOMP CONNECT                  │
+   │ Authorization: Bearer eyJ...   │
+   │───────────────────────────────▶│
+   │                                │ JwtChannelInterceptor.preSend()
+   │                                │  - read Authorization
+   │                                │  - jwtService.parseAccessToken()
+   │                                │  - accessor.setUser(principal)
+   │                                │
+   │◀───────────────────────────────│ STOMP CONNECTED
+   │                                │
+   │ SUBSCRIBE /topic/ws-test       │
+   │───────────────────────────────▶│
+   │                                │ JwtChannelInterceptor.preSend()
+   │                                │  - not a CONNECT frame, pass through
+   │◀───────────────────────────────│ RECEIPT (implicit)
+```
+
+**Failure paths:**
+- **Refresh fails in `beforeConnect`:** `ensureFreshAccessToken` throws `RefreshFailedError`, we catch it and store `lastError`. stompjs proceeds without an `Authorization` header. CONNECT frame arrives at interceptor with no header → interceptor throws `MessagingException` → client sees `ERROR` frame → `onStompError` fires → `setState({status:"error", detail})` → harness shows error. User has already been redirected to `/login` by the HTTP interceptor's own `RefreshFailedError` catch IF an HTTP request happened in parallel. If WS was the only in-flight consumer, we rely on the `onStompError` surface for now — Epic 04 may add an auth-specific redirect from the WS layer.
+- **Interceptor throws invalid-token:** same — CONNECT gets ERROR frame. `onStompError` sets state to error.
+
+## 8. Reconnection Flow
+
+Stompjs auto-reconnects on WebSocket close with `reconnectDelay: 5_000`. Every reconnect attempt re-runs `beforeConnect`, which re-runs `ensureFreshAccessToken()`, which serves a fresh token. Fresh token → fresh CONNECT auth → success.
+
+```
+t=0     WS connected, happy path
+t=T     backend restart, WS closes
+t=T     onWebSocketClose fires, state → "reconnecting"
+t=T+5s  stompjs retry #1
+        beforeConnect → ensureFreshAccessToken → /api/auth/refresh → new token
+        CONNECT with new token → CONNECTED
+        onConnect fires, state → "connected"
+        stompjs re-sends pending subscriptions
+```
+
+If the backend stays down beyond the access token lifetime (15 min), the refresh cookie still works (7 days), so the next successful reconnect gets a new access token and resumes cleanly. The only unrecoverable state is refresh-cookie expiry or user logout-all — both surface as a failed refresh → `RefreshFailedError` → harness error state.
+
+## 9. Token Refresh Model
+
+**Two sources of refresh:**
+1. HTTP 401 interceptor (existing, unchanged behavior, now delegates to `ensureFreshAccessToken`).
+2. STOMP `beforeConnect` (new).
+
+**Single in-flight promise** guarded by `inFlightRefresh` in `lib/auth/refresh.ts`. If HTTP 401 and STOMP reconnect both hit at the same moment, they await the same promise. The `finally` clause that nulls `inFlightRefresh` lives inside the IIFE (not outside the return) — this is the FOOTGUNS §F.4 invariant, restated in §F.17 for the extracted module.
+
+**Invariants:**
+- `ensureFreshAccessToken()` called N times concurrently ⇒ exactly one `POST /api/auth/refresh`.
+- On success, `setAccessToken(newToken)` fires exactly once, and the resolved promise value is the new token.
+- On failure, `setAccessToken(null)` + `setQueryData(null)` fire exactly once, and `RefreshFailedError` is thrown. `inFlightRefresh` is nulled so the next caller can retry fresh (not stuck on the rejected promise forever).
+
+## 10. Configuration
+
+### 10.1 Backend `application-dev.yml`
+
+No changes. The `dev` profile activates `WsTestController` automatically via `@Profile`.
+
+### 10.2 Backend `application.yml` (shared)
+
+No changes. `cors.allowed-origin` already set.
+
+### 10.3 Frontend environment
+
+Add one env var to `frontend/.env.local.example` (creating it if missing):
+
+```
+NEXT_PUBLIC_API_URL=http://localhost:8080
+NEXT_PUBLIC_WS_URL=http://localhost:8080/ws
+```
+
+**Why a separate `NEXT_PUBLIC_WS_URL`:** in production the WS endpoint may live behind a different origin or subpath (e.g., `wss://realtime.slpa.example.com/ws` while API is at `https://api.slpa.example.com`). Splitting the vars now is cheap and avoids a rename later.
+
+### 10.4 `app/providers.tsx` update
+
+Replace the current `configureApiClient(queryClient)` call with `configureRefresh(queryClient)` (or keep the old name as a passthrough — the plan will pick one). No other provider changes needed.
+
+## 11. Testing Strategy
+
+Four test suites corresponding to Q7a-d.
+
+### 11.1 `JwtChannelInterceptorTest` — Backend Unit
+
+**Location:** `backend/src/test/java/com/slparcelauctions/backend/auth/JwtChannelInterceptorTest.java`
+
+**Setup:**
+- Mockito mock for `JwtService`.
+- Direct interceptor instantiation — no Spring context.
+
+**Test cases:**
+
+1. `preSend_nonConnectFrame_passesThrough` — SEND frame with no `Authorization` returns the message unchanged, interceptor never touches the accessor user.
+2. `preSend_connectFrame_missingAuthHeader_throwsMessagingException` — verify exception message contains "Missing or invalid Authorization header".
+3. `preSend_connectFrame_malformedBearerHeader_throwsMessagingException` — header is `"NotBearer foo"`; same exception.
+4. `preSend_connectFrame_validToken_attachesPrincipal` — mock `jwtService.parseAccessToken(token)` returns an `AuthPrincipal(42L, "test@example.com", 1L)`. Assert `accessor.getUser()` is a `StompAuthenticationToken` whose `.getName()` is `"42"`.
+5. `preSend_connectFrame_expiredToken_throwsMessagingException` — mock throws `TokenExpiredException`, assert `MessagingException` propagated.
+6. `preSend_connectFrame_invalidToken_throwsMessagingException` — mock throws `TokenInvalidException`.
+
+**Why it matters:** these six cases pin every branch of the interceptor logic. A future refactor breaking any branch fails here before it ever reaches an integration test.
+
+### 11.2 `WsTestIntegrationTest` — Backend End-to-End
+
+**Location:** `backend/src/test/java/com/slparcelauctions/backend/wstest/WsTestIntegrationTest.java`
+
+**Setup:**
+- `@SpringBootTest(webEnvironment = RANDOM_PORT)`
+- `@ActiveProfiles("test")` — activates `WsTestController`.
+- `@Autowired` real `JwtService`, `TestRestTemplate`.
+- Use Spring's `WebSocketStompClient` with `SockJsClient`.
+
+**Test cases:**
+
+1. `stompConnectWithValidToken_receivesBroadcast` — (a) issue a JWT via `jwtService.issueAccessToken(principal)`, (b) connect via `WebSocketStompClient` with `connectHeaders.Authorization: Bearer {jwt}`, (c) subscribe to `/topic/ws-test` with a `BlockingQueue<WsTestMessage>` handler, (d) POST to `/api/ws-test/broadcast` with `Authorization: Bearer {jwt}`, (e) `queue.poll(2, SECONDS)` returns the broadcast message with matching content. **This is the single test that proves the entire pipe works end-to-end.**
+2. `stompConnectWithoutToken_isRejected` — connect with no `Authorization` in `connectHeaders`. Assert the session transitions to error / closed within a timeout.
+3. `stompConnectWithInvalidToken_isRejected` — connect with `Authorization: Bearer not-a-real-jwt`. Same assertion.
+
+**Why it matters:** this is the smoke test for the `SecurityConfig` permitlist, the CORS config, the interceptor wiring, the broker registry, and the test profile gating — all at once. If any one of those is wrong, at least one of the three tests fails with a loud, diagnosable message.
+
+**Why `@ActiveProfiles("test")`:** `WsTestController` is `@Profile({"dev", "test"})`. The integration test needs the bean in the graph.
+
+### 11.3 `lib/ws/client.test.ts` — Frontend Client Unit
+
+**Setup:**
+- `vi.mock("@stomp/stompjs")` returns a stub `Client` class whose methods (`activate`, `deactivate`, `subscribe`, etc.) are `vi.fn()`. The mock exposes the captured `beforeConnect`/`onConnect`/`onWebSocketClose`/`onStompError` callbacks so tests can trigger them manually.
+- `vi.mock("@/lib/auth/refresh")` returns a mocked `ensureFreshAccessToken` returning a Promise we resolve manually per-test.
+- `__resetWsClientForTests()` runs in `beforeEach`.
+
+**Test cases:**
+
+1. `firstSubscribe_activatesClient` — call `subscribe("/topic/foo", cb)`. Assert `client.activate()` called once.
+2. `secondSubscribe_reusesClient` — two subscribes. Assert `activate()` called exactly once.
+3. `lastUnsubscribe_schedulesDisconnectWithGrace` — subscribe then unsubscribe. Assert `deactivate()` NOT called synchronously. Use `vi.useFakeTimers()` + `vi.advanceTimersByTime(5_000)`. Assert `deactivate()` called.
+4. `resubscribeWithinGrace_cancelsTeardown` — subscribe, unsubscribe, subscribe again within 4 seconds. Advance 6 seconds. Assert `deactivate()` never called.
+5. `beforeConnect_callsEnsureFreshAccessToken` — trigger the captured `beforeConnect`. Assert `ensureFreshAccessToken` called and `client.connectHeaders.Authorization` set to `"Bearer <returned-token>"`.
+6. `onConnect_transitionsStateToConnected` — subscribe to state via `subscribeToConnectionState`, trigger captured `onConnect`. Assert listener fired with `{status:"connected"}`.
+7. `onWebSocketClose_whileActive_transitionsToReconnecting` — simulate `client.active === true`, trigger `onWebSocketClose`. Assert state is `"reconnecting"`.
+8. `onStompError_transitionsToErrorWithDetail` — trigger `onStompError` with a frame carrying a `message` header. Assert state is `{status:"error", detail:"..."}`.
+9. `subscribe_beforeConnected_defersUntilOnConnect` — mock `client.connected === false` initially. Call `subscribe(...)`. Assert `client.subscribe` NOT called yet. Trigger `onConnect`. Assert `client.subscribe` called with the right destination.
+
+**Budget:** 9 tests. Scoped to the module's public API and state transitions. Does not test stompjs itself.
+
+### 11.4 `lib/auth/refresh.test.ts` — Stampede Canary
+
+**Setup:**
+- `vi.mock("global.fetch")` with a controllable response.
+- Mock `setAccessToken` via module mock on `@/lib/auth/session`.
+- `__resetRefreshStateForTests()` in `beforeEach`.
+
+**Test cases (three — locked as Q7d-i):**
+
+1. `singleCall_hitsBackendOnce_returnsToken` — mock fetch → 200 with `{ accessToken: "abc", user: {...} }`. Call `ensureFreshAccessToken()`. Assert fetch called once, returned value is `"abc"`, `setAccessToken("abc")` called.
+2. `threeConcurrentCalls_hitBackendOnce_allResolveSameToken` — fire three `ensureFreshAccessToken()` in parallel (`Promise.all`). Assert fetch called exactly once, all three resolve with the same token string.
+3. `failedRefresh_clearsInFlightAndRejects_nextCallRetries` — first fetch returns 401, assert `RefreshFailedError` thrown AND `setAccessToken(null)` called. Second call (after first rejected) — mock fetch to succeed — assert fetch called a SECOND time and returns the new token. This proves the `inFlightRefresh = null` finally runs on the reject path.
+
+**Why this canary is non-negotiable:** the extracted module is the only thing standing between "one refresh per auth failure" and "every hook independently slamming /api/auth/refresh", which would trip backend rate-limiting and desync the access token. Three tests, maybe 80 lines, catch every meaningful regression.
+
+### 11.5 `lib/ws/hooks.test.tsx` — Hook Tests
+
+**Budget:** 3 tests.
+1. `useConnectionState_rendersCurrentState_reactsToUpdates` — render a test component using the hook, call `setState(...)` on the underlying module via a spy, assert re-render.
+2. `useStompSubscription_subscribesOnMount_unsubscribesOnUnmount` — use RTL `render` + `unmount`. Assert subscribe returned closure was called on unmount.
+3. `useStompSubscription_stableCallbackAcrossRenders_doesNotResubscribe` — re-render with a new inline callback. Assert `subscribe` called exactly once.
+
+## 12. File Inventory
+
+### Create
+
+**Backend:**
+- `backend/src/main/java/com/slparcelauctions/backend/config/WebSocketConfig.java`
+- `backend/src/main/java/com/slparcelauctions/backend/auth/JwtChannelInterceptor.java`
+- `backend/src/main/java/com/slparcelauctions/backend/auth/StompAuthenticationToken.java`
+- `backend/src/main/java/com/slparcelauctions/backend/wstest/WsTestController.java`
+- `backend/src/main/java/com/slparcelauctions/backend/wstest/dto/WsTestBroadcastRequest.java`
+- `backend/src/test/java/com/slparcelauctions/backend/auth/JwtChannelInterceptorTest.java`
+- `backend/src/test/java/com/slparcelauctions/backend/wstest/WsTestIntegrationTest.java`
+
+**Frontend:**
+- `frontend/src/lib/auth/refresh.ts`
+- `frontend/src/lib/auth/refresh.test.ts`
+- `frontend/src/lib/ws/client.ts`
+- `frontend/src/lib/ws/client.test.ts`
+- `frontend/src/lib/ws/hooks.ts`
+- `frontend/src/lib/ws/hooks.test.tsx`
+- `frontend/src/lib/ws/types.ts`
+- `frontend/src/app/dev/ws-test/page.tsx`
+- `frontend/src/components/dev/WsTestHarness.tsx`
+- `frontend/.env.local.example` (if missing)
+
+**Docs:**
+- `docs/implementation/FOOTGUNS.md` — add §F.16, §F.17, §F.18, §F.19 (see §13 below).
+
+### Modify
+
+- `backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java` — add `/ws/**` permit rule above `/api/**`.
+- `frontend/src/lib/api.ts` — delete `inFlightRefresh`, `queryClientRef`, `handleUnauthorized` IIFE body. Delegate to `ensureFreshAccessToken` from `@/lib/auth/refresh`.
+- `frontend/src/app/providers.tsx` — replace `configureApiClient` call with `configureRefresh` (or keep name if plan chooses passthrough).
+- `frontend/package.json` — add `@stomp/stompjs`, `sockjs-client`, `@types/sockjs-client`.
+- `frontend/src/lib/api.401-interceptor.test.tsx` — verify it still passes against the delegated implementation. Should require zero production-code changes in the test file; the contract (`handleUnauthorized` catches refresh failure → redirect) is preserved.
+- `README.md` — document `/ws` endpoint and the dev test harness page per the auto-memory rule about per-task README sweeps.
+
+### Delete
+
+Nothing.
+
+## 13. FOOTGUNS Additions
+
+Four entries added to the frontend section at the end of the `§F` block. Numbers continue from the existing §F.15.
+
+### §F.16 WebSocket handshake is permitted at HTTP, authenticated at STOMP
+
+**Rule:** `SecurityConfig` must list `/ws/**` as `.permitAll()` above the `/api/**` authenticated catch-all. The HTTP-layer WebSocket upgrade does not carry an `Authorization` header from the browser, so gating it at the HTTP layer is impossible. Authentication happens in `JwtChannelInterceptor.preSend()` on the first STOMP `CONNECT` frame, before the session is usable. Do not "fix" the permit rule by adding `.authenticated()` — every WebSocket connection will fail with a bewildering 401 before the STOMP layer even sees the frame.
+
+**Why:** matcher order is first-match-wins (§B.5). `/ws/**` must appear above `/api/**`. Moving it down silently opens the WebSocket to any URL under `/ws/*` while keeping the behavior correct — this is not a real footgun until `/api/**` gets restructured, but the comment at the matcher codifies the invariant so the next person doesn't need to rediscover it.
+
+### §F.17 `ensureFreshAccessToken` stampede guard — `finally` inside the IIFE
+
+**Rule:** In `lib/auth/refresh.ts`, the `inFlightRefresh = null` cleanup MUST live inside the IIFE's `try { ... } finally { inFlightRefresh = null; }`, not after the outer promise chain. The shared promise between HTTP 401 interceptor and STOMP `beforeConnect` depends on this: if the cleanup runs outside the IIFE, every awaiter nulls the ref as they resolve, and a concurrent refresh kicked off during the resolution window sees `null` and fires a second `/api/auth/refresh`, defeating the stampede guard.
+
+**Why:** this is §F.4 restated for the extracted module. The HTTP 401 canary (`api.401-interceptor.test.tsx`) and the new `refresh.test.ts` canary both pin this behavior. If either test starts failing with "fetch called twice instead of once", the `finally` clause has been moved.
+
+**How to apply:** when touching `lib/auth/refresh.ts`, diff the `finally` placement. If code review ever proposes "flattening the IIFE for readability", reject it.
+
+### §F.18 `beforeConnect` must not throw — stash errors and let stompjs produce the ERROR frame
+
+**Rule:** In `lib/ws/client.ts`, the `beforeConnect` callback wraps `ensureFreshAccessToken` in try/catch. On `RefreshFailedError`, store the message in a module-level `lastError` ref and return normally — do NOT throw from `beforeConnect`. Stompjs treats a thrown `beforeConnect` as a catastrophic failure and either deactivates the client entirely or loops infinitely depending on version. Letting stompjs proceed with no `Authorization` header causes the interceptor to reject the CONNECT frame with an `ERROR` frame, which the client handles gracefully via `onStompError` and our `ConnectionState` machine.
+
+**Why:** the error path is "CONNECT frame arrives with no auth header → interceptor throws `MessagingException` → stompjs surfaces ERROR frame → `onStompError` fires → state becomes error(detail)". Any other path (throwing from `beforeConnect`, calling `deactivate` inside `beforeConnect`, etc.) breaks this contract and either deadlocks the client or hides the error from UI.
+
+**How to apply:** when reviewing `beforeConnect` changes, verify that the catch block only stores state, never throws or calls `client.deactivate()`.
+
+### §F.19 `@stomp/stompjs` `subscribe()` only works when `client.connected === true`
+
+**Rule:** `client.subscribe(destination, callback)` throws if called before the client is connected. Our `lib/ws/client.ts` handles this by deferring the actual `client.subscribe()` call until `onConnect` fires, via an inline `subscribeToConnectionState` listener that unsubscribes itself after one fire.
+
+**Why:** without the deferral, calling `useStompSubscription` during initial page load (before the WS handshake completes) throws a runtime error in the `subscribe()` consumer, which crashes the React tree. The deferral is ~6 lines but load-bearing — do not "simplify" it away.
+
+**How to apply:** any path that eagerly invokes `client.subscribe` must first check `client.connected`, and if false, defer via the state listener. This rule applies equally to Epic 04's auction-room subscription code.
+
+## 14. Out Of Scope (Epic 04 Followups)
+
+1. **Per-auction topic subscriptions** (`/topic/auction/{id}`). Naming convention is declared here; the actual subscriptions and `AuctionMessageHandler` live in Epic 04.
+2. **`@MessageMapping` application handlers.** The `/app` application destination prefix is configured in `WebSocketConfig` but no `@MessageMapping` handlers exist yet. Epic 04 adds bid submission via `/app/bid`.
+3. **Redis pub/sub session eviction on `tv` bump** (Q3d deferral). When bid placement flows through STOMP and the impact of a stale `tv` matters, Epic 04 adds Redis-driven session closure.
+4. **Multi-instance STOMP relay** (RabbitMQ / ActiveMQ). Single-instance in-memory broker is sufficient for Phase 1.
+5. **`WsTestController` removal.** The test harness ships with this task. A future task deletes `wstest/` package and `/dev/ws-test` page once Epic 04 auction-room subscriptions are stable enough to serve as the verification surface.
+6. **Frontend WS layer security review for auth redirect UX.** Currently a `RefreshFailedError` during `beforeConnect` surfaces as a generic error badge. Epic 04 may want to redirect to `/login?next=` from the WS layer itself, similar to the HTTP interceptor's current redirect. This task does not block on it because no production surface consumes the WS layer yet.
+
+## 15. Acceptance Criteria Mapping
+
+From `task-09-websocket-setup.md`:
+
+| Brief AC                                                                 | Covered by                                                                                 |
+|--------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
+| WebSocket connection establishes between frontend and backend            | §11.2 test 1 (STOMP integration), §11.3 test 6 (onConnect transition), manual /dev/ws-test |
+| Frontend can subscribe to a topic and receive messages                   | §11.2 test 1 (round-trip), §11.3 tests 1-2, §11.5 tests 1-3, manual /dev/ws-test           |
+| Connection requires a valid JWT (unauthenticated connections rejected)  | §11.1 tests 2-3, 5-6 (interceptor), §11.2 tests 2-3 (integration)                          |
+| Reconnection works after a brief disconnection                           | §11.3 tests 3-4 (grace/reconnect), §8 (reconnect flow), manual Force Disconnect button     |
+| Test topic proves messages flow from backend to frontend in real-time    | §11.2 test 1 (the load-bearing integration test) + manual /dev/ws-test page                |
+
+All five criteria are covered both by tests and by the manual verification harness.
+
+## 16. Risks and Mitigations
+
+| Risk                                                                                          | Mitigation                                                                                                                                                  |
+|------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SockJS handshake CORS error on first `/ws/info` XHR                                            | `WebSocketConfig.addEndpoint("/ws").setAllowedOrigins(allowedOrigin)` — §5.1. Tested implicitly in §11.2.                                                    |
+| `vi.mock("@stomp/stompjs")` leaks between tests and pollutes module state                      | `__resetWsClientForTests()` in `beforeEach`. Mirrors existing session state reset pattern. Covered in §11.3 setup.                                          |
+| Extracted `lib/auth/refresh.ts` breaks existing HTTP 401 canary                                | Run `api.401-interceptor.test.tsx` unchanged against the delegated implementation. The canary's contract is preserved because `handleUnauthorized` still catches refresh failure and performs the redirect. |
+| Backend integration test is flaky under CI load (2s timeout on `queue.poll`)                   | Pick a generous timeout (5s) in CI; 2s is fine locally. Document in the plan task's TDD step. Trivially tunable.                                           |
+| `beforeConnect` is an async callback and stompjs v7 may not await it in some edge paths        | v7.1+ fully awaits `beforeConnect`. Pinning `^7.1.1` in package.json guarantees the behavior. If a future upgrade breaks this, the canary will fail.       |
+| Next.js 16 RSC boundary: client-only modules imported from `app/dev/ws-test/page.tsx`          | The page.tsx is a Server Component that does `notFound()` in prod and renders `<WsTestHarness />` otherwise. `WsTestHarness` is `"use client"`. Clean split. |
+| `setAllowedOrigins` wildcard-vs-string pitfall (CORS + credentials = not-allowed wildcard)      | Use exact origin string from `application.yml`. Not a wildcard. See §5.1.                                                                                  |
+
+## 17. Self-Review Notes
+
+This section is the controller's own sanity check on the spec before handing off to `writing-plans`. It should be removed before commit if policy says so — leaving it here for now so the plan-writer can see the decisions at a glance.
+
+- **Placeholder scan:** no TBDs, no "implement later" placeholders. Every section either has full code or a specific enough description that the plan-writer can produce full code.
+- **Internal consistency:** §5 (backend modules), §6 (frontend modules), §11 (tests), §12 (file inventory) all list the same file paths. Cross-checked.
+- **Scope check:** single subsystem (WebSocket infra), single concern (JWT-authenticated STOMP pipe + verification harness). Not decomposable — the backend broker, the frontend client, and the test harness are interdependent and must ship together to prove anything.
+- **Ambiguity check:**
+  - "How does the frontend detect unauthenticated-WS-error vs other-STOMP-error?" — unified via `ConnectionState`'s `error` variant with `detail` string. Dev harness shows the detail inline. Epic 04 followup §14.6 noted.
+  - "Where does `configureRefresh` get called?" — `app/providers.tsx`, replacing existing `configureApiClient` call. Explicit in §12.
+  - "Does `useStompSubscription` handle destination changes?" — yes, via the `[destination]` dep array. `[]` would be a bug. Explicit in §6.6.

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,4 @@
+# Copy to .env.local for local development. Never commit .env.local.
+
+NEXT_PUBLIC_API_URL=http://localhost:8080
+NEXT_PUBLIC_WS_URL=http://localhost:8080/ws

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@headlessui/react": "^2.2.10",
         "@hookform/resolvers": "^3.10.0",
+        "@stomp/stompjs": "^7.3.0",
         "@tanstack/react-query": "^5.97.0",
         "clsx": "^2.1.1",
         "lucide-react": "^1.8.0",
@@ -18,6 +19,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-hook-form": "^7.72.1",
+        "sockjs-client": "^1.6.1",
         "tailwind-merge": "^3.5.0",
         "zod": "^3.25.76"
       },
@@ -29,6 +31,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/sockjs-client": "^1.5.4",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/ui": "^4.1.4",
         "eslint": "^9",
@@ -2075,6 +2078,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.3.0.tgz",
+      "integrity": "sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2597,6 +2606,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/sockjs-client": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/sockjs-client/-/sockjs-client-1.5.4.tgz",
+      "integrity": "sha512-zk+uFZeWyvJ5ZFkLIwoGA/DfJ+pYzcZ8eH4H/EILCm2OBZyHH6Hkdna1/UWL/CFruh5wj6ES7g75SvUB0VsH5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/statuses": {
       "version": "2.0.6",
@@ -4848,6 +4864,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4917,6 +4942,18 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/fflate": {
@@ -5366,6 +5403,12 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5412,6 +5455,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -6511,7 +6560,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/msw": {
@@ -7129,6 +7177,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7274,6 +7328,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -7421,6 +7481,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -7725,6 +7805,34 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/sockjs-client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
+        "inherits": "^2.0.4",
+        "url-parse": "^1.5.10"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
+      }
+    },
+    "node_modules/sockjs-client/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/source-map-js": {
@@ -8536,6 +8644,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -8762,6 +8880,29 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/whatwg-mimetype": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@headlessui/react": "^2.2.10",
     "@hookform/resolvers": "^3.10.0",
+    "@stomp/stompjs": "^7.3.0",
     "@tanstack/react-query": "^5.97.0",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",
@@ -27,6 +28,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-hook-form": "^7.72.1",
+    "sockjs-client": "^1.6.1",
     "tailwind-merge": "^3.5.0",
     "zod": "^3.25.76"
   },
@@ -38,6 +40,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/sockjs-client": "^1.5.4",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/ui": "^4.1.4",
     "eslint": "^9",

--- a/frontend/src/app/dev/ws-test/page.tsx
+++ b/frontend/src/app/dev/ws-test/page.tsx
@@ -1,0 +1,11 @@
+// frontend/src/app/dev/ws-test/page.tsx
+import { notFound } from "next/navigation";
+import { WsTestHarness } from "@/components/dev/WsTestHarness";
+
+export default function WsTestPage() {
+  // Route 404s in production — /dev/** is a development-only surface.
+  if (process.env.NODE_ENV === "production") {
+    notFound();
+  }
+  return <WsTestHarness />;
+}

--- a/frontend/src/components/dev/WsTestHarness.tsx
+++ b/frontend/src/components/dev/WsTestHarness.tsx
@@ -1,0 +1,171 @@
+// frontend/src/components/dev/WsTestHarness.tsx
+"use client";
+
+import { useState } from "react";
+import { api } from "@/lib/api";
+import { __devForceDisconnect, __devForceReconnect } from "@/lib/ws/client";
+import { useConnectionState, useStompSubscription } from "@/lib/ws/hooks";
+import type { ConnectionState } from "@/lib/ws/types";
+
+// senderId is a Java Long on the backend, serialized as a JSON number, which
+// parses to a plain JS number here. User IDs are well under 2^53 - 1. See
+// spec §5.4 for the wire-type explanation.
+type WsTestMessage = {
+  message: string;
+  senderId: number;
+  timestamp: string;
+};
+
+const MAX_MESSAGES = 50;
+
+export function WsTestHarness() {
+  const state = useConnectionState();
+  const [messages, setMessages] = useState<WsTestMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+
+  useStompSubscription<WsTestMessage>("/topic/ws-test", (payload) => {
+    setMessages((prev) => [payload, ...prev].slice(0, MAX_MESSAGES));
+  });
+
+  const sendBroadcast = async () => {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    setSending(true);
+    setSendError(null);
+    try {
+      await api.post("/api/ws-test/broadcast", { message: trimmed });
+      setInput("");
+    } catch (err) {
+      setSendError(err instanceof Error ? err.message : "Failed to send");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto max-w-3xl p-8">
+      <h1 className="text-2xl font-semibold text-on-surface">
+        WebSocket Test Harness
+      </h1>
+      <p className="mt-2 text-on-surface-variant">
+        Dev-only page for verifying the STOMP pipe. Returns 404 in production
+        builds.
+      </p>
+
+      <div className="mt-6">
+        <ConnectionBadge state={state} />
+      </div>
+
+      <div className="mt-4 flex gap-2">
+        <button
+          type="button"
+          onClick={__devForceDisconnect}
+          className="rounded-md bg-surface-container px-3 py-2 text-sm text-on-surface hover:bg-surface-container-high"
+        >
+          Force Disconnect
+        </button>
+        <button
+          type="button"
+          onClick={__devForceReconnect}
+          className="rounded-md bg-surface-container px-3 py-2 text-sm text-on-surface hover:bg-surface-container-high"
+        >
+          Force Reconnect
+        </button>
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          void sendBroadcast();
+        }}
+        className="mt-8"
+      >
+        <label
+          htmlFor="ws-test-input"
+          className="block text-sm font-medium text-on-surface"
+        >
+          Send test message
+        </label>
+        <div className="mt-2 flex gap-2">
+          <input
+            id="ws-test-input"
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Type a message"
+            className="flex-1 rounded-md bg-surface-container px-3 py-2 text-on-surface placeholder:text-on-surface-variant"
+          />
+          <button
+            type="submit"
+            disabled={sending || !input.trim()}
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-on-primary disabled:opacity-50"
+          >
+            {sending ? "Sending..." : "Send"}
+          </button>
+        </div>
+        {sendError ? (
+          <p className="mt-2 text-sm text-error">{sendError}</p>
+        ) : null}
+      </form>
+
+      <section className="mt-8">
+        <h2 className="text-lg font-medium text-on-surface">
+          Received ({messages.length})
+        </h2>
+        <ol className="mt-2 space-y-2">
+          {messages.map((m, i) => (
+            <li
+              key={`${m.timestamp}-${i}`}
+              className="rounded-md bg-surface-container p-3"
+            >
+              <div className="flex items-baseline justify-between">
+                <span className="text-on-surface">{m.message}</span>
+                <span className="font-mono text-xs text-on-surface-variant">
+                  {m.timestamp}
+                </span>
+              </div>
+              <div className="mt-1 text-xs text-on-surface-variant">
+                from userId {m.senderId}
+              </div>
+            </li>
+          ))}
+          {messages.length === 0 ? (
+            <li className="rounded-md bg-surface-container p-3 text-sm text-on-surface-variant">
+              No messages yet. Send one or trigger a broadcast from another
+              tab / curl.
+            </li>
+          ) : null}
+        </ol>
+      </section>
+    </main>
+  );
+}
+
+function ConnectionBadge({ state }: { state: ConnectionState }) {
+  const label = {
+    disconnected: "Disconnected",
+    connecting: "Connecting...",
+    connected: "Connected",
+    reconnecting: "Reconnecting...",
+    error: "Error",
+  }[state.status];
+
+  const tone = {
+    disconnected: "bg-surface-container text-on-surface-variant",
+    connecting: "bg-tertiary-container text-on-tertiary-container",
+    connected: "bg-primary-container text-on-primary-container",
+    reconnecting: "bg-tertiary-container text-on-tertiary-container",
+    error: "bg-error-container text-on-error-container",
+  }[state.status];
+
+  return (
+    <div className={`inline-flex flex-col rounded-md px-3 py-2 text-sm ${tone}`}>
+      <span className="font-medium">{label}</span>
+      {state.status === "error" ? (
+        <span className="mt-1 text-xs">{state.detail}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,19 +1,19 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { getAccessToken, setAccessToken } from "@/lib/auth/session";
-
-let queryClientRef: QueryClient | null = null;
-let inFlightRefresh: Promise<void> | null = null;
+import { getAccessToken } from "@/lib/auth/session";
+import {
+  ensureFreshAccessToken,
+  configureRefresh,
+  RefreshFailedError,
+} from "@/lib/auth/refresh";
 
 /**
  * Wires the API client to the app's QueryClient. Called once at app mount from
- * `app/providers.tsx`. Storing the QueryClient reference at module scope lets
- * the 401 interceptor update the session query cache on failed refresh without
- * React lifecycle access.
- *
- * See FOOTGUNS §F.3.
+ * `app/providers.tsx`. Kept as a passthrough to `configureRefresh` so existing
+ * call sites (providers.tsx, api.401-interceptor.test.tsx) do not need to
+ * change when the refresh primitive moved into `lib/auth/refresh.ts`.
  */
 export function configureApiClient(queryClient: QueryClient): void {
-  queryClientRef = queryClient;
+  configureRefresh(queryClient);
 }
 
 /**
@@ -82,55 +82,32 @@ function buildPath(
 }
 
 /**
- * Handles a 401 response from a non-auth path by attempting a token refresh
- * and retrying the original request.
+ * Handles a 401 response from a non-auth path by delegating to the shared
+ * `ensureFreshAccessToken` helper and retrying the original request. On
+ * refresh failure, performs the redirect-to-login side effect.
  *
- * Concurrent-stampede protection: if multiple requests 401 at the same time,
- * they all await the same single refresh promise. Only the creator of that
- * promise clears `inFlightRefresh` (inside the IIFE's try/finally), not every
- * awaiter. This avoids a race where multiple awaiters null out the ref before
- * all callers have awaited it.
- *
- * See FOOTGUNS §F.4.
+ * The stampede-dedup logic lives in `lib/auth/refresh.ts` — see FOOTGUNS §F.4
+ * and §F.17 for why the finally clause must live inside the IIFE there.
  */
-async function handleUnauthorized<T>(path: string, options: RequestOptions): Promise<T> {
-  if (!inFlightRefresh) {
-    inFlightRefresh = (async () => {
-      try {
-        const refreshed = await fetch(`${BASE_URL}/api/auth/refresh`, {
-          method: "POST",
-          credentials: "include",
-        });
-
-        if (!refreshed.ok) {
-          // Refresh failed — clear session and redirect to login.
-          setAccessToken(null);
-          if (queryClientRef) {
-            queryClientRef.setQueryData(["auth", "session"], null);
-          }
-          if (typeof window !== "undefined") {
-            const next = encodeURIComponent(window.location.pathname + window.location.search);
-            window.location.href = `/login?next=${next}`;
-          }
-          const problem: ProblemDetail = { status: 401, title: "Session expired" };
-          throw new ApiError(problem);
-        }
-
-        const refreshBody = (await refreshed.json()) as { accessToken: string; user: unknown };
-        setAccessToken(refreshBody.accessToken);
-        if (queryClientRef) {
-          queryClientRef.setQueryData(["auth", "session"], refreshBody.user);
-        }
-      } finally {
-        inFlightRefresh = null;
+async function handleUnauthorized<T>(
+  path: string,
+  options: RequestOptions
+): Promise<T> {
+  try {
+    await ensureFreshAccessToken();
+  } catch (e) {
+    if (e instanceof RefreshFailedError) {
+      if (typeof window !== "undefined") {
+        const next = encodeURIComponent(
+          window.location.pathname + window.location.search
+        );
+        window.location.href = `/login?next=${next}`;
       }
-    })();
+      const problem: ProblemDetail = { status: 401, title: "Session expired" };
+      throw new ApiError(problem);
+    }
+    throw e;
   }
-
-  await inFlightRefresh;
-
-  // Retry the original request once with the new access token.
-  // isRetry=true prevents infinite refresh loops on a subsequent 401.
   return request<T>(path, options, /* isRetry */ true);
 }
 
@@ -153,8 +130,6 @@ async function request<T>(
   });
 
   if (response.status === 401 && !isRetry && !path.startsWith("/api/auth/")) {
-    // Auth-path 401s (login, refresh, etc.) are real failures the caller must
-    // see. Non-auth-path 401s trigger the refresh-and-retry flow.
     return handleUnauthorized<T>(path, { body, headers, params, ...rest });
   }
 
@@ -163,8 +138,6 @@ async function request<T>(
     try {
       problem = (await response.json()) as ProblemDetail;
     } catch {
-      // Backend returned a non-JSON error body (proxy 502, network blip).
-      // Synthesize a minimal ProblemDetail so callers see a consistent shape.
       problem = { status: response.status, title: response.statusText };
     }
     throw new ApiError(problem);

--- a/frontend/src/lib/auth/refresh.test.ts
+++ b/frontend/src/lib/auth/refresh.test.ts
@@ -1,0 +1,132 @@
+// frontend/src/lib/auth/refresh.test.ts
+//
+// CANARY — see FOOTGUNS §F.17. This test pins the stampede-dedup contract for
+// the shared refresh helper. Both the HTTP 401 interceptor and the STOMP
+// beforeConnect hook depend on `inFlightRefresh` being nulled inside the IIFE's
+// finally clause. If this canary starts failing with "fetch called twice",
+// someone has moved the finally out of the IIFE.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { QueryClient } from "@tanstack/react-query";
+import { server } from "@/test/msw/server";
+import {
+  RefreshFailedError,
+  configureRefresh,
+  ensureFreshAccessToken,
+  __resetRefreshStateForTests,
+} from "./refresh";
+import { getAccessToken, setAccessToken } from "./session";
+
+describe("ensureFreshAccessToken (stampede canary)", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    configureRefresh(queryClient);
+    setAccessToken("stale-token");
+  });
+
+  afterEach(() => {
+    __resetRefreshStateForTests();
+    setAccessToken(null);
+  });
+
+  it("single call hits /api/auth/refresh once and returns the fresh token", async () => {
+    let refreshCount = 0;
+    server.use(
+      http.post("*/api/auth/refresh", () => {
+        refreshCount++;
+        return HttpResponse.json({
+          accessToken: "fresh-token-A",
+          user: {
+            id: 1,
+            email: "t@example.com",
+            displayName: null,
+            slAvatarUuid: null,
+            verified: false,
+          },
+        });
+      })
+    );
+
+    const token = await ensureFreshAccessToken();
+
+    expect(refreshCount).toBe(1);
+    expect(token).toBe("fresh-token-A");
+    expect(getAccessToken()).toBe("fresh-token-A");
+    expect(queryClient.getQueryData(["auth", "session"])).toMatchObject({
+      id: 1,
+    });
+  });
+
+  it("three concurrent calls hit the backend exactly once and all resolve with the same token", async () => {
+    let refreshCount = 0;
+    server.use(
+      http.post("*/api/auth/refresh", async () => {
+        refreshCount++;
+        // Small delay so the stampede has a window to form.
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return HttpResponse.json({
+          accessToken: "fresh-token-B",
+          user: {
+            id: 2,
+            email: "t2@example.com",
+            displayName: null,
+            slAvatarUuid: null,
+            verified: false,
+          },
+        });
+      })
+    );
+
+    const results = await Promise.all([
+      ensureFreshAccessToken(),
+      ensureFreshAccessToken(),
+      ensureFreshAccessToken(),
+    ]);
+
+    expect(refreshCount).toBe(1);
+    expect(results).toEqual(["fresh-token-B", "fresh-token-B", "fresh-token-B"]);
+    expect(getAccessToken()).toBe("fresh-token-B");
+  });
+
+  it("failed refresh clears session, throws RefreshFailedError, and allows the next call to retry", async () => {
+    let refreshCount = 0;
+    server.use(
+      http.post("*/api/auth/refresh", () => {
+        refreshCount++;
+        if (refreshCount === 1) {
+          return HttpResponse.json(
+            { code: "AUTH_TOKEN_MISSING", status: 401 },
+            { status: 401 }
+          );
+        }
+        return HttpResponse.json({
+          accessToken: "fresh-token-C",
+          user: {
+            id: 3,
+            email: "t3@example.com",
+            displayName: null,
+            slAvatarUuid: null,
+            verified: false,
+          },
+        });
+      })
+    );
+
+    // First call — fails.
+    await expect(ensureFreshAccessToken()).rejects.toThrow(RefreshFailedError);
+    expect(getAccessToken()).toBeNull();
+    expect(queryClient.getQueryData(["auth", "session"])).toBeNull();
+
+    // Second call — proves inFlightRefresh was cleared in the finally block
+    // on the failure path. Fetch is called a SECOND time and resolves fresh.
+    const token = await ensureFreshAccessToken();
+    expect(refreshCount).toBe(2);
+    expect(token).toBe("fresh-token-C");
+    expect(getAccessToken()).toBe("fresh-token-C");
+  });
+});

--- a/frontend/src/lib/auth/refresh.ts
+++ b/frontend/src/lib/auth/refresh.ts
@@ -1,0 +1,81 @@
+// frontend/src/lib/auth/refresh.ts
+//
+// Shared refresh-token stampede guard. Both the HTTP 401 interceptor
+// (lib/api.ts) and the STOMP beforeConnect hook (lib/ws/client.ts) call
+// ensureFreshAccessToken() — a single in-flight promise dedupes concurrent
+// refresh attempts from either source.
+//
+// The finally clause that clears inFlightRefresh MUST live inside the IIFE,
+// not outside the Promise chain. See FOOTGUNS §F.4 and §F.17.
+
+import type { QueryClient } from "@tanstack/react-query";
+import { setAccessToken } from "./session";
+import type { AuthUser } from "./session";
+
+let queryClientRef: QueryClient | null = null;
+let inFlightRefresh: Promise<string> | null = null;
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
+const SESSION_QUERY_KEY = ["auth", "session"] as const;
+
+type RefreshResponse = { accessToken: string; user: AuthUser };
+
+export class RefreshFailedError extends Error {
+  readonly status: number;
+  constructor(status: number) {
+    super(`Refresh failed with status ${status}`);
+    this.name = "RefreshFailedError";
+    this.status = status;
+  }
+}
+
+export function configureRefresh(queryClient: QueryClient): void {
+  queryClientRef = queryClient;
+}
+
+/**
+ * Refreshes the access token, deduping concurrent callers onto a single
+ * in-flight promise. Returns the new access token string. On failure, clears
+ * the in-memory access token and the session query cache, then throws
+ * RefreshFailedError.
+ *
+ * Callers that need redirect-to-login behavior (HTTP 401 interceptor) do so
+ * after catching RefreshFailedError.
+ */
+export async function ensureFreshAccessToken(): Promise<string> {
+  if (inFlightRefresh) return inFlightRefresh;
+
+  inFlightRefresh = (async () => {
+    try {
+      const response = await fetch(`${BASE_URL}/api/auth/refresh`, {
+        method: "POST",
+        credentials: "include",
+      });
+
+      if (!response.ok) {
+        setAccessToken(null);
+        if (queryClientRef) {
+          queryClientRef.setQueryData(SESSION_QUERY_KEY, null);
+        }
+        throw new RefreshFailedError(response.status);
+      }
+
+      const body = (await response.json()) as RefreshResponse;
+      setAccessToken(body.accessToken);
+      if (queryClientRef) {
+        queryClientRef.setQueryData(SESSION_QUERY_KEY, body.user);
+      }
+      return body.accessToken;
+    } finally {
+      inFlightRefresh = null;
+    }
+  })();
+
+  return inFlightRefresh;
+}
+
+// Test-only reset. The ugly name signals "do not call from production code".
+export function __resetRefreshStateForTests(): void {
+  inFlightRefresh = null;
+  queryClientRef = null;
+}

--- a/frontend/src/lib/ws/client.test.ts
+++ b/frontend/src/lib/ws/client.test.ts
@@ -1,0 +1,195 @@
+// frontend/src/lib/ws/client.test.ts
+//
+// Unit tests for lib/ws/client.ts. Mocks @stomp/stompjs so tests run without
+// a real WebSocket — the captured callbacks on the mock Client instance let
+// us simulate onConnect, onWebSocketClose, onStompError etc. manually.
+
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+// The mocked Client class. Captured callbacks and flags live on the instance
+// so tests can trigger lifecycle events on demand.
+type MockStompClient = {
+  activate: Mock;
+  deactivate: Mock;
+  subscribe: Mock;
+  connected: boolean;
+  active: boolean;
+  connectHeaders: Record<string, string>;
+  beforeConnect?: () => void | Promise<void>;
+  onConnect?: () => void;
+  onWebSocketClose?: () => void;
+  onStompError?: (frame: { headers: Record<string, string> }) => void;
+};
+
+let mockClientInstance: MockStompClient | null = null;
+
+vi.mock("@stomp/stompjs", () => {
+  // Use a regular function (not arrow) so `new Client(...)` works — vitest's
+  // mocked arrow functions can't be used as constructors.
+  function MockClient(this: unknown, config: Partial<MockStompClient>) {
+    const instance: MockStompClient = {
+      activate: vi.fn(() => {
+        instance.active = true;
+      }),
+      deactivate: vi.fn(() => {
+        instance.active = false;
+        instance.connected = false;
+      }),
+      subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })),
+      connected: false,
+      active: false,
+      connectHeaders: {},
+      beforeConnect: config.beforeConnect,
+      onConnect: config.onConnect,
+      onWebSocketClose: config.onWebSocketClose,
+      onStompError: config.onStompError,
+    };
+    mockClientInstance = instance;
+    return instance;
+  }
+  return {
+    Client: MockClient,
+  };
+});
+
+vi.mock("sockjs-client", () => ({
+  default: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock("@/lib/auth/refresh", () => ({
+  ensureFreshAccessToken: vi.fn(async () => "mock-access-token"),
+  RefreshFailedError: class extends Error {
+    readonly status: number;
+    constructor(status: number) {
+      super(`Refresh failed ${status}`);
+      this.status = status;
+    }
+  },
+}));
+
+// Import UNDER TEST after the mocks are declared.
+import {
+  __resetWsClientForTests,
+  getConnectionState,
+  subscribe,
+  subscribeToConnectionState,
+} from "./client";
+import { ensureFreshAccessToken } from "@/lib/auth/refresh";
+
+describe("lib/ws/client", () => {
+  beforeEach(() => {
+    __resetWsClientForTests();
+    mockClientInstance = null;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    __resetWsClientForTests();
+  });
+
+  it("first subscribe activates the client", () => {
+    subscribe<unknown>("/topic/foo", () => {});
+
+    expect(mockClientInstance).not.toBeNull();
+    expect(mockClientInstance!.activate).toHaveBeenCalledTimes(1);
+  });
+
+  it("second subscribe reuses the existing client (single activate)", () => {
+    subscribe<unknown>("/topic/foo", () => {});
+    subscribe<unknown>("/topic/bar", () => {});
+
+    expect(mockClientInstance!.activate).toHaveBeenCalledTimes(1);
+  });
+
+  it("last unsubscribe schedules disconnect with 5s grace period", () => {
+    vi.useFakeTimers();
+    try {
+      const unsub = subscribe<unknown>("/topic/foo", () => {});
+
+      unsub();
+      // Not yet — grace period.
+      expect(mockClientInstance!.deactivate).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(5_000);
+      expect(mockClientInstance!.deactivate).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resubscribe within grace window cancels the scheduled teardown", () => {
+    vi.useFakeTimers();
+    try {
+      const unsub1 = subscribe<unknown>("/topic/foo", () => {});
+
+      unsub1();
+      vi.advanceTimersByTime(4_000);
+      // Second subscribe within grace — teardown should cancel.
+      subscribe<unknown>("/topic/bar", () => {});
+      vi.advanceTimersByTime(5_000);
+
+      expect(mockClientInstance!.deactivate).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("beforeConnect calls ensureFreshAccessToken and sets Authorization header", async () => {
+    subscribe<unknown>("/topic/foo", () => {});
+
+    // Invoke the captured beforeConnect callback.
+    await mockClientInstance!.beforeConnect!();
+
+    expect(ensureFreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(mockClientInstance!.connectHeaders.Authorization).toBe("Bearer mock-access-token");
+  });
+
+  it("onConnect transitions ConnectionState to connected", () => {
+    const states: string[] = [];
+    subscribeToConnectionState((s) => states.push(s.status));
+
+    subscribe<unknown>("/topic/foo", () => {});
+    // Simulate the captured onConnect firing.
+    mockClientInstance!.onConnect!();
+
+    expect(getConnectionState().status).toBe("connected");
+    expect(states).toContain("connected");
+  });
+
+  it("onWebSocketClose while active transitions ConnectionState to reconnecting", () => {
+    subscribe<unknown>("/topic/foo", () => {});
+    mockClientInstance!.active = true;
+
+    mockClientInstance!.onWebSocketClose!();
+
+    expect(getConnectionState().status).toBe("reconnecting");
+  });
+
+  it("onStompError transitions ConnectionState to error with the frame detail", () => {
+    subscribe<unknown>("/topic/foo", () => {});
+
+    mockClientInstance!.onStompError!({ headers: { message: "Auth failed" } });
+
+    const state = getConnectionState();
+    expect(state.status).toBe("error");
+    if (state.status === "error") {
+      expect(state.detail).toBe("Auth failed");
+    }
+  });
+
+  it("subscribe before connected defers the stompjs subscribe until onConnect", () => {
+    const handler = vi.fn();
+    subscribe<{ msg: string }>("/topic/foo", handler);
+
+    // Client is not connected yet.
+    mockClientInstance!.connected = false;
+    expect(mockClientInstance!.subscribe).not.toHaveBeenCalled();
+
+    // Now connect — the deferred attach should fire.
+    mockClientInstance!.connected = true;
+    mockClientInstance!.onConnect!();
+
+    expect(mockClientInstance!.subscribe).toHaveBeenCalledTimes(1);
+    expect(mockClientInstance!.subscribe.mock.calls[0][0]).toBe("/topic/foo");
+  });
+});

--- a/frontend/src/lib/ws/client.ts
+++ b/frontend/src/lib/ws/client.ts
@@ -1,0 +1,205 @@
+// frontend/src/lib/ws/client.ts
+"use client";
+
+import { Client, type IMessage, type StompSubscription } from "@stomp/stompjs";
+import SockJS from "sockjs-client";
+import { ensureFreshAccessToken, RefreshFailedError } from "@/lib/auth/refresh";
+import type { ConnectionState, Unsubscribe } from "./types";
+
+const WS_URL = process.env.NEXT_PUBLIC_WS_URL ?? "http://localhost:8080/ws";
+const DISCONNECT_GRACE_MS = 5_000;
+
+let client: Client | null = null;
+let subscriberCount = 0;
+let disconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let connectionState: ConnectionState = { status: "disconnected" };
+const stateListeners = new Set<(state: ConnectionState) => void>();
+
+function setState(next: ConnectionState): void {
+  connectionState = next;
+  for (const listener of stateListeners) listener(next);
+}
+
+export function getConnectionState(): ConnectionState {
+  return connectionState;
+}
+
+export function subscribeToConnectionState(
+  listener: (state: ConnectionState) => void
+): Unsubscribe {
+  stateListeners.add(listener);
+  // Fire immediately with current state so consumers have something to render.
+  listener(connectionState);
+  return () => {
+    stateListeners.delete(listener);
+  };
+}
+
+function getOrCreateClient(): Client {
+  if (client) return client;
+
+  client = new Client({
+    webSocketFactory: () => new SockJS(WS_URL),
+    reconnectDelay: 5_000,
+    heartbeatIncoming: 10_000,
+    heartbeatOutgoing: 10_000,
+    beforeConnect: async () => {
+      if (!client) return;
+      setState({ status: "connecting" });
+      try {
+        const token = await ensureFreshAccessToken();
+        client.connectHeaders = { Authorization: `Bearer ${token}` };
+      } catch (e) {
+        // Do NOT throw from beforeConnect — stompjs handles a thrown
+        // beforeConnect as a catastrophic failure. Instead, let stompjs
+        // proceed without an Authorization header; the interceptor will
+        // reject the CONNECT frame, onStompError will fire, and the
+        // ConnectionState machine will surface the error.
+        //
+        // See FOOTGUNS §F.18.
+        if (e instanceof RefreshFailedError) {
+          setState({
+            status: "error",
+            detail: "Session expired — please sign in again",
+          });
+        } else {
+          setState({
+            status: "error",
+            detail: "Could not refresh access token",
+          });
+        }
+      }
+    },
+    onConnect: () => {
+      setState({ status: "connected" });
+    },
+    onWebSocketClose: () => {
+      if (client?.active) {
+        setState({ status: "reconnecting" });
+      } else {
+        setState({ status: "disconnected" });
+      }
+    },
+    onStompError: (frame) => {
+      const detail = frame.headers["message"] ?? "STOMP error";
+      setState({ status: "error", detail });
+    },
+  });
+
+  return client;
+}
+
+/**
+ * Subscribe to a STOMP destination. Returns an unsubscribe closure. The
+ * callback receives the JSON-parsed message payload typed as `T`. Malformed
+ * JSON is logged via `console.error` and the subscription stays alive.
+ *
+ * Reference counting: the first subscribe activates the singleton client;
+ * the last unsubscribe schedules a `DISCONNECT_GRACE_MS` deactivation. A new
+ * subscribe inside the grace window cancels the teardown.
+ *
+ * Deferral: if the client is not yet connected, the actual `client.subscribe`
+ * call is deferred until `onConnect` fires. See FOOTGUNS §F.19.
+ */
+export function subscribe<T>(
+  destination: string,
+  onMessage: (payload: T) => void
+): Unsubscribe {
+  const c = getOrCreateClient();
+  subscriberCount += 1;
+
+  if (disconnectTimer) {
+    clearTimeout(disconnectTimer);
+    disconnectTimer = null;
+  }
+
+  if (!c.active) {
+    c.activate();
+  }
+
+  let stompSub: StompSubscription | null = null;
+
+  const attach = () => {
+    stompSub = c.subscribe(destination, (frame: IMessage) => {
+      try {
+        const parsed = JSON.parse(frame.body) as T;
+        onMessage(parsed);
+      } catch (err) {
+        console.error(
+          `[ws] Failed to parse message body on ${destination}:`,
+          err,
+          frame.body
+        );
+      }
+    });
+  };
+
+  if (c.connected) {
+    attach();
+  } else {
+    // KNOWN RACE (Epic 04 hardening followup, spec §14.7):
+    //   If onConnect → onWebSocketClose fires in rapid succession, the
+    //   listener sees "reconnecting" mid-cycle and keeps waiting through the
+    //   reconnect. On the next successful connect the listener fires and
+    //   attach() runs — subscription not lost, just delayed by one reconnect
+    //   cycle. Acceptable for 01-09; Epic 04 will want a more robust
+    //   re-attach strategy.
+    const stateUnsub = subscribeToConnectionState((state) => {
+      if (state.status === "connected") {
+        attach();
+        stateUnsub();
+      }
+    });
+  }
+
+  return () => {
+    if (stompSub) stompSub.unsubscribe();
+    subscriberCount = Math.max(0, subscriberCount - 1);
+    if (subscriberCount === 0) {
+      scheduleTeardown();
+    }
+  };
+}
+
+function scheduleTeardown(): void {
+  if (disconnectTimer) return;
+  disconnectTimer = setTimeout(() => {
+    disconnectTimer = null;
+    if (subscriberCount === 0 && client) {
+      client.deactivate();
+      setState({ status: "disconnected" });
+    }
+  }, DISCONNECT_GRACE_MS);
+}
+
+// Manual controls for the /dev/ws-test page's Disconnect / Reconnect buttons.
+// Consumers should NOT use these in production code — they bypass reference
+// counting and can leave other subscribers stranded.
+export function __devForceDisconnect(): void {
+  if (client?.active) client.deactivate();
+  setState({ status: "disconnected" });
+}
+
+export function __devForceReconnect(): void {
+  const c = getOrCreateClient();
+  if (!c.active) c.activate();
+}
+
+// Test-only reset. Clears all module state so each test starts from scratch.
+export function __resetWsClientForTests(): void {
+  if (client) {
+    try {
+      client.deactivate();
+    } catch {
+      // Ignore — mocked client may not implement deactivate cleanly.
+    }
+  }
+  client = null;
+  subscriberCount = 0;
+  if (disconnectTimer) {
+    clearTimeout(disconnectTimer);
+    disconnectTimer = null;
+  }
+  stateListeners.clear();
+  connectionState = { status: "disconnected" };
+}

--- a/frontend/src/lib/ws/hooks.test.tsx
+++ b/frontend/src/lib/ws/hooks.test.tsx
@@ -1,0 +1,96 @@
+// frontend/src/lib/ws/hooks.test.tsx
+
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { render, renderHook, act } from "@testing-library/react";
+
+// Track calls to the module primitives without pulling in stompjs.
+// vi.hoisted keeps these accessible from the hoisted vi.mock factory below.
+const { subscribeMock, subscribeToConnectionStateMock, getConnectionStateMock } =
+  vi.hoisted(() => ({
+    subscribeMock: vi.fn(),
+    subscribeToConnectionStateMock: vi.fn(),
+    getConnectionStateMock: vi.fn(() => ({ status: "disconnected" as const })),
+  }));
+
+vi.mock("./client", () => ({
+  // Forward to the spy and return whatever its mockImplementation returns so
+  // tests can override the unsubscribe closure per-case.
+  subscribe: (...args: unknown[]) => subscribeMock(...args),
+  subscribeToConnectionState: (
+    listener: (state: { status: string }) => void
+  ) => subscribeToConnectionStateMock(listener),
+  getConnectionState: getConnectionStateMock,
+}));
+
+import { useConnectionState, useStompSubscription } from "./hooks";
+
+describe("lib/ws/hooks", () => {
+  beforeEach(() => {
+    subscribeMock.mockReset();
+    (subscribeMock as unknown as Mock).mockImplementation(() => () => {});
+    subscribeToConnectionStateMock.mockReset();
+    getConnectionStateMock.mockReset();
+    getConnectionStateMock.mockReturnValue({ status: "disconnected" });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("useConnectionState renders the current state and reacts to updates", () => {
+    let capturedListener: ((s: { status: string }) => void) | null = null;
+    subscribeToConnectionStateMock.mockImplementation((listener) => {
+      capturedListener = listener;
+      listener({ status: "disconnected" });
+      return () => {};
+    });
+
+    const { result } = renderHook(() => useConnectionState());
+    expect(result.current.status).toBe("disconnected");
+
+    act(() => {
+      capturedListener!({ status: "connected" });
+    });
+
+    expect(result.current.status).toBe("connected");
+  });
+
+  it("useStompSubscription subscribes on mount and unsubscribes on unmount", () => {
+    const unsubscribeMock = vi.fn();
+    subscribeMock.mockImplementation(() => unsubscribeMock);
+
+    function Probe() {
+      useStompSubscription<{ msg: string }>("/topic/foo", () => {});
+      return null;
+    }
+
+    const { unmount } = render(<Probe />);
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
+    expect(subscribeMock.mock.calls[0][0]).toBe("/topic/foo");
+
+    unmount();
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("useStompSubscription does not re-subscribe when the callback identity changes", () => {
+    const unsubscribeMock = vi.fn();
+    subscribeMock.mockImplementation(() => unsubscribeMock);
+
+    let renderCount = 0;
+    function Probe() {
+      renderCount++;
+      // Inline arrow creates a new function identity on every render.
+      useStompSubscription<{ msg: string }>("/topic/foo", () => {
+        // noop
+      });
+      return null;
+    }
+
+    const { rerender } = render(<Probe />);
+    rerender(<Probe />);
+    rerender(<Probe />);
+
+    expect(renderCount).toBe(3);
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/ws/hooks.ts
+++ b/frontend/src/lib/ws/hooks.ts
@@ -1,0 +1,50 @@
+// frontend/src/lib/ws/hooks.ts
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  getConnectionState,
+  subscribe,
+  subscribeToConnectionState,
+} from "./client";
+import type { ConnectionState } from "./types";
+
+/**
+ * React-friendly accessor for the module-level ConnectionState. Re-renders
+ * whenever the underlying state changes. Fires immediately on mount with the
+ * current state (the listener is invoked synchronously inside
+ * `subscribeToConnectionState`).
+ */
+export function useConnectionState(): ConnectionState {
+  const [state, setState] = useState<ConnectionState>(() => getConnectionState());
+  useEffect(() => {
+    return subscribeToConnectionState(setState);
+  }, []);
+  return state;
+}
+
+/**
+ * React-friendly wrapper around `subscribe()`. The callback is held in a ref
+ * so re-renders with a new inline function identity do not re-subscribe; only
+ * a change to the `destination` string triggers a new subscription.
+ */
+export function useStompSubscription<T>(
+  destination: string,
+  onMessage: (payload: T) => void
+): void {
+  const callbackRef = useRef(onMessage);
+  // Intentional stable-callback pattern: assign the latest callback to the
+  // ref during render so the effect below never closes over a stale value and
+  // a new inline-function identity does NOT trigger a resubscribe. Moving
+  // this into a useEffect would defeat the purpose (the effect runs AFTER
+  // render, so the ref would lag by one render).
+  // eslint-disable-next-line react-hooks/refs -- intentional stable-callback ref
+  callbackRef.current = onMessage;
+
+  useEffect(() => {
+    const unsubscribe = subscribe<T>(destination, (payload) => {
+      callbackRef.current(payload);
+    });
+    return unsubscribe;
+  }, [destination]);
+}

--- a/frontend/src/lib/ws/types.ts
+++ b/frontend/src/lib/ws/types.ts
@@ -1,0 +1,28 @@
+// frontend/src/lib/ws/types.ts
+//
+// Type-only module for the WebSocket layer. Separate from client.ts so tests
+// can import the types without pulling in client.ts's module-level state.
+
+/**
+ * Discriminated union of the five states the WebSocket connection can be in.
+ * Consumers branch on `status` and TypeScript narrows the shape.
+ *
+ *   disconnected  — initial state, or after the last subscriber unsubscribed
+ *                   past the grace window.
+ *   connecting    — beforeConnect has fired; awaiting STOMP CONNECTED.
+ *   connected     — STOMP session is live, subscriptions can flow.
+ *   reconnecting  — WebSocket closed unexpectedly and stompjs is retrying.
+ *   error         — a STOMP ERROR frame arrived or auth refresh failed.
+ */
+export type ConnectionState =
+  | { status: "disconnected" }
+  | { status: "connecting" }
+  | { status: "connected" }
+  | { status: "reconnecting" }
+  | { status: "error"; detail: string };
+
+/**
+ * Unsubscribe handle returned by `subscribe()` and `subscribeToConnectionState()`.
+ * Calling the handle removes the subscription; idempotent.
+ */
+export type Unsubscribe = () => void;


### PR DESCRIPTION
## Summary

Ships the JWT-authenticated STOMP over WebSocket pipe between the Next.js frontend and Spring Boot backend, plus an end-to-end verification harness. Infrastructure only — no user-facing auction features (those are Epic 04).

**Backend:**
- `WebSocketConfig` — simple in-memory broker on `/topic`, `/app` application prefix (ready for Epic 04 `@MessageMapping`), SockJS endpoint at `/ws`.
- `JwtChannelInterceptor` + `StompAuthenticationToken` — validates the STOMP `CONNECT` frame's `Authorization: Bearer <jwt>` via the existing `JwtService` and attaches the principal to the session.
- `SecurityConfig` — `/ws/**` `permitAll` above `/api/**` catch-all (browsers can't send `Authorization` on WS upgrade, so auth must happen at the STOMP layer).
- `WsTestController` + `WsTestBroadcastRequest` — dev/test profile-gated `POST /api/ws-test/broadcast` pushes to `/topic/ws-test` via `SimpMessagingTemplate`.

**Frontend:**
- `lib/auth/refresh.ts` — extracted stampede guard. Shared by HTTP 401 interceptor and STOMP `beforeConnect` hook. Three-test canary pins dedup + failure-retry invariants.
- `lib/api.ts` — delegates 401 handling to `ensureFreshAccessToken`. Existing HTTP 401 canary unchanged and still green.
- `lib/ws/client.ts` — singleton `@stomp/stompjs` client, reference-counted subscriptions, 5s disconnect grace, observable `ConnectionState` discriminated union, generic JSON-payload `subscribe<T>` wrapper. Nine unit tests.
- `lib/ws/hooks.ts` — `useConnectionState` + `useStompSubscription<T>` with stable-callback ref. Three hook tests.
- `/dev/ws-test` — four-zone verification harness (status badge, force disconnect/reconnect, broadcast form, received log). 404s in production via `NODE_ENV` guard.

**Tests:**
- `JwtChannelInterceptorTest` — 6 unit tests (TDD'd)
- `WsTestIntegrationTest` — 3 `@SpringBootTest` end-to-end tests with real `WebSocketStompClient`
- `refresh.test.ts` — 3 stampede canary tests
- `client.test.ts` — 9 unit tests with mocked `@stomp/stompjs`
- `hooks.test.tsx` — 3 React hook tests
- `api.401-interceptor.test.tsx` — unchanged (pre-existing HTTP 401 canary still green)

**FOOTGUNS added:**
- §F.16 — `/ws/**` must be `permitAll` at HTTP layer; auth is at STOMP
- §F.17 — `ensureFreshAccessToken` `finally` clause must live inside the IIFE
- §F.18 — `beforeConnect` must not throw; stash errors in `ConnectionState`
- §F.19 — `@stomp/stompjs` `subscribe()` requires `client.connected`; deferral pattern

**Plan corrections captured during execution** (not in spec/plan but worth noting for Epic 04 authors):
1. `SimpMessagingTemplate.convertAndSend(String, Map<...>)` is ambiguous under Java 26 — must extract to `Object payload` local to bind to `convertAndSend(D, Object payload)`.
2. No `application-test.yml` exists; integration tests use `@ActiveProfiles("dev")` which activates `@Profile({"dev","test"})` beans via the `dev` branch.
3. Vitest 4.1.4 hoists `vi.mock()` above top-level `const` — shared mock spies must use `vi.hoisted(() => ({...}))`.
4. `vi.mock` factories must forward + return spy results (not wrap in noop closures) so per-test `mockImplementation` flows through.
5. React 19 compiler flags `ref.current = x;` during render — the stable-callback pattern needs an explicit `// eslint-disable-next-line react-hooks/refs`.

## Test plan

**Automated (done in this session — all green):**
- [x] Backend `./mvnw test`: 100/0/0/0
- [x] Frontend `npm test`: 37 files, 164 passed + 1 todo
- [x] Frontend `npm run lint`: clean
- [x] Frontend `npm run verify` (no-dark-variants, no-hex-colors, no-inline-styles, coverage): all OK
- [x] Frontend `npm run build`: 14 routes prerendered including `/dev/ws-test`

**Manual smoke (requires reviewer to exercise):**
- [ ] Start backend (`./mvnw spring-boot:run`) and frontend (`npm run dev`)
- [ ] Register a test user via `/register`, log in
- [ ] Navigate to `http://localhost:3000/dev/ws-test` — verify status badge cycles Connecting → Connected
- [ ] Send a test message via the form — verify it appears in Zone 4 (received log) with correct userId and timestamp
- [ ] Click Force Disconnect → status transitions to Disconnected
- [ ] Click Force Reconnect → status transitions back to Connected
- [ ] Restart the backend (Ctrl+C then `spring-boot:run` again) — verify frontend auto-reconnects via `beforeConnect` → fresh token → new CONNECT
- [ ] Build production bundle (`npm run build && npm run start`) and verify `http://localhost:3000/dev/ws-test` returns 404

## Scope

- **13 commits** implementing the plan (one per task), plus 3 earlier commits for the spec/plan docs on this branch
- Spec: `docs/superpowers/specs/2026-04-12-task-01-09-websocket-stomp-design.md`
- Plan: `docs/superpowers/plans/2026-04-12-task-01-09-websocket-stomp.md`