### PR TITLE
Epic 08 sub-spec 1 — Reviews & Reputation

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java
@@ -197,9 +197,10 @@ public class AuctionDtoMapper {
      * — every persisted auction has a non-null seller). Avatar URL points at
      * the existing {@code GET /api/v1/users/{id}/avatar/256} endpoint, which
      * already serves cached + placeholder avatars. {@code completionRate} is
-     * delegated to {@link SellerCompletionRateMapper#compute(int, int)} so the
-     * rounding + zero-denominator policy lives in one place and the private
-     * {@code cancelledWithBids} counter never reaches the wire.
+     * delegated to {@link SellerCompletionRateMapper#compute(int, int, int)} so
+     * the rounding + zero-denominator policy lives in one place and the private
+     * {@code cancelledWithBids} + {@code escrowExpiredUnfulfilled} counters
+     * never reach the wire. See Epic 08 sub-spec 1 §3.5 for the 3-arg widening.
      */
     private SellerSummary sellerSummary(User s) {
         if (s == null) {
@@ -207,8 +208,10 @@ public class AuctionDtoMapper {
         }
         Integer completed = s.getCompletedSales();
         Integer cancelled = s.getCancelledWithBids();
+        Integer expiredUnfulfilled = s.getEscrowExpiredUnfulfilled();
         int completedInt = completed == null ? 0 : completed;
         int cancelledInt = cancelled == null ? 0 : cancelled;
+        int expiredUnfulfilledInt = expiredUnfulfilled == null ? 0 : expiredUnfulfilled;
         return new SellerSummary(
                 s.getId(),
                 s.getDisplayName(),
@@ -216,7 +219,7 @@ public class AuctionDtoMapper {
                 s.getAvgSellerRating(),
                 s.getTotalSellerReviews(),
                 completed,
-                SellerCompletionRateMapper.compute(completedInt, cancelledInt),
+                SellerCompletionRateMapper.compute(completedInt, cancelledInt, expiredUnfulfilledInt),
                 s.getCreatedAt() == null ? null : s.getCreatedAt().toLocalDate());
     }
 

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/dto/PublicAuctionResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/dto/PublicAuctionResponse.java
@@ -29,7 +29,7 @@ import com.slparcelauctions.backend.parceltag.dto.ParcelTagResponse;
  * completedSales, completionRate, memberSince) for the listing-detail
  * page's seller card. {@code completionRate} is server-computed by
  * {@code SellerCompletionRateMapper} so the private {@code cancelledWithBids}
- * counter never appears in the response.
+ * and {@code escrowExpiredUnfulfilled} counters never appear in the response.
  */
 public record PublicAuctionResponse(
         Long id,
@@ -64,8 +64,8 @@ public record PublicAuctionResponse(
      * and {@code completionRate} are nullable for new sellers; the UI renders
      * "—" rather than a misleading zero. {@code completionRate} is the
      * server-computed ratio of {@code completedSales / (completedSales +
-     * cancelledWithBids)}; the {@code cancelledWithBids} counter itself is
-     * intentionally absent from this DTO.
+     * cancelledWithBids + escrowExpiredUnfulfilled)}; the two denominator-
+     * only counters are intentionally absent from this DTO.
      */
     public record SellerSummary(
             Long id,

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/search/AuctionSearchResultMapper.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/search/AuctionSearchResultMapper.java
@@ -96,7 +96,8 @@ public class AuctionSearchResultMapper {
                 s.getDisplayName(),
                 avatarUrl(s),
                 s.getAvgSellerRating(),
-                s.getTotalSellerReviews());
+                s.getTotalSellerReviews(),
+                s.getCompletedSales());
 
         boolean snipeProtect = Boolean.TRUE.equals(a.getSnipeProtect());
 

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/search/SellerSummaryDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/search/SellerSummaryDto.java
@@ -2,10 +2,22 @@ package com.slparcelauctions.backend.auction.search;
 
 import java.math.BigDecimal;
 
+/**
+ * Seller card embedded in each {@link AuctionSearchResultDto}. Epic 08
+ * sub-spec 1 adds {@code completedSales} so the browse page can render
+ * the "N sales" trust signal alongside the average rating without
+ * requiring a follow-up call to the profile endpoint.
+ *
+ * <p>The private denominator counters ({@code cancelledWithBids},
+ * {@code escrowExpiredUnfulfilled}) are intentionally omitted — only
+ * the server-computed completion rate belongs on the wire, and search
+ * cards do not render it today.
+ */
 public record SellerSummaryDto(
         Long id,
         String displayName,
         String avatarUrl,
         BigDecimal averageRating,
-        Integer reviewCount) {
+        Integer reviewCount,
+        Integer completedSales) {
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
@@ -162,6 +162,19 @@ public class SecurityConfig {
                         // FOOTGUNS §B.5: this MUST sit before the
                         // /api/v1/** catch-all (first-match-wins).
                         .requestMatchers(HttpMethod.POST, "/api/v1/auctions/*/reviews").authenticated()
+                        // Review read endpoints (Epic 08 sub-spec 1 Task 2).
+                        // GET /auctions/{id}/reviews and
+                        // GET /users/{id}/reviews are public — the service
+                        // enriches the auction-scoped response when a
+                        // principal is present but non-party or anon
+                        // callers see only visible reviews.
+                        // GET /users/me/pending-reviews is authenticated
+                        // so only the owner sees their pending queue.
+                        // The /me/ rule MUST come before the /{id}
+                        // wildcard (first-match-wins, FOOTGUNS §B.5).
+                        .requestMatchers(HttpMethod.GET, "/api/v1/auctions/*/reviews").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/users/me/pending-reviews").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/users/*/reviews").permitAll()
                         // Bot worker queue + callback surface (Epic 06 Task 3).
                         // Authentication is a shared bearer token validated by
                         // BotSharedSecretAuthorizer (constant-time compare via

--- a/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
@@ -154,6 +154,14 @@ public class SecurityConfig {
                         // /api/v1/users/** authenticated rules.
                         .requestMatchers(HttpMethod.GET, "/api/v1/users/*/auctions").permitAll()
                         // --- End Epic 03 sub-spec 1 Task 9 additions ---
+                        // Review submit endpoint (Epic 08 sub-spec 1 Task 1).
+                        // JWT-required so ReviewController can read the
+                        // caller's userId off the AuthPrincipal. Explicit
+                        // so Task 2's GET /reviews paths (public) can be
+                        // added in-place without disturbing the POST rule.
+                        // FOOTGUNS §B.5: this MUST sit before the
+                        // /api/v1/** catch-all (first-match-wins).
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auctions/*/reviews").authenticated()
                         // Bot worker queue + callback surface (Epic 06 Task 3).
                         // Authentication is a shared bearer token validated by
                         // BotSharedSecretAuthorizer (constant-time compare via

--- a/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
@@ -175,6 +175,18 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/auctions/*/reviews").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/users/me/pending-reviews").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/users/*/reviews").permitAll()
+                        // Review secondary actions (Epic 08 sub-spec 1
+                        // Task 3). Both require a JWT so the controller
+                        // can read the caller's userId off the
+                        // AuthPrincipal for the reviewee / reviewer
+                        // identity check in the service layer. Explicit
+                        // rules (rather than relying on the /api/v1/**
+                        // catch-all) keep the auth contract for this slice
+                        // readable alongside the other review matchers
+                        // and simplifies adjusting these paths later.
+                        // FOOTGUNS §B.5: must sit before /api/v1/**.
+                        .requestMatchers(HttpMethod.POST, "/api/v1/reviews/*/respond").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/reviews/*/flag").authenticated()
                         // Bot worker queue + callback surface (Epic 06 Task 3).
                         // Authentication is a shared bearer token validated by
                         // BotSharedSecretAuthorizer (constant-time compare via

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowRepository.java
@@ -96,12 +96,18 @@ public interface EscrowRepository extends JpaRepository<Escrow, Long> {
      * The caller filters out escrows the user already reviewed inside
      * the service so an already-reviewed escrow does not round-trip
      * through this method once the reviewer submits.
+     *
+     * <p>Ordered by {@code completedAt} ascending so the most-urgent
+     * rows (oldest {@code completedAt} = soonest {@code windowClosesAt}
+     * since the 14-day offset is constant) surface first in the
+     * dashboard list.
      */
     @Query("""
             SELECT e FROM Escrow e
             WHERE e.state = com.slparcelauctions.backend.escrow.EscrowState.COMPLETED
               AND e.completedAt > :threshold
               AND (e.auction.seller.id = :userId OR e.auction.winnerUserId = :userId)
+            ORDER BY e.completedAt ASC
             """)
     List<Escrow> findCompletedEscrowsForUser(
             @Param("userId") Long userId,

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowRepository.java
@@ -87,4 +87,23 @@ public interface EscrowRepository extends JpaRepository<Escrow, Long> {
                         com.slparcelauctions.backend.escrow.command.TerminalCommandStatus.FAILED))
             """)
     List<Long> findExpiredTransferPendingIds(@Param("now") OffsetDateTime now);
+
+    /**
+     * Every COMPLETED escrow where {@code userId} is either seller or
+     * winner AND the escrow completed strictly after the supplied
+     * threshold — i.e., the 14-day review window is still open. Backs
+     * the pending-reviews dashboard endpoint (Epic 08 sub-spec 1 §4.2).
+     * The caller filters out escrows the user already reviewed inside
+     * the service so an already-reviewed escrow does not round-trip
+     * through this method once the reviewer submits.
+     */
+    @Query("""
+            SELECT e FROM Escrow e
+            WHERE e.state = com.slparcelauctions.backend.escrow.EscrowState.COMPLETED
+              AND e.completedAt > :threshold
+              AND (e.auction.seller.id = :userId OR e.auction.winnerUserId = :userId)
+            """)
+    List<Escrow> findCompletedEscrowsForUser(
+            @Param("userId") Long userId,
+            @Param("threshold") OffsetDateTime threshold);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
@@ -686,6 +686,18 @@ public class EscrowService {
 
         queueRefundIfFunded(escrow);
 
+        // Epic 08 sub-spec 1 §3.4 / §6.1: a transfer-timeout is seller-fault
+        // (the seller never handed the parcel over inside the 72h window).
+        // Increment the seller's escrowExpiredUnfulfilled counter inside the
+        // same transaction that flips the escrow to EXPIRED so the counter
+        // can't drift on crash-between-steps. The buyer-fault counterpart
+        // (expirePayment) intentionally does NOT touch this counter.
+        User seller = escrow.getAuction().getSeller();
+        int prior = seller.getEscrowExpiredUnfulfilled() == null
+                ? 0 : seller.getEscrowExpiredUnfulfilled();
+        seller.setEscrowExpiredUnfulfilled(prior + 1);
+        userRepo.save(seller);
+
         final EscrowExpiredEnvelope envelope =
                 EscrowExpiredEnvelope.of(escrow, "TRANSFER_TIMEOUT", now);
         TransactionSynchronizationManager.registerSynchronization(

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/command/TerminalCommandService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/command/TerminalCommandService.java
@@ -219,6 +219,18 @@ public class TerminalCommandService {
         // Cancel any live MONITOR_ESCROW rows. No-op for non-BOT escrows.
         monitorLifecycle.onEscrowTerminal(escrow);
 
+        // Epic 08 sub-spec 1 §3.4 / §6.1: track completed sales for the
+        // seller. The counter has been declared on User since Epic 02 but
+        // was never written; sub-spec 1 starts writing it so the
+        // completion-rate mapper + reputation aggregates have a real number
+        // to work with. Incremented inside the same transaction that flipped
+        // the escrow to COMPLETED so the counter cannot drift on a crash
+        // between steps.
+        User seller = escrow.getAuction().getSeller();
+        int prior = seller.getCompletedSales() == null ? 0 : seller.getCompletedSales();
+        seller.setCompletedSales(prior + 1);
+        userRepo.save(seller);
+
         // PAYOUT and COMMISSION land as separate ledger rows so audit and
         // accounting can bucket them independently. Spec §7.2.
         ledgerRepo.save(EscrowTransaction.builder()

--- a/backend/src/main/java/com/slparcelauctions/backend/review/Aggregate.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/Aggregate.java
@@ -1,0 +1,28 @@
+package com.slparcelauctions.backend.review;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * JPQL projection record for AVG + COUNT over a reviewee's visible
+ * reviews. The JPQL returns {@link Double} and {@link Long}; the
+ * constructor normalises {@code avg} to a {@link BigDecimal} at scale
+ * 2 with {@link RoundingMode#HALF_UP} so the shape matches the
+ * {@code precision(3, scale=2)} columns on {@code User.avgSellerRating}
+ * / {@code avgBuyerRating}.
+ *
+ * <p>Task 1 defines the projection shape; Task 2 wires the repository
+ * queries that return it and the aggregate-recompute path that consumes
+ * it.
+ */
+public record Aggregate(BigDecimal avg, int count) {
+
+    public Aggregate(Double avgRaw, Long countRaw) {
+        this(
+                avgRaw == null
+                        ? null
+                        : BigDecimal.valueOf(avgRaw).setScale(2, RoundingMode.HALF_UP),
+                countRaw == null ? 0 : countRaw.intValue()
+        );
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/BlindReviewRevealTask.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/BlindReviewRevealTask.java
@@ -1,0 +1,88 @@
+package com.slparcelauctions.backend.review;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Hourly scheduler that flips day-14 pending reviews to
+ * {@code visible=true} (spec §5). Runs at the top of every hour and
+ * processes up to {@value #BATCH_LIMIT} reviews per tick; batch-limit
+ * hits are logged at WARN so operators notice sustained backlog (catch
+ * up on the next tick is fine — reveal is idempotent).
+ *
+ * <p>Each per-review reveal runs inside its own transaction via
+ * {@link ReviewService#reveal(Long)} so a single failing row doesn't
+ * poison the rest of the batch. {@code findByIdForUpdate} inside
+ * {@code reveal} serialises against a racing simultaneous-submit path
+ * that might flip the same row — the idempotent early-return absorbs
+ * that race harmlessly.
+ *
+ * <p>Gated by {@code slpa.review.scheduler.enabled} ({@code matchIfMissing=true})
+ * so unit-test slices can disable the scheduler without forcing a test
+ * profile. When disabled the bean is not registered at all, which also
+ * keeps {@code @EnableScheduling} from spinning up a thread for it.
+ */
+@Component
+@ConditionalOnProperty(
+        name = "slpa.review.scheduler.enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+@RequiredArgsConstructor
+@Slf4j
+public class BlindReviewRevealTask {
+
+    /** Keep in sync with {@link ReviewService#REVIEW_WINDOW}. */
+    private static final Duration REVIEW_WINDOW = Duration.ofDays(14);
+    private static final int BATCH_LIMIT = 500;
+
+    private final ReviewRepository reviewRepo;
+    private final ReviewService reviewService;
+    private final Clock clock;
+
+    /** Top of every hour. Cron: {@code second minute hour day month dow}. */
+    @Scheduled(cron = "0 0 * * * *")
+    public void run() {
+        runOnce();
+    }
+
+    /**
+     * Package-private entry used by integration tests that prefer to
+     * invoke the tick explicitly rather than wait for the scheduler
+     * thread. Returns the number of reviews revealed this tick so tests
+     * can assert on batch size.
+     */
+    int runOnce() {
+        OffsetDateTime threshold = OffsetDateTime.now(clock).minus(REVIEW_WINDOW);
+        List<Review> revealable = reviewRepo.findRevealable(
+                threshold, PageRequest.of(0, BATCH_LIMIT));
+        if (revealable.isEmpty()) {
+            return 0;
+        }
+
+        log.info("BlindReviewReveal: {} reviews past day-14 window", revealable.size());
+        int processed = 0;
+        for (Review r : revealable) {
+            try {
+                reviewService.reveal(r.getId());
+                processed++;
+            } catch (Exception e) {
+                log.error("Failed to reveal review {}: {}", r.getId(), e.toString());
+            }
+        }
+        if (revealable.size() == BATCH_LIMIT) {
+            log.warn("BlindReviewReveal: hit batch limit {}; re-running next tick",
+                    BATCH_LIMIT);
+        }
+        return processed;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/Review.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/Review.java
@@ -1,0 +1,127 @@
+package com.slparcelauctions.backend.review;
+
+import java.time.OffsetDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.user.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Blind-reveal review of one party's behaviour on a completed auction
+ * (Epic 08 sub-spec 1 §3.1). Created via
+ * {@code POST /api/v1/auctions/{id}/reviews} with {@code visible=false}
+ * and flipped to {@code visible=true} either (a) when the counterparty
+ * also submits inside the 14-day window or (b) when the day-14 scheduler
+ * sweep runs. The {@code reviewedRole} column is persisted (not derived
+ * from reviewer/reviewee roles) so per-role aggregate queries use an
+ * index-only scan over {@code idx_reviews_reviewee_visible}.
+ *
+ * <p>The uniqueness constraint on {@code (auction_id, reviewer_id)}
+ * enforces "one review per party per auction" at the DB level —
+ * {@code ReviewService.submit} checks this in application code first so
+ * callers get a {@code 409 ReviewAlreadySubmittedException} instead of a
+ * constraint-violation stack trace, but the DB constraint is the last-
+ * line-of-defence for concurrent submits.
+ */
+@Entity
+@Table(name = "reviews",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_reviews_auction_reviewer",
+                columnNames = {"auction_id", "reviewer_id"}),
+        indexes = {
+                @Index(name = "idx_reviews_reviewee_visible",
+                        columnList = "reviewee_id, reviewed_role, visible"),
+                @Index(name = "idx_reviews_auction", columnList = "auction_id")
+        })
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "auction_id", nullable = false)
+    private Auction auction;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reviewer_id", nullable = false)
+    private User reviewer;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reviewee_id", nullable = false)
+    private User reviewee;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reviewed_role", nullable = false, length = 10)
+    private ReviewedRole reviewedRole;
+
+    /**
+     * 1..5 integer rating. Range enforced at the DTO layer via Bean
+     * Validation {@code @Min(1) @Max(5)}, not at the entity column —
+     * the entity is the persistence model, not the input validator.
+     */
+    @Column(nullable = false)
+    private Integer rating;
+
+    /**
+     * Optional free-text body, capped at 500 chars. Nullable by design:
+     * rating-only reviews are legitimate input.
+     */
+    @Column(length = 500)
+    private String text;
+
+    /**
+     * Visibility gate. {@code false} on submit; flipped to {@code true}
+     * by {@code ReviewService.reveal} once the counterparty also
+     * submits (Task 2 simultaneous-reveal path) or the day-14 scheduler
+     * sweeps. Task 1 only ever persists this column as {@code false}.
+     */
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean visible = false;
+
+    @CreationTimestamp
+    @Column(name = "submitted_at", nullable = false, updatable = false)
+    private OffsetDateTime submittedAt;
+
+    /**
+     * Stamped by {@code ReviewService.reveal} at the moment the row
+     * becomes visible. Null until then. Task 2 populates this.
+     */
+    @Column(name = "revealed_at")
+    private OffsetDateTime revealedAt;
+
+    /**
+     * Running count of {@link ReviewFlag} rows pointing at this
+     * review. Incremented by the flag endpoint (Task 3). No auto-hide;
+     * flags are moderation signal, not censorship.
+     */
+    @Builder.Default
+    @Column(name = "flag_count", nullable = false)
+    private Integer flagCount = 0;
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/ReviewActionController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/ReviewActionController.java
@@ -1,0 +1,85 @@
+package com.slparcelauctions.backend.review;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.review.dto.ReviewFlagRequest;
+import com.slparcelauctions.backend.review.dto.ReviewResponseDto;
+import com.slparcelauctions.backend.review.dto.ReviewResponseSubmitRequest;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserNotFoundException;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Review secondary-action endpoints (Epic 08 sub-spec 1 Task 3): post one
+ * reviewee response, or raise a moderation flag against someone else's
+ * review. Split from {@link ReviewController} because the paths root at
+ * {@code /api/v1/reviews/{id}/*} rather than
+ * {@code /api/v1/auctions/{id}/reviews}; keeping the two classes separate
+ * avoids the two {@code @RequestMapping} prefixes colliding on a single
+ * controller and mirrors the {@link UserReviewsController} split that
+ * Task 2 already established.
+ *
+ * <p>Both endpoints gate behind the JWT filter — the caller's {@link User}
+ * is loaded from the {@link AuthPrincipal} at the controller boundary so
+ * the service layer has a managed reference for the reviewee-check /
+ * reviewer-check and the FKs on {@code ReviewResponse} / {@code ReviewFlag}.
+ * Per FOOTGUNS §B.1, this codebase uses {@link AuthPrincipal}, never
+ * {@code UserDetails}.
+ */
+@RestController
+@RequestMapping("/api/v1/reviews")
+@RequiredArgsConstructor
+public class ReviewActionController {
+
+    private final ReviewService reviewService;
+    private final UserRepository userRepository;
+
+    /**
+     * Reviewee posts a one-time response to a review about them. Service
+     * rejects non-reviewees with 403 and a second response on the same
+     * review with 409; request validation ({@code @NotBlank},
+     * {@code @Size(max=500)}) fires at the controller boundary before the
+     * service is called.
+     */
+    @PostMapping("/{id}/respond")
+    public ResponseEntity<ReviewResponseDto> respond(
+            @PathVariable("id") Long reviewId,
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @Valid @RequestBody ReviewResponseSubmitRequest request) {
+        User caller = userRepository.findById(principal.userId())
+                .orElseThrow(() -> new UserNotFoundException(principal.userId()));
+        ReviewResponseDto dto = reviewService.respondTo(reviewId, caller, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(dto);
+    }
+
+    /**
+     * Any authenticated user other than the review's author may flag the
+     * review for admin review. Class-level
+     * {@link com.slparcelauctions.backend.review.exception.ElaborationRequiredWhenOther}
+     * enforces the "{@code elaboration} required when {@code reason=OTHER}"
+     * cross-field rule at request-bind time. 204 No Content mirrors the
+     * spec §4.4 contract; the flag is a fire-and-forget signal for
+     * moderators.
+     */
+    @PostMapping("/{id}/flag")
+    public ResponseEntity<Void> flag(
+            @PathVariable("id") Long reviewId,
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @Valid @RequestBody ReviewFlagRequest request) {
+        User caller = userRepository.findById(principal.userId())
+                .orElseThrow(() -> new UserNotFoundException(principal.userId()));
+        reviewService.flag(reviewId, caller, request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/ReviewController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/ReviewController.java
@@ -1,0 +1,52 @@
+package com.slparcelauctions.backend.review;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.review.dto.ReviewDto;
+import com.slparcelauctions.backend.review.dto.ReviewSubmitRequest;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserNotFoundException;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * REST entry points for the blind-reveal review pipeline. Task 1 ships
+ * only the submit endpoint; Task 2 adds the GET list path on the same
+ * controller.
+ */
+@RestController
+@RequestMapping("/api/v1/auctions")
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+    private final UserRepository userRepository;
+
+    /**
+     * Submit a review for an auction. Authenticated; the caller's User
+     * entity is loaded from the JWT-bearing {@link AuthPrincipal} so
+     * the service has a managed reference for the {@code reviewer} FK
+     * without another round-trip. Eligibility and duplicate-checks live
+     * in the service so the controller stays thin.
+     */
+    @PostMapping("/{auctionId}/reviews")
+    public ResponseEntity<ReviewDto> submit(
+            @PathVariable Long auctionId,
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @Valid @RequestBody ReviewSubmitRequest request) {
+        User caller = userRepository.findById(principal.userId())
+                .orElseThrow(() -> new UserNotFoundException(principal.userId()));
+        ReviewDto dto = reviewService.submit(auctionId, caller, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(dto);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/ReviewController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/ReviewController.java
@@ -3,6 +3,7 @@ package com.slparcelauctions.backend.review;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.review.dto.AuctionReviewsResponse;
 import com.slparcelauctions.backend.review.dto.ReviewDto;
 import com.slparcelauctions.backend.review.dto.ReviewSubmitRequest;
 import com.slparcelauctions.backend.user.User;
@@ -20,9 +22,12 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 /**
- * REST entry points for the blind-reveal review pipeline. Task 1 ships
- * only the submit endpoint; Task 2 adds the GET list path on the same
- * controller.
+ * REST entry points for the blind-reveal review pipeline. Task 1 shipped
+ * the submit endpoint; Task 2 adds the GET list path on the same
+ * controller. The GET is public so anon browsers can see the visible
+ * reviews, but authenticates a principal when one is present so the
+ * response can enrich with the caller's own pending submission +
+ * {@code canReview} flag.
  */
 @RestController
 @RequestMapping("/api/v1/auctions")
@@ -48,5 +53,24 @@ public class ReviewController {
                 .orElseThrow(() -> new UserNotFoundException(principal.userId()));
         ReviewDto dto = reviewService.submit(auctionId, caller, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(dto);
+    }
+
+    /**
+     * Public GET of all reviews for an auction. Anonymous callers get
+     * only the visible reviews; authenticated callers who are a party
+     * to the completed escrow additionally see {@code myPendingReview},
+     * {@code canReview}, and {@code windowClosesAt} so the UI can render
+     * the "compose your review" affordance without a second round-trip.
+     * Non-party authenticated callers see the same anon-shape response
+     * (no pending / no canReview).
+     */
+    @GetMapping("/{auctionId}/reviews")
+    public AuctionReviewsResponse list(
+            @PathVariable Long auctionId,
+            @AuthenticationPrincipal AuthPrincipal principal) {
+        User caller = principal == null
+                ? null
+                : userRepository.findById(principal.userId()).orElse(null);
+        return reviewService.listForAuction(auctionId, caller);
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/review/ReviewFlag.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/ReviewFlag.java
@@ -1,0 +1,73 @@
+package com.slparcelauctions.backend.review;
+
+import java.time.OffsetDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import com.slparcelauctions.backend.user.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Per-user flag row against a {@link Review} (Epic 08 sub-spec 1 §3.3).
+ * The {@code (review_id, flagger_id)} uniqueness constraint enforces
+ * "one flag per user per review" at the DB level — the flag endpoint in
+ * Task 3 checks this first so callers get a {@code 409
+ * ReviewFlagAlreadyExistsException}, but the DB is the last line of
+ * defence under concurrent flags.
+ *
+ * <p>{@code elaboration} is optional except when
+ * {@code reason=OTHER} — that cross-field validation lives at the DTO
+ * layer in Task 3, not on the entity.
+ */
+@Entity
+@Table(name = "review_flags",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_review_flags_review_flagger",
+                columnNames = {"review_id", "flagger_id"}))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewFlag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review review;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "flagger_id", nullable = false)
+    private User flagger;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ReviewFlagReason reason;
+
+    @Column(length = 500)
+    private String elaboration;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/ReviewFlagReason.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/ReviewFlagReason.java
@@ -1,0 +1,13 @@
+package com.slparcelauctions.backend.review;
+
+/**
+ * Enumerated flag reason for {@link ReviewFlag}. {@code OTHER} requires a
+ * non-null {@code elaboration} (enforced at the DTO layer in Task 3).
+ */
+public enum ReviewFlagReason {
+    SPAM,
+    ABUSIVE,
+    OFF_TOPIC,
+    FALSE_INFO,
+    OTHER
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/ReviewFlagRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/ReviewFlagRepository.java
@@ -1,0 +1,14 @@
+package com.slparcelauctions.backend.review;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Spring Data repository for {@link ReviewFlag}. {@code (reviewId, flaggerId)}
+ * uniqueness is enforced at the DB; the {@code existsBy...} helper lets
+ * the Task 3 flag-submission path return a 409 without triggering the
+ * constraint violation.
+ */
+public interface ReviewFlagRepository extends JpaRepository<ReviewFlag, Long> {
+
+    boolean existsByReviewIdAndFlaggerId(Long reviewId, Long flaggerId);
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/ReviewRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/ReviewRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import jakarta.persistence.LockModeType;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -67,4 +68,29 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             order by r.id
             """)
     List<Review> findRevealable(@Param("threshold") OffsetDateTime threshold, Pageable page);
+
+    /**
+     * Visible reviews for an auction (both sides — seller + buyer). Used
+     * by {@code GET /api/v1/auctions/{id}/reviews} to populate the
+     * {@code reviews} array. {@code revealedAt DESC} ordering matches the
+     * public profile listing contract so the most recent reveal appears
+     * first.
+     */
+    @Query("""
+            select r from Review r
+            where r.auction.id = :auctionId
+              and r.visible = true
+            order by r.revealedAt desc
+            """)
+    List<Review> findByAuctionIdAndVisibleTrue(@Param("auctionId") Long auctionId);
+
+    /**
+     * Paginated visible reviews for a user in a specific role — backs
+     * the public profile page's reviews tab. Derived-query method name
+     * resolves to {@code reviewee_id + reviewed_role + visible} which
+     * exactly hits the composite index
+     * {@code idx_reviews_reviewee_visible}.
+     */
+    Page<Review> findByRevieweeIdAndReviewedRoleAndVisibleTrue(
+            Long revieweeId, ReviewedRole reviewedRole, Pageable page);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/review/ReviewRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/ReviewRepository.java
@@ -1,0 +1,70 @@
+package com.slparcelauctions.backend.review;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.persistence.LockModeType;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * Spring Data repository for {@link Review}. The {@code findByIdForUpdate}
+ * method takes a pessimistic write lock for the Task 2 reveal path; the
+ * aggregate projections materialise into {@link Aggregate} records that
+ * the aggregate-recompute routine consumes. Task 1 uses only
+ * {@link #findByAuctionIdAndReviewerId}; the other methods are defined
+ * here so Task 2 can ship reveal + aggregates without re-touching this
+ * file (see plan §Task 2).
+ */
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    Optional<Review> findByAuctionIdAndReviewerId(Long auctionId, Long reviewerId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select r from Review r where r.id = :id")
+    Optional<Review> findByIdForUpdate(@Param("id") Long id);
+
+    @Query("""
+            select new com.slparcelauctions.backend.review.Aggregate(
+                avg(r.rating), count(r))
+            from Review r
+            where r.reviewee.id = :revieweeId
+              and r.reviewedRole = com.slparcelauctions.backend.review.ReviewedRole.SELLER
+              and r.visible = true
+            """)
+    Aggregate computeSellerAggregate(@Param("revieweeId") Long revieweeId);
+
+    @Query("""
+            select new com.slparcelauctions.backend.review.Aggregate(
+                avg(r.rating), count(r))
+            from Review r
+            where r.reviewee.id = :revieweeId
+              and r.reviewedRole = com.slparcelauctions.backend.review.ReviewedRole.BUYER
+              and r.visible = true
+            """)
+    Aggregate computeBuyerAggregate(@Param("revieweeId") Long revieweeId);
+
+    /**
+     * Pending reviews whose auction's escrow completed at or before the
+     * supplied threshold — i.e., day-14 reveal candidates for the
+     * scheduler in Task 2. Returns {@code id}-ordered pages; the caller
+     * is expected to lock each row individually inside its own
+     * transaction via {@link #findByIdForUpdate(Long)}.
+     */
+    @Query("""
+            select r from Review r
+            where r.visible = false
+              and r.auction.id in (
+                select e.auction.id from com.slparcelauctions.backend.escrow.Escrow e
+                where e.state = com.slparcelauctions.backend.escrow.EscrowState.COMPLETED
+                  and e.completedAt < :threshold
+              )
+            order by r.id
+            """)
+    List<Review> findRevealable(@Param("threshold") OffsetDateTime threshold, Pageable page);
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/ReviewResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/ReviewResponse.java
@@ -1,0 +1,52 @@
+package com.slparcelauctions.backend.review;
+
+import java.time.OffsetDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * One-time reviewee response to a {@link Review} (Epic 08 sub-spec 1
+ * §3.2). The {@code review_id} FK is unique, so the constraint enforces
+ * "one response per review" at the DB level. Creation is gated in
+ * Task 3 via {@code POST /api/v1/reviews/{id}/respond} to the review's
+ * {@code reviewee}.
+ */
+@Entity
+@Table(name = "review_responses")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewResponse {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "review_id", nullable = false, unique = true)
+    private Review review;
+
+    @Column(nullable = false, length = 500)
+    private String text;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/ReviewResponseRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/ReviewResponseRepository.java
@@ -1,0 +1,18 @@
+package com.slparcelauctions.backend.review;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Spring Data repository for {@link ReviewResponse}. One response per
+ * review is enforced at the DB via the unique FK; the repository helpers
+ * here let the service and DTO-builder paths avoid re-loading a response
+ * they already know doesn't exist.
+ */
+public interface ReviewResponseRepository extends JpaRepository<ReviewResponse, Long> {
+
+    Optional<ReviewResponse> findByReviewId(Long reviewId);
+
+    boolean existsByReviewId(Long reviewId);
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/ReviewRevealedEnvelope.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/ReviewRevealedEnvelope.java
@@ -1,0 +1,42 @@
+package com.slparcelauctions.backend.review;
+
+import java.time.OffsetDateTime;
+
+/**
+ * WebSocket envelope broadcast on {@code /topic/auction/{auctionId}} the
+ * moment a {@link Review} flips from {@code visible=false} to
+ * {@code visible=true} — either via the simultaneous-reveal branch in
+ * {@code ReviewService.submit} or the hourly {@code BlindReviewRevealTask}
+ * scheduler sweep. The spec (§7) defines this envelope as part of the
+ * auction topic; the frontend's {@code AuctionTopicEnvelope} TypeScript
+ * union gains a {@code REVIEW_REVEALED} variant in Task 5. Emitted on
+ * {@code afterCommit} so subscribers never observe a reveal that gets
+ * rolled back.
+ *
+ * <p>Payload intentionally omits the rating/text fields — clients that
+ * receive a {@code REVIEW_REVEALED} invalidate their
+ * {@code useAuctionReviews(auctionId)} query and refetch through the
+ * authenticated GET path, which is the single place visibility rules
+ * and viewer-specific gating live. Passing rating/text here would duplicate
+ * the gating logic and leak content to any subscriber on the public topic.
+ */
+public record ReviewRevealedEnvelope(
+        String type,
+        Long auctionId,
+        Long reviewId,
+        Long reviewerId,
+        Long revieweeId,
+        ReviewedRole reviewedRole,
+        OffsetDateTime revealedAt) {
+
+    public static ReviewRevealedEnvelope of(Review r) {
+        return new ReviewRevealedEnvelope(
+                "REVIEW_REVEALED",
+                r.getAuction().getId(),
+                r.getId(),
+                r.getReviewer().getId(),
+                r.getReviewee().getId(),
+                r.getReviewedRole(),
+                r.getRevealedAt());
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/ReviewService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/ReviewService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -27,10 +28,15 @@ import com.slparcelauctions.backend.review.broadcast.ReviewBroadcastPublisher;
 import com.slparcelauctions.backend.review.dto.AuctionReviewsResponse;
 import com.slparcelauctions.backend.review.dto.PendingReviewDto;
 import com.slparcelauctions.backend.review.dto.ReviewDto;
+import com.slparcelauctions.backend.review.dto.ReviewFlagRequest;
+import com.slparcelauctions.backend.review.dto.ReviewResponseDto;
+import com.slparcelauctions.backend.review.dto.ReviewResponseSubmitRequest;
 import com.slparcelauctions.backend.review.dto.ReviewSubmitRequest;
 import com.slparcelauctions.backend.review.exception.ReviewAlreadySubmittedException;
+import com.slparcelauctions.backend.review.exception.ReviewFlagAlreadyExistsException;
 import com.slparcelauctions.backend.review.exception.ReviewIneligibleException;
 import com.slparcelauctions.backend.review.exception.ReviewNotFoundException;
+import com.slparcelauctions.backend.review.exception.ReviewResponseAlreadyExistsException;
 import com.slparcelauctions.backend.review.exception.ReviewWindowClosedException;
 import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.user.UserNotFoundException;
@@ -71,6 +77,7 @@ public class ReviewService {
 
     private final ReviewRepository reviewRepo;
     private final ReviewResponseRepository responseRepo;
+    private final ReviewFlagRepository flagRepo;
     private final AuctionRepository auctionRepo;
     private final EscrowRepository escrowRepo;
     private final UserRepository userRepo;
@@ -343,6 +350,74 @@ public class ReviewService {
                 .map(e -> PendingReviewDto.of(e, caller,
                         resolveCounterparty(e, caller), now))
                 .toList();
+    }
+
+    /**
+     * Persist a one-time reviewee response to a review (Epic 08 sub-spec
+     * 1 §4.3). Only the {@code review.reviewee} may respond — every other
+     * caller (including the reviewer and any third party) is rejected as
+     * 403. A second response on the same review is rejected as 409; the
+     * {@code review_id}-unique FK on {@code review_responses} is the
+     * last-line-of-defence under concurrent double-clicks, mapped to the
+     * same 409 by {@code ReviewExceptionHandler}'s constraint-name
+     * fallback.
+     */
+    @Transactional
+    public ReviewResponseDto respondTo(Long reviewId, User caller,
+                                       ReviewResponseSubmitRequest req) {
+        Review r = reviewRepo.findById(reviewId)
+                .orElseThrow(() -> new ReviewNotFoundException(reviewId));
+        if (!r.getReviewee().getId().equals(caller.getId())) {
+            throw new AccessDeniedException("Only the reviewee can respond to a review.");
+        }
+        if (responseRepo.existsByReviewId(reviewId)) {
+            throw new ReviewResponseAlreadyExistsException(reviewId);
+        }
+        ReviewResponse resp = responseRepo.save(ReviewResponse.builder()
+                .review(r)
+                .text(req.text())
+                .build());
+        log.info("Review {} response persisted: reviewee={}, responseId={}",
+                reviewId, caller.getId(), resp.getId());
+        return ReviewResponseDto.of(resp);
+    }
+
+    /**
+     * Persist a moderation flag against a review (Epic 08 sub-spec 1
+     * §4.4). The review's reviewer cannot flag their own review (403);
+     * every other authenticated user may flag at most one time per
+     * review. Side-effect: {@code review.flagCount} is incremented inside
+     * the same transaction so the admin moderation queue (Epic 10) sees a
+     * consistent count. No auto-hide — flags are a moderation signal, not
+     * censorship. The {@code uq_review_flags_review_flagger} unique
+     * constraint backs the pre-check; a racing flag by the same user is
+     * mapped to the same 409 by {@code ReviewExceptionHandler}'s
+     * constraint-name fallback.
+     *
+     * <p>The review row is loaded with a pessimistic write lock
+     * ({@code findByIdForUpdate}) so two concurrent flags on the same
+     * review do not race on {@code flagCount}.
+     */
+    @Transactional
+    public void flag(Long reviewId, User caller, ReviewFlagRequest req) {
+        Review r = reviewRepo.findByIdForUpdate(reviewId)
+                .orElseThrow(() -> new ReviewNotFoundException(reviewId));
+        if (r.getReviewer().getId().equals(caller.getId())) {
+            throw new AccessDeniedException("You cannot flag your own review.");
+        }
+        if (flagRepo.existsByReviewIdAndFlaggerId(reviewId, caller.getId())) {
+            throw new ReviewFlagAlreadyExistsException(reviewId);
+        }
+        flagRepo.save(ReviewFlag.builder()
+                .review(r)
+                .flagger(caller)
+                .reason(req.reason())
+                .elaboration(req.elaboration())
+                .build());
+        r.setFlagCount(r.getFlagCount() + 1);
+        reviewRepo.save(r);
+        log.info("Review {} flagged by user {} (reason={}); flagCount={}",
+                reviewId, caller.getId(), req.reason(), r.getFlagCount());
     }
 
     private User resolveCounterparty(Escrow e, User viewer) {

--- a/backend/src/main/java/com/slparcelauctions/backend/review/ReviewService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/ReviewService.java
@@ -1,0 +1,178 @@
+package com.slparcelauctions.backend.review;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Comparator;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionPhoto;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
+import com.slparcelauctions.backend.escrow.Escrow;
+import com.slparcelauctions.backend.escrow.EscrowRepository;
+import com.slparcelauctions.backend.escrow.EscrowState;
+import com.slparcelauctions.backend.review.dto.ReviewDto;
+import com.slparcelauctions.backend.review.dto.ReviewSubmitRequest;
+import com.slparcelauctions.backend.review.exception.ReviewAlreadySubmittedException;
+import com.slparcelauctions.backend.review.exception.ReviewIneligibleException;
+import com.slparcelauctions.backend.review.exception.ReviewWindowClosedException;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserNotFoundException;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Blind-reveal review service (Epic 08 sub-spec 1 §4.1). Task 1 ships
+ * the {@link #submit(Long, User, ReviewSubmitRequest)} entry point only —
+ * the simultaneous-reveal branch, the day-14 scheduler path, aggregate
+ * recompute, and the read endpoints all land in Task 2. The Task 2 code
+ * will add {@code reveal(Long)} + {@code recomputeAggregates(...)} +
+ * list endpoints without re-touching the write path here.
+ *
+ * <p>Every submit opens a fresh JPA transaction. Eligibility is checked
+ * in a fixed order so the 422 / 409 / 404 responses are stable for the
+ * frontend: auction-not-found → escrow-missing / not-COMPLETED →
+ * window-closed → caller-not-a-party → duplicate-review.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReviewService {
+
+    /**
+     * Hard cutoff for the review window. Reviews submitted strictly after
+     * {@code escrow.completedAt + 14 days} are rejected with
+     * {@link ReviewWindowClosedException} (422). The day-14 scheduler
+     * sweep (Task 2) uses the same duration so a review submitted at
+     * {@code T+13d23h59m} is accepted but the sweep that fires at
+     * {@code T+14d} reveals it.
+     */
+    public static final Duration REVIEW_WINDOW = Duration.ofDays(14);
+
+    private final ReviewRepository reviewRepo;
+    private final ReviewResponseRepository responseRepo;
+    private final AuctionRepository auctionRepo;
+    private final EscrowRepository escrowRepo;
+    private final UserRepository userRepo;
+    private final Clock clock;
+
+    /**
+     * Persist a new {@link Review} for the caller against the given
+     * auction. Runs every eligibility check before the INSERT so the
+     * caller sees a clean 422 / 409 instead of a constraint-violation
+     * stack trace, but the DB's {@code uq_reviews_auction_reviewer}
+     * unique constraint is the last-line-of-defence under concurrent
+     * submits by the same reviewer (duplicate INSERT → DB error →
+     * handled by the slice's exception advice chain).
+     *
+     * <p>Task 1 persists {@code visible=false} and returns. Task 2 adds
+     * the simultaneous-reveal branch: if the counterparty already
+     * submitted, both rows are flipped visible inside the same tx and a
+     * {@code REVIEW_REVEALED} envelope is broadcast on afterCommit.
+     */
+    @Transactional
+    public ReviewDto submit(Long auctionId, User caller, ReviewSubmitRequest req) {
+        Auction auction = auctionRepo.findById(auctionId)
+                .orElseThrow(() -> new AuctionNotFoundException(auctionId));
+
+        Escrow escrow = escrowRepo.findByAuctionId(auctionId)
+                .orElseThrow(() -> new ReviewIneligibleException(
+                        "Auction has no escrow; reviews open only after the sale closes."));
+
+        if (escrow.getState() != EscrowState.COMPLETED) {
+            throw new ReviewIneligibleException(
+                    "Reviews are only accepted once the escrow has completed.");
+        }
+
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        OffsetDateTime windowCloses = escrow.getCompletedAt().plus(REVIEW_WINDOW);
+        if (now.isAfter(windowCloses)) {
+            throw new ReviewWindowClosedException(
+                    "The 14-day review window for this auction has closed.");
+        }
+
+        Long sellerId = auction.getSeller().getId();
+        Long winnerUserId = auction.getWinnerUserId();
+        Long callerId = caller.getId();
+
+        if (winnerUserId == null) {
+            // Defensive — a COMPLETED escrow must have a winner; this
+            // branch indicates data corruption worth surfacing rather
+            // than quietly 403-ing.
+            throw new ReviewIneligibleException(
+                    "Auction has no recorded winner; reviews are unavailable.");
+        }
+        boolean callerIsSeller = callerId.equals(sellerId);
+        boolean callerIsWinner = callerId.equals(winnerUserId);
+        if (!callerIsSeller && !callerIsWinner) {
+            throw new ReviewIneligibleException(
+                    "Only the seller or winner of this auction can submit a review.");
+        }
+
+        if (reviewRepo.findByAuctionIdAndReviewerId(auctionId, callerId).isPresent()) {
+            throw new ReviewAlreadySubmittedException(
+                    "You have already submitted a review for this auction.");
+        }
+
+        // Derive reviewee + reviewedRole from caller's role. Caller =
+        // seller → reviewing the winner's BUYER behaviour; caller =
+        // winner → reviewing the seller's SELLER behaviour. Auction
+        // carries only the winner's numeric id (not a managed User
+        // reference), so the seller-submitting-about-buyer branch
+        // loads the winner User explicitly.
+        User reviewee;
+        ReviewedRole reviewedRole;
+        if (callerIsSeller) {
+            reviewee = userRepo.findById(winnerUserId)
+                    .orElseThrow(() -> new UserNotFoundException(winnerUserId));
+            reviewedRole = ReviewedRole.BUYER;
+        } else {
+            reviewee = auction.getSeller();
+            reviewedRole = ReviewedRole.SELLER;
+        }
+
+        Review mine = reviewRepo.save(Review.builder()
+                .auction(auction)
+                .reviewer(caller)
+                .reviewee(reviewee)
+                .reviewedRole(reviewedRole)
+                .rating(req.rating())
+                .text(req.text())
+                .visible(false)
+                .build());
+
+        log.info("Review {} submitted on auction {}: reviewer={}, reviewedRole={}, visible=false",
+                mine.getId(), auctionId, callerId, reviewedRole);
+
+        // Task 2 will add the simultaneous-reveal branch here (counterparty
+        // already submitted → flip both visible, recompute aggregates,
+        // broadcast REVIEW_REVEALED). Task 1 intentionally leaves this
+        // out; see plan §Task 1 Step 21 note.
+
+        // Surface the reviewer's pending submission to themselves so
+        // the UI can render the "waiting for the other party" state.
+        return ReviewDto.of(mine, callerId,
+                responseRepo.findByReviewId(mine.getId()),
+                resolvePrimaryPhotoUrl(auction));
+    }
+
+    /**
+     * Mirrors the listing-detail primary-photo fallback: first photo by
+     * {@code sortOrder}, else the parcel's {@code snapshotUrl}. Returned
+     * URL is the public {@code /api/v1/auctions/{id}/photos/{photoId}/bytes}
+     * proxy path so renderers do not need to know S3 object keys.
+     */
+    private String resolvePrimaryPhotoUrl(Auction auction) {
+        return auction.getPhotos().stream()
+                .sorted(Comparator.comparing(AuctionPhoto::getSortOrder))
+                .findFirst()
+                .map(p -> "/api/v1/auctions/" + auction.getId() + "/photos/" + p.getId() + "/bytes")
+                .orElseGet(() -> auction.getParcel() == null ? null : auction.getParcel().getSnapshotUrl());
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/ReviewService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/ReviewService.java
@@ -4,9 +4,17 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import com.slparcelauctions.backend.auction.Auction;
 import com.slparcelauctions.backend.auction.AuctionPhoto;
@@ -15,10 +23,14 @@ import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
 import com.slparcelauctions.backend.escrow.Escrow;
 import com.slparcelauctions.backend.escrow.EscrowRepository;
 import com.slparcelauctions.backend.escrow.EscrowState;
+import com.slparcelauctions.backend.review.broadcast.ReviewBroadcastPublisher;
+import com.slparcelauctions.backend.review.dto.AuctionReviewsResponse;
+import com.slparcelauctions.backend.review.dto.PendingReviewDto;
 import com.slparcelauctions.backend.review.dto.ReviewDto;
 import com.slparcelauctions.backend.review.dto.ReviewSubmitRequest;
 import com.slparcelauctions.backend.review.exception.ReviewAlreadySubmittedException;
 import com.slparcelauctions.backend.review.exception.ReviewIneligibleException;
+import com.slparcelauctions.backend.review.exception.ReviewNotFoundException;
 import com.slparcelauctions.backend.review.exception.ReviewWindowClosedException;
 import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.user.UserNotFoundException;
@@ -28,16 +40,18 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Blind-reveal review service (Epic 08 sub-spec 1 §4.1). Task 1 ships
- * the {@link #submit(Long, User, ReviewSubmitRequest)} entry point only —
- * the simultaneous-reveal branch, the day-14 scheduler path, aggregate
- * recompute, and the read endpoints all land in Task 2. The Task 2 code
- * will add {@code reveal(Long)} + {@code recomputeAggregates(...)} +
- * list endpoints without re-touching the write path here.
+ * Blind-reveal review service (Epic 08 sub-spec 1 §4.1 / §5). Task 1
+ * shipped submit; Task 2 fills in the rest — reveal + aggregate recompute
+ * + WS broadcast + list endpoints. The simultaneous-reveal branch in
+ * {@link #submit(Long, User, ReviewSubmitRequest)} fires when the
+ * counterparty already submitted: both reviews flip to {@code visible=true}
+ * inside the same transaction, aggregates are recomputed for both
+ * reviewees, and a {@code REVIEW_REVEALED} envelope fires on afterCommit
+ * for each.
  *
- * <p>Every submit opens a fresh JPA transaction. Eligibility is checked
- * in a fixed order so the 422 / 409 / 404 responses are stable for the
- * frontend: auction-not-found → escrow-missing / not-COMPLETED →
+ * <p>Every submit / reveal opens a fresh JPA transaction. Eligibility is
+ * checked in a fixed order so the 422 / 409 / 404 responses are stable
+ * for the frontend: auction-not-found → escrow-missing / not-COMPLETED →
  * window-closed → caller-not-a-party → duplicate-review.
  */
 @Service
@@ -49,7 +63,7 @@ public class ReviewService {
      * Hard cutoff for the review window. Reviews submitted strictly after
      * {@code escrow.completedAt + 14 days} are rejected with
      * {@link ReviewWindowClosedException} (422). The day-14 scheduler
-     * sweep (Task 2) uses the same duration so a review submitted at
+     * sweep uses the same duration so a review submitted at
      * {@code T+13d23h59m} is accepted but the sweep that fires at
      * {@code T+14d} reveals it.
      */
@@ -60,6 +74,7 @@ public class ReviewService {
     private final AuctionRepository auctionRepo;
     private final EscrowRepository escrowRepo;
     private final UserRepository userRepo;
+    private final ReviewBroadcastPublisher broadcastPublisher;
     private final Clock clock;
 
     /**
@@ -71,10 +86,12 @@ public class ReviewService {
      * submits by the same reviewer (duplicate INSERT → DB error →
      * handled by the slice's exception advice chain).
      *
-     * <p>Task 1 persists {@code visible=false} and returns. Task 2 adds
-     * the simultaneous-reveal branch: if the counterparty already
-     * submitted, both rows are flipped visible inside the same tx and a
-     * {@code REVIEW_REVEALED} envelope is broadcast on afterCommit.
+     * <p>If the counterparty already submitted a pending review, both
+     * rows flip to {@code visible=true} inside this transaction and a
+     * {@code REVIEW_REVEALED} envelope fires on afterCommit for each —
+     * aggregates are recomputed for both reviewees in the same tx so
+     * the UI's refetch sees a consistent {@code User.avg*Rating} /
+     * {@code total*Reviews} snapshot.
      */
     @Transactional
     public ReviewDto submit(Long auctionId, User caller, ReviewSubmitRequest req) {
@@ -150,16 +167,194 @@ public class ReviewService {
         log.info("Review {} submitted on auction {}: reviewer={}, reviewedRole={}, visible=false",
                 mine.getId(), auctionId, callerId, reviewedRole);
 
-        // Task 2 will add the simultaneous-reveal branch here (counterparty
-        // already submitted → flip both visible, recompute aggregates,
-        // broadcast REVIEW_REVEALED). Task 1 intentionally leaves this
-        // out; see plan §Task 1 Step 21 note.
+        // Simultaneous-reveal branch (spec §5 Q9 blind-on-fact). If the
+        // counterparty already submitted a pending review, flip both
+        // rows visible inside the same transaction so aggregates + WS
+        // broadcast fire atomically. Counterparty = the OTHER party
+        // (seller XOR winner) — distinct from {@code reviewee}, which
+        // is whoever the caller is reviewing. If the caller is the
+        // seller they are reviewing the winner (buyer-role), so the
+        // counterparty's own submission — their review of the seller —
+        // has reviewerId == winnerUserId.
+        Long counterpartyId = callerIsSeller ? winnerUserId : sellerId;
+        Optional<Review> counterparty = reviewRepo
+                .findByAuctionIdAndReviewerId(auctionId, counterpartyId);
+        if (counterparty.isPresent()
+                && !Boolean.TRUE.equals(counterparty.get().getVisible())) {
+            revealNow(mine, now);
+            revealNow(counterparty.get(), now);
+            recomputeAggregates(mine.getReviewee(), mine.getReviewedRole());
+            recomputeAggregates(counterparty.get().getReviewee(),
+                    counterparty.get().getReviewedRole());
+            registerBroadcast(mine);
+            registerBroadcast(counterparty.get());
+        }
 
         // Surface the reviewer's pending submission to themselves so
         // the UI can render the "waiting for the other party" state.
         return ReviewDto.of(mine, callerId,
                 responseRepo.findByReviewId(mine.getId()),
                 resolvePrimaryPhotoUrl(auction));
+    }
+
+    /**
+     * Flip a single review from {@code visible=false} to {@code true},
+     * recompute the reviewee's aggregate, and queue a
+     * {@code REVIEW_REVEALED} envelope on afterCommit. Idempotent — a
+     * second call on an already-visible review is a no-op so the
+     * scheduler can retry after a crash without overwriting
+     * {@code revealedAt} or double-broadcasting. Takes a pessimistic
+     * write lock to prevent two schedulers (or a scheduler and a
+     * simultaneous-submit) from racing on the same row.
+     */
+    @Transactional
+    public void reveal(Long reviewId) {
+        Review r = reviewRepo.findByIdForUpdate(reviewId)
+                .orElseThrow(() -> new ReviewNotFoundException(reviewId));
+        if (Boolean.TRUE.equals(r.getVisible())) {
+            return; // idempotent early return
+        }
+
+        revealNow(r, OffsetDateTime.now(clock));
+        recomputeAggregates(r.getReviewee(), r.getReviewedRole());
+        registerBroadcast(r);
+
+        log.info("Review {} revealed: auction={}, reviewee={}, role={}",
+                r.getId(), r.getAuction().getId(), r.getReviewee().getId(),
+                r.getReviewedRole());
+    }
+
+    /**
+     * Full recompute of {@code avg*Rating} + {@code total*Reviews} over
+     * the reviewee's currently-visible reviews in the given role. Runs
+     * after every reveal — a full recompute (not incremental) because
+     * the scheduler can catch up on multiple reveals across a single
+     * reviewee and the running-total math would drift if a flag moderation
+     * action ever marks a row invisible. {@code Aggregate} normalises the
+     * null-AVG case (COUNT=0 → avg=null) so the DECIMAL(3,2) column
+     * accepts the write.
+     */
+    @Transactional
+    public void recomputeAggregates(User reviewee, ReviewedRole role) {
+        if (role == ReviewedRole.SELLER) {
+            Aggregate agg = reviewRepo.computeSellerAggregate(reviewee.getId());
+            reviewee.setAvgSellerRating(agg.avg());
+            reviewee.setTotalSellerReviews(agg.count());
+        } else {
+            Aggregate agg = reviewRepo.computeBuyerAggregate(reviewee.getId());
+            reviewee.setAvgBuyerRating(agg.avg());
+            reviewee.setTotalBuyerReviews(agg.count());
+        }
+        userRepo.save(reviewee);
+    }
+
+    /**
+     * Auction-scoped review list. Public — anon callers see the visible
+     * reviews only. When the caller is authenticated AND a party to the
+     * completed escrow, the response enriches with their own pending
+     * submission, a {@code canReview} bool, and the absolute
+     * {@code windowClosesAt} timestamp so the UI can render the "14 day"
+     * countdown without a second round-trip.
+     */
+    @Transactional(readOnly = true)
+    public AuctionReviewsResponse listForAuction(Long auctionId, User caller) {
+        Auction auction = auctionRepo.findById(auctionId)
+                .orElseThrow(() -> new AuctionNotFoundException(auctionId));
+        Optional<Escrow> maybeEscrow = escrowRepo.findByAuctionId(auctionId);
+
+        List<Review> visible = reviewRepo.findByAuctionIdAndVisibleTrue(auctionId);
+        String primaryPhoto = resolvePrimaryPhotoUrl(auction);
+        Long callerId = caller == null ? null : caller.getId();
+
+        List<ReviewDto> visibleDtos = visible.stream()
+                .map(r -> ReviewDto.of(r, callerId,
+                        responseRepo.findByReviewId(r.getId()), primaryPhoto))
+                .toList();
+
+        ReviewDto myPending = null;
+        boolean canReview = false;
+        OffsetDateTime windowCloses = null;
+
+        if (caller != null && maybeEscrow.isPresent()
+                && maybeEscrow.get().getState() == EscrowState.COMPLETED) {
+            Escrow e = maybeEscrow.get();
+            Long sellerId = auction.getSeller().getId();
+            Long winnerId = auction.getWinnerUserId();
+            boolean isParty = callerId.equals(sellerId)
+                    || (winnerId != null && callerId.equals(winnerId));
+            if (isParty) {
+                windowCloses = e.getCompletedAt().plus(REVIEW_WINDOW);
+                OffsetDateTime now = OffsetDateTime.now(clock);
+                boolean windowOpen = !now.isAfter(windowCloses);
+                Optional<Review> mine = reviewRepo
+                        .findByAuctionIdAndReviewerId(auctionId, callerId);
+                canReview = windowOpen && mine.isEmpty();
+                myPending = mine
+                        .filter(r -> !Boolean.TRUE.equals(r.getVisible()))
+                        .map(r -> ReviewDto.of(r, callerId,
+                                responseRepo.findByReviewId(r.getId()), primaryPhoto))
+                        .orElse(null);
+            }
+        }
+
+        return new AuctionReviewsResponse(visibleDtos, myPending, canReview, windowCloses);
+    }
+
+    /**
+     * Paginated public list of a user's visible reviews in the given
+     * role. Sort order is {@code revealedAt DESC} so the newest reveal
+     * is first on each page. Viewer gating is disabled (passing
+     * {@code null} to {@link ReviewDto#of}) because the profile-page use
+     * case is third-party browsing — the reviewer always sees their own
+     * pending reviews via the dashboard's pending-review endpoint, not
+     * here.
+     */
+    @Transactional(readOnly = true)
+    public Page<ReviewDto> listForUser(Long userId, ReviewedRole role, Pageable page) {
+        Pageable sorted = PageRequest.of(page.getPageNumber(), page.getPageSize(),
+                Sort.by(Sort.Direction.DESC, "revealedAt"));
+        Page<Review> reviews = reviewRepo
+                .findByRevieweeIdAndReviewedRoleAndVisibleTrue(userId, role, sorted);
+        return reviews.map(r -> ReviewDto.of(r, null,
+                responseRepo.findByReviewId(r.getId()),
+                resolvePrimaryPhotoUrl(r.getAuction())));
+    }
+
+    /**
+     * Every completed escrow where the caller is seller or winner, the
+     * 14-day window is still open, and the caller has not yet submitted
+     * a review. Used by the dashboard's "waiting for your review" tab.
+     * {@link PendingReviewDto#of} takes {@code now} from this method's
+     * Clock so a frozen-clock test can assert {@code hoursRemaining}
+     * deterministically. The counterparty is resolved here (the seller
+     * is a managed {@link User} ref on {@code Auction.seller}; the
+     * winner is only a numeric id via {@code Auction.winnerUserId}, so
+     * we load it explicitly when the caller is the seller).
+     */
+    @Transactional(readOnly = true)
+    public List<PendingReviewDto> listPendingForCaller(User caller) {
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        OffsetDateTime threshold = now.minus(REVIEW_WINDOW);
+        return escrowRepo.findCompletedEscrowsForUser(caller.getId(), threshold)
+                .stream()
+                .filter(e -> reviewRepo
+                        .findByAuctionIdAndReviewerId(e.getAuction().getId(), caller.getId())
+                        .isEmpty())
+                .map(e -> PendingReviewDto.of(e, caller,
+                        resolveCounterparty(e, caller), now))
+                .toList();
+    }
+
+    private User resolveCounterparty(Escrow e, User viewer) {
+        Long sellerId = e.getAuction().getSeller().getId();
+        if (sellerId.equals(viewer.getId())) {
+            Long winnerUserId = e.getAuction().getWinnerUserId();
+            if (winnerUserId == null) {
+                return null;
+            }
+            return userRepo.findById(winnerUserId).orElse(null);
+        }
+        return e.getAuction().getSeller();
     }
 
     /**
@@ -174,5 +369,35 @@ public class ReviewService {
                 .findFirst()
                 .map(p -> "/api/v1/auctions/" + auction.getId() + "/photos/" + p.getId() + "/bytes")
                 .orElseGet(() -> auction.getParcel() == null ? null : auction.getParcel().getSnapshotUrl());
+    }
+
+    private void revealNow(Review r, OffsetDateTime now) {
+        r.setVisible(true);
+        r.setRevealedAt(now);
+        reviewRepo.save(r);
+    }
+
+    /**
+     * Register an afterCommit callback that publishes the
+     * {@code REVIEW_REVEALED} envelope. The envelope snapshot is built
+     * inside the tx — {@code r.getRevealedAt()} is the value we just
+     * stamped — so the afterCommit callback does not re-read a possibly
+     * detached entity. If no transaction is active (e.g. unit test with
+     * a spied service), the publisher is called immediately; this matches
+     * the escrow publisher's behaviour and keeps slice tests simple.
+     */
+    private void registerBroadcast(Review r) {
+        ReviewRevealedEnvelope envelope = ReviewRevealedEnvelope.of(r);
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            broadcastPublisher.publishReviewRevealed(envelope);
+                        }
+                    });
+        } else {
+            broadcastPublisher.publishReviewRevealed(envelope);
+        }
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/review/ReviewedRole.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/ReviewedRole.java
@@ -1,0 +1,17 @@
+package com.slparcelauctions.backend.review;
+
+/**
+ * Role whose behaviour a {@link Review} rates. Persisted (not derived) on
+ * the Review row so aggregate queries over a reviewee's visible reviews
+ * use an index-only scan — see
+ * {@code idx_reviews_reviewee_visible}.
+ *
+ * <p>A seller→buyer review (seller rates the winner) carries
+ * {@code reviewedRole=BUYER}; on reveal, the reviewee's
+ * {@code avgBuyerRating} + {@code totalBuyerReviews} recompute. A
+ * winner→seller review carries {@code reviewedRole=SELLER}.
+ */
+public enum ReviewedRole {
+    SELLER,
+    BUYER
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/UserReviewsController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/UserReviewsController.java
@@ -1,0 +1,70 @@
+package com.slparcelauctions.backend.review;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.common.PagedResponse;
+import com.slparcelauctions.backend.review.dto.PendingReviewDto;
+import com.slparcelauctions.backend.review.dto.ReviewDto;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserNotFoundException;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Reviews endpoints scoped to a user rather than an auction. Two paths:
+ * <ul>
+ *   <li>{@code GET /users/{id}/reviews?role=SELLER|BUYER} — public
+ *       paginated list of visible reviews for a user in a specific
+ *       role. Backs the profile page's reviews tab.</li>
+ *   <li>{@code GET /users/me/pending-reviews} — authenticated; lists
+ *       completed escrows where the caller is a party and has not yet
+ *       submitted a review within the 14-day window. Backs the
+ *       dashboard's "waiting for your review" card.</li>
+ * </ul>
+ *
+ * <p>Split out of {@link ReviewController} because the paths are rooted
+ * under {@code /users}, not {@code /auctions}, and mirroring the spec
+ * layout keeps the SecurityConfig matchers legible.
+ */
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class UserReviewsController {
+
+    private static final int MAX_PAGE_SIZE = 50;
+
+    private final ReviewService reviewService;
+    private final UserRepository userRepository;
+
+    @GetMapping("/users/{id}/reviews")
+    public PagedResponse<ReviewDto> listForUser(
+            @PathVariable("id") Long userId,
+            @RequestParam("role") ReviewedRole role,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size) {
+        int clampedSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+        int clampedPage = Math.max(page, 0);
+        Page<ReviewDto> result = reviewService.listForUser(userId, role,
+                PageRequest.of(clampedPage, clampedSize));
+        return PagedResponse.from(result);
+    }
+
+    @GetMapping("/users/me/pending-reviews")
+    public List<PendingReviewDto> listPending(
+            @AuthenticationPrincipal AuthPrincipal principal) {
+        User caller = userRepository.findById(principal.userId())
+                .orElseThrow(() -> new UserNotFoundException(principal.userId()));
+        return reviewService.listPendingForCaller(caller);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/broadcast/NoOpReviewBroadcastPublisher.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/broadcast/NoOpReviewBroadcastPublisher.java
@@ -1,0 +1,40 @@
+package com.slparcelauctions.backend.review.broadcast;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.slparcelauctions.backend.review.ReviewRevealedEnvelope;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Fallback {@link ReviewBroadcastPublisher} that logs the envelope and
+ * drops it. Kept on the classpath as a safety net for unit-test slices or
+ * degenerate configurations that omit {@link StompReviewBroadcastPublisher}.
+ * In normal dev/prod runs the Stomp bean is present, this
+ * {@code @ConditionalOnMissingBean} default steps aside automatically, and
+ * the real publisher fans the envelope out to {@code /topic/auction/{id}}.
+ *
+ * <p>Wired through a dedicated {@code @Configuration} class (not a
+ * {@code @Component}) so {@code @ConditionalOnMissingBean} is evaluated
+ * against other beans of the publisher type. Mirrors
+ * {@link com.slparcelauctions.backend.escrow.broadcast.NoOpEscrowBroadcastPublisher}
+ * and {@link com.slparcelauctions.backend.auction.broadcast.NoOpAuctionBroadcastPublisher}.
+ */
+@Configuration
+@Slf4j
+public class NoOpReviewBroadcastPublisher {
+
+    @Bean
+    @ConditionalOnMissingBean(ReviewBroadcastPublisher.class)
+    public ReviewBroadcastPublisher defaultReviewBroadcastPublisher() {
+        return new ReviewBroadcastPublisher() {
+            @Override
+            public void publishReviewRevealed(ReviewRevealedEnvelope envelope) {
+                log.debug("no-op publishReviewRevealed: auctionId={}, reviewId={}, revealedAt={}",
+                        envelope.auctionId(), envelope.reviewId(), envelope.revealedAt());
+            }
+        };
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/broadcast/ReviewBroadcastPublisher.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/broadcast/ReviewBroadcastPublisher.java
@@ -1,0 +1,32 @@
+package com.slparcelauctions.backend.review.broadcast;
+
+import com.slparcelauctions.backend.review.ReviewRevealedEnvelope;
+
+/**
+ * Abstraction over the WebSocket broadcast layer for review reveal events.
+ * The production implementation is {@link StompReviewBroadcastPublisher}; a
+ * no-op fallback ({@link NoOpReviewBroadcastPublisher}) steps aside when
+ * the Stomp bean is on the classpath. Mirrors the
+ * {@code EscrowBroadcastPublisher} / {@code AuctionBroadcastPublisher}
+ * separation so review broadcasts can be asserted in isolation by
+ * {@code @MockitoBean} in slice tests without dragging escrow + auction
+ * publish surfaces.
+ *
+ * <p>Every publish method is safe to invoke from a
+ * {@code TransactionSynchronization.afterCommit} callback — the review
+ * row is already durable by the time we reach here, so a broker failure
+ * is best-effort degradation (clients re-fetch on reconnect) rather than
+ * data loss.
+ */
+public interface ReviewBroadcastPublisher {
+
+    /**
+     * Publishes a {@link ReviewRevealedEnvelope} to
+     * {@code /topic/auction/{auctionId}} after the reveal transaction
+     * commits. Called by {@code ReviewService.reveal} (both the
+     * simultaneous-submit path and the day-14 scheduler path) via an
+     * {@code afterCommit} callback so subscribers never observe a reveal
+     * that rolls back on a late DB failure.
+     */
+    void publishReviewRevealed(ReviewRevealedEnvelope envelope);
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/broadcast/StompReviewBroadcastPublisher.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/broadcast/StompReviewBroadcastPublisher.java
@@ -1,0 +1,46 @@
+package com.slparcelauctions.backend.review.broadcast;
+
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import com.slparcelauctions.backend.review.ReviewRevealedEnvelope;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Production {@link ReviewBroadcastPublisher}. Forwards envelopes to the
+ * STOMP broker under {@code /topic/auction/{auctionId}} using Spring's
+ * {@link SimpMessagingTemplate}. Always invoked from
+ * {@code TransactionSynchronization.afterCommit} callbacks registered by
+ * {@code ReviewService.reveal}, so subscribers never observe an
+ * uncommitted reveal.
+ *
+ * <p>{@code convertAndSend} failures are caught + logged at WARN so broker
+ * issues don't surface back through the afterCommit callback — Spring's
+ * {@code TransactionSynchronizationUtils} would otherwise re-log at ERROR
+ * and drown operators in alarm noise. The review row is already durable
+ * in the DB by the time we publish, so a dropped envelope is best-effort
+ * degradation (clients re-fetch on reconnect), not data loss.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class StompReviewBroadcastPublisher implements ReviewBroadcastPublisher {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Override
+    public void publishReviewRevealed(ReviewRevealedEnvelope envelope) {
+        String destination = "/topic/auction/" + envelope.auctionId();
+        log.debug("Publishing REVIEW_REVEALED to {}: reviewId={}",
+                destination, envelope.reviewId());
+        try {
+            messagingTemplate.convertAndSend(destination, envelope);
+        } catch (MessagingException e) {
+            log.warn("Failed to publish REVIEW_REVEALED for auction {}: {}",
+                    envelope.auctionId(), e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/dto/AuctionReviewsResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/dto/AuctionReviewsResponse.java
@@ -1,0 +1,23 @@
+package com.slparcelauctions.backend.review.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * Wire shape for {@code GET /api/v1/auctions/{id}/reviews}. Public —
+ * anonymous callers see only {@code reviews}; {@code myPendingReview}
+ * and {@code canReview} + {@code windowClosesAt} are null / false for
+ * non-party or anonymous viewers (Epic 08 sub-spec 1 §4.1, spec §5).
+ *
+ * <p>{@code windowClosesAt} is the absolute server timestamp at which
+ * the 14-day window closes (escrow.completedAt + 14d) — the UI derives
+ * its countdown from the delta against {@code Date.now()} on the
+ * client rather than receiving a pre-computed hoursRemaining the
+ * moment the response was built.
+ */
+public record AuctionReviewsResponse(
+        List<ReviewDto> reviews,
+        ReviewDto myPendingReview,
+        Boolean canReview,
+        OffsetDateTime windowClosesAt) {
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/dto/PendingReviewDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/dto/PendingReviewDto.java
@@ -1,0 +1,81 @@
+package com.slparcelauctions.backend.review.dto;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Comparator;
+
+import com.slparcelauctions.backend.auction.AuctionPhoto;
+import com.slparcelauctions.backend.escrow.Escrow;
+import com.slparcelauctions.backend.review.ReviewService;
+import com.slparcelauctions.backend.review.ReviewedRole;
+import com.slparcelauctions.backend.user.User;
+
+/**
+ * Wire shape for the dashboard's "reviews waiting for you to submit"
+ * card. One row per completed escrow where the caller is a party and has
+ * not yet submitted a review within the 14-day window (Epic 08 sub-spec 1
+ * §4.2). {@link #of(Escrow, User, User, OffsetDateTime)} takes an
+ * explicit {@code now} so the service layer's Clock owns time — a
+ * frozen-clock test can assert {@code hoursRemaining} deterministically.
+ * The pre-resolved {@code counterparty} is provided by the service (the
+ * {@link Escrow} only carries {@code winnerUserId} as a numeric id, not
+ * a managed User ref) so this record stays pure.
+ *
+ * <p>{@code viewerRole} describes the reviewer's role in the transaction
+ * (what the frontend card badge reads — "Seller"/"Buyer"), NOT the role
+ * of the person being reviewed. A seller who owes a review has
+ * {@code viewerRole=SELLER} even though they will be writing about their
+ * buyer's behaviour.
+ */
+public record PendingReviewDto(
+        Long auctionId,
+        String title,
+        String primaryPhotoUrl,
+        Long counterpartyId,
+        String counterpartyDisplayName,
+        String counterpartyAvatarUrl,
+        OffsetDateTime escrowCompletedAt,
+        OffsetDateTime windowClosesAt,
+        long hoursRemaining,
+        ReviewedRole viewerRole) {
+
+    /**
+     * Build a {@link PendingReviewDto} from a COMPLETED {@link Escrow},
+     * the viewer, the pre-resolved counterparty, and the service's
+     * injected {@code now}.
+     */
+    public static PendingReviewDto of(Escrow e, User viewer, User counterparty,
+                                       OffsetDateTime now) {
+        boolean viewerIsSeller = e.getAuction().getSeller().getId().equals(viewer.getId());
+        OffsetDateTime windowCloses = e.getCompletedAt().plus(ReviewService.REVIEW_WINDOW);
+        long hoursRemaining = Math.max(0L,
+                Duration.between(now, windowCloses).toHours());
+
+        ReviewedRole viewerRole = viewerIsSeller ? ReviewedRole.SELLER : ReviewedRole.BUYER;
+
+        String photo = e.getAuction().getPhotos().stream()
+                .sorted(Comparator.comparing(AuctionPhoto::getSortOrder))
+                .findFirst()
+                .map(p -> "/api/v1/auctions/" + e.getAuction().getId()
+                        + "/photos/" + p.getId() + "/bytes")
+                .orElseGet(() -> e.getAuction().getParcel() == null
+                        ? null
+                        : e.getAuction().getParcel().getSnapshotUrl());
+
+        return new PendingReviewDto(
+                e.getAuction().getId(),
+                e.getAuction().getTitle(),
+                photo,
+                counterparty == null ? null : counterparty.getId(),
+                counterparty == null ? null : counterparty.getDisplayName(),
+                counterparty == null ? null : avatarUrl(counterparty.getId()),
+                e.getCompletedAt(),
+                windowCloses,
+                hoursRemaining,
+                viewerRole);
+    }
+
+    private static String avatarUrl(Long userId) {
+        return userId == null ? null : "/api/v1/users/" + userId + "/avatar/256";
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/dto/ReviewDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/dto/ReviewDto.java
@@ -1,0 +1,83 @@
+package com.slparcelauctions.backend.review.dto;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import com.slparcelauctions.backend.review.Review;
+import com.slparcelauctions.backend.review.ReviewResponse;
+import com.slparcelauctions.backend.review.ReviewedRole;
+
+/**
+ * Wire shape for a single review row. {@code of(...)} is the single
+ * entry point for mapping a persisted {@link Review} to the public DTO
+ * — it pulls the reviewer's live display name / avatar (so a rename
+ * immediately reflects in every visible review) and gates
+ * {@code text}, {@code rating}, {@code submittedAt} behind a visibility
+ * check: the reviewer always sees their own pending submission with
+ * text; everyone else sees nothing until the row is revealed.
+ *
+ * <p>{@code pending} is a derived viewer-specific hint: {@code true}
+ * means the viewer is this review's reviewer AND the row is not yet
+ * visible. The counterparty sees no hint of the viewer's submission
+ * (Q9 blind-on-fact decision in spec §4.2).
+ */
+public record ReviewDto(
+        Long id,
+        Long auctionId,
+        String auctionTitle,
+        String auctionPrimaryPhotoUrl,
+        Long reviewerId,
+        String reviewerDisplayName,
+        String reviewerAvatarUrl,
+        Long revieweeId,
+        ReviewedRole reviewedRole,
+        Integer rating,
+        String text,
+        Boolean visible,
+        Boolean pending,
+        OffsetDateTime submittedAt,
+        OffsetDateTime revealedAt,
+        ReviewResponseDto response) {
+
+    /**
+     * Build a {@link ReviewDto} for {@code viewerId}. When the viewer is
+     * the reviewer, {@code pending=true} and {@code text}/{@code rating}
+     * are exposed even if the row is not yet visible, so the author sees
+     * their own submission in the UI. {@code viewerId} is nullable —
+     * anonymous readers get the public-visible shape.
+     *
+     * <p>{@code primaryPhotoUrl} is resolved by the service (matches the
+     * listing-detail mapper's photo-or-parcel-snapshot fallback) so the
+     * DTO stays free of Auction→Photo traversal details.
+     */
+    public static ReviewDto of(Review r, Long viewerId,
+                                Optional<ReviewResponse> resp,
+                                String primaryPhotoUrl) {
+        boolean viewerIsReviewer = viewerId != null
+                && r.getReviewer().getId().equals(viewerId);
+        boolean visible = Boolean.TRUE.equals(r.getVisible());
+        boolean pending = !visible && viewerIsReviewer;
+        boolean exposeText = visible || viewerIsReviewer;
+        return new ReviewDto(
+                r.getId(),
+                r.getAuction().getId(),
+                r.getAuction().getTitle(),
+                primaryPhotoUrl,
+                r.getReviewer().getId(),
+                r.getReviewer().getDisplayName(),
+                avatarUrl(r.getReviewer().getId()),
+                r.getReviewee().getId(),
+                r.getReviewedRole(),
+                exposeText ? r.getRating() : null,
+                exposeText ? r.getText() : null,
+                r.getVisible(),
+                pending,
+                exposeText ? r.getSubmittedAt() : null,
+                r.getRevealedAt(),
+                resp.map(ReviewResponseDto::of).orElse(null));
+    }
+
+    private static String avatarUrl(Long userId) {
+        return userId == null ? null : "/api/v1/users/" + userId + "/avatar/256";
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/dto/ReviewFlagRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/dto/ReviewFlagRequest.java
@@ -1,0 +1,22 @@
+package com.slparcelauctions.backend.review.dto;
+
+import com.slparcelauctions.backend.review.ReviewFlagReason;
+import com.slparcelauctions.backend.review.exception.ElaborationRequiredWhenOther;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request body for {@code POST /api/v1/reviews/{id}/flag} (Epic 08
+ * sub-spec 1 §4.4). {@code reason} is always required; {@code
+ * elaboration} is optional except when {@code reason=OTHER}, enforced by
+ * the class-level {@link ElaborationRequiredWhenOther} cross-field
+ * validator.
+ */
+@ElaborationRequiredWhenOther
+public record ReviewFlagRequest(
+        @NotNull
+        ReviewFlagReason reason,
+        @Size(max = 500)
+        String elaboration) {
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/dto/ReviewResponseDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/dto/ReviewResponseDto.java
@@ -1,0 +1,21 @@
+package com.slparcelauctions.backend.review.dto;
+
+import java.time.OffsetDateTime;
+
+import com.slparcelauctions.backend.review.ReviewResponse;
+
+/**
+ * Wire shape for a persisted {@link ReviewResponse} embedded inside a
+ * {@link ReviewDto}. The reviewee's response text is already public at
+ * the point the response exists (it can only be written on a visible
+ * review in Task 3), so no visibility-gate fields are carried here.
+ */
+public record ReviewResponseDto(
+        Long id,
+        String text,
+        OffsetDateTime createdAt) {
+
+    public static ReviewResponseDto of(ReviewResponse r) {
+        return new ReviewResponseDto(r.getId(), r.getText(), r.getCreatedAt());
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/dto/ReviewResponseSubmitRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/dto/ReviewResponseSubmitRequest.java
@@ -1,0 +1,18 @@
+package com.slparcelauctions.backend.review.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request body for {@code POST /api/v1/reviews/{id}/respond} (Epic 08
+ * sub-spec 1 §4.3). The reviewee posts a one-time textual response to a
+ * review written about them; responses are non-empty and capped at 500
+ * chars. Lower-bound enforcement ({@code @NotBlank}) is deliberate — an
+ * empty response is useless and likely a UI bug the caller will want to
+ * see surfaced as 400.
+ */
+public record ReviewResponseSubmitRequest(
+        @NotBlank
+        @Size(max = 500)
+        String text) {
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/dto/ReviewSubmitRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/dto/ReviewSubmitRequest.java
@@ -1,0 +1,18 @@
+package com.slparcelauctions.backend.review.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request body for {@code POST /api/v1/auctions/{id}/reviews}. The
+ * rating is bounded at the DTO level (not the entity column) because
+ * entity-level validation happens after persistence decisions and
+ * wouldn't let the controller produce a clean 400 ProblemDetail. Text
+ * is optional — rating-only reviews are legitimate input.
+ */
+public record ReviewSubmitRequest(
+        @NotNull @Min(1) @Max(5) Integer rating,
+        @Size(max = 500) String text) {
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/exception/ElaborationRequiredWhenOther.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/exception/ElaborationRequiredWhenOther.java
@@ -1,0 +1,33 @@
+package com.slparcelauctions.backend.review.exception;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+/**
+ * Class-level cross-field validator for
+ * {@link com.slparcelauctions.backend.review.dto.ReviewFlagRequest}: when
+ * {@code reason=OTHER}, {@code elaboration} must be a non-blank string.
+ * Every other enum value accepts a null/blank elaboration. Enforcing
+ * this at the DTO layer (not the entity) keeps the constraint visible to
+ * the API surface — violations render as 400 with a per-field message
+ * via {@code GlobalExceptionHandler.handleValidation}.
+ */
+@Documented
+@Constraint(validatedBy = ElaborationRequiredWhenOtherValidator.class)
+@Target(TYPE)
+@Retention(RUNTIME)
+public @interface ElaborationRequiredWhenOther {
+
+    String message() default "Elaboration is required when reason is OTHER.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/exception/ElaborationRequiredWhenOtherValidator.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/exception/ElaborationRequiredWhenOtherValidator.java
@@ -1,0 +1,43 @@
+package com.slparcelauctions.backend.review.exception;
+
+import com.slparcelauctions.backend.review.ReviewFlagReason;
+import com.slparcelauctions.backend.review.dto.ReviewFlagRequest;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * Implementation of {@link ElaborationRequiredWhenOther}. When {@code
+ * reason=OTHER} we require a non-null, non-blank {@code elaboration};
+ * every other reason is valid regardless of the elaboration value. The
+ * violation is attached to the {@code elaboration} field (not the class)
+ * so the default {@code errors} map rendered by {@code
+ * GlobalExceptionHandler} surfaces the message under an explicit field
+ * key for the frontend.
+ */
+public class ElaborationRequiredWhenOtherValidator
+        implements ConstraintValidator<ElaborationRequiredWhenOther, ReviewFlagRequest> {
+
+    @Override
+    public boolean isValid(ReviewFlagRequest request, ConstraintValidatorContext ctx) {
+        if (request == null) {
+            // A null body is handled upstream by Jackson / @RequestBody;
+            // returning true here defers to that layer rather than
+            // shadowing it with a confusing class-level message.
+            return true;
+        }
+        if (request.reason() != ReviewFlagReason.OTHER) {
+            return true;
+        }
+        String elab = request.elaboration();
+        boolean ok = elab != null && !elab.isBlank();
+        if (!ok) {
+            ctx.disableDefaultConstraintViolation();
+            ctx.buildConstraintViolationWithTemplate(
+                            "Elaboration is required when reason is OTHER.")
+                    .addPropertyNode("elaboration")
+                    .addConstraintViolation();
+        }
+        return ok;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewAlreadySubmittedException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewAlreadySubmittedException.java
@@ -1,0 +1,12 @@
+package com.slparcelauctions.backend.review.exception;
+
+/**
+ * Caller has already submitted a review for this auction — a duplicate
+ * POST would violate the {@code uq_reviews_auction_reviewer}
+ * constraint. Maps to HTTP 409 via {@code ReviewExceptionHandler}.
+ */
+public class ReviewAlreadySubmittedException extends RuntimeException {
+    public ReviewAlreadySubmittedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewExceptionHandler.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewExceptionHandler.java
@@ -21,22 +21,31 @@ import lombok.extern.slf4j.Slf4j;
  * {@code common/exception/GlobalExceptionHandler}. See FOOTGUNS §F.26
  * — alphabetical ordering is not a safe precedence guarantee.
  *
- * <p>Mapping table (Epic 08 sub-spec 1 §4.1):
+ * <p>Mapping table (Epic 08 sub-spec 1 §4.1 / §4.3 / §4.4):
  * <ul>
  *   <li>{@link ReviewIneligibleException} → 422</li>
  *   <li>{@link ReviewWindowClosedException} → 422 (distinct so the UI
  *       can render a window-specific message)</li>
  *   <li>{@link ReviewAlreadySubmittedException} → 409</li>
- *   <li>{@link ReviewNotFoundException} → 404 (used by Task 2 GETs)</li>
+ *   <li>{@link ReviewResponseAlreadyExistsException} → 409 (Task 3)</li>
+ *   <li>{@link ReviewFlagAlreadyExistsException} → 409 (Task 3)</li>
+ *   <li>{@link ReviewNotFoundException} → 404 (used by Task 2 GETs and
+ *       the Task 3 action endpoints)</li>
  * </ul>
  *
- * <p><strong>Race fallback:</strong> {@code ReviewService#submit} pre-checks
- * duplicates via {@code reviewRepo.findByAuctionIdAndReviewerId}, but two
- * concurrent POSTs from the same reviewer can both pass the check and race
- * to INSERT. Postgres' {@code uq_reviews_auction_reviewer} unique constraint
- * rejects the loser with a {@link DataIntegrityViolationException}; the
- * handler below maps that specific constraint name to the same 409 shape as
- * the pre-check path. Unknown constraints rethrow so
+ * <p><strong>Race fallback:</strong> every write path pre-checks
+ * uniqueness, but two concurrent POSTs from the same caller can both pass
+ * the check and race to INSERT. Postgres rejects the loser with a
+ * {@link DataIntegrityViolationException}; the handler below inspects the
+ * constraint name and maps three known constraints to the same 409 shape
+ * as the pre-check path:
+ * <ul>
+ *   <li>{@code uq_reviews_auction_reviewer} — double-submit on Task 1</li>
+ *   <li>{@code uq_review_responses_review} / {@code review_id} unique FK
+ *       on {@code review_responses} — double-respond on Task 3</li>
+ *   <li>{@code uq_review_flags_review_flagger} — double-flag on Task 3</li>
+ * </ul>
+ * Unknown constraints rethrow so
  * {@link com.slparcelauctions.backend.common.exception.GlobalExceptionHandler}
  * still surfaces real bugs as 500.
  */
@@ -99,9 +108,37 @@ public class ReviewExceptionHandler {
         return pd;
     }
 
+    @ExceptionHandler(ReviewResponseAlreadyExistsException.class)
+    public ProblemDetail handleResponseAlreadyExists(ReviewResponseAlreadyExistsException e,
+                                                     HttpServletRequest req) {
+        log.info("Review response rejected (duplicate) on {}: {}",
+                req.getRequestURI(), e.getMessage());
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(
+                HttpStatus.CONFLICT, e.getMessage());
+        pd.setType(URI.create("https://slpa.example/problems/review/response-already-exists"));
+        pd.setTitle("Review response already exists");
+        pd.setInstance(URI.create(req.getRequestURI()));
+        pd.setProperty("code", "REVIEW_RESPONSE_ALREADY_EXISTS");
+        return pd;
+    }
+
+    @ExceptionHandler(ReviewFlagAlreadyExistsException.class)
+    public ProblemDetail handleFlagAlreadyExists(ReviewFlagAlreadyExistsException e,
+                                                 HttpServletRequest req) {
+        log.info("Review flag rejected (duplicate) on {}: {}",
+                req.getRequestURI(), e.getMessage());
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(
+                HttpStatus.CONFLICT, e.getMessage());
+        pd.setType(URI.create("https://slpa.example/problems/review/flag-already-exists"));
+        pd.setTitle("Review flag already exists");
+        pd.setInstance(URI.create(req.getRequestURI()));
+        pd.setProperty("code", "REVIEW_FLAG_ALREADY_EXISTS");
+        return pd;
+    }
+
     /**
-     * Race fallback for the {@code uq_reviews_auction_reviewer} unique
-     * constraint. See class javadoc. Unknown constraints are rethrown so
+     * Race fallback for the three known review-package unique constraints.
+     * See class javadoc. Unknown constraints are rethrown so
      * {@link com.slparcelauctions.backend.common.exception.GlobalExceptionHandler}
      * still catches real bugs as 500.
      *
@@ -122,8 +159,55 @@ public class ReviewExceptionHandler {
                             "You have already submitted a review for this auction."),
                     req);
         }
+        if ("uq_review_flags_review_flagger".equals(constraintName)) {
+            log.warn("Review flag race: uq_review_flags_review_flagger fired on {}. "
+                    + "Mapping to ReviewFlagAlreadyExistsException response.",
+                    req.getRequestURI());
+            return handleFlagAlreadyExists(
+                    new ReviewFlagAlreadyExistsException(extractReviewIdFromUri(req)),
+                    req);
+        }
+        // The ReviewResponse FK is simply the review_id-unique column on
+        // review_responses — no named table-level constraint. Postgres
+        // reports its auto-generated name (typically
+        // review_responses_review_id_key). Match either the conventional
+        // name or a generated suffix so the 409 maps consistently.
+        if (constraintName != null
+                && (constraintName.equals("uq_review_responses_review")
+                        || constraintName.endsWith("review_responses_review_id_key"))) {
+            log.warn("Review response race: {} fired on {}. "
+                    + "Mapping to ReviewResponseAlreadyExistsException response.",
+                    constraintName, req.getRequestURI());
+            return handleResponseAlreadyExists(
+                    new ReviewResponseAlreadyExistsException(extractReviewIdFromUri(req)),
+                    req);
+        }
         // Unknown constraint — bubble to GlobalExceptionHandler (500).
         throw e;
+    }
+
+    /**
+     * Best-effort parse of the review-id path variable from
+     * {@code /api/v1/reviews/{id}/...}. Used only to construct a
+     * user-facing error message — if the URI shape is unexpected we
+     * fall back to {@code null} so the 409 renders without an id
+     * rather than throwing from inside an exception handler.
+     */
+    private static Long extractReviewIdFromUri(HttpServletRequest req) {
+        String uri = req.getRequestURI();
+        String prefix = "/api/v1/reviews/";
+        int start = uri.indexOf(prefix);
+        if (start < 0) {
+            return null;
+        }
+        int idStart = start + prefix.length();
+        int idEnd = uri.indexOf('/', idStart);
+        String token = idEnd < 0 ? uri.substring(idStart) : uri.substring(idStart, idEnd);
+        try {
+            return Long.parseLong(token);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
     }
 
     /**

--- a/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewExceptionHandler.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewExceptionHandler.java
@@ -1,0 +1,89 @@
+package com.slparcelauctions.backend.review.exception;
+
+import java.net.URI;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Slice-scoped exception handler for the {@code review/} package. Uses
+ * the Epic 02 convention ({@code @Order(Ordered.LOWEST_PRECEDENCE -
+ * 100)}) so slice handlers reliably win over the catch-all in
+ * {@code common/exception/GlobalExceptionHandler}. See FOOTGUNS §F.26
+ * — alphabetical ordering is not a safe precedence guarantee.
+ *
+ * <p>Mapping table (Epic 08 sub-spec 1 §4.1):
+ * <ul>
+ *   <li>{@link ReviewIneligibleException} → 422</li>
+ *   <li>{@link ReviewWindowClosedException} → 422 (distinct so the UI
+ *       can render a window-specific message)</li>
+ *   <li>{@link ReviewAlreadySubmittedException} → 409</li>
+ *   <li>{@link ReviewNotFoundException} → 404 (used by Task 2 GETs)</li>
+ * </ul>
+ */
+@RestControllerAdvice(basePackages = "com.slparcelauctions.backend.review")
+@Order(Ordered.LOWEST_PRECEDENCE - 100)
+@Slf4j
+public class ReviewExceptionHandler {
+
+    @ExceptionHandler(ReviewIneligibleException.class)
+    public ProblemDetail handleIneligible(ReviewIneligibleException e,
+                                          HttpServletRequest req) {
+        log.info("Review submission rejected (ineligible) on {}: {}",
+                req.getRequestURI(), e.getMessage());
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(
+                HttpStatus.UNPROCESSABLE_ENTITY, e.getMessage());
+        pd.setType(URI.create("https://slpa.example/problems/review/ineligible"));
+        pd.setTitle("Review not eligible");
+        pd.setInstance(URI.create(req.getRequestURI()));
+        pd.setProperty("code", "REVIEW_INELIGIBLE");
+        return pd;
+    }
+
+    @ExceptionHandler(ReviewWindowClosedException.class)
+    public ProblemDetail handleWindowClosed(ReviewWindowClosedException e,
+                                            HttpServletRequest req) {
+        log.info("Review submission rejected (window closed) on {}: {}",
+                req.getRequestURI(), e.getMessage());
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(
+                HttpStatus.UNPROCESSABLE_ENTITY, e.getMessage());
+        pd.setType(URI.create("https://slpa.example/problems/review/window-closed"));
+        pd.setTitle("Review window closed");
+        pd.setInstance(URI.create(req.getRequestURI()));
+        pd.setProperty("code", "REVIEW_WINDOW_CLOSED");
+        return pd;
+    }
+
+    @ExceptionHandler(ReviewAlreadySubmittedException.class)
+    public ProblemDetail handleAlreadySubmitted(ReviewAlreadySubmittedException e,
+                                                HttpServletRequest req) {
+        log.info("Review submission rejected (duplicate) on {}: {}",
+                req.getRequestURI(), e.getMessage());
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(
+                HttpStatus.CONFLICT, e.getMessage());
+        pd.setType(URI.create("https://slpa.example/problems/review/already-submitted"));
+        pd.setTitle("Review already submitted");
+        pd.setInstance(URI.create(req.getRequestURI()));
+        pd.setProperty("code", "REVIEW_ALREADY_SUBMITTED");
+        return pd;
+    }
+
+    @ExceptionHandler(ReviewNotFoundException.class)
+    public ProblemDetail handleNotFound(ReviewNotFoundException e,
+                                        HttpServletRequest req) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(
+                HttpStatus.NOT_FOUND, e.getMessage());
+        pd.setType(URI.create("https://slpa.example/problems/review/not-found"));
+        pd.setTitle("Review not found");
+        pd.setInstance(URI.create(req.getRequestURI()));
+        pd.setProperty("code", "REVIEW_NOT_FOUND");
+        return pd;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewExceptionHandler.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewExceptionHandler.java
@@ -2,8 +2,10 @@ package com.slparcelauctions.backend.review.exception;
 
 import java.net.URI;
 
+import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -27,6 +29,16 @@ import lombok.extern.slf4j.Slf4j;
  *   <li>{@link ReviewAlreadySubmittedException} → 409</li>
  *   <li>{@link ReviewNotFoundException} → 404 (used by Task 2 GETs)</li>
  * </ul>
+ *
+ * <p><strong>Race fallback:</strong> {@code ReviewService#submit} pre-checks
+ * duplicates via {@code reviewRepo.findByAuctionIdAndReviewerId}, but two
+ * concurrent POSTs from the same reviewer can both pass the check and race
+ * to INSERT. Postgres' {@code uq_reviews_auction_reviewer} unique constraint
+ * rejects the loser with a {@link DataIntegrityViolationException}; the
+ * handler below maps that specific constraint name to the same 409 shape as
+ * the pre-check path. Unknown constraints rethrow so
+ * {@link com.slparcelauctions.backend.common.exception.GlobalExceptionHandler}
+ * still surfaces real bugs as 500.
  */
 @RestControllerAdvice(basePackages = "com.slparcelauctions.backend.review")
 @Order(Ordered.LOWEST_PRECEDENCE - 100)
@@ -85,5 +97,51 @@ public class ReviewExceptionHandler {
         pd.setInstance(URI.create(req.getRequestURI()));
         pd.setProperty("code", "REVIEW_NOT_FOUND");
         return pd;
+    }
+
+    /**
+     * Race fallback for the {@code uq_reviews_auction_reviewer} unique
+     * constraint. See class javadoc. Unknown constraints are rethrown so
+     * {@link com.slparcelauctions.backend.common.exception.GlobalExceptionHandler}
+     * still catches real bugs as 500.
+     *
+     * <p>Uses Hibernate's {@link ConstraintViolationException#getConstraintName()}
+     * via cause-chain walk — NOT {@code jakarta.validation.ConstraintViolationException},
+     * which shares a simple name but does not carry a DB constraint name.
+     */
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ProblemDetail handleDataIntegrity(DataIntegrityViolationException e,
+                                             HttpServletRequest req) {
+        String constraintName = extractConstraintName(e);
+        if ("uq_reviews_auction_reviewer".equals(constraintName)) {
+            log.warn("Review submit race: uq_reviews_auction_reviewer fired on {}. "
+                    + "Mapping to ReviewAlreadySubmittedException response.",
+                    req.getRequestURI());
+            return handleAlreadySubmitted(
+                    new ReviewAlreadySubmittedException(
+                            "You have already submitted a review for this auction."),
+                    req);
+        }
+        // Unknown constraint — bubble to GlobalExceptionHandler (500).
+        throw e;
+    }
+
+    /**
+     * Walks the cause chain to Hibernate's {@link ConstraintViolationException}
+     * to pull the Postgres constraint name. Returns empty string if the chain
+     * does not contain one. Kept private (not shared with {@code sl/ConstraintNameExtractor})
+     * because the two slices have diverged on detection semantics and sharing
+     * would drag in an accidental cross-package dependency.
+     */
+    private static String extractConstraintName(DataIntegrityViolationException e) {
+        Throwable cursor = e;
+        while (cursor != null) {
+            if (cursor instanceof ConstraintViolationException cve) {
+                String name = cve.getConstraintName();
+                return name == null ? "" : name;
+            }
+            cursor = cursor.getCause();
+        }
+        return "";
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewFlagAlreadyExistsException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewFlagAlreadyExistsException.java
@@ -1,0 +1,15 @@
+package com.slparcelauctions.backend.review.exception;
+
+/**
+ * The caller already flagged this review — a second POST to
+ * {@code /api/v1/reviews/{id}/flag} from the same user would violate the
+ * {@code uq_review_flags_review_flagger} unique constraint. Maps to HTTP
+ * 409 via {@code ReviewExceptionHandler}. The DB constraint is the
+ * last-line-of-defence under concurrent flags by the same caller.
+ */
+public class ReviewFlagAlreadyExistsException extends RuntimeException {
+
+    public ReviewFlagAlreadyExistsException(Long reviewId) {
+        super("You have already flagged review " + reviewId + ".");
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewIneligibleException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewIneligibleException.java
@@ -1,0 +1,13 @@
+package com.slparcelauctions.backend.review.exception;
+
+/**
+ * Caller attempted to submit a review for an auction they cannot review
+ * (not a party; escrow not COMPLETED; escrow missing). Maps to HTTP 422
+ * via {@code ReviewExceptionHandler} so the frontend can distinguish
+ * authentic-user-just-wrong-context (422) from forbidden-role (403).
+ */
+public class ReviewIneligibleException extends RuntimeException {
+    public ReviewIneligibleException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewNotFoundException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewNotFoundException.java
@@ -1,0 +1,13 @@
+package com.slparcelauctions.backend.review.exception;
+
+/**
+ * Lookup for a {@link com.slparcelauctions.backend.review.Review} by id
+ * returned empty. Maps to HTTP 404 via {@code ReviewExceptionHandler}.
+ * Landed in Task 1 so Task 2's GET endpoints have the exception
+ * available; Task 1 itself does not raise this exception.
+ */
+public class ReviewNotFoundException extends RuntimeException {
+    public ReviewNotFoundException(Long id) {
+        super("Review not found: " + id);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewResponseAlreadyExistsException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewResponseAlreadyExistsException.java
@@ -1,0 +1,15 @@
+package com.slparcelauctions.backend.review.exception;
+
+/**
+ * The reviewee has already posted a response to this review — a second
+ * POST to {@code /api/v1/reviews/{id}/respond} would violate the
+ * {@code review_id}-unique FK on {@code review_responses}. Maps to HTTP
+ * 409 via {@code ReviewExceptionHandler}. The DB constraint is the
+ * last-line-of-defence under concurrent responses by the same reviewee.
+ */
+public class ReviewResponseAlreadyExistsException extends RuntimeException {
+
+    public ReviewResponseAlreadyExistsException(Long reviewId) {
+        super("Review " + reviewId + " already has a response.");
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewWindowClosedException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/exception/ReviewWindowClosedException.java
@@ -1,0 +1,14 @@
+package com.slparcelauctions.backend.review.exception;
+
+/**
+ * Caller attempted to submit a review after the 14-day window
+ * ({@code escrow.completedAt + 14 days}) has passed. Separate exception
+ * from {@link ReviewIneligibleException} so the frontend can render a
+ * window-specific message without string-matching the ineligible
+ * explanation. Maps to HTTP 422.
+ */
+public class ReviewWindowClosedException extends RuntimeException {
+    public ReviewWindowClosedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/user/SellerCompletionRateMapper.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/SellerCompletionRateMapper.java
@@ -4,23 +4,35 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 /**
- * Server-computed completion rate for the listing-detail endpoint's
- * seller card. Keeps {@code cancelledWithBids} — a private seller
- * reliability signal — off the wire. Centralizes rounding + zero-
- * denominator handling in one place so DTO mappers do not re-derive
- * it inline.
+ * Server-computed completion rate for seller-card DTOs (listing-detail,
+ * browse/search result, public profile). Keeps the two private
+ * reliability counters — {@code cancelledWithBids} and
+ * {@code escrowExpiredUnfulfilled} — off the wire and centralises
+ * rounding + zero-denominator handling.
  *
- * <p>Returns {@code null} for a brand-new seller (no completed sales
- * and no cancelled-with-bids), so the public API can render "—" rather
- * than a misleading "0%". Otherwise scales the result to two decimal
- * places using {@link RoundingMode#HALF_UP}.
+ * <p>Epic 08 sub-spec 1 §3.5 widened the denominator from
+ * {@code completed + cancelledWithBids} to
+ * {@code completed + cancelledWithBids + escrowExpiredUnfulfilled} so a
+ * seller who silently lets the 72h transfer window lapse is visibly
+ * penalised alongside a seller who cancels an auction mid-flight. Both
+ * failure modes are seller-attributed; buyer-side payment timeouts do not
+ * increment {@code escrowExpiredUnfulfilled} and therefore never affect
+ * the seller's rate.
+ *
+ * <p>Returns {@code null} for a brand-new seller (all three counters at
+ * zero), so the public API can render "—" rather than a misleading
+ * "0%". Otherwise scales the result to two decimal places using
+ * {@link RoundingMode#HALF_UP}.
  */
 public final class SellerCompletionRateMapper {
 
     private SellerCompletionRateMapper() {}
 
-    public static BigDecimal compute(int completedSales, int cancelledWithBids) {
-        int denom = completedSales + cancelledWithBids;
+    public static BigDecimal compute(
+            int completedSales,
+            int cancelledWithBids,
+            int escrowExpiredUnfulfilled) {
+        int denom = completedSales + cancelledWithBids + escrowExpiredUnfulfilled;
         if (denom <= 0) {
             return null;
         }

--- a/backend/src/main/java/com/slparcelauctions/backend/user/User.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/User.java
@@ -100,6 +100,26 @@ public class User {
     @Column(name = "cancelled_with_bids", nullable = false)
     private Integer cancelledWithBids = 0;
 
+    /**
+     * Count of escrows whose 72h transfer deadline elapsed with no parcel
+     * handover — the seller-fault denominator in the three-counter
+     * completion-rate formula. Incremented inside
+     * {@code EscrowService.expireTransfer} in the same transaction that
+     * flips the escrow to {@code EXPIRED}. Not touched by
+     * {@code expirePayment} (buyer-fault). Added in Epic 08 sub-spec 1
+     * §3.4; see {@link SellerCompletionRateMapper#compute(int, int, int)}.
+     *
+     * <p>The {@code columnDefinition} supplies a SQL-side default so
+     * Hibernate's {@code ddl-auto: update} can add this NOT NULL column to
+     * existing rows on local dev databases without failing. The
+     * {@code @Builder.Default} handles the Java-side default for newly-
+     * constructed entities.
+     */
+    @Builder.Default
+    @Column(name = "escrow_expired_unfulfilled", nullable = false,
+            columnDefinition = "integer not null default 0")
+    private Integer escrowExpiredUnfulfilled = 0;
+
     @Column(name = "listing_suspension_until")
     private OffsetDateTime listingSuspensionUntil;
 

--- a/backend/src/main/java/com/slparcelauctions/backend/user/dto/UserProfileResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/dto/UserProfileResponse.java
@@ -4,8 +4,28 @@ import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
+import com.slparcelauctions.backend.user.SellerCompletionRateMapper;
 import com.slparcelauctions.backend.user.User;
 
+/**
+ * Public profile wire shape. Epic 08 sub-spec 1 §6.2 adds two derived
+ * fields:
+ *
+ * <ul>
+ *   <li>{@code completionRate} — server-computed via
+ *       {@link SellerCompletionRateMapper} over the three denominator
+ *       counters. {@code null} when all three are zero so the UI can
+ *       render "—".</li>
+ *   <li>{@code isNewSeller} — {@code true} when {@code completedSales}
+ *       is below the 3-sale trust threshold. Exposed as a direct
+ *       boolean so the profile card can render the "New Seller" badge
+ *       without recomputing the threshold on the client.</li>
+ * </ul>
+ *
+ * <p>The private reliability counters ({@code cancelledWithBids},
+ * {@code escrowExpiredUnfulfilled}) are intentionally absent from the
+ * response — only the computed rate surfaces to the wire.
+ */
 public record UserProfileResponse(
         Long id,
         String displayName,
@@ -20,9 +40,24 @@ public record UserProfileResponse(
         Integer totalSellerReviews,
         Integer totalBuyerReviews,
         Integer completedSales,
+        BigDecimal completionRate,
+        Boolean isNewSeller,
         OffsetDateTime createdAt) {
 
+    /**
+     * "New Seller" threshold. Kept public on the DTO so tests can
+     * reference it without duplicating the constant.
+     */
+    public static final int NEW_SELLER_THRESHOLD = 3;
+
     public static UserProfileResponse from(User user) {
+        int completed = user.getCompletedSales() == null ? 0 : user.getCompletedSales();
+        int cancelled = user.getCancelledWithBids() == null ? 0 : user.getCancelledWithBids();
+        int expiredUnfulfilled = user.getEscrowExpiredUnfulfilled() == null
+                ? 0 : user.getEscrowExpiredUnfulfilled();
+        BigDecimal rate = SellerCompletionRateMapper.compute(
+                completed, cancelled, expiredUnfulfilled);
+        boolean isNewSeller = completed < NEW_SELLER_THRESHOLD;
         return new UserProfileResponse(
                 user.getId(),
                 user.getDisplayName(),
@@ -37,6 +72,8 @@ public record UserProfileResponse(
                 user.getTotalSellerReviews(),
                 user.getTotalBuyerReviews(),
                 user.getCompletedSales(),
+                rate,
+                isNewSeller,
                 user.getCreatedAt());
     }
 }

--- a/backend/src/test/java/com/slparcelauctions/backend/config/SecurityConfigTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/config/SecurityConfigTest.java
@@ -104,6 +104,42 @@ class SecurityConfigTest {
                 });
     }
 
+    // ── Review read endpoints (Epic 08 sub-spec 1 Task 2) ────────────────────
+
+    @Test
+    void auctionReviewsGet_isPublic() throws Exception {
+        // Anonymous GET — may return 404 because the auction doesn't
+        // exist in this dev-profile DB, but MUST NOT 401.
+        mockMvc.perform(get("/api/v1/auctions/999/reviews"))
+                .andExpect(result -> {
+                    int status = result.getResponse().getStatus();
+                    if (status == 401) {
+                        throw new AssertionError(
+                                "Expected security to permitAll for GET /auctions/{id}/reviews, "
+                                + "got HTTP 401");
+                    }
+                });
+    }
+
+    @Test
+    void userReviewsGet_isPublic() throws Exception {
+        mockMvc.perform(get("/api/v1/users/10/reviews?role=SELLER"))
+                .andExpect(result -> {
+                    int status = result.getResponse().getStatus();
+                    if (status == 401) {
+                        throw new AssertionError(
+                                "Expected security to permitAll for GET /users/{id}/reviews, "
+                                + "got HTTP 401");
+                    }
+                });
+    }
+
+    @Test
+    void pendingReviewsGet_requiresAuth() throws Exception {
+        mockMvc.perform(get("/api/v1/users/me/pending-reviews"))
+                .andExpect(status().isUnauthorized());
+    }
+
     // ── CORS ──────────────────────────────────────────────────────────────────
 
     @Test

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowEndToEndIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowEndToEndIntegrationTest.java
@@ -258,6 +258,14 @@ class EscrowEndToEndIntegrationTest {
         assertThat(env.auctionId()).isEqualTo(seededAuctionId);
         assertThat(env.escrowId()).isEqualTo(seededEscrowId);
         assertThat(env.state()).isEqualTo(EscrowState.COMPLETED);
+
+        // Epic 08 sub-spec 1 §3.4 / §6.1: the seller's completedSales
+        // counter must bump in the same transaction that flipped the escrow
+        // to COMPLETED. Prior to sub-spec 1 this counter was declared but
+        // never written; the reputation & completion-rate pipeline hangs
+        // off this increment landing inside the payout-success handler.
+        User seller = userRepo.findById(seededSellerId).orElseThrow();
+        assertThat(seller.getCompletedSales()).isEqualTo(1);
     }
 
     // -------------------------------------------------------------------------

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowTimeoutIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowTimeoutIntegrationTest.java
@@ -196,6 +196,13 @@ class EscrowTimeoutIntegrationTest {
         assertThat(env.escrowId()).isEqualTo(seededEscrowId);
         assertThat(env.state()).isEqualTo(EscrowState.EXPIRED);
         assertThat(env.reason()).isEqualTo("PAYMENT_TIMEOUT");
+
+        // Epic 08 sub-spec 1 §6.1: a payment-timeout is buyer-fault, not
+        // seller-fault. The seller's escrowExpiredUnfulfilled counter must
+        // stay at zero — if it incremented here, a seller's completion rate
+        // would drop every time a winner failed to pay.
+        User seller = userRepo.findById(seededSellerId).orElseThrow();
+        assertThat(seller.getEscrowExpiredUnfulfilled()).isEqualTo(0);
     }
 
     @Test
@@ -228,6 +235,14 @@ class EscrowTimeoutIntegrationTest {
         EscrowExpiredEnvelope env = capturingEscrowPublisher.expired.get(0);
         assertThat(env.reason()).isEqualTo("TRANSFER_TIMEOUT");
         assertThat(env.state()).isEqualTo(EscrowState.EXPIRED);
+
+        // Epic 08 sub-spec 1 §3.4 / §6.1: a transfer-timeout is seller-fault
+        // (the seller never handed the parcel over inside the 72h window), so
+        // the seller's escrowExpiredUnfulfilled counter must bump from 0 to 1.
+        // This counter drops the seller's completion rate via the 3-arg
+        // SellerCompletionRateMapper denominator.
+        User seller = userRepo.findById(seededSellerId).orElseThrow();
+        assertThat(seller.getEscrowExpiredUnfulfilled()).isEqualTo(1);
     }
 
     @Test

--- a/backend/src/test/java/com/slparcelauctions/backend/review/BlindReviewRevealTaskTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/BlindReviewRevealTaskTest.java
@@ -1,0 +1,141 @@
+package com.slparcelauctions.backend.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Unit coverage for {@link BlindReviewRevealTask}. The scheduler's job is
+ * to compute the day-14 threshold, fetch up to 500 revealable reviews,
+ * dispatch each to {@link ReviewService#reveal(Long)}, and survive
+ * per-row failures without poisoning the batch.
+ */
+@ExtendWith(MockitoExtension.class)
+class BlindReviewRevealTaskTest {
+
+    private static final Instant FIXED_NOW = Instant.parse("2026-05-15T00:00:00Z");
+    private static final OffsetDateTime NOW = OffsetDateTime.ofInstant(FIXED_NOW, ZoneOffset.UTC);
+
+    @Mock ReviewRepository reviewRepo;
+    @Mock ReviewService reviewService;
+
+    BlindReviewRevealTask task;
+
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+        task = new BlindReviewRevealTask(reviewRepo, reviewService, clock);
+    }
+
+    private Review pending(Long id) {
+        Review r = new Review();
+        r.setId(id);
+        return r;
+    }
+
+    @Test
+    void run_noRevealable_returnsImmediately() {
+        when(reviewRepo.findRevealable(any(OffsetDateTime.class), any(Pageable.class)))
+                .thenReturn(List.of());
+
+        task.run();
+
+        verifyNoInteractions(reviewService);
+    }
+
+    @Test
+    void run_dispatchesEachRevealableReview() {
+        when(reviewRepo.findRevealable(any(OffsetDateTime.class), any(Pageable.class)))
+                .thenReturn(List.of(pending(1L), pending(2L), pending(3L)));
+
+        int processed = task.runOnce();
+
+        assertThat(processed).isEqualTo(3);
+        InOrder inOrder = inOrder(reviewService);
+        inOrder.verify(reviewService).reveal(1L);
+        inOrder.verify(reviewService).reveal(2L);
+        inOrder.verify(reviewService).reveal(3L);
+    }
+
+    @Test
+    void run_perRowFailureDoesNotPoisonBatch() {
+        when(reviewRepo.findRevealable(any(OffsetDateTime.class), any(Pageable.class)))
+                .thenReturn(List.of(pending(1L), pending(2L), pending(3L)));
+        // lenient() — other reveal(id) calls have no stubs and must
+        // silently succeed (Mockito strict-stubbing otherwise treats
+        // reveal(1L) / reveal(3L) as arg-mismatches on the reveal(2L)
+        // stub).
+        lenient().doThrow(new RuntimeException("db hiccup"))
+                .when(reviewService).reveal(2L);
+
+        int processed = task.runOnce();
+
+        // Row 2 throws; rows 1 and 3 still dispatch. processed counts 2 (1 and 3).
+        assertThat(processed).isEqualTo(2);
+        verify(reviewService).reveal(1L);
+        verify(reviewService).reveal(2L);
+        verify(reviewService).reveal(3L);
+    }
+
+    @Test
+    void run_appliesDay14ThresholdFromClock() {
+        when(reviewRepo.findRevealable(any(OffsetDateTime.class), any(Pageable.class)))
+                .thenReturn(List.of());
+
+        task.run();
+
+        ArgumentCaptor<OffsetDateTime> cap = ArgumentCaptor.forClass(OffsetDateTime.class);
+        verify(reviewRepo).findRevealable(cap.capture(), any(Pageable.class));
+        // threshold = now - 14d
+        assertThat(cap.getValue()).isEqualTo(NOW.minusDays(14));
+    }
+
+    @Test
+    void run_batchLimit500_loggedAsWarn() {
+        // 500-element batch should all be dispatched.
+        List<Review> fullBatch = IntStream.rangeClosed(1, 500)
+                .mapToObj(i -> pending((long) i))
+                .toList();
+        when(reviewRepo.findRevealable(any(OffsetDateTime.class), any(Pageable.class)))
+                .thenReturn(fullBatch);
+
+        int processed = task.runOnce();
+
+        assertThat(processed).isEqualTo(500);
+        verify(reviewService, times(500)).reveal(any(Long.class));
+    }
+
+    @Test
+    void run_idempotentOnRerun() {
+        // First call reveals. Second call sees empty (reveal flipped rows).
+        when(reviewRepo.findRevealable(any(OffsetDateTime.class), any(Pageable.class)))
+                .thenReturn(List.of(pending(1L)), List.of());
+
+        task.run();
+        task.run();
+
+        verify(reviewService, times(1)).reveal(1L);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/review/ReviewActionControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/ReviewActionControllerTest.java
@@ -1,0 +1,300 @@
+package com.slparcelauctions.backend.review;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.auth.test.WithMockAuthPrincipal;
+import com.slparcelauctions.backend.common.exception.GlobalExceptionHandler;
+import com.slparcelauctions.backend.review.dto.ReviewFlagRequest;
+import com.slparcelauctions.backend.review.dto.ReviewResponseDto;
+import com.slparcelauctions.backend.review.dto.ReviewResponseSubmitRequest;
+import com.slparcelauctions.backend.review.exception.ReviewExceptionHandler;
+import com.slparcelauctions.backend.review.exception.ReviewFlagAlreadyExistsException;
+import com.slparcelauctions.backend.review.exception.ReviewNotFoundException;
+import com.slparcelauctions.backend.review.exception.ReviewResponseAlreadyExistsException;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Slice tests for {@link ReviewActionController}. Filters are off (the
+ * SecurityConfig matchers are covered in {@code SecurityConfigTest}), so
+ * every test stages an {@link com.slparcelauctions.backend.auth.AuthPrincipal}
+ * into the context via {@link WithMockAuthPrincipal} and exercises the
+ * controller → service boundary, the validation errors, and the exception
+ * → ProblemDetail mappings pulled in by
+ * {@link ReviewExceptionHandler}.
+ */
+@WebMvcTest(controllers = ReviewActionController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({GlobalExceptionHandler.class, ReviewExceptionHandler.class})
+class ReviewActionControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockitoBean private ReviewService reviewService;
+    @MockitoBean private UserRepository userRepository;
+    @MockitoBean private JwtService jwtService;
+
+    private User mockCaller() {
+        User caller = User.builder().email("test@example.com").passwordHash("x").build();
+        caller.setId(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(caller));
+        return caller;
+    }
+
+    // ---------- POST /reviews/{id}/respond ----------
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void respond_returns201_withDto() throws Exception {
+        mockCaller();
+        ReviewResponseDto dto = new ReviewResponseDto(9_001L, "Thanks!",
+                OffsetDateTime.parse("2026-05-01T10:00:00Z"));
+        when(reviewService.respondTo(eq(1_234L), any(User.class),
+                any(ReviewResponseSubmitRequest.class))).thenReturn(dto);
+
+        ReviewResponseSubmitRequest req = new ReviewResponseSubmitRequest("Thanks!");
+        mockMvc.perform(post("/api/v1/reviews/1234/respond")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(9_001))
+                .andExpect(jsonPath("$.text").value("Thanks!"));
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void respond_returns400_whenTextBlank() throws Exception {
+        ReviewResponseSubmitRequest req = new ReviewResponseSubmitRequest("   ");
+        mockMvc.perform(post("/api/v1/reviews/1234/respond")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.text").exists());
+        verifyNoInteractions(reviewService);
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void respond_returns400_whenTextMissing() throws Exception {
+        mockMvc.perform(post("/api/v1/reviews/1234/respond")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.text").exists());
+        verifyNoInteractions(reviewService);
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void respond_returns400_whenTextTooLong() throws Exception {
+        String tooLong = "a".repeat(501);
+        ReviewResponseSubmitRequest req = new ReviewResponseSubmitRequest(tooLong);
+        mockMvc.perform(post("/api/v1/reviews/1234/respond")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.text").exists());
+        verifyNoInteractions(reviewService);
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void respond_returns403_whenNotReviewee() throws Exception {
+        mockCaller();
+        when(reviewService.respondTo(eq(1_234L), any(User.class),
+                any(ReviewResponseSubmitRequest.class)))
+                .thenThrow(new AccessDeniedException("Only the reviewee can respond to a review."));
+
+        ReviewResponseSubmitRequest req = new ReviewResponseSubmitRequest("Hi");
+        mockMvc.perform(post("/api/v1/reviews/1234/respond")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void respond_returns404_whenReviewMissing() throws Exception {
+        mockCaller();
+        when(reviewService.respondTo(eq(1_234L), any(User.class),
+                any(ReviewResponseSubmitRequest.class)))
+                .thenThrow(new ReviewNotFoundException(1_234L));
+
+        ReviewResponseSubmitRequest req = new ReviewResponseSubmitRequest("Hi");
+        mockMvc.perform(post("/api/v1/reviews/1234/respond")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("REVIEW_NOT_FOUND"));
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void respond_returns409_whenDuplicate() throws Exception {
+        mockCaller();
+        when(reviewService.respondTo(eq(1_234L), any(User.class),
+                any(ReviewResponseSubmitRequest.class)))
+                .thenThrow(new ReviewResponseAlreadyExistsException(1_234L));
+
+        ReviewResponseSubmitRequest req = new ReviewResponseSubmitRequest("Thanks!");
+        mockMvc.perform(post("/api/v1/reviews/1234/respond")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("REVIEW_RESPONSE_ALREADY_EXISTS"));
+    }
+
+    // ---------- POST /reviews/{id}/flag ----------
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void flag_returns204_onFirstFlag() throws Exception {
+        mockCaller();
+        doNothing().when(reviewService).flag(eq(1_234L), any(User.class),
+                any(ReviewFlagRequest.class));
+
+        ReviewFlagRequest req = new ReviewFlagRequest(ReviewFlagReason.SPAM, null);
+        mockMvc.perform(post("/api/v1/reviews/1234/flag")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isNoContent());
+
+        verify(reviewService).flag(eq(1_234L), any(User.class),
+                any(ReviewFlagRequest.class));
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void flag_returns400_whenReasonMissing() throws Exception {
+        mockMvc.perform(post("/api/v1/reviews/1234/flag")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.reason").exists());
+        verifyNoInteractions(reviewService);
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void flag_returns400_whenOtherWithoutElaboration() throws Exception {
+        ReviewFlagRequest req = new ReviewFlagRequest(ReviewFlagReason.OTHER, null);
+        mockMvc.perform(post("/api/v1/reviews/1234/flag")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.elaboration").exists());
+        verifyNoInteractions(reviewService);
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void flag_returns400_whenOtherWithBlankElaboration() throws Exception {
+        ReviewFlagRequest req = new ReviewFlagRequest(ReviewFlagReason.OTHER, "   ");
+        mockMvc.perform(post("/api/v1/reviews/1234/flag")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.elaboration").exists());
+        verifyNoInteractions(reviewService);
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void flag_returns400_whenElaborationTooLong() throws Exception {
+        String tooLong = "a".repeat(501);
+        ReviewFlagRequest req = new ReviewFlagRequest(ReviewFlagReason.OTHER, tooLong);
+        mockMvc.perform(post("/api/v1/reviews/1234/flag")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.elaboration").exists());
+        verifyNoInteractions(reviewService);
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void flag_returns204_whenOtherWithElaboration() throws Exception {
+        mockCaller();
+        doNothing().when(reviewService).flag(eq(1_234L), any(User.class),
+                any(ReviewFlagRequest.class));
+
+        ReviewFlagRequest req = new ReviewFlagRequest(ReviewFlagReason.OTHER,
+                "Contains a scam link");
+        mockMvc.perform(post("/api/v1/reviews/1234/flag")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void flag_returns403_whenCallerIsReviewer() throws Exception {
+        mockCaller();
+        doThrow(new AccessDeniedException("You cannot flag your own review."))
+                .when(reviewService).flag(eq(1_234L), any(User.class),
+                        any(ReviewFlagRequest.class));
+
+        ReviewFlagRequest req = new ReviewFlagRequest(ReviewFlagReason.SPAM, null);
+        mockMvc.perform(post("/api/v1/reviews/1234/flag")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void flag_returns404_whenReviewMissing() throws Exception {
+        mockCaller();
+        doThrow(new ReviewNotFoundException(1_234L))
+                .when(reviewService).flag(eq(1_234L), any(User.class),
+                        any(ReviewFlagRequest.class));
+
+        ReviewFlagRequest req = new ReviewFlagRequest(ReviewFlagReason.SPAM, null);
+        mockMvc.perform(post("/api/v1/reviews/1234/flag")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("REVIEW_NOT_FOUND"));
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void flag_returns409_whenDuplicate() throws Exception {
+        mockCaller();
+        doThrow(new ReviewFlagAlreadyExistsException(1_234L))
+                .when(reviewService).flag(eq(1_234L), any(User.class),
+                        any(ReviewFlagRequest.class));
+
+        ReviewFlagRequest req = new ReviewFlagRequest(ReviewFlagReason.SPAM, null);
+        mockMvc.perform(post("/api/v1/reviews/1234/flag")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("REVIEW_FLAG_ALREADY_EXISTS"));
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/review/ReviewControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/ReviewControllerTest.java
@@ -2,12 +2,15 @@ package com.slparcelauctions.backend.review;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -23,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.slparcelauctions.backend.auth.JwtService;
 import com.slparcelauctions.backend.auth.test.WithMockAuthPrincipal;
 import com.slparcelauctions.backend.common.exception.GlobalExceptionHandler;
+import com.slparcelauctions.backend.review.dto.AuctionReviewsResponse;
 import com.slparcelauctions.backend.review.dto.ReviewDto;
 import com.slparcelauctions.backend.review.dto.ReviewSubmitRequest;
 import com.slparcelauctions.backend.review.exception.ReviewAlreadySubmittedException;
@@ -184,5 +188,37 @@ class ReviewControllerTest {
                         .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code").value("REVIEW_ALREADY_SUBMITTED"));
+    }
+
+    @Test
+    void listReviews_anon_returns200_withVisibleReviewsOnly() throws Exception {
+        when(reviewService.listForAuction(eq(555L), isNull()))
+                .thenReturn(new AuctionReviewsResponse(
+                        List.of(sampleDto()), null, false, null));
+
+        mockMvc.perform(get("/api/v1/auctions/555/reviews"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reviews").isArray())
+                .andExpect(jsonPath("$.reviews[0].id").value(1_234))
+                .andExpect(jsonPath("$.myPendingReview").doesNotExist())
+                .andExpect(jsonPath("$.canReview").value(false))
+                .andExpect(jsonPath("$.windowClosesAt").doesNotExist());
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void listReviews_authenticatedParty_returns200_withEnrichedShape() throws Exception {
+        User caller = User.builder().email("test@example.com").passwordHash("x").build();
+        caller.setId(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(caller));
+        OffsetDateTime windowCloses = OffsetDateTime.now().plusDays(13);
+        when(reviewService.listForAuction(eq(555L), any(User.class)))
+                .thenReturn(new AuctionReviewsResponse(
+                        List.of(), null, true, windowCloses));
+
+        mockMvc.perform(get("/api/v1/auctions/555/reviews"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.canReview").value(true))
+                .andExpect(jsonPath("$.windowClosesAt").exists());
     }
 }

--- a/backend/src/test/java/com/slparcelauctions/backend/review/ReviewControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/ReviewControllerTest.java
@@ -1,0 +1,188 @@
+package com.slparcelauctions.backend.review;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.auth.test.WithMockAuthPrincipal;
+import com.slparcelauctions.backend.common.exception.GlobalExceptionHandler;
+import com.slparcelauctions.backend.review.dto.ReviewDto;
+import com.slparcelauctions.backend.review.dto.ReviewSubmitRequest;
+import com.slparcelauctions.backend.review.exception.ReviewAlreadySubmittedException;
+import com.slparcelauctions.backend.review.exception.ReviewExceptionHandler;
+import com.slparcelauctions.backend.review.exception.ReviewIneligibleException;
+import com.slparcelauctions.backend.review.exception.ReviewWindowClosedException;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Slice tests for {@link ReviewController}. Mirrors the shape of
+ * {@code UserControllerTest}: filters off (the security filter chain is
+ * exercised in {@code SecurityConfigTest}), slice + global exception
+ * handlers imported so status-code mappings resolve, and both the
+ * service and user repository mocked.
+ */
+@WebMvcTest(controllers = ReviewController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({GlobalExceptionHandler.class, ReviewExceptionHandler.class})
+class ReviewControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockitoBean private ReviewService reviewService;
+    @MockitoBean private UserRepository userRepository;
+    @MockitoBean private JwtService jwtService;
+
+    private ReviewDto sampleDto() {
+        return new ReviewDto(
+                1_234L,
+                555L,
+                "Lakefront",
+                "/api/v1/auctions/555/photos/1/bytes",
+                1L,
+                "Viewer",
+                "/api/v1/users/1/avatar/256",
+                10L,
+                ReviewedRole.SELLER,
+                5,
+                "Great",
+                false,
+                true,
+                OffsetDateTime.now(),
+                null,
+                null);
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void submitReview_returns201_withDto() throws Exception {
+        User caller = User.builder().email("test@example.com").passwordHash("x").build();
+        caller.setId(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(caller));
+        when(reviewService.submit(eq(555L), any(User.class), any(ReviewSubmitRequest.class)))
+                .thenReturn(sampleDto());
+
+        ReviewSubmitRequest req = new ReviewSubmitRequest(5, "Great");
+        mockMvc.perform(post("/api/v1/auctions/555/reviews")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1_234))
+                .andExpect(jsonPath("$.auctionId").value(555))
+                .andExpect(jsonPath("$.pending").value(true))
+                .andExpect(jsonPath("$.visible").value(false));
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void submitReview_ratingOutOfRange_returns400() throws Exception {
+        ReviewSubmitRequest req = new ReviewSubmitRequest(6, null);
+        mockMvc.perform(post("/api/v1/auctions/555/reviews")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.rating").exists());
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void submitReview_ratingZero_returns400() throws Exception {
+        ReviewSubmitRequest req = new ReviewSubmitRequest(0, null);
+        mockMvc.perform(post("/api/v1/auctions/555/reviews")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.rating").exists());
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void submitReview_ratingMissing_returns400() throws Exception {
+        mockMvc.perform(post("/api/v1/auctions/555/reviews")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.rating").exists());
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void submitReview_textTooLong_returns400() throws Exception {
+        String tooLong = "a".repeat(501);
+        ReviewSubmitRequest req = new ReviewSubmitRequest(5, tooLong);
+        mockMvc.perform(post("/api/v1/auctions/555/reviews")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.text").exists());
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void submitReview_ineligible_returns422_REVIEW_INELIGIBLE() throws Exception {
+        User caller = User.builder().email("test@example.com").passwordHash("x").build();
+        caller.setId(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(caller));
+        when(reviewService.submit(eq(555L), any(User.class), any(ReviewSubmitRequest.class)))
+                .thenThrow(new ReviewIneligibleException("Reviews are only accepted once the escrow has completed."));
+
+        ReviewSubmitRequest req = new ReviewSubmitRequest(5, null);
+        mockMvc.perform(post("/api/v1/auctions/555/reviews")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("REVIEW_INELIGIBLE"));
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void submitReview_windowClosed_returns422_REVIEW_WINDOW_CLOSED() throws Exception {
+        User caller = User.builder().email("test@example.com").passwordHash("x").build();
+        caller.setId(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(caller));
+        when(reviewService.submit(eq(555L), any(User.class), any(ReviewSubmitRequest.class)))
+                .thenThrow(new ReviewWindowClosedException("Window closed"));
+
+        ReviewSubmitRequest req = new ReviewSubmitRequest(5, null);
+        mockMvc.perform(post("/api/v1/auctions/555/reviews")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("REVIEW_WINDOW_CLOSED"));
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void submitReview_duplicate_returns409_REVIEW_ALREADY_SUBMITTED() throws Exception {
+        User caller = User.builder().email("test@example.com").passwordHash("x").build();
+        caller.setId(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(caller));
+        when(reviewService.submit(eq(555L), any(User.class), any(ReviewSubmitRequest.class)))
+                .thenThrow(new ReviewAlreadySubmittedException("Already submitted"));
+
+        ReviewSubmitRequest req = new ReviewSubmitRequest(5, null);
+        mockMvc.perform(post("/api/v1/auctions/555/reviews")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("REVIEW_ALREADY_SUBMITTED"));
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/review/ReviewEntityTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/ReviewEntityTest.java
@@ -1,0 +1,30 @@
+package com.slparcelauctions.backend.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.slparcelauctions.backend.user.User;
+
+/**
+ * Pure POJO-level assertions for the {@link Review} entity's
+ * {@code @Builder.Default} contract. Protects the {@code visible=false}
+ * and {@code flagCount=0} defaults — a regression here would silently
+ * surface unrevealed reviews on the public list endpoint.
+ */
+class ReviewEntityTest {
+
+    @Test
+    void visibleDefaultsFalseAndFlagCountZero() {
+        User u = User.builder().email("x@y.z").passwordHash("x").build();
+        Review r = Review.builder()
+                .reviewer(u)
+                .reviewee(u)
+                .reviewedRole(ReviewedRole.SELLER)
+                .rating(5)
+                .build();
+        assertThat(r.getVisible()).isFalse();
+        assertThat(r.getFlagCount()).isEqualTo(0);
+        assertThat(r.getRevealedAt()).isNull();
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceActionTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceActionTest.java
@@ -1,0 +1,282 @@
+package com.slparcelauctions.backend.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.escrow.EscrowRepository;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.review.broadcast.ReviewBroadcastPublisher;
+import com.slparcelauctions.backend.review.dto.ReviewFlagRequest;
+import com.slparcelauctions.backend.review.dto.ReviewResponseDto;
+import com.slparcelauctions.backend.review.dto.ReviewResponseSubmitRequest;
+import com.slparcelauctions.backend.review.exception.ReviewFlagAlreadyExistsException;
+import com.slparcelauctions.backend.review.exception.ReviewNotFoundException;
+import com.slparcelauctions.backend.review.exception.ReviewResponseAlreadyExistsException;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Unit coverage for {@link ReviewService#respondTo(Long, User,
+ * ReviewResponseSubmitRequest)} and {@link ReviewService#flag(Long, User,
+ * ReviewFlagRequest)}. Every branch is exercised: happy path, 404
+ * review-not-found, 403 wrong-caller, 409 duplicate. The
+ * {@code flagCount++} side-effect is asserted via ArgumentCaptor on the
+ * review save.
+ */
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceActionTest {
+
+    private static final Instant FIXED_NOW = Instant.parse("2026-05-01T10:00:00Z");
+    private static final OffsetDateTime NOW = OffsetDateTime.ofInstant(FIXED_NOW, ZoneOffset.UTC);
+
+    @Mock ReviewRepository reviewRepo;
+    @Mock ReviewResponseRepository responseRepo;
+    @Mock ReviewFlagRepository flagRepo;
+    @Mock AuctionRepository auctionRepo;
+    @Mock EscrowRepository escrowRepo;
+    @Mock UserRepository userRepo;
+    @Mock ReviewBroadcastPublisher broadcastPublisher;
+
+    ReviewService service;
+
+    User seller;
+    User winner;
+    User stranger;
+    Auction auction;
+    Review review; // Winner reviewing seller — reviewee=seller, reviewer=winner
+
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+        service = new ReviewService(reviewRepo, responseRepo, flagRepo, auctionRepo,
+                escrowRepo, userRepo, broadcastPublisher, clock);
+
+        seller = User.builder().email("seller@example.com").passwordHash("x").build();
+        seller.setId(10L);
+        seller.setDisplayName("Sally");
+        winner = User.builder().email("winner@example.com").passwordHash("x").build();
+        winner.setId(20L);
+        winner.setDisplayName("Willy");
+        stranger = User.builder().email("stranger@example.com").passwordHash("x").build();
+        stranger.setId(99L);
+        stranger.setDisplayName("Sam");
+
+        Parcel parcel = Parcel.builder().snapshotUrl("https://snap/1.jpg").build();
+        auction = Auction.builder()
+                .title("Lakefront")
+                .seller(seller)
+                .parcel(parcel)
+                .winnerUserId(winner.getId())
+                .photos(List.of())
+                .build();
+        auction.setId(555L);
+
+        review = Review.builder()
+                .auction(auction)
+                .reviewer(winner)
+                .reviewee(seller)
+                .reviewedRole(ReviewedRole.SELLER)
+                .rating(5)
+                .text("Smooth")
+                .visible(true)
+                .flagCount(0)
+                .build();
+        review.setId(1_001L);
+    }
+
+    // ---------- respondTo ----------
+
+    @Test
+    void respond_rejectsWhenReviewNotFound() {
+        when(reviewRepo.findById(1_001L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                service.respondTo(1_001L, seller, new ReviewResponseSubmitRequest("Thanks!")))
+                .isInstanceOf(ReviewNotFoundException.class);
+
+        verify(responseRepo, never()).save(any());
+    }
+
+    @Test
+    void respond_rejectsWhenCallerIsNotReviewee() {
+        when(reviewRepo.findById(1_001L)).thenReturn(Optional.of(review));
+
+        // Reviewer attempting to respond to their own review is NOT the
+        // reviewee — 403.
+        assertThatThrownBy(() ->
+                service.respondTo(1_001L, winner, new ReviewResponseSubmitRequest("Thanks!")))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("reviewee");
+
+        verify(responseRepo, never()).save(any());
+    }
+
+    @Test
+    void respond_rejectsWhenCallerIsThirdParty() {
+        when(reviewRepo.findById(1_001L)).thenReturn(Optional.of(review));
+
+        assertThatThrownBy(() ->
+                service.respondTo(1_001L, stranger, new ReviewResponseSubmitRequest("Hi")))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(responseRepo, never()).save(any());
+    }
+
+    @Test
+    void respond_rejectsWhenResponseAlreadyExists() {
+        when(reviewRepo.findById(1_001L)).thenReturn(Optional.of(review));
+        when(responseRepo.existsByReviewId(1_001L)).thenReturn(true);
+
+        assertThatThrownBy(() ->
+                service.respondTo(1_001L, seller, new ReviewResponseSubmitRequest("Thanks!")))
+                .isInstanceOf(ReviewResponseAlreadyExistsException.class);
+
+        verify(responseRepo, never()).save(any());
+    }
+
+    @Test
+    void respond_persistsAndReturnsDto() {
+        when(reviewRepo.findById(1_001L)).thenReturn(Optional.of(review));
+        when(responseRepo.existsByReviewId(1_001L)).thenReturn(false);
+        when(responseRepo.save(any(ReviewResponse.class))).thenAnswer(inv -> {
+            ReviewResponse r = inv.getArgument(0);
+            r.setId(9_001L);
+            r.setCreatedAt(NOW);
+            return r;
+        });
+
+        ReviewResponseDto dto = service.respondTo(1_001L, seller,
+                new ReviewResponseSubmitRequest("Appreciate it!"));
+
+        ArgumentCaptor<ReviewResponse> cap = ArgumentCaptor.forClass(ReviewResponse.class);
+        verify(responseRepo).save(cap.capture());
+        ReviewResponse saved = cap.getValue();
+        assertThat(saved.getReview()).isEqualTo(review);
+        assertThat(saved.getText()).isEqualTo("Appreciate it!");
+
+        assertThat(dto.id()).isEqualTo(9_001L);
+        assertThat(dto.text()).isEqualTo("Appreciate it!");
+        assertThat(dto.createdAt()).isEqualTo(NOW);
+    }
+
+    // ---------- flag ----------
+
+    @Test
+    void flag_rejectsWhenReviewNotFound() {
+        when(reviewRepo.findByIdForUpdate(1_001L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                service.flag(1_001L, stranger,
+                        new ReviewFlagRequest(ReviewFlagReason.SPAM, null)))
+                .isInstanceOf(ReviewNotFoundException.class);
+
+        verify(flagRepo, never()).save(any());
+    }
+
+    @Test
+    void flag_rejectsWhenCallerIsReviewer() {
+        when(reviewRepo.findByIdForUpdate(1_001L)).thenReturn(Optional.of(review));
+
+        // Winner wrote the review — can't flag own review.
+        assertThatThrownBy(() ->
+                service.flag(1_001L, winner,
+                        new ReviewFlagRequest(ReviewFlagReason.SPAM, null)))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("own review");
+
+        verify(flagRepo, never()).save(any());
+    }
+
+    @Test
+    void flag_rejectsWhenDuplicate() {
+        when(reviewRepo.findByIdForUpdate(1_001L)).thenReturn(Optional.of(review));
+        when(flagRepo.existsByReviewIdAndFlaggerId(1_001L, stranger.getId())).thenReturn(true);
+
+        assertThatThrownBy(() ->
+                service.flag(1_001L, stranger,
+                        new ReviewFlagRequest(ReviewFlagReason.ABUSIVE, null)))
+                .isInstanceOf(ReviewFlagAlreadyExistsException.class);
+
+        verify(flagRepo, never()).save(any());
+    }
+
+    @Test
+    void flag_persistsAndIncrementsFlagCount_byReviewee() {
+        when(reviewRepo.findByIdForUpdate(1_001L)).thenReturn(Optional.of(review));
+        when(flagRepo.existsByReviewIdAndFlaggerId(1_001L, seller.getId())).thenReturn(false);
+        when(flagRepo.save(any(ReviewFlag.class))).thenAnswer(inv -> {
+            ReviewFlag f = inv.getArgument(0);
+            f.setId(8_001L);
+            return f;
+        });
+
+        service.flag(1_001L, seller,
+                new ReviewFlagRequest(ReviewFlagReason.SPAM, null));
+
+        ArgumentCaptor<ReviewFlag> flagCap = ArgumentCaptor.forClass(ReviewFlag.class);
+        verify(flagRepo).save(flagCap.capture());
+        ReviewFlag saved = flagCap.getValue();
+        assertThat(saved.getReview()).isEqualTo(review);
+        assertThat(saved.getFlagger()).isEqualTo(seller);
+        assertThat(saved.getReason()).isEqualTo(ReviewFlagReason.SPAM);
+        assertThat(saved.getElaboration()).isNull();
+
+        // flagCount incremented on the managed entity and persisted.
+        ArgumentCaptor<Review> reviewCap = ArgumentCaptor.forClass(Review.class);
+        verify(reviewRepo).save(reviewCap.capture());
+        assertThat(reviewCap.getValue().getFlagCount()).isEqualTo(1);
+    }
+
+    @Test
+    void flag_persistsOtherReasonWithElaboration_byThirdParty() {
+        when(reviewRepo.findByIdForUpdate(1_001L)).thenReturn(Optional.of(review));
+        when(flagRepo.existsByReviewIdAndFlaggerId(1_001L, stranger.getId())).thenReturn(false);
+        when(flagRepo.save(any(ReviewFlag.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service.flag(1_001L, stranger,
+                new ReviewFlagRequest(ReviewFlagReason.OTHER, "Contains a scam link"));
+
+        ArgumentCaptor<ReviewFlag> flagCap = ArgumentCaptor.forClass(ReviewFlag.class);
+        verify(flagRepo).save(flagCap.capture());
+        ReviewFlag saved = flagCap.getValue();
+        assertThat(saved.getReason()).isEqualTo(ReviewFlagReason.OTHER);
+        assertThat(saved.getElaboration()).isEqualTo("Contains a scam link");
+        assertThat(saved.getFlagger()).isEqualTo(stranger);
+    }
+
+    @Test
+    void flag_incrementsFromExistingNonZeroFlagCount() {
+        review.setFlagCount(3);
+        when(reviewRepo.findByIdForUpdate(1_001L)).thenReturn(Optional.of(review));
+        when(flagRepo.existsByReviewIdAndFlaggerId(1_001L, stranger.getId())).thenReturn(false);
+        when(flagRepo.save(any(ReviewFlag.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service.flag(1_001L, stranger,
+                new ReviewFlagRequest(ReviewFlagReason.FALSE_INFO, null));
+
+        ArgumentCaptor<Review> reviewCap = ArgumentCaptor.forClass(Review.class);
+        verify(reviewRepo).save(reviewCap.capture());
+        assertThat(reviewCap.getValue().getFlagCount()).isEqualTo(4);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceListTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceListTest.java
@@ -1,0 +1,298 @@
+package com.slparcelauctions.backend.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
+import com.slparcelauctions.backend.escrow.Escrow;
+import com.slparcelauctions.backend.escrow.EscrowRepository;
+import com.slparcelauctions.backend.escrow.EscrowState;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.review.broadcast.ReviewBroadcastPublisher;
+import com.slparcelauctions.backend.review.dto.AuctionReviewsResponse;
+import com.slparcelauctions.backend.review.dto.PendingReviewDto;
+import com.slparcelauctions.backend.review.dto.ReviewDto;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Unit coverage for the list paths on {@link ReviewService} —
+ * {@code listForAuction}, {@code listForUser}, {@code listPendingForCaller}.
+ */
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceListTest {
+
+    private static final Instant FIXED_NOW = Instant.parse("2026-05-01T10:00:00Z");
+    private static final OffsetDateTime NOW = OffsetDateTime.ofInstant(FIXED_NOW, ZoneOffset.UTC);
+
+    @Mock ReviewRepository reviewRepo;
+    @Mock ReviewResponseRepository responseRepo;
+    @Mock AuctionRepository auctionRepo;
+    @Mock EscrowRepository escrowRepo;
+    @Mock UserRepository userRepo;
+    @Mock ReviewBroadcastPublisher broadcastPublisher;
+
+    ReviewService service;
+
+    User seller;
+    User winner;
+    User stranger;
+    Auction auction;
+    Escrow escrow;
+
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+        service = new ReviewService(reviewRepo, responseRepo, auctionRepo,
+                escrowRepo, userRepo, broadcastPublisher, clock);
+
+        seller = User.builder().email("seller@example.com").passwordHash("x").build();
+        seller.setId(10L);
+        seller.setDisplayName("Sally");
+        winner = User.builder().email("winner@example.com").passwordHash("x").build();
+        winner.setId(20L);
+        winner.setDisplayName("Willy");
+        stranger = User.builder().email("x@example.com").passwordHash("x").build();
+        stranger.setId(99L);
+
+        Parcel parcel = Parcel.builder().snapshotUrl("https://snap/1.jpg").build();
+        auction = Auction.builder()
+                .title("Lakefront")
+                .seller(seller)
+                .parcel(parcel)
+                .winnerUserId(winner.getId())
+                .photos(List.of())
+                .build();
+        auction.setId(555L);
+
+        escrow = Escrow.builder()
+                .auction(auction)
+                .state(EscrowState.COMPLETED)
+                .completedAt(NOW.minusDays(1))
+                .finalBidAmount(1_000L)
+                .commissionAmt(50L)
+                .payoutAmt(950L)
+                .paymentDeadline(NOW.minusDays(3))
+                .build();
+    }
+
+    private Review makeVisible(Long id, User reviewer, User reviewee, ReviewedRole role, int rating) {
+        Review r = Review.builder()
+                .auction(auction)
+                .reviewer(reviewer)
+                .reviewee(reviewee)
+                .reviewedRole(role)
+                .rating(rating)
+                .visible(true)
+                .build();
+        r.setId(id);
+        r.setSubmittedAt(NOW.minusDays(10));
+        r.setRevealedAt(NOW.minusDays(5));
+        return r;
+    }
+
+    private Review makePending(Long id, User reviewer, User reviewee, ReviewedRole role, int rating) {
+        Review r = Review.builder()
+                .auction(auction)
+                .reviewer(reviewer)
+                .reviewee(reviewee)
+                .reviewedRole(role)
+                .rating(rating)
+                .visible(false)
+                .build();
+        r.setId(id);
+        r.setSubmittedAt(NOW.minusHours(2));
+        return r;
+    }
+
+    @Test
+    void listForAuction_throwsWhenAuctionNotFound() {
+        when(auctionRepo.findById(555L)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.listForAuction(555L, null))
+                .isInstanceOf(AuctionNotFoundException.class);
+    }
+
+    @Test
+    void listForAuction_anonymousCaller_seesOnlyVisibleReviews() {
+        Review r = makeVisible(1L, winner, seller, ReviewedRole.SELLER, 5);
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.of(escrow));
+        when(reviewRepo.findByAuctionIdAndVisibleTrue(555L)).thenReturn(List.of(r));
+        when(responseRepo.findByReviewId(1L)).thenReturn(Optional.empty());
+
+        AuctionReviewsResponse resp = service.listForAuction(555L, null);
+
+        assertThat(resp.reviews()).hasSize(1);
+        assertThat(resp.reviews().get(0).id()).isEqualTo(1L);
+        assertThat(resp.myPendingReview()).isNull();
+        assertThat(resp.canReview()).isFalse();
+        assertThat(resp.windowClosesAt()).isNull();
+    }
+
+    @Test
+    void listForAuction_partyCaller_canReviewWithOpenWindow() {
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.of(escrow));
+        when(reviewRepo.findByAuctionIdAndVisibleTrue(555L)).thenReturn(List.of());
+        when(reviewRepo.findByAuctionIdAndReviewerId(555L, winner.getId()))
+                .thenReturn(Optional.empty());
+
+        AuctionReviewsResponse resp = service.listForAuction(555L, winner);
+
+        assertThat(resp.reviews()).isEmpty();
+        assertThat(resp.canReview()).isTrue();
+        assertThat(resp.myPendingReview()).isNull();
+        assertThat(resp.windowClosesAt()).isEqualTo(escrow.getCompletedAt()
+                .plus(ReviewService.REVIEW_WINDOW));
+    }
+
+    @Test
+    void listForAuction_partyCaller_withPendingReview_exposesPending() {
+        Review mine = makePending(77L, winner, seller, ReviewedRole.SELLER, 5);
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.of(escrow));
+        when(reviewRepo.findByAuctionIdAndVisibleTrue(555L)).thenReturn(List.of());
+        when(reviewRepo.findByAuctionIdAndReviewerId(555L, winner.getId()))
+                .thenReturn(Optional.of(mine));
+        when(responseRepo.findByReviewId(77L)).thenReturn(Optional.empty());
+
+        AuctionReviewsResponse resp = service.listForAuction(555L, winner);
+
+        assertThat(resp.canReview()).isFalse(); // already submitted
+        assertThat(resp.myPendingReview()).isNotNull();
+        assertThat(resp.myPendingReview().id()).isEqualTo(77L);
+        assertThat(resp.myPendingReview().pending()).isTrue();
+    }
+
+    @Test
+    void listForAuction_partyCaller_windowClosed_cannotReview() {
+        escrow.setCompletedAt(NOW.minusDays(15));
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.of(escrow));
+        when(reviewRepo.findByAuctionIdAndVisibleTrue(555L)).thenReturn(List.of());
+        when(reviewRepo.findByAuctionIdAndReviewerId(555L, winner.getId()))
+                .thenReturn(Optional.empty());
+
+        AuctionReviewsResponse resp = service.listForAuction(555L, winner);
+
+        assertThat(resp.canReview()).isFalse();
+        assertThat(resp.windowClosesAt()).isBefore(NOW);
+    }
+
+    @Test
+    void listForAuction_strangerAuthenticated_noPendingNoCanReview() {
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.of(escrow));
+        when(reviewRepo.findByAuctionIdAndVisibleTrue(555L)).thenReturn(List.of());
+
+        AuctionReviewsResponse resp = service.listForAuction(555L, stranger);
+
+        assertThat(resp.canReview()).isFalse();
+        assertThat(resp.myPendingReview()).isNull();
+        assertThat(resp.windowClosesAt()).isNull();
+    }
+
+    @Test
+    void listForAuction_escrowNotCompleted_noEnrichment() {
+        escrow.setState(EscrowState.TRANSFER_PENDING);
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.of(escrow));
+        when(reviewRepo.findByAuctionIdAndVisibleTrue(555L)).thenReturn(List.of());
+
+        AuctionReviewsResponse resp = service.listForAuction(555L, winner);
+
+        assertThat(resp.canReview()).isFalse();
+        assertThat(resp.myPendingReview()).isNull();
+        assertThat(resp.windowClosesAt()).isNull();
+    }
+
+    @Test
+    void listForUser_returnsPagedReviews() {
+        Review r = makeVisible(5L, winner, seller, ReviewedRole.SELLER, 5);
+        Page<Review> pageResult = new PageImpl<>(List.of(r), PageRequest.of(0, 10), 1);
+        when(reviewRepo.findByRevieweeIdAndReviewedRoleAndVisibleTrue(
+                eq(seller.getId()), eq(ReviewedRole.SELLER), any(Pageable.class)))
+                .thenReturn(pageResult);
+        when(responseRepo.findByReviewId(5L)).thenReturn(Optional.empty());
+
+        Page<ReviewDto> result = service.listForUser(seller.getId(),
+                ReviewedRole.SELLER, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).id()).isEqualTo(5L);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    void listPendingForCaller_returnsOpenEscrowsWithoutReviews() {
+        when(escrowRepo.findCompletedEscrowsForUser(eq(winner.getId()), any()))
+                .thenReturn(List.of(escrow));
+        when(reviewRepo.findByAuctionIdAndReviewerId(555L, winner.getId()))
+                .thenReturn(Optional.empty());
+
+        List<PendingReviewDto> result = service.listPendingForCaller(winner);
+
+        assertThat(result).hasSize(1);
+        PendingReviewDto p = result.get(0);
+        assertThat(p.auctionId()).isEqualTo(555L);
+        assertThat(p.viewerRole()).isEqualTo(ReviewedRole.BUYER);
+        // counterparty is the seller for a winner-viewer
+        assertThat(p.counterpartyId()).isEqualTo(seller.getId());
+        assertThat(p.counterpartyDisplayName()).isEqualTo("Sally");
+        // window closes escrow.completedAt + 14d; now is 1 day after completion
+        // → 13 days remaining → 13*24 = 312 hours.
+        assertThat(p.hoursRemaining()).isEqualTo(13L * 24L);
+    }
+
+    @Test
+    void listPendingForCaller_filtersOutAuctionsAlreadyReviewed() {
+        Review already = makePending(88L, winner, seller, ReviewedRole.SELLER, 5);
+        when(escrowRepo.findCompletedEscrowsForUser(eq(winner.getId()), any()))
+                .thenReturn(List.of(escrow));
+        when(reviewRepo.findByAuctionIdAndReviewerId(555L, winner.getId()))
+                .thenReturn(Optional.of(already));
+
+        List<PendingReviewDto> result = service.listPendingForCaller(winner);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void listPendingForCaller_sellerView_counterpartyIsWinner() {
+        when(escrowRepo.findCompletedEscrowsForUser(eq(seller.getId()), any()))
+                .thenReturn(List.of(escrow));
+        when(reviewRepo.findByAuctionIdAndReviewerId(555L, seller.getId()))
+                .thenReturn(Optional.empty());
+        when(userRepo.findById(winner.getId())).thenReturn(Optional.of(winner));
+
+        List<PendingReviewDto> result = service.listPendingForCaller(seller);
+
+        assertThat(result).hasSize(1);
+        PendingReviewDto p = result.get(0);
+        assertThat(p.viewerRole()).isEqualTo(ReviewedRole.SELLER);
+        assertThat(p.counterpartyId()).isEqualTo(winner.getId());
+        assertThat(p.counterpartyDisplayName()).isEqualTo("Willy");
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceListTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceListTest.java
@@ -49,6 +49,7 @@ class ReviewServiceListTest {
 
     @Mock ReviewRepository reviewRepo;
     @Mock ReviewResponseRepository responseRepo;
+    @Mock ReviewFlagRepository flagRepo;
     @Mock AuctionRepository auctionRepo;
     @Mock EscrowRepository escrowRepo;
     @Mock UserRepository userRepo;
@@ -65,7 +66,7 @@ class ReviewServiceListTest {
     @BeforeEach
     void setUp() {
         Clock clock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
-        service = new ReviewService(reviewRepo, responseRepo, auctionRepo,
+        service = new ReviewService(reviewRepo, responseRepo, flagRepo, auctionRepo,
                 escrowRepo, userRepo, broadcastPublisher, clock);
 
         seller = User.builder().email("seller@example.com").passwordHash("x").build();

--- a/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceListTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceListTest.java
@@ -280,6 +280,94 @@ class ReviewServiceListTest {
     }
 
     @Test
+    void listPendingForCaller_preservesRepositoryOrderMostUrgentFirst() {
+        // Repo query sorts by completedAt ASC (windowClosesAt = completedAt
+        // + 14d is a constant offset, so oldest completedAt = most urgent).
+        // Service must not re-order; assert the output list mirrors the
+        // repo's ascending-completedAt ordering.
+        Parcel parcel = Parcel.builder().snapshotUrl("https://snap/x.jpg").build();
+
+        Auction auctionOld = Auction.builder()
+                .title("Oldest")
+                .seller(seller)
+                .parcel(parcel)
+                .winnerUserId(winner.getId())
+                .photos(List.of())
+                .build();
+        auctionOld.setId(100L);
+        Escrow escrowOld = Escrow.builder()
+                .auction(auctionOld)
+                .state(EscrowState.COMPLETED)
+                .completedAt(NOW.minusDays(10))
+                .finalBidAmount(1_000L)
+                .commissionAmt(50L)
+                .payoutAmt(950L)
+                .paymentDeadline(NOW.minusDays(12))
+                .build();
+
+        Auction auctionMid = Auction.builder()
+                .title("Middle")
+                .seller(seller)
+                .parcel(parcel)
+                .winnerUserId(winner.getId())
+                .photos(List.of())
+                .build();
+        auctionMid.setId(200L);
+        Escrow escrowMid = Escrow.builder()
+                .auction(auctionMid)
+                .state(EscrowState.COMPLETED)
+                .completedAt(NOW.minusDays(5))
+                .finalBidAmount(1_000L)
+                .commissionAmt(50L)
+                .payoutAmt(950L)
+                .paymentDeadline(NOW.minusDays(7))
+                .build();
+
+        Auction auctionNew = Auction.builder()
+                .title("Newest")
+                .seller(seller)
+                .parcel(parcel)
+                .winnerUserId(winner.getId())
+                .photos(List.of())
+                .build();
+        auctionNew.setId(300L);
+        Escrow escrowNew = Escrow.builder()
+                .auction(auctionNew)
+                .state(EscrowState.COMPLETED)
+                .completedAt(NOW.minusHours(6))
+                .finalBidAmount(1_000L)
+                .commissionAmt(50L)
+                .payoutAmt(950L)
+                .paymentDeadline(NOW.minusDays(2))
+                .build();
+
+        // Mock returns rows already sorted ASC by completedAt (mimics the
+        // JPQL `ORDER BY e.completedAt ASC`) — service must preserve order.
+        when(escrowRepo.findCompletedEscrowsForUser(eq(winner.getId()), any()))
+                .thenReturn(List.of(escrowOld, escrowMid, escrowNew));
+        when(reviewRepo.findByAuctionIdAndReviewerId(100L, winner.getId()))
+                .thenReturn(Optional.empty());
+        when(reviewRepo.findByAuctionIdAndReviewerId(200L, winner.getId()))
+                .thenReturn(Optional.empty());
+        when(reviewRepo.findByAuctionIdAndReviewerId(300L, winner.getId()))
+                .thenReturn(Optional.empty());
+
+        List<PendingReviewDto> result = service.listPendingForCaller(winner);
+
+        assertThat(result).hasSize(3);
+        assertThat(result).extracting(PendingReviewDto::auctionId)
+                .containsExactly(100L, 200L, 300L);
+        // hoursRemaining strictly ascending rules out any re-ordering;
+        // equivalently windowClosesAt is ascending → most-urgent-first.
+        assertThat(result.get(0).hoursRemaining())
+                .isLessThan(result.get(1).hoursRemaining());
+        assertThat(result.get(1).hoursRemaining())
+                .isLessThan(result.get(2).hoursRemaining());
+        assertThat(result).extracting(PendingReviewDto::windowClosesAt)
+                .isSortedAccordingTo(OffsetDateTime::compareTo);
+    }
+
+    @Test
     void listPendingForCaller_sellerView_counterpartyIsWinner() {
         when(escrowRepo.findCompletedEscrowsForUser(eq(seller.getId()), any()))
                 .thenReturn(List.of(escrow));

--- a/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceRevealTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceRevealTest.java
@@ -48,6 +48,7 @@ class ReviewServiceRevealTest {
 
     @Mock ReviewRepository reviewRepo;
     @Mock ReviewResponseRepository responseRepo;
+    @Mock ReviewFlagRepository flagRepo;
     @Mock AuctionRepository auctionRepo;
     @Mock EscrowRepository escrowRepo;
     @Mock UserRepository userRepo;
@@ -63,7 +64,7 @@ class ReviewServiceRevealTest {
     @BeforeEach
     void setUp() {
         Clock clock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
-        service = new ReviewService(reviewRepo, responseRepo, auctionRepo,
+        service = new ReviewService(reviewRepo, responseRepo, flagRepo, auctionRepo,
                 escrowRepo, userRepo, broadcastPublisher, clock);
 
         seller = User.builder().email("seller@example.com").passwordHash("x").build();

--- a/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceRevealTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceRevealTest.java
@@ -1,0 +1,309 @@
+package com.slparcelauctions.backend.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.escrow.Escrow;
+import com.slparcelauctions.backend.escrow.EscrowRepository;
+import com.slparcelauctions.backend.escrow.EscrowState;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.review.broadcast.ReviewBroadcastPublisher;
+import com.slparcelauctions.backend.review.dto.ReviewDto;
+import com.slparcelauctions.backend.review.dto.ReviewSubmitRequest;
+import com.slparcelauctions.backend.review.exception.ReviewNotFoundException;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Unit coverage for {@link ReviewService#reveal(Long)} +
+ * {@link ReviewService#recomputeAggregates(User, ReviewedRole)} + the
+ * simultaneous-reveal branch in {@code submit}.
+ */
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceRevealTest {
+
+    private static final Instant FIXED_NOW = Instant.parse("2026-05-01T10:00:00Z");
+    private static final OffsetDateTime NOW = OffsetDateTime.ofInstant(FIXED_NOW, ZoneOffset.UTC);
+
+    @Mock ReviewRepository reviewRepo;
+    @Mock ReviewResponseRepository responseRepo;
+    @Mock AuctionRepository auctionRepo;
+    @Mock EscrowRepository escrowRepo;
+    @Mock UserRepository userRepo;
+    @Mock ReviewBroadcastPublisher broadcastPublisher;
+
+    ReviewService service;
+
+    User seller;
+    User winner;
+    Auction auction;
+    Escrow escrow;
+
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+        service = new ReviewService(reviewRepo, responseRepo, auctionRepo,
+                escrowRepo, userRepo, broadcastPublisher, clock);
+
+        seller = User.builder().email("seller@example.com").passwordHash("x").build();
+        seller.setId(10L);
+        seller.setDisplayName("Sally");
+        winner = User.builder().email("winner@example.com").passwordHash("x").build();
+        winner.setId(20L);
+        winner.setDisplayName("Willy");
+
+        Parcel parcel = Parcel.builder().snapshotUrl("https://snap/1.jpg").build();
+        auction = Auction.builder()
+                .title("Lakefront")
+                .seller(seller)
+                .parcel(parcel)
+                .winnerUserId(winner.getId())
+                .photos(List.of())
+                .build();
+        auction.setId(555L);
+
+        escrow = Escrow.builder()
+                .auction(auction)
+                .state(EscrowState.COMPLETED)
+                .completedAt(NOW.minusDays(1))
+                .finalBidAmount(1_000L)
+                .commissionAmt(50L)
+                .payoutAmt(950L)
+                .paymentDeadline(NOW.minusDays(3))
+                .build();
+    }
+
+    private Review pendingReview(Long id, User reviewer, User reviewee, ReviewedRole role, int rating) {
+        Review r = Review.builder()
+                .auction(auction)
+                .reviewer(reviewer)
+                .reviewee(reviewee)
+                .reviewedRole(role)
+                .rating(rating)
+                .visible(false)
+                .build();
+        r.setId(id);
+        return r;
+    }
+
+    @Test
+    void reveal_flipsVisibilityAndStampsRevealedAt() {
+        Review r = pendingReview(100L, winner, seller, ReviewedRole.SELLER, 5);
+        when(reviewRepo.findByIdForUpdate(100L)).thenReturn(Optional.of(r));
+        when(reviewRepo.computeSellerAggregate(seller.getId()))
+                .thenReturn(new Aggregate(new BigDecimal("5.00"), 1));
+
+        service.reveal(100L);
+
+        assertThat(r.getVisible()).isTrue();
+        assertThat(r.getRevealedAt()).isEqualTo(NOW);
+        verify(reviewRepo).save(r);
+        verify(broadcastPublisher).publishReviewRevealed(any(ReviewRevealedEnvelope.class));
+    }
+
+    @Test
+    void reveal_recomputesSellerAggregate() {
+        Review r = pendingReview(101L, winner, seller, ReviewedRole.SELLER, 3);
+        when(reviewRepo.findByIdForUpdate(101L)).thenReturn(Optional.of(r));
+        when(reviewRepo.computeSellerAggregate(seller.getId()))
+                .thenReturn(new Aggregate(new BigDecimal("4.25"), 4));
+
+        service.reveal(101L);
+
+        assertThat(seller.getAvgSellerRating()).isEqualByComparingTo(new BigDecimal("4.25"));
+        assertThat(seller.getTotalSellerReviews()).isEqualTo(4);
+        verify(userRepo).save(seller);
+    }
+
+    @Test
+    void reveal_recomputesBuyerAggregate_whenReviewedRoleIsBuyer() {
+        Review r = pendingReview(102L, seller, winner, ReviewedRole.BUYER, 4);
+        when(reviewRepo.findByIdForUpdate(102L)).thenReturn(Optional.of(r));
+        when(reviewRepo.computeBuyerAggregate(winner.getId()))
+                .thenReturn(new Aggregate(new BigDecimal("4.00"), 1));
+
+        service.reveal(102L);
+
+        assertThat(winner.getAvgBuyerRating()).isEqualByComparingTo(new BigDecimal("4.00"));
+        assertThat(winner.getTotalBuyerReviews()).isEqualTo(1);
+    }
+
+    @Test
+    void reveal_idempotent_whenAlreadyVisible() {
+        Review r = pendingReview(103L, winner, seller, ReviewedRole.SELLER, 5);
+        r.setVisible(true);
+        r.setRevealedAt(NOW.minusDays(2));
+        when(reviewRepo.findByIdForUpdate(103L)).thenReturn(Optional.of(r));
+
+        service.reveal(103L);
+
+        // Early-return path — no save, no broadcast, no recompute.
+        verify(reviewRepo, never()).save(any(Review.class));
+        verify(userRepo, never()).save(any(User.class));
+        verify(broadcastPublisher, never())
+                .publishReviewRevealed(any(ReviewRevealedEnvelope.class));
+        // revealedAt unchanged
+        assertThat(r.getRevealedAt()).isEqualTo(NOW.minusDays(2));
+    }
+
+    @Test
+    void reveal_throwsWhenReviewNotFound() {
+        when(reviewRepo.findByIdForUpdate(999L)).thenReturn(Optional.empty());
+
+        try {
+            service.reveal(999L);
+        } catch (ReviewNotFoundException e) {
+            assertThat(e.getMessage()).contains("999");
+            return;
+        }
+        throw new AssertionError("expected ReviewNotFoundException");
+    }
+
+    @Test
+    void reveal_envelopeCarriesRevealedAtFromClock() {
+        Review r = pendingReview(104L, winner, seller, ReviewedRole.SELLER, 5);
+        when(reviewRepo.findByIdForUpdate(104L)).thenReturn(Optional.of(r));
+        when(reviewRepo.computeSellerAggregate(seller.getId()))
+                .thenReturn(new Aggregate(new BigDecimal("5.00"), 1));
+
+        service.reveal(104L);
+
+        ArgumentCaptor<ReviewRevealedEnvelope> cap =
+                ArgumentCaptor.forClass(ReviewRevealedEnvelope.class);
+        verify(broadcastPublisher).publishReviewRevealed(cap.capture());
+        ReviewRevealedEnvelope env = cap.getValue();
+        assertThat(env.type()).isEqualTo("REVIEW_REVEALED");
+        assertThat(env.auctionId()).isEqualTo(555L);
+        assertThat(env.reviewId()).isEqualTo(104L);
+        assertThat(env.reviewerId()).isEqualTo(20L);
+        assertThat(env.revieweeId()).isEqualTo(10L);
+        assertThat(env.reviewedRole()).isEqualTo(ReviewedRole.SELLER);
+        assertThat(env.revealedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    void submit_simultaneousReveal_flipsBothRowsAndRecomputesBoth() {
+        // Counterparty (seller) already submitted a pending review about the winner.
+        Review sellerPending = pendingReview(200L, seller, winner, ReviewedRole.BUYER, 4);
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.of(escrow));
+        when(reviewRepo.findByAuctionIdAndReviewerId(555L, winner.getId()))
+                .thenReturn(Optional.empty());
+        when(reviewRepo.findByAuctionIdAndReviewerId(555L, seller.getId()))
+                .thenReturn(Optional.of(sellerPending));
+        when(reviewRepo.save(any(Review.class))).thenAnswer(inv -> {
+            Review saved = inv.getArgument(0);
+            if (saved.getId() == null) saved.setId(201L);
+            saved.setSubmittedAt(NOW);
+            return saved;
+        });
+        when(reviewRepo.computeSellerAggregate(seller.getId()))
+                .thenReturn(new Aggregate(new BigDecimal("5.00"), 1));
+        when(reviewRepo.computeBuyerAggregate(winner.getId()))
+                .thenReturn(new Aggregate(new BigDecimal("4.00"), 1));
+        when(responseRepo.findByReviewId(any())).thenReturn(Optional.empty());
+
+        ReviewDto dto = service.submit(555L, winner, new ReviewSubmitRequest(5, "gg"));
+
+        // Both reviews should be visible now.
+        assertThat(sellerPending.getVisible()).isTrue();
+        assertThat(sellerPending.getRevealedAt()).isEqualTo(NOW);
+
+        // Capture the winner's newly saved review (visible + revealedAt stamped).
+        ArgumentCaptor<Review> cap = ArgumentCaptor.forClass(Review.class);
+        verify(reviewRepo, times(3)).save(cap.capture());
+        Review winnerReview = cap.getAllValues().stream()
+                .filter(r -> r.getReviewer().getId().equals(winner.getId()))
+                .findFirst().orElseThrow();
+        assertThat(winnerReview.getVisible()).isTrue();
+        assertThat(winnerReview.getRevealedAt()).isEqualTo(NOW);
+
+        // Both aggregates recomputed.
+        verify(reviewRepo).computeSellerAggregate(seller.getId());
+        verify(reviewRepo).computeBuyerAggregate(winner.getId());
+
+        // Both envelopes broadcast.
+        verify(broadcastPublisher, times(2))
+                .publishReviewRevealed(any(ReviewRevealedEnvelope.class));
+
+        // Viewer sees their own DTO as visible post-reveal.
+        assertThat(dto.visible()).isTrue();
+    }
+
+    @Test
+    void submit_noCounterparty_doesNotReveal() {
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.of(escrow));
+        when(reviewRepo.findByAuctionIdAndReviewerId(555L, winner.getId()))
+                .thenReturn(Optional.empty());
+        when(reviewRepo.findByAuctionIdAndReviewerId(555L, seller.getId()))
+                .thenReturn(Optional.empty());
+        when(reviewRepo.save(any(Review.class))).thenAnswer(inv -> {
+            Review saved = inv.getArgument(0);
+            saved.setId(300L);
+            saved.setSubmittedAt(NOW);
+            return saved;
+        });
+        when(responseRepo.findByReviewId(300L)).thenReturn(Optional.empty());
+
+        ReviewDto dto = service.submit(555L, winner, new ReviewSubmitRequest(5, "gg"));
+
+        assertThat(dto.visible()).isFalse();
+        verify(broadcastPublisher, never())
+                .publishReviewRevealed(any(ReviewRevealedEnvelope.class));
+    }
+
+    @Test
+    void submit_counterpartyAlreadyVisible_doesNotRevealAgain() {
+        // Edge case: counterparty review exists and is already visible —
+        // the scheduler previously flipped it. We should NOT re-flip or
+        // re-broadcast. The new row still lands as visible=false until
+        // its own day-14 sweep.
+        Review sellerAlreadyRevealed = pendingReview(400L, seller, winner, ReviewedRole.BUYER, 4);
+        sellerAlreadyRevealed.setVisible(true);
+        sellerAlreadyRevealed.setRevealedAt(NOW.minusDays(1));
+
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.of(escrow));
+        when(reviewRepo.findByAuctionIdAndReviewerId(555L, winner.getId()))
+                .thenReturn(Optional.empty());
+        when(reviewRepo.findByAuctionIdAndReviewerId(555L, seller.getId()))
+                .thenReturn(Optional.of(sellerAlreadyRevealed));
+        when(reviewRepo.save(any(Review.class))).thenAnswer(inv -> {
+            Review saved = inv.getArgument(0);
+            saved.setId(401L);
+            saved.setSubmittedAt(NOW);
+            return saved;
+        });
+        when(responseRepo.findByReviewId(401L)).thenReturn(Optional.empty());
+
+        ReviewDto dto = service.submit(555L, winner, new ReviewSubmitRequest(5, "gg"));
+
+        assertThat(dto.visible()).isFalse();
+        // Not re-revealed.
+        assertThat(sellerAlreadyRevealed.getRevealedAt()).isEqualTo(NOW.minusDays(1));
+        verify(broadcastPublisher, never())
+                .publishReviewRevealed(any(ReviewRevealedEnvelope.class));
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceSubmitTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceSubmitTest.java
@@ -264,7 +264,7 @@ class ReviewServiceSubmitTest {
     }
 
     @Test
-    void submit_acceptsAtExactWindowCloseMinusOneSecond() {
+    void submit_acceptsAtExactWindowBoundary() {
         // Boundary: exactly at escrow.completedAt + 14 days = now. isAfter
         // returns false at the boundary (strict inequality), so submit
         // succeeds. A submit at now + 1 nanosecond would be rejected.

--- a/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceSubmitTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceSubmitTest.java
@@ -28,6 +28,7 @@ import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
 import com.slparcelauctions.backend.escrow.Escrow;
 import com.slparcelauctions.backend.escrow.EscrowRepository;
 import com.slparcelauctions.backend.escrow.EscrowState;
+import com.slparcelauctions.backend.review.broadcast.ReviewBroadcastPublisher;
 import com.slparcelauctions.backend.review.dto.ReviewDto;
 import com.slparcelauctions.backend.review.dto.ReviewSubmitRequest;
 import com.slparcelauctions.backend.review.exception.ReviewAlreadySubmittedException;
@@ -54,6 +55,7 @@ class ReviewServiceSubmitTest {
     @Mock AuctionRepository auctionRepo;
     @Mock EscrowRepository escrowRepo;
     @Mock UserRepository userRepo;
+    @Mock ReviewBroadcastPublisher broadcastPublisher;
 
     ReviewService service;
 
@@ -67,7 +69,7 @@ class ReviewServiceSubmitTest {
     void setUp() {
         Clock clock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
         service = new ReviewService(reviewRepo, responseRepo, auctionRepo,
-                escrowRepo, userRepo, clock);
+                escrowRepo, userRepo, broadcastPublisher, clock);
 
         seller = User.builder().email("seller@example.com").passwordHash("x").build();
         seller.setId(10L);

--- a/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceSubmitTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceSubmitTest.java
@@ -1,0 +1,288 @@
+package com.slparcelauctions.backend.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
+import com.slparcelauctions.backend.escrow.Escrow;
+import com.slparcelauctions.backend.escrow.EscrowRepository;
+import com.slparcelauctions.backend.escrow.EscrowState;
+import com.slparcelauctions.backend.review.dto.ReviewDto;
+import com.slparcelauctions.backend.review.dto.ReviewSubmitRequest;
+import com.slparcelauctions.backend.review.exception.ReviewAlreadySubmittedException;
+import com.slparcelauctions.backend.review.exception.ReviewIneligibleException;
+import com.slparcelauctions.backend.review.exception.ReviewWindowClosedException;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Unit coverage for {@link ReviewService#submit(Long, User, ReviewSubmitRequest)}.
+ * All dependencies are mocked; the happy path and every 4xx branch are
+ * exercised. The simultaneous-reveal path is intentionally NOT tested here —
+ * Task 1 does not ship it; Task 2 will.
+ */
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceSubmitTest {
+
+    private static final Instant FIXED_NOW = Instant.parse("2026-05-01T10:00:00Z");
+    private static final OffsetDateTime NOW = OffsetDateTime.ofInstant(FIXED_NOW, ZoneOffset.UTC);
+
+    @Mock ReviewRepository reviewRepo;
+    @Mock ReviewResponseRepository responseRepo;
+    @Mock AuctionRepository auctionRepo;
+    @Mock EscrowRepository escrowRepo;
+    @Mock UserRepository userRepo;
+
+    ReviewService service;
+
+    User seller;
+    User winner;
+    User stranger;
+    Auction auction;
+    Escrow escrow;
+
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+        service = new ReviewService(reviewRepo, responseRepo, auctionRepo,
+                escrowRepo, userRepo, clock);
+
+        seller = User.builder().email("seller@example.com").passwordHash("x").build();
+        seller.setId(10L);
+        seller.setDisplayName("Sally");
+        winner = User.builder().email("winner@example.com").passwordHash("x").build();
+        winner.setId(20L);
+        winner.setDisplayName("Willy");
+        stranger = User.builder().email("stranger@example.com").passwordHash("x").build();
+        stranger.setId(99L);
+
+        Parcel parcel = Parcel.builder().snapshotUrl("https://snap/1.jpg").build();
+        auction = Auction.builder()
+                .title("Lakefront")
+                .seller(seller)
+                .parcel(parcel)
+                .winnerUserId(winner.getId())
+                .photos(List.of())
+                .build();
+        auction.setId(555L);
+
+        // Escrow: COMPLETED 1 day ago — well within the 14-day window.
+        escrow = Escrow.builder()
+                .auction(auction)
+                .state(EscrowState.COMPLETED)
+                .completedAt(NOW.minusDays(1))
+                .finalBidAmount(1_000L)
+                .commissionAmt(50L)
+                .payoutAmt(950L)
+                .paymentDeadline(NOW.minusDays(3))
+                .build();
+    }
+
+    @Test
+    void submit_rejectsWhenAuctionNotFound() {
+        when(auctionRepo.findById(555L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                service.submit(555L, winner, new ReviewSubmitRequest(5, null)))
+                .isInstanceOf(AuctionNotFoundException.class);
+
+        verify(reviewRepo, never()).save(any());
+    }
+
+    @Test
+    void submit_rejectsWhenEscrowMissing() {
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                service.submit(555L, winner, new ReviewSubmitRequest(5, null)))
+                .isInstanceOf(ReviewIneligibleException.class)
+                .hasMessageContaining("no escrow");
+
+        verify(reviewRepo, never()).save(any());
+    }
+
+    @Test
+    void submit_rejectsWhenEscrowNotCompleted() {
+        escrow.setState(EscrowState.TRANSFER_PENDING);
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.of(escrow));
+
+        assertThatThrownBy(() ->
+                service.submit(555L, winner, new ReviewSubmitRequest(5, null)))
+                .isInstanceOf(ReviewIneligibleException.class)
+                .hasMessageContaining("escrow has completed");
+
+        verify(reviewRepo, never()).save(any());
+    }
+
+    @Test
+    void submit_rejectsAfterFourteenDayWindow() {
+        escrow.setCompletedAt(NOW.minusDays(15));
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.of(escrow));
+
+        assertThatThrownBy(() ->
+                service.submit(555L, winner, new ReviewSubmitRequest(5, null)))
+                .isInstanceOf(ReviewWindowClosedException.class);
+
+        verify(reviewRepo, never()).save(any());
+    }
+
+    @Test
+    void submit_rejectsCallerNotParty() {
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.of(escrow));
+
+        assertThatThrownBy(() ->
+                service.submit(555L, stranger, new ReviewSubmitRequest(5, null)))
+                .isInstanceOf(ReviewIneligibleException.class)
+                .hasMessageContaining("seller or winner");
+
+        verify(reviewRepo, never()).save(any());
+    }
+
+    @Test
+    void submit_rejectsWhenAuctionHasNoWinner() {
+        auction.setWinnerUserId(null);
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.of(escrow));
+
+        assertThatThrownBy(() ->
+                service.submit(555L, seller, new ReviewSubmitRequest(5, null)))
+                .isInstanceOf(ReviewIneligibleException.class)
+                .hasMessageContaining("no recorded winner");
+    }
+
+    @Test
+    void submit_rejectsDuplicate() {
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.of(escrow));
+        Review existing = Review.builder().auction(auction).reviewer(winner)
+                .reviewee(seller).reviewedRole(ReviewedRole.SELLER)
+                .rating(4).visible(true).build();
+        when(reviewRepo.findByAuctionIdAndReviewerId(555L, 20L))
+                .thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() ->
+                service.submit(555L, winner, new ReviewSubmitRequest(5, null)))
+                .isInstanceOf(ReviewAlreadySubmittedException.class);
+
+        verify(reviewRepo, never()).save(any());
+    }
+
+    @Test
+    void submit_winnerReviewingSeller_persistsPending() {
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.of(escrow));
+        when(reviewRepo.findByAuctionIdAndReviewerId(555L, 20L))
+                .thenReturn(Optional.empty());
+        when(reviewRepo.save(any(Review.class))).thenAnswer(inv -> {
+            Review r = inv.getArgument(0);
+            r.setId(1_001L);
+            r.setSubmittedAt(NOW);
+            return r;
+        });
+        when(responseRepo.findByReviewId(1_001L)).thenReturn(Optional.empty());
+
+        ReviewDto dto = service.submit(555L, winner,
+                new ReviewSubmitRequest(5, "Smooth transfer"));
+
+        ArgumentCaptor<Review> cap = ArgumentCaptor.forClass(Review.class);
+        verify(reviewRepo).save(cap.capture());
+        Review saved = cap.getValue();
+        assertThat(saved.getReviewer()).isEqualTo(winner);
+        assertThat(saved.getReviewee()).isEqualTo(seller);
+        assertThat(saved.getReviewedRole()).isEqualTo(ReviewedRole.SELLER);
+        assertThat(saved.getRating()).isEqualTo(5);
+        assertThat(saved.getText()).isEqualTo("Smooth transfer");
+        assertThat(saved.getVisible()).isFalse();
+
+        // DTO visible flag + pending flag for the reviewer's own view.
+        assertThat(dto.visible()).isFalse();
+        assertThat(dto.pending()).isTrue();
+        assertThat(dto.reviewedRole()).isEqualTo(ReviewedRole.SELLER);
+        assertThat(dto.rating()).isEqualTo(5);
+        assertThat(dto.text()).isEqualTo("Smooth transfer");
+        // Parcel snapshot URL fallback — no photos on the seeded auction.
+        assertThat(dto.auctionPrimaryPhotoUrl()).isEqualTo("https://snap/1.jpg");
+    }
+
+    @Test
+    void submit_sellerReviewingWinner_persistsPending_withBuyerRole() {
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.of(escrow));
+        when(userRepo.findById(20L)).thenReturn(Optional.of(winner));
+        when(reviewRepo.findByAuctionIdAndReviewerId(555L, 10L))
+                .thenReturn(Optional.empty());
+        when(reviewRepo.save(any(Review.class))).thenAnswer(inv -> {
+            Review r = inv.getArgument(0);
+            r.setId(1_002L);
+            r.setSubmittedAt(NOW);
+            return r;
+        });
+        when(responseRepo.findByReviewId(1_002L)).thenReturn(Optional.empty());
+
+        ReviewDto dto = service.submit(555L, seller,
+                new ReviewSubmitRequest(4, null));
+
+        ArgumentCaptor<Review> cap = ArgumentCaptor.forClass(Review.class);
+        verify(reviewRepo).save(cap.capture());
+        Review saved = cap.getValue();
+        assertThat(saved.getReviewer()).isEqualTo(seller);
+        assertThat(saved.getReviewee()).isEqualTo(winner);
+        assertThat(saved.getReviewedRole()).isEqualTo(ReviewedRole.BUYER);
+        assertThat(saved.getRating()).isEqualTo(4);
+        assertThat(saved.getText()).isNull();
+        assertThat(saved.getVisible()).isFalse();
+
+        assertThat(dto.reviewedRole()).isEqualTo(ReviewedRole.BUYER);
+        assertThat(dto.revieweeId()).isEqualTo(winner.getId());
+        assertThat(dto.pending()).isTrue();
+    }
+
+    @Test
+    void submit_acceptsAtExactWindowCloseMinusOneSecond() {
+        // Boundary: exactly at escrow.completedAt + 14 days = now. isAfter
+        // returns false at the boundary (strict inequality), so submit
+        // succeeds. A submit at now + 1 nanosecond would be rejected.
+        escrow.setCompletedAt(NOW.minusDays(14));
+        when(auctionRepo.findById(555L)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(555L)).thenReturn(Optional.of(escrow));
+        when(reviewRepo.findByAuctionIdAndReviewerId(555L, 20L))
+                .thenReturn(Optional.empty());
+        when(reviewRepo.save(any(Review.class))).thenAnswer(inv -> {
+            Review r = inv.getArgument(0);
+            r.setId(1_003L);
+            r.setSubmittedAt(NOW);
+            return r;
+        });
+        when(responseRepo.findByReviewId(1_003L)).thenReturn(Optional.empty());
+
+        ReviewDto dto = service.submit(555L, winner, new ReviewSubmitRequest(5, null));
+
+        assertThat(dto.id()).isEqualTo(1_003L);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceSubmitTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceSubmitTest.java
@@ -52,6 +52,7 @@ class ReviewServiceSubmitTest {
 
     @Mock ReviewRepository reviewRepo;
     @Mock ReviewResponseRepository responseRepo;
+    @Mock ReviewFlagRepository flagRepo;
     @Mock AuctionRepository auctionRepo;
     @Mock EscrowRepository escrowRepo;
     @Mock UserRepository userRepo;
@@ -68,7 +69,7 @@ class ReviewServiceSubmitTest {
     @BeforeEach
     void setUp() {
         Clock clock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
-        service = new ReviewService(reviewRepo, responseRepo, auctionRepo,
+        service = new ReviewService(reviewRepo, responseRepo, flagRepo, auctionRepo,
                 escrowRepo, userRepo, broadcastPublisher, clock);
 
         seller = User.builder().email("seller@example.com").passwordHash("x").build();

--- a/backend/src/test/java/com/slparcelauctions/backend/review/UserReviewsControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/UserReviewsControllerTest.java
@@ -1,0 +1,115 @@
+package com.slparcelauctions.backend.review;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.auth.test.WithMockAuthPrincipal;
+import com.slparcelauctions.backend.common.exception.GlobalExceptionHandler;
+import com.slparcelauctions.backend.review.dto.PendingReviewDto;
+import com.slparcelauctions.backend.review.dto.ReviewDto;
+import com.slparcelauctions.backend.review.exception.ReviewExceptionHandler;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Slice tests for {@link UserReviewsController}. Filters off (the
+ * security filter chain is exercised in {@code SecurityConfigTest}).
+ */
+@WebMvcTest(controllers = UserReviewsController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({GlobalExceptionHandler.class, ReviewExceptionHandler.class})
+class UserReviewsControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private ReviewService reviewService;
+    @MockitoBean private UserRepository userRepository;
+    @MockitoBean private JwtService jwtService;
+
+    private ReviewDto sampleDto() {
+        return new ReviewDto(
+                1_234L, 555L, "Lakefront",
+                "/api/v1/auctions/555/photos/1/bytes",
+                1L, "Viewer", "/api/v1/users/1/avatar/256",
+                10L, ReviewedRole.SELLER,
+                5, "Great", true, false,
+                OffsetDateTime.now(), OffsetDateTime.now(), null);
+    }
+
+    @Test
+    void listForUser_publicGet_returnsPagedResponse_shape() throws Exception {
+        Page<ReviewDto> pageResult = new PageImpl<>(
+                List.of(sampleDto()), PageRequest.of(0, 10), 1);
+        when(reviewService.listForUser(eq(10L), eq(ReviewedRole.SELLER), any(Pageable.class)))
+                .thenReturn(pageResult);
+
+        mockMvc.perform(get("/api/v1/users/10/reviews?role=SELLER"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].id").value(1_234))
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.totalPages").value(1))
+                .andExpect(jsonPath("$.number").value(0))
+                .andExpect(jsonPath("$.size").value(10));
+    }
+
+    @Test
+    void listForUser_clampsPageSizeAt50() throws Exception {
+        Page<ReviewDto> pageResult = new PageImpl<>(
+                List.of(), PageRequest.of(0, 50), 0);
+        when(reviewService.listForUser(eq(10L), eq(ReviewedRole.BUYER), any(Pageable.class)))
+                .thenReturn(pageResult);
+
+        // Size 9999 request → clamped to 50 (and so forwarded to service).
+        mockMvc.perform(get("/api/v1/users/10/reviews?role=BUYER&size=9999"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size").value(50));
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 1L)
+    void listPending_returnsListOfPendingReviewDto() throws Exception {
+        User caller = User.builder().email("test@example.com").passwordHash("x").build();
+        caller.setId(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(caller));
+
+        PendingReviewDto pending = new PendingReviewDto(
+                555L, "Lakefront",
+                "/api/v1/auctions/555/photos/1/bytes",
+                10L, "Sally", "/api/v1/users/10/avatar/256",
+                OffsetDateTime.now().minusDays(1),
+                OffsetDateTime.now().plusDays(13),
+                312L,
+                ReviewedRole.BUYER);
+        when(reviewService.listPendingForCaller(any(User.class)))
+                .thenReturn(List.of(pending));
+
+        mockMvc.perform(get("/api/v1/users/me/pending-reviews"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].auctionId").value(555))
+                .andExpect(jsonPath("$[0].counterpartyDisplayName").value("Sally"))
+                .andExpect(jsonPath("$[0].hoursRemaining").value(312));
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/review/exception/ReviewExceptionHandlerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/exception/ReviewExceptionHandlerTest.java
@@ -51,6 +51,55 @@ class ReviewExceptionHandlerTest {
     }
 
     @Test
+    void knownFlagConstraint_returnsFlagAlreadyExistsProblem() {
+        // URI needs to look like the flag endpoint so the id extractor resolves.
+        MockHttpServletRequest mockReq = new MockHttpServletRequest();
+        mockReq.setRequestURI("/api/v1/reviews/42/flag");
+        HttpServletRequest flagReq = mockReq;
+
+        DataIntegrityViolationException dataEx = wrap("uq_review_flags_review_flagger");
+
+        ProblemDetail pd = handler.handleDataIntegrity(dataEx, flagReq);
+
+        assertThat(pd.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(pd.getType().toString())
+                .isEqualTo("https://slpa.example/problems/review/flag-already-exists");
+        assertThat(pd.getTitle()).isEqualTo("Review flag already exists");
+        assertThat(pd.getProperties()).containsEntry("code", "REVIEW_FLAG_ALREADY_EXISTS");
+    }
+
+    @Test
+    void knownResponseConstraint_returnsResponseAlreadyExistsProblem() {
+        MockHttpServletRequest mockReq = new MockHttpServletRequest();
+        mockReq.setRequestURI("/api/v1/reviews/42/respond");
+        HttpServletRequest respondReq = mockReq;
+
+        DataIntegrityViolationException dataEx = wrap("review_responses_review_id_key");
+
+        ProblemDetail pd = handler.handleDataIntegrity(dataEx, respondReq);
+
+        assertThat(pd.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(pd.getType().toString())
+                .isEqualTo("https://slpa.example/problems/review/response-already-exists");
+        assertThat(pd.getTitle()).isEqualTo("Review response already exists");
+        assertThat(pd.getProperties()).containsEntry("code", "REVIEW_RESPONSE_ALREADY_EXISTS");
+    }
+
+    @Test
+    void knownResponseConstraint_conventionalName_mapsTo409() {
+        MockHttpServletRequest mockReq = new MockHttpServletRequest();
+        mockReq.setRequestURI("/api/v1/reviews/42/respond");
+        HttpServletRequest respondReq = mockReq;
+
+        DataIntegrityViolationException dataEx = wrap("uq_review_responses_review");
+
+        ProblemDetail pd = handler.handleDataIntegrity(dataEx, respondReq);
+
+        assertThat(pd.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(pd.getProperties()).containsEntry("code", "REVIEW_RESPONSE_ALREADY_EXISTS");
+    }
+
+    @Test
     void unknownConstraint_rethrowsOriginalException() {
         DataIntegrityViolationException dataEx = wrap("some_other_constraint");
 

--- a/backend/src/test/java/com/slparcelauctions/backend/review/exception/ReviewExceptionHandlerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/exception/ReviewExceptionHandlerTest.java
@@ -1,0 +1,76 @@
+package com.slparcelauctions.backend.review.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.SQLException;
+
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Direct unit test for {@link ReviewExceptionHandler#handleDataIntegrity}.
+ * Mocks a {@link DataIntegrityViolationException} wrapping Hibernate's
+ * {@link ConstraintViolationException} for both the known
+ * {@code uq_reviews_auction_reviewer} constraint and an unknown one, and
+ * verifies the handler maps correctly. Covers the race-path branch that
+ * {@code ReviewServiceSubmitTest} cannot reach because the service-level
+ * pre-check trips before save in a single-threaded mocked test.
+ */
+class ReviewExceptionHandlerTest {
+
+    private ReviewExceptionHandler handler;
+    private HttpServletRequest req;
+
+    @BeforeEach
+    void setup() {
+        handler = new ReviewExceptionHandler();
+        MockHttpServletRequest mockReq = new MockHttpServletRequest();
+        mockReq.setRequestURI("/api/v1/auctions/42/review");
+        req = mockReq;
+    }
+
+    @Test
+    void knownReviewsConstraint_returnsAlreadySubmittedProblem() {
+        DataIntegrityViolationException dataEx = wrap("uq_reviews_auction_reviewer");
+
+        ProblemDetail pd = handler.handleDataIntegrity(dataEx, req);
+
+        assertThat(pd.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(pd.getType().toString())
+                .isEqualTo("https://slpa.example/problems/review/already-submitted");
+        assertThat(pd.getTitle()).isEqualTo("Review already submitted");
+        assertThat(pd.getProperties()).containsEntry("code", "REVIEW_ALREADY_SUBMITTED");
+    }
+
+    @Test
+    void unknownConstraint_rethrowsOriginalException() {
+        DataIntegrityViolationException dataEx = wrap("some_other_constraint");
+
+        assertThatThrownBy(() -> handler.handleDataIntegrity(dataEx, req))
+                .isSameAs(dataEx);
+    }
+
+    @Test
+    void nullConstraintChain_rethrowsOriginalException() {
+        DataIntegrityViolationException dataEx =
+                new DataIntegrityViolationException("no cause", new RuntimeException());
+
+        assertThatThrownBy(() -> handler.handleDataIntegrity(dataEx, req))
+                .isSameAs(dataEx);
+    }
+
+    private DataIntegrityViolationException wrap(String constraintName) {
+        SQLException sql = new SQLException("pg exception");
+        ConstraintViolationException hib =
+                new ConstraintViolationException("dup", sql, constraintName);
+        return new DataIntegrityViolationException("wrapped", hib);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/user/SellerCompletionRateMapperTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/user/SellerCompletionRateMapperTest.java
@@ -9,35 +9,56 @@ import org.junit.jupiter.api.Test;
 class SellerCompletionRateMapperTest {
 
     @Test
-    void bothZero_returnsNull() {
-        assertThat(SellerCompletionRateMapper.compute(0, 0)).isNull();
+    void allCountersZero_returnsNull() {
+        assertThat(SellerCompletionRateMapper.compute(0, 0, 0)).isNull();
     }
 
     @Test
-    void noCancellations_returns1_00() {
-        assertThat(SellerCompletionRateMapper.compute(10, 0))
+    void noCancellationsOrExpiredUnfulfilled_returns1_00() {
+        assertThat(SellerCompletionRateMapper.compute(10, 0, 0))
                 .isEqualByComparingTo(new BigDecimal("1.00"));
     }
 
     @Test
     void onlyCancellations_returns0_00() {
-        assertThat(SellerCompletionRateMapper.compute(0, 5))
+        assertThat(SellerCompletionRateMapper.compute(0, 5, 0))
                 .isEqualByComparingTo(new BigDecimal("0.00"));
     }
 
     @Test
-    void twoThirds_roundsTo_0_67() {
-        assertThat(SellerCompletionRateMapper.compute(2, 1))
+    void onlyExpiredUnfulfilled_returns0_00() {
+        assertThat(SellerCompletionRateMapper.compute(0, 0, 3))
+                .isEqualByComparingTo(new BigDecimal("0.00"));
+    }
+
+    @Test
+    void expiredUnfulfilledDragsTheRate() {
+        // 5 completed / (5 + 0 + 5) = 0.50 — an unfulfilled transfer
+        // counts against the denominator the same way a cancellation does.
+        assertThat(SellerCompletionRateMapper.compute(5, 0, 5))
+                .isEqualByComparingTo(new BigDecimal("0.50"));
+    }
+
+    @Test
+    void threeWayDenominator_roundsHalfUp() {
+        // 10 / (10 + 2 + 3) = 10/15 = 0.6666... -> 0.67
+        assertThat(SellerCompletionRateMapper.compute(10, 2, 3))
                 .isEqualByComparingTo(new BigDecimal("0.67"));
     }
 
     @Test
-    void roundsHalfUp() {
-        // 5/(5+2) = 0.7142857... -> 0.71
-        assertThat(SellerCompletionRateMapper.compute(5, 2))
+    void twoThirds_roundsTo_0_67() {
+        assertThat(SellerCompletionRateMapper.compute(2, 1, 0))
+                .isEqualByComparingTo(new BigDecimal("0.67"));
+    }
+
+    @Test
+    void roundsHalfUp_moreCases() {
+        // 5/(5+2+0) = 0.7142857... -> 0.71
+        assertThat(SellerCompletionRateMapper.compute(5, 2, 0))
                 .isEqualByComparingTo(new BigDecimal("0.71"));
-        // 1/3 = 0.3333... -> 0.33
-        assertThat(SellerCompletionRateMapper.compute(1, 2))
+        // 1/(1+2+0) = 0.3333... -> 0.33
+        assertThat(SellerCompletionRateMapper.compute(1, 2, 0))
                 .isEqualByComparingTo(new BigDecimal("0.33"));
     }
 }

--- a/backend/src/test/java/com/slparcelauctions/backend/user/UserControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/user/UserControllerTest.java
@@ -134,7 +134,7 @@ class UserControllerTest {
     void getUserProfile_returns200() throws Exception {
         UserProfileResponse profile = new UserProfileResponse(
                 42L, "Bob", "hello", null, null, null, null,
-                false, null, null, 0, 0, 0, OffsetDateTime.now());
+                false, null, null, 0, 0, 0, null, true, OffsetDateTime.now());
         when(userService.getPublicProfile(42L)).thenReturn(profile);
 
         mockMvc.perform(get("/api/v1/users/42"))

--- a/backend/src/test/java/com/slparcelauctions/backend/user/UserEntityTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/user/UserEntityTest.java
@@ -1,0 +1,36 @@
+package com.slparcelauctions.backend.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure POJO-level assertions for the {@link User} entity's built-in
+ * defaults. Keeps the new {@code escrowExpiredUnfulfilled} counter
+ * from drifting to {@code null} if a future edit ever removes the
+ * {@code @Builder.Default}. See Epic 08 sub-spec 1 §3.4.
+ */
+class UserEntityTest {
+
+    @Test
+    void escrowExpiredUnfulfilledDefaultsToZero() {
+        User u = User.builder()
+                .email("a@b.com")
+                .passwordHash("x")
+                .build();
+        assertThat(u.getEscrowExpiredUnfulfilled()).isEqualTo(0);
+    }
+
+    @Test
+    void completedSalesAndCancelledWithBidsDefaultToZero() {
+        // Paired with the escrowExpiredUnfulfilled default so a regression
+        // on any of the three completion-rate denominator counters trips
+        // the test file.
+        User u = User.builder()
+                .email("a@b.com")
+                .passwordHash("x")
+                .build();
+        assertThat(u.getCompletedSales()).isEqualTo(0);
+        assertThat(u.getCancelledWithBids()).isEqualTo(0);
+    }
+}

--- a/docs/implementation/DEFERRED_WORK.md
+++ b/docs/implementation/DEFERRED_WORK.md
@@ -39,12 +39,6 @@ When finishing a sub-spec that completes a deferred item, remove the entry.
 - **When:** Phase 11
 - **Notes:** Replace the `useCurrentUser({ refetchInterval: 5000 })` polling with a STOMP subscription on `/topic/user/{userId}/verification`.
 
-### Partial-star rendering for ReputationStars
-- **From:** Epic 02 sub-spec 2b (Task 02-05 public profile)
-- **Why:** Phase 1 ships a simpler numeric "4.7 ★" display. Partial-star SVG rendering is polish that only matters when review counts are non-trivial.
-- **When:** Epic 06 (Ratings & Reputation) when real review data exists
-- **Notes:** Current `ReputationStars.tsx` at `frontend/src/components/user/ReputationStars.tsx`.
-
 ### Email change flow
 - **From:** Epic 02 sub-spec 2b (Task 02-04 profile edit)
 - **Why:** Requires a re-verification flow (new email → confirmation link → swap). Out of scope for the profile edit shipped in 2b. Not a browse/discovery concern — does not belong in Epic 07.
@@ -80,12 +74,6 @@ When finishing a sub-spec that completes a deferred item, remove the entry.
 - **Why:** Current drop zone uses a static border highlight. Polished version would animate border-color transition and a scale effect on drop.
 - **When:** Indefinite (cosmetic)
 - **Notes:** `frontend/src/components/user/ProfilePictureUploader.tsx`.
-
-### Recent reviews section on public profile
-- **From:** Epic 02 sub-spec 2b (Task 02-05 public profile)
-- **Why:** Review data requires the reviews model from Epic 06. Public profile ships with empty-state placeholder.
-- **When:** Epic 06 (Ratings & Reputation)
-- **Notes:** `PublicProfileView` renders `<EmptyState icon={MessageSquare}>` for this section.
 
 ### PARCEL code generation rate tracking (fraud signal)
 - **From:** Epic 03 sub-spec 1 (Method B rezzable callback flow)

--- a/docs/superpowers/plans/2026-04-24-epic-08-sub-1-reviews-reputation.md
+++ b/docs/superpowers/plans/2026-04-24-epic-08-sub-1-reviews-reputation.md
@@ -1,0 +1,2018 @@
+# Epic 08 Sub-Spec 1 — Reviews & Reputation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship blind-reveal reviews backend + reputation aggregation + full reviews UI end-to-end.
+
+**Architecture:** New `review` backend package (entities + service + 6 endpoints + hourly scheduler) coupled with new `components/reviews/` frontend package. Aggregate pipeline hooks into existing `TerminalCommandService` and `EscrowService`. Completion rate derives at read time from three `User` counters (no stored `completion_rate` column). WebSocket `REVIEW_REVEALED` envelope piggy-backs on existing `/topic/auction/{id}` channel.
+
+**Tech Stack:** Spring Boot 4 / Java 26 / JPA with `ddl-auto: update` (no Flyway migrations). Next.js 16 / React 19 / TanStack Query v5 / Vitest 4 / MSW 2 / Headless UI.
+
+**Spec:** `docs/superpowers/specs/2026-04-24-epic-08-sub-1-reviews-reputation.md`
+
+---
+
+## Task 1 — Backend: Review domain + submit endpoint + counters wiring
+
+**Goal:** Land the Review entity, eligibility checks, submit endpoint (with simultaneous-reveal path), plus the `User` counter wire-ups in escrow paths so completion rate starts tracking correctly from sub-spec 1 forward.
+
+**Files:**
+
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/Review.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/ReviewResponse.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/ReviewFlag.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/ReviewedRole.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/ReviewFlagReason.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/ReviewRepository.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/ReviewResponseRepository.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/ReviewFlagRepository.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/Aggregate.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/ReviewService.java` (partial — submit path only)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/ReviewController.java` (submit endpoint only in this task)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/dto/*.java` (submit request/response DTOs, ReviewDto)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/exception/*.java` (exception classes + handler)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/user/User.java` — add `escrowExpiredUnfulfilled` column
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/user/SellerCompletionRateMapper.java` — 3-arg signature
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java` — pass 3rd arg
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/user/dto/UserProfileResponse.java` — add `completionRate`, `isNewSeller`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/user/UserService.java` (or wherever profile response is built) — populate new fields
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java` — `expireTransfer` increments seller's `escrowExpiredUnfulfilled`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/escrow/command/TerminalCommandService.java` — `handleEscrowPayoutSuccess` increments seller's `completedSales`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/search/SellerSummaryDto.java` — add `completedSales`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/search/AuctionSearchResultMapper.java` — populate it
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java` — permit GET + require JWT on POST review paths
+- Tests: mirror paths under `backend/src/test/java/...`
+
+### Step-by-step
+
+- [ ] **Step 1: Write the failing test — User.escrowExpiredUnfulfilled column exists and defaults to 0**
+
+File: `backend/src/test/java/com/slparcelauctions/backend/user/UserEntityTest.java` (create if needed)
+
+```java
+@Test
+void escrowExpiredUnfulfilledDefaultsToZero() {
+    User u = User.builder()
+            .email("a@b.com")
+            .passwordHash("x")
+            .build();
+    assertThat(u.getEscrowExpiredUnfulfilled()).isEqualTo(0);
+}
+```
+
+- [ ] **Step 2: Add the column to `User`**
+
+Edit `User.java`, add above `createdAt`:
+
+```java
+@Builder.Default
+@Column(name = "escrow_expired_unfulfilled", nullable = false,
+        columnDefinition = "integer not null default 0")
+private Integer escrowExpiredUnfulfilled = 0;
+```
+
+Run: `./mvnw test -Dtest=UserEntityTest` — passes.
+
+- [ ] **Step 3: Update `SellerCompletionRateMapper` signature (3 args)**
+
+Existing tests for the mapper will fail after signature change. Write the new test first:
+
+File: `backend/src/test/java/com/slparcelauctions/backend/user/SellerCompletionRateMapperTest.java`
+
+```java
+@Test
+void threeWayDenominator() {
+    // 10 completed / (10 + 2 + 3) = 0.67
+    assertThat(SellerCompletionRateMapper.compute(10, 2, 3))
+            .isEqualByComparingTo(new BigDecimal("0.67"));
+}
+
+@Test
+void nullWhenAllCountersZero() {
+    assertThat(SellerCompletionRateMapper.compute(0, 0, 0)).isNull();
+}
+
+@Test
+void expiredUnfulfilledDragsTheRate() {
+    // 5 completed / (5 + 0 + 5) = 0.50
+    assertThat(SellerCompletionRateMapper.compute(5, 0, 5))
+            .isEqualByComparingTo(new BigDecimal("0.50"));
+}
+```
+
+Run: compile fails (2-arg → 3-arg).
+
+Edit `SellerCompletionRateMapper.java`:
+
+```java
+public static BigDecimal compute(
+        int completedSales,
+        int cancelledWithBids,
+        int escrowExpiredUnfulfilled) {
+    int denom = completedSales + cancelledWithBids + escrowExpiredUnfulfilled;
+    if (denom <= 0) return null;
+    return BigDecimal.valueOf(completedSales)
+            .divide(BigDecimal.valueOf(denom), 2, RoundingMode.HALF_UP);
+}
+```
+
+Update `AuctionDtoMapper.java:208` to pass `s.getEscrowExpiredUnfulfilled()` as the third arg. Grep for any other callers and update.
+
+Run: `./mvnw test` — relevant tests pass.
+
+- [ ] **Step 4: Write the failing test — `expireTransfer` increments seller.escrowExpiredUnfulfilled**
+
+File: `backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowServiceExpireTransferTest.java`
+
+```java
+@Test
+void expireTransferIncrementsSellerEscrowExpiredUnfulfilled() {
+    User seller = userRepo.save(User.builder().email("s@x.com").passwordHash("p").build());
+    User buyer = userRepo.save(User.builder().email("b@x.com").passwordHash("p").build());
+    Auction a = persistAuctionFor(seller);
+    Escrow escrow = escrowService.open(a, buyer, L(1000));
+    // Force to TRANSFER_PENDING; details depend on existing helpers
+    advanceToTransferPending(escrow);
+    OffsetDateTime now = OffsetDateTime.now();
+
+    txTemplate.executeWithoutResult(s ->
+            escrowService.expireTransfer(escrowRepo.findByIdForUpdate(escrow.getId()).orElseThrow(), now));
+
+    assertThat(userRepo.findById(seller.getId()).orElseThrow()
+            .getEscrowExpiredUnfulfilled()).isEqualTo(1);
+}
+
+@Test
+void expirePaymentDoesNotIncrementEscrowExpiredUnfulfilled() {
+    // mirror but call expirePayment on a fresh ESCROW_PENDING escrow
+    // assert counter remains 0 (buyer-fault, not seller's)
+}
+```
+
+Run: both fail (counter not incremented).
+
+- [ ] **Step 5: Implement the increment in `EscrowService.expireTransfer`**
+
+Find line 678-700 range. Inside the `expireTransfer` method, after `escrow = escrowRepo.save(escrow);`, add:
+
+```java
+// Seller failed to transfer the parcel in time. Count this against the
+// seller's completion rate (formula B denominator).
+User seller = escrow.getAuction().getSeller();
+seller.setEscrowExpiredUnfulfilled(seller.getEscrowExpiredUnfulfilled() + 1);
+userRepo.save(seller);
+```
+
+Inject `UserRepository` via `@RequiredArgsConstructor` if not already. Do NOT touch `expirePayment` — buyer-fault, different attribution.
+
+Run: `./mvnw test -Dtest=EscrowServiceExpireTransferTest` — passes.
+
+- [ ] **Step 6: Write failing test — `handleEscrowPayoutSuccess` increments seller.completedSales**
+
+File: `backend/src/test/java/com/slparcelauctions/backend/escrow/command/TerminalCommandPayoutSuccessTest.java`
+
+```java
+@Test
+void payoutSuccessIncrementsSellerCompletedSales() {
+    User seller = createUser("s@x.com");
+    int before = seller.getCompletedSales();
+    // Set up escrow in TRANSFER_PENDING with a PAYOUT command in flight
+    Escrow escrow = setupEscrowWithPayoutCommand(seller);
+    String slTxn = "tx-" + UUID.randomUUID();
+
+    // Simulate the callback that flips escrow to COMPLETED
+    terminalCommandService.applyCallback(commandId, slTxn);
+
+    assertThat(userRepo.findById(seller.getId()).orElseThrow().getCompletedSales())
+            .isEqualTo(before + 1);
+    assertThat(escrowRepo.findById(escrow.getId()).orElseThrow().getState())
+            .isEqualTo(EscrowState.COMPLETED);
+}
+```
+
+Run: fails (counter not incremented today).
+
+- [ ] **Step 7: Implement in `TerminalCommandService.handleEscrowPayoutSuccess`**
+
+At line 211-ish, after `escrow = escrowRepo.save(escrow);`, add:
+
+```java
+// New in Epic 08 sub-spec 1: track completed sales for seller
+// completion-rate. Incremented inside the same tx that flips escrow →
+// COMPLETED so the counter can't drift.
+User seller = escrow.getAuction().getSeller();
+seller.setCompletedSales(seller.getCompletedSales() + 1);
+userRepo.save(seller);
+```
+
+Inject `UserRepository` if not already present.
+
+Run: passes.
+
+- [ ] **Step 8: Commit Task 1 partial — counters**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/user/User.java \
+        backend/src/main/java/com/slparcelauctions/backend/user/SellerCompletionRateMapper.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java \
+        backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java \
+        backend/src/main/java/com/slparcelauctions/backend/escrow/command/TerminalCommandService.java \
+        backend/src/test/java/com/slparcelauctions/backend/user/SellerCompletionRateMapperTest.java \
+        backend/src/test/java/com/slparcelauctions/backend/user/UserEntityTest.java \
+        backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowServiceExpireTransferTest.java \
+        backend/src/test/java/com/slparcelauctions/backend/escrow/command/TerminalCommandPayoutSuccessTest.java
+git commit -m "feat(user): User.escrowExpiredUnfulfilled counter + 3-arg completion rate + live escrow increments"
+```
+
+- [ ] **Step 9: Write failing tests — `Review` entity persists, unique constraint works**
+
+File: `backend/src/test/java/com/slparcelauctions/backend/review/ReviewEntityTest.java`
+
+```java
+@Test
+void reviewPersistsWithDefaults() { ... }
+
+@Test
+void uniqueConstraintOnAuctionReviewer() {
+    // attempt to insert two reviews with same auction_id + reviewer_id
+    // expect DataIntegrityViolationException on second save
+}
+
+@Test
+void visibleDefaultsFalse() { ... }
+```
+
+Run: fails (entity doesn't exist).
+
+- [ ] **Step 10: Create `ReviewedRole`, `ReviewFlagReason` enums**
+
+```java
+// ReviewedRole.java
+public enum ReviewedRole { SELLER, BUYER }
+
+// ReviewFlagReason.java
+public enum ReviewFlagReason { SPAM, ABUSIVE, OFF_TOPIC, FALSE_INFO, OTHER }
+```
+
+- [ ] **Step 11: Create `Review.java`**
+
+Full entity per spec §3.1. Use `@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder`. FetchType.LAZY on ManyToOne. `@CreationTimestamp` on `submittedAt`. Unique constraint: `@UniqueConstraint(columnNames = {"auction_id", "reviewer_id"}, name = "uq_reviews_auction_reviewer")`. Indexes: `idx_reviews_reviewee_visible` on `(reviewee_id, reviewed_role, visible)`, `idx_reviews_auction` on `auction_id`.
+
+- [ ] **Step 12: Create `ReviewResponse.java` and `ReviewFlag.java`**
+
+Per spec §3.2, §3.3.
+
+- [ ] **Step 13: Create the three repositories**
+
+```java
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    Optional<Review> findByAuctionIdAndReviewerId(Long auctionId, Long reviewerId);
+
+    @Query("select r from Review r where r.id = :id")
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Review> findByIdForUpdate(@Param("id") Long id);
+
+    @Query("select new com.slparcelauctions.backend.review.Aggregate(" +
+           "  avg(r.rating), count(r)) " +
+           "from Review r " +
+           "where r.reviewee.id = :revieweeId " +
+           "  and r.reviewedRole = com.slparcelauctions.backend.review.ReviewedRole.SELLER " +
+           "  and r.visible = true")
+    Aggregate computeSellerAggregate(@Param("revieweeId") Long revieweeId);
+
+    @Query("select new com.slparcelauctions.backend.review.Aggregate(" +
+           "  avg(r.rating), count(r)) " +
+           "from Review r " +
+           "where r.reviewee.id = :revieweeId " +
+           "  and r.reviewedRole = com.slparcelauctions.backend.review.ReviewedRole.BUYER " +
+           "  and r.visible = true")
+    Aggregate computeBuyerAggregate(@Param("revieweeId") Long revieweeId);
+
+    @Query("""
+           select r from Review r
+           where r.visible = false
+             and r.auction.id in (
+               select e.auction.id from Escrow e
+               where e.state = 'COMPLETED'
+                 and e.completedAt < :threshold
+             )
+           order by r.id
+           """)
+    List<Review> findRevealable(@Param("threshold") OffsetDateTime threshold, Pageable page);
+}
+
+public interface ReviewResponseRepository extends JpaRepository<ReviewResponse, Long> {
+    Optional<ReviewResponse> findByReviewId(Long reviewId);
+    boolean existsByReviewId(Long reviewId);
+}
+
+public interface ReviewFlagRepository extends JpaRepository<ReviewFlag, Long> {
+    boolean existsByReviewIdAndFlaggerId(Long reviewId, Long flaggerId);
+}
+```
+
+- [ ] **Step 14: Create `Aggregate.java`**
+
+```java
+package com.slparcelauctions.backend.review;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * JPQL projection record for AVG+COUNT over visible reviews. The JPQL
+ * returns Double and Long; we normalize avg to a BigDecimal with scale=2,
+ * RoundingMode.HALF_UP, to match the User column precision(3, scale=2).
+ */
+public record Aggregate(BigDecimal avg, int count) {
+    public Aggregate(Double avgRaw, Long countRaw) {
+        this(
+            avgRaw == null
+                ? null
+                : BigDecimal.valueOf(avgRaw).setScale(2, RoundingMode.HALF_UP),
+            countRaw == null ? 0 : countRaw.intValue()
+        );
+    }
+}
+```
+
+- [ ] **Step 15: Run entity tests — pass**
+
+Run: `./mvnw test -Dtest=ReviewEntityTest` — passes.
+
+- [ ] **Step 16: Write failing test — `ReviewService.submit` eligibility**
+
+File: `backend/src/test/java/com/slparcelauctions/backend/review/ReviewServiceSubmitTest.java`
+
+Tests to write (use Mockito for dependencies):
+
+```java
+@Test
+void submitRejectsWhenEscrowNotCompleted() {
+    // escrow state = ESCROW_PENDING
+    // expect ReviewIneligibleException
+}
+
+@Test
+void submitRejectsWhenCallerNotPartyToAuction() {
+    // caller.id = 999 (not seller, not winner)
+    // expect ReviewIneligibleException (or 403 at controller layer)
+}
+
+@Test
+void submitRejectsAfterWindowCloses() {
+    // escrow.completedAt = 15 days ago
+    // expect ReviewWindowClosedException
+}
+
+@Test
+void submitRejectsDuplicateFromSameReviewer() {
+    // existing Review with (auctionId, callerId)
+    // expect ReviewAlreadySubmittedException
+}
+
+@Test
+void submitSucceedsForSellerSubmittingAboutBuyer() {
+    // caller = seller → reviewedRole=BUYER, reviewee=winner
+    // assert Review persisted with visible=false, reviewedRole=BUYER, reviewee=winner
+}
+
+@Test
+void submitSucceedsForWinnerSubmittingAboutSeller() {
+    // caller = winner → reviewedRole=SELLER, reviewee=seller
+}
+
+@Test
+void simultaneousSubmitRevealsBoth() {
+    // step 1: winner submits (visible=false)
+    // step 2: seller submits
+    // after step 2: both rows visible=true, revealedAt stamped, aggregates recomputed
+}
+```
+
+Run: fails (service + exceptions don't exist).
+
+- [ ] **Step 17: Create exception classes**
+
+```java
+// ReviewIneligibleException — 422
+public class ReviewIneligibleException extends RuntimeException {
+    public ReviewIneligibleException(String msg) { super(msg); }
+}
+
+// ReviewAlreadySubmittedException — 409
+public class ReviewAlreadySubmittedException extends RuntimeException { ... }
+
+// ReviewWindowClosedException — 422
+public class ReviewWindowClosedException extends RuntimeException { ... }
+
+// ReviewNotFoundException — 404
+public class ReviewNotFoundException extends RuntimeException { ... }
+```
+
+- [ ] **Step 18: Create `ReviewSubmitRequest.java`**
+
+```java
+public record ReviewSubmitRequest(
+    @Min(1) @Max(5) Integer rating,
+    @Size(max = 500) String text  // nullable
+) {}
+```
+
+- [ ] **Step 19: Create `ReviewDto.java`**
+
+```java
+public record ReviewDto(
+    Long id,
+    Long auctionId,
+    String auctionTitle,
+    String auctionPrimaryPhotoUrl,
+    Long reviewerId,
+    String reviewerDisplayName,
+    String reviewerAvatarUrl,
+    Long revieweeId,
+    ReviewedRole reviewedRole,
+    Integer rating,
+    String text,
+    Boolean visible,
+    Boolean pending,
+    OffsetDateTime submittedAt,
+    OffsetDateTime revealedAt,
+    ReviewResponseDto response
+) {
+    /**
+     * Build a ReviewDto from a persisted Review. Resolves the reviewer's
+     * live display name + avatar so renamed users immediately show as
+     * renamed. If `viewerId` equals `reviewer.id`, flags pending=true and
+     * includes submittedAt for private-view use.
+     */
+    public static ReviewDto of(Review r, Long viewerId, Optional<ReviewResponse> resp,
+                                String primaryPhotoUrl) {
+        boolean viewerIsReviewer = r.getReviewer().getId().equals(viewerId);
+        boolean pending = !Boolean.TRUE.equals(r.getVisible()) && viewerIsReviewer;
+        boolean exposeText = Boolean.TRUE.equals(r.getVisible()) || viewerIsReviewer;
+        return new ReviewDto(
+            r.getId(),
+            r.getAuction().getId(),
+            r.getAuction().getTitle(),
+            primaryPhotoUrl,
+            r.getReviewer().getId(),
+            r.getReviewer().getDisplayName(),
+            r.getReviewer().getProfilePicUrl(),
+            r.getReviewee().getId(),
+            r.getReviewedRole(),
+            exposeText ? r.getRating() : null,
+            exposeText ? r.getText() : null,
+            r.getVisible(),
+            pending,
+            exposeText ? r.getSubmittedAt() : null,
+            r.getRevealedAt(),
+            resp.map(ReviewResponseDto::of).orElse(null)
+        );
+    }
+}
+```
+
+- [ ] **Step 20: Create `ReviewResponseDto.java`**
+
+```java
+public record ReviewResponseDto(
+    Long id,
+    String text,
+    OffsetDateTime createdAt
+) {
+    public static ReviewResponseDto of(ReviewResponse r) {
+        return new ReviewResponseDto(r.getId(), r.getText(), r.getCreatedAt());
+    }
+}
+```
+
+- [ ] **Step 21: Create `ReviewService.java` (submit path only for Task 1)**
+
+```java
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReviewService {
+    private static final Duration REVIEW_WINDOW = Duration.ofDays(14);
+
+    private final ReviewRepository reviewRepo;
+    private final ReviewResponseRepository responseRepo;
+    private final AuctionRepository auctionRepo;
+    private final EscrowRepository escrowRepo;
+    private final UserRepository userRepo;
+    private final Clock clock;
+    private final EscrowBroadcastPublisher broadcastPublisher;  // reused; publishReviewRevealed added in Task 2
+
+    @Transactional
+    public ReviewDto submit(Long auctionId, User caller, ReviewSubmitRequest req) {
+        Auction auction = auctionRepo.findById(auctionId)
+                .orElseThrow(() -> new AuctionNotFoundException(auctionId));
+        Escrow escrow = escrowRepo.findByAuctionId(auctionId)
+                .orElseThrow(() -> new ReviewIneligibleException(
+                        "Auction has no escrow"));
+
+        if (escrow.getState() != EscrowState.COMPLETED) {
+            throw new ReviewIneligibleException(
+                    "Can only review auctions whose escrow has completed.");
+        }
+
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        OffsetDateTime windowCloses = escrow.getCompletedAt().plus(REVIEW_WINDOW);
+        if (now.isAfter(windowCloses)) {
+            throw new ReviewWindowClosedException(
+                    "The 14-day review window for this auction has closed.");
+        }
+
+        Long sellerId = auction.getSeller().getId();
+        Long winnerId = escrow.getWinner().getId();
+        Long callerId = caller.getId();
+
+        if (!callerId.equals(sellerId) && !callerId.equals(winnerId)) {
+            throw new ReviewIneligibleException(
+                    "Only the seller or winner can review this auction.");
+        }
+
+        if (reviewRepo.findByAuctionIdAndReviewerId(auctionId, callerId).isPresent()) {
+            throw new ReviewAlreadySubmittedException(
+                    "You have already submitted a review for this auction.");
+        }
+
+        // Derive reviewee + reviewedRole. Caller's role determines whose
+        // behavior is being rated. Caller = seller → reviewing the winner's
+        // BUYER behavior. Caller = winner → reviewing the seller's SELLER
+        // behavior.
+        User reviewee;
+        ReviewedRole reviewedRole;
+        if (callerId.equals(sellerId)) {
+            reviewee = escrow.getWinner();
+            reviewedRole = ReviewedRole.BUYER;
+        } else {
+            reviewee = auction.getSeller();
+            reviewedRole = ReviewedRole.SELLER;
+        }
+
+        Review mine = reviewRepo.save(Review.builder()
+                .auction(auction)
+                .reviewer(caller)
+                .reviewee(reviewee)
+                .reviewedRole(reviewedRole)
+                .rating(req.rating())
+                .text(req.text())
+                .visible(false)
+                .build());
+
+        // Simultaneous-reveal branch — if the counterparty already
+        // submitted, flip both visible atomically and recompute both
+        // reviewees' aggregates inside this transaction.
+        Long counterpartyId = callerId.equals(sellerId) ? winnerId : sellerId;
+        Optional<Review> theirs = reviewRepo.findByAuctionIdAndReviewerId(auctionId, counterpartyId);
+        if (theirs.isPresent() && !Boolean.TRUE.equals(theirs.get().getVisible())) {
+            reveal(mine.getId());
+            reveal(theirs.get().getId());
+        }
+
+        // For the pending-view DTO, include submittedAt/text so the caller
+        // sees their own review immediately.
+        return ReviewDto.of(mine, callerId,
+                responseRepo.findByReviewId(mine.getId()),
+                resolvePrimaryPhotoUrl(mine.getAuction()));
+    }
+
+    // reveal() + recomputeAggregates() added in Task 2; Task 1 only uses
+    // submit(). For Task 1 commit stability, include reveal() as a stub
+    // that throws UnsupportedOperationException; Task 2 will replace.
+    //
+    // NO — better: move the simultaneous-reveal-path test to Task 2 so
+    // we don't have a stub. For Task 1, the service does NOT attempt
+    // simultaneous reveal; it just persists the row and returns.
+    // Adjust Step 16's "simultaneousSubmitRevealsBoth" test to land in
+    // Task 2 instead.
+
+    private String resolvePrimaryPhotoUrl(Auction auction) {
+        // Match the pattern used in AuctionDtoMapper: first AuctionPhoto by
+        // sort_order, else parcel snapshotUrl.
+        return auction.getPhotos().stream()
+                .sorted(Comparator.comparing(AuctionPhoto::getSortOrder))
+                .findFirst()
+                .map(AuctionPhoto::getUrl)
+                .orElseGet(() -> auction.getParcel().getSnapshotUrl());
+    }
+}
+```
+
+**Important revision:** The simultaneous-reveal logic and `reveal()` live in Task 2. Task 1's submit only persists the row with `visible=false`. Adjust Step 16's test list accordingly: remove `simultaneousSubmitRevealsBoth`, keep the eligibility tests only.
+
+- [ ] **Step 22: Create `ReviewController.java` (submit endpoint only)**
+
+```java
+@RestController
+@RequestMapping("/api/v1/auctions/{id}/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+    private final ReviewService reviewService;
+    private final UserService userService;  // for @AuthenticationPrincipal → User resolution
+
+    @PostMapping
+    public ResponseEntity<ReviewDto> submit(
+            @PathVariable("id") Long auctionId,
+            @AuthenticationPrincipal UserDetails principal,
+            @Valid @RequestBody ReviewSubmitRequest request) {
+        User caller = userService.requireByEmail(principal.getUsername());
+        ReviewDto dto = reviewService.submit(auctionId, caller, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(dto);
+    }
+}
+```
+
+- [ ] **Step 23: Create `ReviewExceptionHandler.java`**
+
+```java
+@RestControllerAdvice(basePackageClasses = ReviewController.class)
+@Slf4j
+public class ReviewExceptionHandler {
+
+    @ExceptionHandler(ReviewNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorResponse notFound(ReviewNotFoundException ex) { ... }
+
+    @ExceptionHandler(ReviewIneligibleException.class)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    public ErrorResponse ineligible(ReviewIneligibleException ex) { ... }
+
+    @ExceptionHandler(ReviewWindowClosedException.class)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    public ErrorResponse windowClosed(ReviewWindowClosedException ex) { ... }
+
+    @ExceptionHandler(ReviewAlreadySubmittedException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorResponse alreadySubmitted(ReviewAlreadySubmittedException ex) { ... }
+}
+```
+
+Follow existing `ErrorResponse` shape from `common/`.
+
+- [ ] **Step 24: Write slice test — `@WebMvcTest(ReviewController.class)`**
+
+File: `backend/src/test/java/com/slparcelauctions/backend/review/ReviewControllerTest.java`
+
+```java
+@Test void submitReturns201() { ... }
+@Test void submitReturns422WhenIneligible() { ... }
+@Test void submitReturns422WhenWindowClosed() { ... }
+@Test void submitReturns409WhenDuplicate() { ... }
+@Test void submitReturns401WhenUnauthenticated() { ... }
+@Test void submitReturns400WhenRatingOutOfRange() { ... }
+@Test void submitReturns400WhenTextTooLong() { ... }
+```
+
+- [ ] **Step 25: Update `SecurityConfig.java`**
+
+Ensure POST `/api/v1/auctions/*/reviews` requires authentication. GET endpoints will be added in Task 2 — those will be public.
+
+- [ ] **Step 26: Add `SellerSummaryDto.completedSales` field**
+
+Modify `SellerSummaryDto.java`:
+
+```java
+public record SellerSummaryDto(
+        Long id,
+        String displayName,
+        String avatarUrl,
+        BigDecimal averageRating,
+        Integer reviewCount,
+        Integer completedSales
+) {}
+```
+
+Update `AuctionSearchResultMapper.java` to populate `completedSales`. Update any DTO constructors in tests.
+
+- [ ] **Step 27: Extend `UserProfileResponse.java` with `completionRate`, `isNewSeller`**
+
+```java
+public record UserProfileResponse(
+        Long id,
+        String displayName,
+        String bio,
+        String profilePicUrl,
+        UUID slAvatarUuid,
+        String slUsername,
+        String slDisplayName,
+        Boolean verified,
+        BigDecimal avgSellerRating,
+        BigDecimal avgBuyerRating,
+        Integer totalSellerReviews,
+        Integer totalBuyerReviews,
+        Integer completedSales,
+        BigDecimal completionRate,
+        Boolean isNewSeller,
+        OffsetDateTime createdAt) {
+
+    public static UserProfileResponse from(User user) {
+        BigDecimal rate = SellerCompletionRateMapper.compute(
+                user.getCompletedSales(),
+                user.getCancelledWithBids(),
+                user.getEscrowExpiredUnfulfilled());
+        boolean isNewSeller = user.getCompletedSales() < 3;
+        return new UserProfileResponse(
+                user.getId(),
+                user.getDisplayName(),
+                user.getBio(),
+                user.getProfilePicUrl(),
+                user.getSlAvatarUuid(),
+                user.getSlUsername(),
+                user.getSlDisplayName(),
+                user.getVerified(),
+                user.getAvgSellerRating(),
+                user.getAvgBuyerRating(),
+                user.getTotalSellerReviews(),
+                user.getTotalBuyerReviews(),
+                user.getCompletedSales(),
+                rate,
+                isNewSeller,
+                user.getCreatedAt());
+    }
+}
+```
+
+- [ ] **Step 28: Run all backend tests**
+
+Run: `./mvnw test`. All pass. If any unrelated tests break because they constructed `SellerSummaryDto` or `UserProfileResponse` with old constructors, fix those too.
+
+- [ ] **Step 29: Commit Task 1**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/review/ \
+        backend/src/test/java/com/slparcelauctions/backend/review/ \
+        backend/src/main/java/com/slparcelauctions/backend/user/dto/UserProfileResponse.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/search/SellerSummaryDto.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/search/AuctionSearchResultMapper.java \
+        backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
+git commit -m "feat(review): entities + submit endpoint + exception mapping"
+```
+
+---
+
+## Task 2 — Backend: Reveal scheduler, aggregates, list endpoints, WS
+
+**Goal:** Complete the review read path and visibility machinery. Hourly scheduler flips day-14 reviews visible. Simultaneous submit-path now triggers synchronous reveal + aggregate recompute + WS broadcast.
+
+**Files:**
+
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/BlindReviewRevealTask.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/ReviewRevealedEnvelope.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/UserReviewsController.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/dto/AuctionReviewsResponse.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/review/dto/PendingReviewDto.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/review/ReviewService.java` — add `reveal`, `recomputeAggregates`, `listForAuction`, `listForUser`, `listPendingForCaller`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/review/ReviewController.java` — add GET /auctions/{id}/reviews
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/escrow/broadcast/*` — add `publishReviewRevealed`
+- Tests for each
+
+### Steps
+
+- [ ] **Step 1: Write failing test — `ReviewService.reveal` flips visibility and recomputes**
+
+```java
+@Test
+void revealFlipsVisibilityAndStampsRevealedAt() {
+    Review r = persistPendingReview();
+    reviewService.reveal(r.getId());
+    Review updated = reviewRepo.findById(r.getId()).orElseThrow();
+    assertThat(updated.getVisible()).isTrue();
+    assertThat(updated.getRevealedAt()).isNotNull();
+}
+
+@Test
+void revealRecomputesAggregatesForReviewee() {
+    User reviewee = createUser();
+    persistThreeVisibleReviewsWithRatings(reviewee, 4, 5, 5, ReviewedRole.SELLER);
+    Review fourth = persistPendingReview(reviewee, 3, ReviewedRole.SELLER);
+    reviewService.reveal(fourth.getId());
+    User updated = userRepo.findById(reviewee.getId()).orElseThrow();
+    // AVG(4, 5, 5, 3) = 17/4 = 4.25
+    assertThat(updated.getAvgSellerRating())
+            .isEqualByComparingTo(new BigDecimal("4.25"));
+    assertThat(updated.getTotalSellerReviews()).isEqualTo(4);
+}
+
+@Test
+void revealIsIdempotent() {
+    Review r = persistPendingReview();
+    reviewService.reveal(r.getId());
+    OffsetDateTime first = reviewRepo.findById(r.getId()).orElseThrow().getRevealedAt();
+    reviewService.reveal(r.getId());  // second call
+    OffsetDateTime second = reviewRepo.findById(r.getId()).orElseThrow().getRevealedAt();
+    assertThat(second).isEqualTo(first);  // not overwritten
+}
+```
+
+- [ ] **Step 2: Implement `ReviewService.reveal` + `recomputeAggregates`**
+
+```java
+@Transactional
+public void reveal(Long reviewId) {
+    Review r = reviewRepo.findByIdForUpdate(reviewId)
+            .orElseThrow(() -> new ReviewNotFoundException(reviewId));
+    if (Boolean.TRUE.equals(r.getVisible())) return;  // idempotent
+
+    r.setVisible(true);
+    r.setRevealedAt(OffsetDateTime.now(clock));
+    reviewRepo.save(r);
+
+    recomputeAggregates(r.getReviewee(), r.getReviewedRole());
+
+    ReviewRevealedEnvelope envelope = ReviewRevealedEnvelope.of(r);
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+            @Override public void afterCommit() {
+                broadcastPublisher.publishReviewRevealed(envelope);
+            }
+        });
+    log.info("Review {} revealed: auction={}, reviewee={}, role={}",
+            r.getId(), r.getAuction().getId(), r.getReviewee().getId(),
+            r.getReviewedRole());
+}
+
+private void recomputeAggregates(User reviewee, ReviewedRole role) {
+    if (role == ReviewedRole.SELLER) {
+        Aggregate agg = reviewRepo.computeSellerAggregate(reviewee.getId());
+        reviewee.setAvgSellerRating(agg.avg());
+        reviewee.setTotalSellerReviews(agg.count());
+    } else {
+        Aggregate agg = reviewRepo.computeBuyerAggregate(reviewee.getId());
+        reviewee.setAvgBuyerRating(agg.avg());
+        reviewee.setTotalBuyerReviews(agg.count());
+    }
+    userRepo.save(reviewee);
+}
+```
+
+- [ ] **Step 3: Add the simultaneous-reveal branch back to `submit`**
+
+Uncomment/add the "Simultaneous-reveal branch" described in Task 1 Step 21. Write test:
+
+```java
+@Test
+void simultaneousSubmitRevealsBoth() {
+    Auction a = auctionWithCompletedEscrow();
+    reviewService.submit(a.getId(), winnerUser, new ReviewSubmitRequest(5, "gg"));
+    reviewService.submit(a.getId(), sellerUser, new ReviewSubmitRequest(4, "fast pay"));
+
+    // Both reviews visible after the second submit
+    List<Review> reviews = reviewRepo.findAll().stream()
+            .filter(r -> r.getAuction().getId().equals(a.getId()))
+            .toList();
+    assertThat(reviews).hasSize(2)
+            .allMatch(r -> Boolean.TRUE.equals(r.getVisible()))
+            .allMatch(r -> r.getRevealedAt() != null);
+
+    // Both reviewees' aggregates updated
+    User sellerAfter = userRepo.findById(sellerUser.getId()).orElseThrow();
+    User winnerAfter = userRepo.findById(winnerUser.getId()).orElseThrow();
+    assertThat(sellerAfter.getTotalSellerReviews()).isEqualTo(1);
+    assertThat(winnerAfter.getTotalBuyerReviews()).isEqualTo(1);
+}
+```
+
+- [ ] **Step 4: Create `ReviewRevealedEnvelope.java`**
+
+```java
+package com.slparcelauctions.backend.review;
+
+import com.slparcelauctions.backend.auction.AuctionTopicEnvelope;
+import java.time.OffsetDateTime;
+
+public record ReviewRevealedEnvelope(
+    String type,
+    Long auctionId,
+    Long reviewId,
+    Long reviewerId,
+    Long revieweeId,
+    ReviewedRole reviewedRole,
+    OffsetDateTime revealedAt
+) implements AuctionTopicEnvelope {
+    public static ReviewRevealedEnvelope of(Review r) {
+        return new ReviewRevealedEnvelope(
+            "REVIEW_REVEALED",
+            r.getAuction().getId(),
+            r.getId(),
+            r.getReviewer().getId(),
+            r.getReviewee().getId(),
+            r.getReviewedRole(),
+            r.getRevealedAt()
+        );
+    }
+}
+```
+
+Note: `AuctionTopicEnvelope` is a sealed interface in the auction package today. Add `ReviewRevealedEnvelope` to its `permits` clause (or add the marker interface if it uses one). Read `AuctionEnvelope`/`EscrowEnvelope` to match the pattern.
+
+- [ ] **Step 5: Add `publishReviewRevealed` to broadcast publisher**
+
+Find the existing `EscrowBroadcastPublisher` (or equivalent). Add:
+
+```java
+public void publishReviewRevealed(ReviewRevealedEnvelope envelope) {
+    messaging.convertAndSend(
+            "/topic/auction/" + envelope.auctionId(),
+            envelope);
+    log.debug("Broadcast REVIEW_REVEALED: reviewId={}", envelope.reviewId());
+}
+```
+
+- [ ] **Step 6: Create `BlindReviewRevealTask`**
+
+```java
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnProperty(
+    name = "slpa.review.scheduler.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class BlindReviewRevealTask {
+    private static final Duration REVIEW_WINDOW = Duration.ofDays(14);
+    private static final int BATCH_LIMIT = 500;
+
+    private final ReviewRepository reviewRepo;
+    private final ReviewService reviewService;
+    private final Clock clock;
+
+    /** Top of every hour. */
+    @Scheduled(cron = "0 0 * * * *")
+    public void run() {
+        OffsetDateTime threshold = OffsetDateTime.now(clock).minus(REVIEW_WINDOW);
+        List<Review> revealable = reviewRepo.findRevealable(
+                threshold, PageRequest.of(0, BATCH_LIMIT));
+        if (revealable.isEmpty()) return;
+
+        log.info("BlindReviewReveal: {} reviews past day-14 window", revealable.size());
+        for (Review r : revealable) {
+            try {
+                reviewService.reveal(r.getId());
+            } catch (Exception e) {
+                log.error("Failed to reveal review {}: {}", r.getId(), e.toString());
+            }
+        }
+        if (revealable.size() == BATCH_LIMIT) {
+            log.warn("BlindReviewReveal: hit batch limit {}; re-running next tick", BATCH_LIMIT);
+        }
+    }
+}
+```
+
+- [ ] **Step 7: Write scheduler test**
+
+File: `BlindReviewRevealTaskTest.java`
+
+```java
+@Test
+void revealsReviewsOlderThan14Days() {
+    // escrow.completedAt = 15 days ago, review still visible=false
+    // run task
+    // assert review.visible=true
+}
+
+@Test
+void skipsReviewsWithin14Days() {
+    // escrow.completedAt = 10 days ago
+    // run task
+    // assert review.visible=false
+}
+
+@Test
+void idempotentOnRerun() {
+    // run twice, assert revealedAt unchanged on second
+}
+```
+
+- [ ] **Step 8: Create `AuctionReviewsResponse.java`**
+
+```java
+public record AuctionReviewsResponse(
+    List<ReviewDto> reviews,
+    ReviewDto myPendingReview,  // nullable
+    Boolean canReview,
+    OffsetDateTime windowClosesAt  // nullable
+) {}
+```
+
+- [ ] **Step 9: Add `GET /api/v1/auctions/{id}/reviews` endpoint**
+
+In `ReviewController.java`:
+
+```java
+@GetMapping
+public AuctionReviewsResponse list(
+        @PathVariable("id") Long auctionId,
+        @AuthenticationPrincipal UserDetails principal) {
+    User caller = principal == null
+            ? null
+            : userService.findByEmail(principal.getUsername()).orElse(null);
+    return reviewService.listForAuction(auctionId, caller);
+}
+```
+
+- [ ] **Step 10: Implement `ReviewService.listForAuction`**
+
+```java
+@Transactional(readOnly = true)
+public AuctionReviewsResponse listForAuction(Long auctionId, User caller) {
+    Auction auction = auctionRepo.findById(auctionId)
+            .orElseThrow(() -> new AuctionNotFoundException(auctionId));
+    Optional<Escrow> maybeEscrow = escrowRepo.findByAuctionId(auctionId);
+
+    List<Review> visible = reviewRepo.findByAuctionIdAndVisibleTrue(auctionId);
+    String primaryPhoto = resolvePrimaryPhotoUrl(auction);
+
+    List<ReviewDto> visibleDtos = visible.stream()
+            .map(r -> ReviewDto.of(r, caller == null ? null : caller.getId(),
+                    responseRepo.findByReviewId(r.getId()), primaryPhoto))
+            .toList();
+
+    ReviewDto myPending = null;
+    boolean canReview = false;
+    OffsetDateTime windowCloses = null;
+
+    if (caller != null && maybeEscrow.isPresent()
+            && maybeEscrow.get().getState() == EscrowState.COMPLETED) {
+        Escrow e = maybeEscrow.get();
+        Long sellerId = auction.getSeller().getId();
+        Long winnerId = e.getWinner().getId();
+        boolean isParty = caller.getId().equals(sellerId)
+                || caller.getId().equals(winnerId);
+        if (isParty) {
+            windowCloses = e.getCompletedAt().plus(REVIEW_WINDOW);
+            OffsetDateTime now = OffsetDateTime.now(clock);
+            boolean windowOpen = now.isBefore(windowCloses);
+            Optional<Review> mine = reviewRepo
+                    .findByAuctionIdAndReviewerId(auctionId, caller.getId());
+            canReview = windowOpen && mine.isEmpty();
+            myPending = mine
+                    .filter(r -> !Boolean.TRUE.equals(r.getVisible()))
+                    .map(r -> ReviewDto.of(r, caller.getId(),
+                            responseRepo.findByReviewId(r.getId()), primaryPhoto))
+                    .orElse(null);
+        }
+    }
+
+    return new AuctionReviewsResponse(visibleDtos, myPending, canReview, windowCloses);
+}
+```
+
+- [ ] **Step 11: Add `findByAuctionIdAndVisibleTrue` to `ReviewRepository`**
+
+```java
+@Query("select r from Review r where r.auction.id = :auctionId and r.visible = true " +
+       "order by r.revealedAt desc")
+List<Review> findByAuctionIdAndVisibleTrue(@Param("auctionId") Long auctionId);
+```
+
+- [ ] **Step 12: Create `UserReviewsController.java`**
+
+```java
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class UserReviewsController {
+    private final ReviewService reviewService;
+    private final UserService userService;
+
+    @GetMapping("/users/{id}/reviews")
+    public PagedResponse<ReviewDto> listForUser(
+            @PathVariable("id") Long userId,
+            @RequestParam("role") ReviewedRole role,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size) {
+        Page<ReviewDto> result = reviewService.listForUser(userId, role,
+                PageRequest.of(page, Math.min(size, 50)));
+        return PagedResponse.from(result);
+    }
+
+    @GetMapping("/users/me/pending-reviews")
+    public List<PendingReviewDto> listPending(
+            @AuthenticationPrincipal UserDetails principal) {
+        User caller = userService.requireByEmail(principal.getUsername());
+        return reviewService.listPendingForCaller(caller);
+    }
+}
+```
+
+- [ ] **Step 13: Implement `listForUser` and `listPendingForCaller`**
+
+```java
+@Transactional(readOnly = true)
+public Page<ReviewDto> listForUser(Long userId, ReviewedRole role, Pageable page) {
+    Page<Review> reviews = reviewRepo.findByRevieweeIdAndReviewedRoleAndVisibleTrue(
+            userId, role, page.withSort(Sort.by(Sort.Direction.DESC, "revealedAt")));
+    return reviews.map(r -> ReviewDto.of(r, null,
+            responseRepo.findByReviewId(r.getId()),
+            resolvePrimaryPhotoUrl(r.getAuction())));
+}
+
+@Transactional(readOnly = true)
+public List<PendingReviewDto> listPendingForCaller(User caller) {
+    // Completed escrows where caller is seller or winner, window open, no review yet
+    OffsetDateTime now = OffsetDateTime.now(clock);
+    OffsetDateTime threshold = now.minus(REVIEW_WINDOW);
+    return escrowRepo.findCompletedEscrowsForUser(caller.getId(), threshold)
+            .stream()
+            .filter(e -> reviewRepo
+                    .findByAuctionIdAndReviewerId(e.getAuction().getId(), caller.getId())
+                    .isEmpty())
+            .map(e -> PendingReviewDto.of(e, caller, now))
+            .toList();
+}
+```
+
+Add `findCompletedEscrowsForUser` to `EscrowRepository`:
+
+```java
+@Query("""
+       select e from Escrow e
+       where e.state = 'COMPLETED'
+         and e.completedAt > :threshold
+         and (e.auction.seller.id = :userId or e.winner.id = :userId)
+       """)
+List<Escrow> findCompletedEscrowsForUser(
+        @Param("userId") Long userId,
+        @Param("threshold") OffsetDateTime threshold);
+```
+
+Add `findByRevieweeIdAndReviewedRoleAndVisibleTrue` to `ReviewRepository`:
+
+```java
+Page<Review> findByRevieweeIdAndReviewedRoleAndVisibleTrue(
+        Long revieweeId, ReviewedRole role, Pageable page);
+```
+
+- [ ] **Step 14: Create `PendingReviewDto.java`**
+
+```java
+public record PendingReviewDto(
+    Long auctionId,
+    String title,
+    String primaryPhotoUrl,
+    Long counterpartyId,
+    String counterpartyDisplayName,
+    String counterpartyAvatarUrl,
+    OffsetDateTime escrowCompletedAt,
+    OffsetDateTime windowClosesAt,
+    long hoursRemaining,
+    ReviewedRole viewerRole
+) {
+    public static PendingReviewDto of(Escrow e, User viewer, OffsetDateTime now) {
+        boolean viewerIsSeller = e.getAuction().getSeller().getId().equals(viewer.getId());
+        User counterparty = viewerIsSeller ? e.getWinner() : e.getAuction().getSeller();
+        OffsetDateTime windowCloses = e.getCompletedAt().plus(Duration.ofDays(14));
+        long hoursRemaining = Math.max(0,
+                Duration.between(now, windowCloses).toHours());
+
+        // ViewerRole here means "role of the person who needs to submit the
+        // review" — if viewer is seller, they review the BUYER side. But the
+        // frontend card shows their OWN role in the transaction, so use
+        // SELLER/BUYER to describe the viewer.
+        ReviewedRole viewerRole = viewerIsSeller ? ReviewedRole.SELLER : ReviewedRole.BUYER;
+
+        String photo = e.getAuction().getPhotos().stream()
+                .sorted(Comparator.comparing(AuctionPhoto::getSortOrder))
+                .findFirst()
+                .map(AuctionPhoto::getUrl)
+                .orElseGet(() -> e.getAuction().getParcel().getSnapshotUrl());
+
+        return new PendingReviewDto(
+            e.getAuction().getId(),
+            e.getAuction().getTitle(),
+            photo,
+            counterparty.getId(),
+            counterparty.getDisplayName(),
+            counterparty.getProfilePicUrl(),
+            e.getCompletedAt(),
+            windowCloses,
+            hoursRemaining,
+            viewerRole
+        );
+    }
+}
+```
+
+- [ ] **Step 15: Update `SecurityConfig.java`**
+
+Permit GET on review paths; JWT on write paths:
+
+```java
+.requestMatchers(HttpMethod.GET, "/api/v1/auctions/*/reviews").permitAll()
+.requestMatchers(HttpMethod.GET, "/api/v1/users/*/reviews").permitAll()
+.requestMatchers(HttpMethod.GET, "/api/v1/users/me/pending-reviews").authenticated()
+.requestMatchers(HttpMethod.POST, "/api/v1/auctions/*/reviews").authenticated()
+```
+
+- [ ] **Step 16: Update frontend envelope type (deferred to Task 5)**
+
+Note: leaves `AuctionTopicEnvelope` TS union at Task 5.
+
+- [ ] **Step 17: Run all backend tests**
+
+Run: `./mvnw test`. All pass.
+
+- [ ] **Step 18: Commit Task 2**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/review/ \
+        backend/src/test/java/com/slparcelauctions/backend/review/ \
+        backend/src/main/java/com/slparcelauctions/backend/escrow/broadcast/ \
+        backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowRepository.java \
+        backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/AuctionTopicEnvelope.java  # if sealed
+git commit -m "feat(review): reveal scheduler + aggregates + list endpoints + WS"
+```
+
+---
+
+## Task 3 — Backend: Response + flag endpoints
+
+**Goal:** Ship the two secondary review actions. Small task — mostly repository + service + controller + exception wiring.
+
+**Files:**
+
+- Create: `backend/.../review/dto/ReviewResponseSubmitRequest.java`
+- Create: `backend/.../review/dto/ReviewFlagRequest.java`
+- Create: `backend/.../review/exception/ReviewResponseAlreadyExistsException.java`
+- Create: `backend/.../review/exception/ReviewFlagAlreadyExistsException.java`
+- Create: `backend/.../review/exception/ElaborationRequiredWhenOther.java` (annotation)
+- Create: `backend/.../review/exception/ElaborationRequiredWhenOtherValidator.java`
+- Modify: `ReviewService.java` — add `respondTo`, `flag` methods
+- Modify: `ReviewController.java` — add POST /reviews/{id}/respond, POST /reviews/{id}/flag
+- Modify: `ReviewExceptionHandler.java` — handle new exception types
+- Tests for each path
+
+### Steps
+
+- [ ] **Step 1: Write failing test — respond**
+
+```java
+@Test
+void respondReturns201FirstTime() { ... }
+@Test
+void respondReturns403WhenNotReviewee() { ... }
+@Test
+void respondReturns409OnDuplicate() { ... }
+@Test
+void respondReturns400OnEmptyText() { ... }
+@Test
+void respondReturns400OnTextTooLong() { ... }
+```
+
+- [ ] **Step 2: Create `ReviewResponseSubmitRequest`**
+
+```java
+public record ReviewResponseSubmitRequest(
+    @NotBlank @Size(max = 500) String text
+) {}
+```
+
+- [ ] **Step 3: Create `ReviewResponseAlreadyExistsException`** (409)
+
+- [ ] **Step 4: Implement `ReviewService.respondTo`**
+
+```java
+@Transactional
+public ReviewResponseDto respondTo(Long reviewId, User caller,
+                                    ReviewResponseSubmitRequest req) {
+    Review r = reviewRepo.findById(reviewId)
+            .orElseThrow(() -> new ReviewNotFoundException(reviewId));
+    if (!r.getReviewee().getId().equals(caller.getId())) {
+        throw new AccessDeniedException("Only the reviewee can respond.");
+    }
+    if (responseRepo.existsByReviewId(reviewId)) {
+        throw new ReviewResponseAlreadyExistsException(reviewId);
+    }
+    ReviewResponse resp = responseRepo.save(ReviewResponse.builder()
+            .review(r)
+            .text(req.text())
+            .build());
+    return ReviewResponseDto.of(resp);
+}
+```
+
+- [ ] **Step 5: Add endpoint in `ReviewController`**
+
+```java
+@RestController
+@RequestMapping("/api/v1/reviews")
+@RequiredArgsConstructor
+public class ReviewActionController {  // separate controller to avoid path collision
+
+    private final ReviewService reviewService;
+    private final UserService userService;
+
+    @PostMapping("/{id}/respond")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ReviewResponseDto respond(
+            @PathVariable("id") Long reviewId,
+            @AuthenticationPrincipal UserDetails principal,
+            @Valid @RequestBody ReviewResponseSubmitRequest request) {
+        User caller = userService.requireByEmail(principal.getUsername());
+        return reviewService.respondTo(reviewId, caller, request);
+    }
+}
+```
+
+Two controller classes (one for `/auctions/{id}/reviews`, one for `/reviews/{id}/*`) keeps path conflicts trivial.
+
+- [ ] **Step 6: Tests for flag**
+
+```java
+@Test
+void flagReturns204OnFirstFlag() { ... }
+@Test
+void flagReturns403WhenCallerIsReviewer() { ... }
+@Test
+void flagReturns409OnDuplicate() { ... }
+@Test
+void flagReturns400WhenOtherWithoutElaboration() { ... }
+@Test
+void flagIncrementsReviewFlagCount() { ... }
+```
+
+- [ ] **Step 7: Create `ElaborationRequiredWhenOther` validator**
+
+```java
+@Documented
+@Constraint(validatedBy = ElaborationRequiredWhenOtherValidator.class)
+@Target(TYPE)
+@Retention(RUNTIME)
+public @interface ElaborationRequiredWhenOther {
+    String message() default "Elaboration is required when reason is OTHER.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}
+
+public class ElaborationRequiredWhenOtherValidator
+        implements ConstraintValidator<ElaborationRequiredWhenOther, ReviewFlagRequest> {
+    @Override
+    public boolean isValid(ReviewFlagRequest r, ConstraintValidatorContext ctx) {
+        if (r.reason() != ReviewFlagReason.OTHER) return true;
+        return r.elaboration() != null && !r.elaboration().isBlank();
+    }
+}
+```
+
+- [ ] **Step 8: Create `ReviewFlagRequest`**
+
+```java
+@ElaborationRequiredWhenOther
+public record ReviewFlagRequest(
+    @NotNull ReviewFlagReason reason,
+    @Size(max = 500) String elaboration
+) {}
+```
+
+- [ ] **Step 9: Implement `ReviewService.flag`**
+
+```java
+@Transactional
+public void flag(Long reviewId, User caller, ReviewFlagRequest req) {
+    Review r = reviewRepo.findByIdForUpdate(reviewId)
+            .orElseThrow(() -> new ReviewNotFoundException(reviewId));
+    if (r.getReviewer().getId().equals(caller.getId())) {
+        throw new AccessDeniedException("Cannot flag your own review.");
+    }
+    if (flagRepo.existsByReviewIdAndFlaggerId(reviewId, caller.getId())) {
+        throw new ReviewFlagAlreadyExistsException(reviewId);
+    }
+    flagRepo.save(ReviewFlag.builder()
+            .review(r)
+            .flagger(caller)
+            .reason(req.reason())
+            .elaboration(req.elaboration())
+            .build());
+    r.setFlagCount(r.getFlagCount() + 1);
+    reviewRepo.save(r);
+    log.info("Review {} flagged by user {} (reason={})",
+            reviewId, caller.getId(), req.reason());
+}
+```
+
+- [ ] **Step 10: Endpoint for flag**
+
+```java
+@PostMapping("/{id}/flag")
+@ResponseStatus(HttpStatus.NO_CONTENT)
+public void flag(
+        @PathVariable("id") Long reviewId,
+        @AuthenticationPrincipal UserDetails principal,
+        @Valid @RequestBody ReviewFlagRequest request) {
+    User caller = userService.requireByEmail(principal.getUsername());
+    reviewService.flag(reviewId, caller, request);
+}
+```
+
+- [ ] **Step 11: Extend exception handler**
+
+Add `@ExceptionHandler(ReviewResponseAlreadyExistsException.class)` and `@ExceptionHandler(ReviewFlagAlreadyExistsException.class)` — both map to 409.
+
+- [ ] **Step 12: Update `SecurityConfig.java`**
+
+```java
+.requestMatchers(HttpMethod.POST, "/api/v1/reviews/*/respond").authenticated()
+.requestMatchers(HttpMethod.POST, "/api/v1/reviews/*/flag").authenticated()
+```
+
+- [ ] **Step 13: Run all tests + commit**
+
+```bash
+./mvnw test
+git add backend/src/main/java/com/slparcelauctions/backend/review/ \
+        backend/src/test/java/com/slparcelauctions/backend/review/ \
+        backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
+git commit -m "feat(review): respond + flag endpoints with one-per-user guards"
+```
+
+---
+
+## Task 4 — Frontend: Primitives + hooks + API client
+
+**Goal:** Build all review-related primitives, hooks, and API client so Task 5 and Task 6 can focus on page integration.
+
+**Files:**
+
+- Create: `frontend/src/types/review.ts`
+- Create: `frontend/src/lib/api/reviews.ts`
+- Create: `frontend/src/hooks/useReviews.ts`
+- Create: `frontend/src/components/reviews/RatingSummary.tsx`
+- Create: `frontend/src/components/reviews/StarSelector.tsx`
+- Create: `frontend/src/components/reviews/ReviewCard.tsx`
+- Create: `frontend/src/components/reviews/FlagModal.tsx`
+- Create: `frontend/src/components/reviews/RespondModal.tsx`
+- Modify: `frontend/src/components/user/ReputationStars.tsx` — thin wrapper around RatingSummary
+- Tests for each
+
+### Steps (abbreviated — TDD pattern repeats)
+
+- [ ] **Step 1: `types/review.ts`**
+
+```typescript
+export type ReviewedRole = "SELLER" | "BUYER";
+
+export type ReviewFlagReason =
+  | "SPAM"
+  | "ABUSIVE"
+  | "OFF_TOPIC"
+  | "FALSE_INFO"
+  | "OTHER";
+
+export interface ReviewResponseDto {
+  id: number;
+  text: string;
+  createdAt: string;
+}
+
+export interface ReviewDto {
+  id: number;
+  auctionId: number;
+  auctionTitle: string;
+  auctionPrimaryPhotoUrl: string | null;
+  reviewerId: number;
+  reviewerDisplayName: string;
+  reviewerAvatarUrl: string | null;
+  revieweeId: number;
+  reviewedRole: ReviewedRole;
+  rating: number | null;
+  text: string | null;
+  visible: boolean;
+  pending: boolean;
+  submittedAt: string | null;
+  revealedAt: string | null;
+  response: ReviewResponseDto | null;
+}
+
+export interface AuctionReviewsResponse {
+  reviews: ReviewDto[];
+  myPendingReview: ReviewDto | null;
+  canReview: boolean;
+  windowClosesAt: string | null;
+}
+
+export interface PendingReviewDto {
+  auctionId: number;
+  title: string;
+  primaryPhotoUrl: string | null;
+  counterpartyId: number;
+  counterpartyDisplayName: string;
+  counterpartyAvatarUrl: string | null;
+  escrowCompletedAt: string;
+  windowClosesAt: string;
+  hoursRemaining: number;
+  viewerRole: ReviewedRole;
+}
+
+export interface ReviewSubmitRequest {
+  rating: number;
+  text?: string;
+}
+
+export interface ReviewResponseSubmitRequest {
+  text: string;
+}
+
+export interface ReviewFlagRequest {
+  reason: ReviewFlagReason;
+  elaboration?: string;
+}
+```
+
+- [ ] **Step 2: `lib/api/reviews.ts`**
+
+```typescript
+import { apiFetch } from "@/lib/api";
+import type {
+  AuctionReviewsResponse,
+  PendingReviewDto,
+  ReviewDto,
+  ReviewFlagRequest,
+  ReviewResponseDto,
+  ReviewResponseSubmitRequest,
+  ReviewSubmitRequest,
+} from "@/types/review";
+import type { PagedResponse } from "@/types/page";
+
+export const getAuctionReviews = (auctionId: number) =>
+  apiFetch<AuctionReviewsResponse>(`/api/v1/auctions/${auctionId}/reviews`);
+
+export const submitReview = (auctionId: number, body: ReviewSubmitRequest) =>
+  apiFetch<ReviewDto>(`/api/v1/auctions/${auctionId}/reviews`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+export const getUserReviews = (
+  userId: number,
+  role: "SELLER" | "BUYER",
+  page = 0,
+  size = 10,
+) =>
+  apiFetch<PagedResponse<ReviewDto>>(
+    `/api/v1/users/${userId}/reviews?role=${role}&page=${page}&size=${size}`,
+  );
+
+export const getPendingReviews = () =>
+  apiFetch<PendingReviewDto[]>("/api/v1/users/me/pending-reviews");
+
+export const respondToReview = (
+  reviewId: number,
+  body: ReviewResponseSubmitRequest,
+) =>
+  apiFetch<ReviewResponseDto>(`/api/v1/reviews/${reviewId}/respond`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+export const flagReview = (reviewId: number, body: ReviewFlagRequest) =>
+  apiFetch<void>(`/api/v1/reviews/${reviewId}/flag`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+```
+
+- [ ] **Step 3: `hooks/useReviews.ts`**
+
+```typescript
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "@/components/ui/Toast";
+import {
+  flagReview,
+  getAuctionReviews,
+  getPendingReviews,
+  getUserReviews,
+  respondToReview,
+  submitReview,
+} from "@/lib/api/reviews";
+import type {
+  ReviewSubmitRequest,
+  ReviewFlagRequest,
+  ReviewResponseSubmitRequest,
+} from "@/types/review";
+
+export const useAuctionReviews = (auctionId: number) =>
+  useQuery({
+    queryKey: ["reviews", "auction", auctionId],
+    queryFn: () => getAuctionReviews(auctionId),
+    enabled: Number.isFinite(auctionId) && auctionId > 0,
+  });
+
+export const useUserReviews = (
+  userId: number,
+  role: "SELLER" | "BUYER",
+  page: number,
+) =>
+  useQuery({
+    queryKey: ["reviews", "user", userId, role, page],
+    queryFn: () => getUserReviews(userId, role, page),
+  });
+
+export const usePendingReviews = () =>
+  useQuery({
+    queryKey: ["reviews", "pending"],
+    queryFn: getPendingReviews,
+  });
+
+export const useSubmitReview = (auctionId: number) => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: ReviewSubmitRequest) => submitReview(auctionId, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["reviews", "auction", auctionId] });
+      qc.invalidateQueries({ queryKey: ["reviews", "pending"] });
+      toast.success({
+        title: "Review submitted",
+        description:
+          "Your review will appear when the other party submits theirs or when the 14-day window closes.",
+      });
+    },
+    onError: () =>
+      toast.error({
+        title: "Could not submit review",
+        description: "Please try again.",
+      }),
+  });
+};
+
+export const useRespondToReview = (reviewId: number) => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: ReviewResponseSubmitRequest) => respondToReview(reviewId, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["reviews"] });
+      toast.success({ title: "Response posted" });
+    },
+    onError: () =>
+      toast.error({ title: "Could not post response", description: "Please try again." }),
+  });
+};
+
+export const useFlagReview = (reviewId: number) => {
+  return useMutation({
+    mutationFn: (body: ReviewFlagRequest) => flagReview(reviewId, body),
+    onSuccess: () =>
+      toast.success({
+        title: "Review flagged",
+        description: "Thanks — our team will review it shortly.",
+      }),
+    onError: (err) => {
+      const already = /already flagged|409/i.test(String(err));
+      toast.error({
+        title: already ? "Already flagged" : "Could not flag review",
+        description: already
+          ? "You've already flagged this review."
+          : "Please try again.",
+      });
+    },
+  });
+};
+```
+
+- [ ] **Step 4: `RatingSummary.tsx` with partial-star SVG**
+
+```tsx
+type Size = "sm" | "md" | "lg";
+
+const SIZE_MAP: Record<Size, { star: string; text: string; count: string }> = {
+  sm: { star: "size-3.5", text: "text-label-md", count: "text-label-sm" },
+  md: { star: "size-4", text: "text-title-md font-bold", count: "text-body-sm" },
+  lg: { star: "size-5", text: "text-title-lg font-bold", count: "text-body-md" },
+};
+
+interface Props {
+  rating: number | null;
+  reviewCount: number;
+  size?: Size;
+  hideCountText?: boolean;
+}
+
+function PartialStar({ fillRatio, className }: { fillRatio: number; className: string }) {
+  const pct = Math.round(fillRatio * 100);
+  const id = `star-${pct}-${Math.random().toString(36).slice(2, 8)}`;
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true" className={className}>
+      <defs>
+        <linearGradient id={id}>
+          <stop offset={`${pct}%`} className="[stop-color:var(--color-primary)]" />
+          <stop offset={`${pct}%`} className="[stop-color:var(--color-surface-variant)]" />
+        </linearGradient>
+      </defs>
+      <path
+        d="M10 1l2.78 5.64 6.22.9-4.5 4.39 1.06 6.2L10 15.27l-5.56 2.86 1.06-6.2L1 7.54l6.22-.9L10 1z"
+        fill={`url(#${id})`}
+        stroke="currentColor"
+        strokeWidth="0.5"
+        className="text-primary"
+      />
+    </svg>
+  );
+}
+
+export function RatingSummary({ rating, reviewCount, size = "md", hideCountText }: Props) {
+  const sz = SIZE_MAP[size];
+  if (rating === null || reviewCount === 0) {
+    return (
+      <span className={`${sz.count} text-on-surface-variant`}>No ratings yet</span>
+    );
+  }
+  const numeric = Number(rating);
+  return (
+    <div className="flex items-center gap-2" role="img"
+         aria-label={`${numeric.toFixed(1)} out of 5 stars, ${reviewCount} review${reviewCount === 1 ? "" : "s"}`}>
+      <div className="flex gap-0.5">
+        {[0, 1, 2, 3, 4].map((i) => (
+          <PartialStar
+            key={i}
+            fillRatio={Math.max(0, Math.min(1, numeric - i))}
+            className={sz.star}
+          />
+        ))}
+      </div>
+      <span className={sz.text}>{numeric.toFixed(1)}</span>
+      {!hideCountText && (
+        <span className={`${sz.count} text-on-surface-variant`}>
+          ({reviewCount} review{reviewCount === 1 ? "" : "s"})
+        </span>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Update `ReputationStars.tsx` to thin wrapper**
+
+```tsx
+import { RatingSummary } from "@/components/reviews/RatingSummary";
+
+interface Props {
+  rating: number | null;
+  reviewCount: number;
+  label?: string;
+}
+
+export function ReputationStars({ rating, reviewCount, label }: Props) {
+  // BigDecimal comes as string in JSON — normalize at the edge. If called
+  // with the raw number, passes through.
+  const normalized =
+    typeof rating === "string" ? Number.parseFloat(rating) : rating;
+  return (
+    <div className="flex flex-col gap-1">
+      {label && (
+        <span className="text-label-sm font-bold uppercase tracking-widest text-on-surface-variant">
+          {label}
+        </span>
+      )}
+      <RatingSummary rating={normalized} reviewCount={reviewCount} size="md" />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: `StarSelector.tsx` (interactive 1-5)**
+
+Per spec §8.7. Keyboard + ARIA. Test hover preview, click, keyboard nav.
+
+- [ ] **Step 7: `ReviewCard.tsx`**
+
+Per spec §8.2. Renders reviewer info, stars (fixed integer-only rating, so use `RatingSummary` with count hidden), text with `white-space: pre-wrap`, response (nested), flag + respond buttons conditionally, auction link.
+
+- [ ] **Step 8: `FlagModal.tsx`**
+
+Headless UI Dialog. Reason radio group, elaboration textarea (required on OTHER), submit, 409 handling.
+
+- [ ] **Step 9: `RespondModal.tsx`**
+
+Textarea, 500-char counter, submit, close-on-success.
+
+- [ ] **Step 10: Write tests for each primitive**
+
+All components: dark + light mode assertions (per project hard rule), keyboard a11y, RTL happy-path interactions.
+
+- [ ] **Step 11: Run all frontend tests + commit**
+
+```bash
+cd frontend && npm test -- --run
+git add frontend/src/types/review.ts \
+        frontend/src/lib/api/reviews.ts \
+        frontend/src/hooks/useReviews.ts \
+        frontend/src/components/reviews/ \
+        frontend/src/components/user/ReputationStars.tsx
+git commit -m "feat(reviews): primitives + hooks + API client + partial-star rendering"
+```
+
+---
+
+## Task 5 — Frontend: ReviewPanel + escrow page wiring
+
+**Goal:** Integrate the review surface on the escrow page. Client subscribes to `REVIEW_REVEALED` envelopes.
+
+**Files:**
+
+- Create: `frontend/src/components/reviews/ReviewPanel.tsx` + test
+- Modify: `frontend/src/types/auction.ts` — extend `AuctionTopicEnvelope` union
+- Modify: `frontend/src/app/auction/[id]/escrow/EscrowPageClient.tsx`
+- Test: `frontend/src/app/auction/[id]/escrow/EscrowPageClient.test.tsx`
+
+### Steps
+
+- [ ] **Step 1: Extend `AuctionTopicEnvelope` union**
+
+```typescript
+// types/auction.ts
+export type ReviewRevealedEnvelope = {
+  type: "REVIEW_REVEALED";
+  auctionId: number;
+  reviewId: number;
+  reviewerId: number;
+  revieweeId: number;
+  reviewedRole: "SELLER" | "BUYER";
+  revealedAt: string;
+};
+
+export type AuctionTopicEnvelope =
+  | AuctionEnvelope
+  | EscrowEnvelope
+  | ReviewRevealedEnvelope;
+```
+
+- [ ] **Step 2: Create `ReviewPanel.tsx` with 5 states per spec §8.1**
+
+Key responsibilities:
+- Fetch via `useAuctionReviews(auctionId)`
+- Derive state from `{ canReview, myPendingReview, reviews, windowClosesAt }`
+- Render matching branch (submit-form, pending, revealed-both, revealed-one, window-closed-none)
+- Submit form uses `useSubmitReview(auctionId)` mutation
+- Host `<RespondModal>` / `<FlagModal>` via portal
+- Has `id="review-panel"` for dashboard hash-scroll
+
+State derivation helper:
+
+```tsx
+function deriveState(
+  auctionReviews: AuctionReviewsResponse | undefined,
+  isPartyAuthed: boolean,
+  now: Date,
+): PanelState {
+  if (!auctionReviews) return "loading";
+  const { canReview, myPendingReview, reviews, windowClosesAt } = auctionReviews;
+  const windowClosed =
+    windowClosesAt !== null && new Date(windowClosesAt) < now;
+  if (canReview) return "submit";
+  if (myPendingReview) return "pending";
+  if (reviews.length >= 2) return "revealed-both";
+  if (reviews.length === 1) return "revealed-one";
+  if (isPartyAuthed && windowClosed) return "window-closed-none";
+  return "read-only"; // anonymous viewer, no reviews yet
+}
+```
+
+- [ ] **Step 3: Wire `ReviewPanel` into `EscrowPageClient`**
+
+```tsx
+{escrow && escrow.state === "COMPLETED" && (
+  <ReviewPanel auctionId={auctionId} role={role} />
+)}
+```
+
+- [ ] **Step 4: Extend WS handler**
+
+```tsx
+(env) => {
+  if (env.type.startsWith("ESCROW_")) {
+    queryClient.invalidateQueries({ queryKey: escrowKey(auctionId) });
+  } else if (env.type === "REVIEW_REVEALED") {
+    queryClient.invalidateQueries({
+      queryKey: ["reviews", "auction", auctionId],
+    });
+  }
+}
+```
+
+- [ ] **Step 5: Write tests**
+
+```tsx
+it("renders submit state when canReview=true, no pending review", ...);
+it("renders pending state when myPendingReview is set", ...);
+it("renders revealed-both when 2 visible reviews", ...);
+it("renders revealed-one when 1 visible review", ...);
+it("renders window-closed-none when party and past windowClosesAt", ...);
+it("invalidates reviews query on REVIEW_REVEALED envelope", ...);
+it("scrolls into view when URL hash #review-panel is set", ...);
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/reviews/ReviewPanel.tsx \
+        frontend/src/components/reviews/ReviewPanel.test.tsx \
+        frontend/src/types/auction.ts \
+        frontend/src/app/auction/[id]/escrow/EscrowPageClient.tsx \
+        frontend/src/app/auction/[id]/escrow/EscrowPageClient.test.tsx
+git commit -m "feat(reviews): ReviewPanel on escrow page + REVIEW_REVEALED WS invalidation"
+```
+
+---
+
+## Task 6 — Frontend: Profile tabs + dashboard pending section + deferred ledger cleanup
+
+**Goal:** Two remaining public surfaces. Tabbed profile reviews section, dashboard pending-reviews card.
+
+**Files:**
+
+- Create: `frontend/src/components/reviews/ProfileReviewTabs.tsx` + test
+- Create: `frontend/src/components/reviews/ReviewList.tsx` + test
+- Create: `frontend/src/components/reviews/PendingReviewsSection.tsx` + test
+- Modify: `frontend/src/components/user/PublicProfileView.tsx` — replace empty-state
+- Modify: `frontend/src/app/dashboard/(verified)/overview/page.tsx` — append pending section
+- Modify: `docs/implementation/DEFERRED_WORK.md` — remove resolved entries
+
+### Steps
+
+- [ ] **Step 1: `ReviewList.tsx`**
+
+Paginated list. Takes `userId`, `role`, `page`. Renders a list of `<ReviewCard>`s. Pagination control below. Empty state per role.
+
+- [ ] **Step 2: `ProfileReviewTabs.tsx`**
+
+Tabs via Headless UI or existing Tab primitive. Default active = "As Seller". Tab state synced to URL `?tab=seller|buyer`. Each tab hosts its own `<ReviewList>` with independent page state.
+
+- [ ] **Step 3: Replace empty-state in `PublicProfileView.tsx`**
+
+Remove the "Placeholder: Reviews" `<Card>` with its `<EmptyState>` and replace:
+
+```tsx
+<Card>
+  <Card.Header>
+    <h2 className="text-title-md font-bold">Reviews</h2>
+  </Card.Header>
+  <Card.Body>
+    <ProfileReviewTabs userId={profile.id} />
+  </Card.Body>
+</Card>
+```
+
+- [ ] **Step 4: `PendingReviewsSection.tsx`**
+
+Per spec §8.4. Uses `usePendingReviews()`. Renders null when `items.length === 0`. Each row: photo, title, counterparty name, "Closes in X days", CTA link to `/auction/{id}/escrow#review-panel`.
+
+- [ ] **Step 5: Wire into dashboard overview**
+
+```tsx
+// frontend/src/app/dashboard/(verified)/overview/page.tsx
+<PendingReviewsSection />
+{/* existing My Listings / My Bids sections */}
+```
+
+Place above (or below) existing sections — placement per design system heuristics.
+
+- [ ] **Step 6: Remove deferred entries**
+
+Edit `docs/implementation/DEFERRED_WORK.md` — delete the two entries:
+- "Partial-star rendering for ReputationStars"
+- "Recent reviews section on public profile"
+
+- [ ] **Step 7: Write tests**
+
+- `ReviewList.test.tsx` — pagination, empty state, newest-first sort assumed from API
+- `ProfileReviewTabs.test.tsx` — tab switching, URL sync, independent pagination
+- `PendingReviewsSection.test.tsx` — renders nothing when empty, hash link correct
+- `PublicProfileView.test.tsx` — updated to not expect the old empty-state
+
+- [ ] **Step 8: Run all tests + commit**
+
+```bash
+cd frontend && npm test -- --run
+cd ..
+git add frontend/src/components/reviews/ \
+        frontend/src/components/user/PublicProfileView.tsx \
+        frontend/src/components/user/PublicProfileView.test.tsx \
+        frontend/src/app/dashboard/\(verified\)/overview/ \
+        docs/implementation/DEFERRED_WORK.md
+git commit -m "feat(reviews): profile tabs + dashboard pending + deferred ledger cleanup"
+```
+
+---
+
+## Final steps — PR
+
+- [ ] **All tests pass** — backend `./mvnw test`, frontend `npm test -- --run`, frontend `npm run build`, frontend `npm run lint`.
+- [ ] **Cross-branch code review** via final code-reviewer subagent.
+- [ ] **PR to `dev`** — title: "Epic 08 sub-spec 1 — Reviews & Reputation", body includes list of commits per task, resolved deferred items, test plan.
+
+---
+
+## Self-review (plan)
+
+1. **Spec coverage:** Every spec section (§2-§14) has a task that implements it. Six tasks map cleanly to spec §13.
+2. **Placeholder scan:** No TBD/TODO — all code snippets are concrete.
+3. **Type consistency:**
+   - `ReviewedRole` enum used consistently both sides (Java enum + TS union type `"SELLER" | "BUYER"`)
+   - `completedSales` field added to `SellerSummaryDto` in Task 1, consumed on listing cards (no code change there — card already reads `seller.completedSales` via `NewSellerBadge`, which is at `frontend/src/components/user/NewSellerBadge.tsx` and takes `completedSales: number`).
+   - `ReviewDto.rating` is `number | null` in TS (matches Java `Integer` which becomes `null` when not exposed per the privacy rule in `ReviewDto.of`).
+4. **Idempotency pins:** `reveal()` checks `visible === true` and returns early. `BlindReviewRevealTask` is safe to re-run. `flag` and `respond` have unique-constraint backed 409s.
+5. **Race pins:** simultaneous-submit test (Task 2 Step 3) asserts both-visible outcome. `findByIdForUpdate` used on the review row inside `reveal()` to serialise against reveal-task-vs-submit race.

--- a/docs/superpowers/specs/2026-04-24-epic-08-sub-1-reviews-reputation.md
+++ b/docs/superpowers/specs/2026-04-24-epic-08-sub-1-reviews-reputation.md
@@ -1,0 +1,1008 @@
+# Epic 08 Sub-Spec 1 — Reviews & Reputation
+
+**Date:** 2026-04-24
+**Epic:** 08 — Ratings & Reputation
+**Sub-spec scope:** Tasks 01 + 02 + 04 from `docs/implementation/epic-08/` (review service + reputation aggregation + reviews UI). Cancellation penalties and 48h post-cancel ownership watcher are deferred to sub-spec 2.
+**Branch:** `task/08-sub-1-reviews-reputation` → `dev`
+
+---
+
+## 1. Goal
+
+Ship the reviews-and-reputation layer end-to-end: blind rating backend, aggregate pipeline, and every public UI surface that shows review data (escrow panel, user profile tabs, dashboard pending-reviews card, listing cards, auction detail seller card, flag / response flows, partial-star rendering).
+
+Scope excludes: cancellation penalties, suspension enforcement, off-platform-sale fraud flags (all Epic 08 sub-spec 2).
+
+---
+
+## 2. Architecture
+
+### 2.1 Backend — one new package
+
+```
+backend/src/main/java/com/slparcelauctions/backend/review/
+├── Review.java                   (@Entity)
+├── ReviewResponse.java           (@Entity)
+├── ReviewFlag.java               (@Entity)
+├── ReviewedRole.java             (enum: SELLER, BUYER)
+├── ReviewFlagReason.java         (enum: SPAM, ABUSIVE, OFF_TOPIC, FALSE_INFO, OTHER)
+├── ReviewRepository.java
+├── ReviewResponseRepository.java
+├── ReviewFlagRepository.java
+├── ReviewService.java            (submit, reveal, recompute-aggregates)
+├── ReviewController.java         (4 endpoints: submit, list-for-auction, respond, flag)
+├── UserReviewsController.java    (2 endpoints: list-for-user, pending-for-me)
+├── BlindReviewRevealTask.java    (hourly scheduler)
+├── ReviewRevealedEnvelope.java   (WS broadcast — added to AuctionTopicEnvelope union)
+├── dto/
+│   ├── ReviewDto.java
+│   ├── ReviewResponseDto.java
+│   ├── ReviewSubmitRequest.java
+│   ├── ReviewResponseSubmitRequest.java
+│   ├── ReviewFlagRequest.java
+│   ├── PendingReviewDto.java
+│   └── ReviewListPage.java       (PagedResponse<ReviewDto>)
+└── exception/
+    ├── ReviewNotFoundException.java
+    ├── ReviewIneligibleException.java   (→ 422)
+    ├── ReviewAlreadySubmittedException.java  (→ 409)
+    ├── ReviewWindowClosedException.java (→ 422)
+    ├── ReviewResponseAlreadyExistsException.java  (→ 409)
+    ├── ReviewFlagAlreadyExistsException.java  (→ 409)
+    └── ReviewExceptionHandler.java
+```
+
+No changes to Flyway. New entities land via JPA `ddl-auto: update`.
+
+### 2.2 Frontend — one new component package
+
+```
+frontend/src/components/reviews/
+├── ReviewPanel.tsx               (escrow page inline panel, 5 states)
+├── ReviewCard.tsx                (single review display, used everywhere)
+├── ReviewList.tsx                (paginated list for profile tab)
+├── RatingSummary.tsx             (partial-star + numeric + count)
+├── StarSelector.tsx              (interactive 1-5 picker, used in ReviewPanel)
+├── RespondModal.tsx              (reviewee responds once)
+├── FlagModal.tsx                 (reason enum + optional textarea)
+├── PendingReviewsSection.tsx     (dashboard card)
+└── ProfileReviewTabs.tsx         (seller / buyer tab container)
+
+frontend/src/hooks/
+└── useReviews.ts                 (React Query: 6 hooks)
+
+frontend/src/lib/api/
+└── reviews.ts                    (6 API functions)
+
+frontend/src/types/
+└── review.ts                     (public DTOs mirroring backend)
+```
+
+Modified surfaces:
+- `components/user/ReputationStars.tsx` — upgrade numeric-only → partial-star SVG
+- `components/user/PublicProfileView.tsx` — replace "No reviews yet" empty-state with `<ProfileReviewTabs>`
+- `app/auction/[id]/escrow/EscrowPageClient.tsx` — append `<ReviewPanel>` when `escrow.state === "COMPLETED"`
+- `app/dashboard/(verified)/overview/page.tsx` (or equivalent) — append `<PendingReviewsSection>`
+- `types/auction.ts` — extend `AuctionTopicEnvelope` union with `REVIEW_REVEALED`
+
+Unchanged:
+- `components/auction/ListingCard.tsx` — already reads `seller.averageRating` / `seller.reviewCount` from `SellerSummaryDto`; new partial-star rendering will land via updates to the shared `ReputationStars` / `RatingSummary` primitives if they are used, or via a compact inline reading if not.
+- `components/user/NewSellerBadge.tsx` — already correct at `completedSales < 3`.
+- `components/auction/SellerProfileCard.tsx` — already renders the seller card on auction detail.
+
+### 2.3 Integration envelope
+
+```
+Escrow COMPLETED ──┬──→ handleEscrowPayoutSuccess (existing)
+                   │      └─→ NEW: user.completedSales += 1 for seller
+                   │
+                   └──→ Review eligibility window opens for seller + winner
+                              │
+                              ↓
+                   [both parties submit OR day 14 passes]
+                              │
+                              ↓
+                   ReviewService.reveal()
+                   ├─→ Review.visible = true
+                   ├─→ Full recompute reviewee aggregates (AVG + COUNT queries)
+                   └─→ ReviewRevealedEnvelope on /topic/auction/{id}
+                              │
+                              ↓
+                   Clients invalidate review query → refetch → "magic moment" UI update
+```
+
+---
+
+## 3. Data model
+
+### 3.1 New entity — `Review`
+
+```java
+@Entity
+@Table(name = "reviews",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"auction_id", "reviewer_id"}),
+       indexes = {
+         @Index(name = "idx_reviews_reviewee_visible",
+                columnList = "reviewee_id, reviewed_role, visible"),
+         @Index(name = "idx_reviews_auction", columnList = "auction_id")
+       })
+public class Review {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) Long id;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "auction_id", nullable = false) Auction auction;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "reviewer_id", nullable = false) User reviewer;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "reviewee_id", nullable = false) User reviewee;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reviewed_role", nullable = false, length = 10)
+    ReviewedRole reviewedRole;   // SELLER = review is about reviewee's seller-side behavior; BUYER = buyer-side
+
+    @Column(nullable = false) Integer rating;   // 1..5 (bean validator enforced at DTO level, not entity)
+
+    @Column(length = 500) String text;          // nullable — text is optional
+
+    @Builder.Default @Column(nullable = false) Boolean visible = false;
+
+    @CreationTimestamp @Column(name = "submitted_at", nullable = false, updatable = false)
+    OffsetDateTime submittedAt;
+
+    @Column(name = "revealed_at") OffsetDateTime revealedAt;  // null until visible flips true
+
+    @Builder.Default @Column(name = "flag_count", nullable = false) Integer flagCount = 0;
+}
+```
+
+`reviewedRole` is persisted (not derived) so aggregate queries use an index-only scan. For a seller→buyer review, `reviewedRole=BUYER`; on reveal, the reviewee's `avgBuyerRating` + `totalBuyerReviews` recompute.
+
+### 3.2 New entity — `ReviewResponse`
+
+```java
+@Entity
+@Table(name = "review_responses")
+public class ReviewResponse {
+    @Id @GeneratedValue Long id;
+
+    @OneToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "review_id", nullable = false, unique = true)
+    Review review;                  // unique FK = one response per review
+
+    @Column(nullable = false, length = 500) String text;     // non-empty, max 500
+
+    @CreationTimestamp @Column(name = "created_at", nullable = false, updatable = false)
+    OffsetDateTime createdAt;
+}
+```
+
+### 3.3 New entity — `ReviewFlag`
+
+```java
+@Entity
+@Table(name = "review_flags",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"review_id", "flagger_id"}))
+public class ReviewFlag {
+    @Id @GeneratedValue Long id;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "review_id", nullable = false) Review review;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "flagger_id", nullable = false) User flagger;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20) ReviewFlagReason reason;
+
+    @Column(length = 500) String elaboration;   // required when reason=OTHER (validator)
+
+    @CreationTimestamp @Column(name = "created_at", nullable = false, updatable = false)
+    OffsetDateTime createdAt;
+}
+```
+
+### 3.4 Modified entity — `User`
+
+**One new column:**
+
+```java
+@Builder.Default
+@Column(name = "escrow_expired_unfulfilled", nullable = false)
+private Integer escrowExpiredUnfulfilled = 0;
+```
+
+**Existing columns — new or changed write paths:**
+
+| Column | Current state | Sub-spec 1 write path |
+|---|---|---|
+| `completedSales` | Declared, never incremented | **NEW**: incremented in `TerminalCommandService.handleEscrowPayoutSuccess` inside the same transaction that flips escrow → COMPLETED. Incremented for the **seller** only (spec §4 confirms it's tracked per Epic). |
+| `escrowExpiredUnfulfilled` | Does not exist today | **NEW**: incremented only in `EscrowService.expireTransfer` (seller failed to transfer). Not touched by `expirePayment` (buyer failure). |
+| `avgSellerRating` | Declared, never written | **NEW**: full recompute on reveal transition for seller-role reviewees. |
+| `avgBuyerRating` | Declared, never written | **NEW**: full recompute on reveal transition for buyer-role reviewees. |
+| `totalSellerReviews` | Declared, never written | **NEW**: full recompute on reveal. Counts only visible reviews. |
+| `totalBuyerReviews` | Declared, never written | **NEW**: full recompute on reveal. Counts only visible reviews. |
+
+### 3.5 `SellerCompletionRateMapper` — extended signature
+
+```java
+// OLD: compute(completedSales, cancelledWithBids)
+// NEW:
+public static BigDecimal compute(
+        int completedSales,
+        int cancelledWithBids,
+        int escrowExpiredUnfulfilled) {
+    int denom = completedSales + cancelledWithBids + escrowExpiredUnfulfilled;
+    if (denom <= 0) return null;
+    return BigDecimal.valueOf(completedSales)
+            .divide(BigDecimal.valueOf(denom), 2, RoundingMode.HALF_UP);
+}
+```
+
+All callers updated. Known call sites (from grep):
+- `AuctionDtoMapper:208`
+- Any DTO that embeds `SellerSummaryDto` and populates a completion rate (search response path flows through `AuctionSearchResultMapper`).
+
+---
+
+## 4. API surface
+
+All endpoints versioned under `/api/v1`. Auth column: `P` = public/no auth, `J` = JWT required.
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| `POST` | `/auctions/{id}/reviews` | J | Submit a review for an auction |
+| `GET` | `/auctions/{id}/reviews` | P* | List visible reviews for an auction (+ own pending if party) |
+| `POST` | `/reviews/{id}/respond` | J | One-time response from reviewee |
+| `POST` | `/reviews/{id}/flag` | J | Flag a review (non-author, once per user per review) |
+| `GET` | `/users/{id}/reviews` | P | Paginated list for profile tab (`?role=SELLER|BUYER&page&size`) |
+| `GET` | `/users/me/pending-reviews` | J | Reviews the viewer still needs to submit |
+
+`P*` = endpoint is public, but if the caller is authenticated **and** is the seller or winner of the auction, the response also includes their own submitted-but-not-yet-visible review with `visible=false, pending=true`. The counterparty sees no hint of submission (Q9 blind-on-fact decision).
+
+### 4.1 `POST /auctions/{id}/reviews`
+
+Request body:
+```json
+{ "rating": 5, "text": "Smooth transfer, recommended." }
+```
+
+Validations:
+- `rating` ∈ [1, 5] (JSR-303 `@Min(1) @Max(5)`)
+- `text` ≤ 500 chars, optional
+- Caller is authenticated
+- Caller is seller or winner of auction (derived from `auction.sellerId` and `escrow.winnerId`)
+- Auction has an escrow with `state=COMPLETED`
+- `escrow.completedAt + 14 days > now` (hard cutoff — returns 422 `ReviewWindowClosedException` otherwise)
+- No existing `Review` with (auctionId, callerId) — returns 409 `ReviewAlreadySubmittedException` otherwise
+
+Server derives:
+- `reviewerId` = caller
+- `revieweeId` = the other party (if caller is seller → reviewee is winner; if caller is winner → reviewee is seller)
+- `reviewedRole` = the reviewee's role in this auction (if reviewee is seller → `SELLER`; if reviewee is winner → `BUYER`)
+
+Response (201):
+```json
+{
+  "id": 42,
+  "auctionId": 1234,
+  "rating": 5,
+  "text": "Smooth transfer, recommended.",
+  "reviewedRole": "SELLER",
+  "visible": false,
+  "submittedAt": "2026-04-24T10:15:00Z",
+  "revealedAt": null,
+  "pending": true
+}
+```
+
+**Simultaneous-reveal path (inside submit transaction):** after inserting the new row, the service queries for the counterparty's review on the same auction. If present and `visible=false`, flip both to `visible=true`, stamp both `revealedAt=now`, recompute both reviewees' aggregates in the same transaction, and enqueue a `ReviewRevealedEnvelope` on `afterCommit` for WS broadcast. If not present, leave both rows in pending state.
+
+### 4.2 `GET /auctions/{id}/reviews`
+
+Response shape:
+```json
+{
+  "reviews": [ /* ReviewDto — only visible=true */ ],
+  "myPendingReview": { /* ReviewDto or null — viewer's own submitted-but-hidden review */ },
+  "canReview": true,        // viewer is party, escrow COMPLETED, within window, no existing review
+  "windowClosesAt": "2026-05-08T10:15:00Z"  // null if viewer is not a party or escrow not COMPLETED
+}
+```
+
+Anonymous callers: `reviews` only, `myPendingReview=null`, `canReview=false`, `windowClosesAt=null`.
+
+### 4.3 `POST /reviews/{id}/respond`
+
+```json
+{ "text": "Thanks for the kind words!" }
+```
+
+Validations:
+- Caller is `review.revieweeId` (403 if not)
+- No existing `ReviewResponse` for this review (409 `ReviewResponseAlreadyExistsException` otherwise)
+- `text` non-empty, ≤ 500
+
+Response (201): `ReviewResponseDto { id, text, createdAt }`.
+
+### 4.4 `POST /reviews/{id}/flag`
+
+```json
+{ "reason": "SPAM", "elaboration": null }
+```
+
+Validations:
+- Caller ≠ `review.reviewerId` (403 — can't flag own review)
+- `reason` ∈ enum
+- `elaboration` required when `reason=OTHER` (custom cross-field validator)
+- No existing `ReviewFlag` with (reviewId, callerId) — 409 `ReviewFlagAlreadyExistsException`
+
+Side effect: `review.flagCount += 1` (increment + save). No auto-hide.
+
+Response (204 No Content).
+
+### 4.5 `GET /users/{id}/reviews?role=SELLER|BUYER&page=0&size=10`
+
+Paginated list of **visible** reviews where `revieweeId=id` and `reviewedRole=role`. Sorted `revealedAt DESC`.
+
+Returns `PagedResponse<ReviewDto>`.
+
+### 4.6 `GET /users/me/pending-reviews`
+
+Scans completed escrows where the viewer is seller or winner, the 14-day window is still open, and the viewer has not yet submitted a review. Sorted by window-remaining ascending (most urgent first).
+
+Response (200):
+```json
+{
+  "items": [
+    {
+      "auctionId": 1234,
+      "title": "Lakefront Parcel in Aurora",
+      "primaryPhotoUrl": "...",
+      "counterpartyId": 78,
+      "counterpartyDisplayName": "Alice",
+      "counterpartyAvatarUrl": "...",
+      "escrowCompletedAt": "2026-04-20T10:15:00Z",
+      "windowClosesAt": "2026-05-04T10:15:00Z",
+      "hoursRemaining": 312,
+      "viewerRole": "SELLER"
+    }
+  ]
+}
+```
+
+### 4.7 `ReviewDto` shape
+
+```java
+public record ReviewDto(
+    Long id,
+    Long auctionId,
+    String auctionTitle,                 // live-joined from Auction
+    String auctionPrimaryPhotoUrl,       // nullable, for card preview
+    Long reviewerId,
+    String reviewerDisplayName,          // live-joined from User
+    String reviewerAvatarUrl,            // live-joined; nullable
+    Long revieweeId,
+    ReviewedRole reviewedRole,
+    Integer rating,
+    String text,                         // nullable
+    Boolean visible,
+    Boolean pending,                     // true when the viewer is the reviewer AND visible=false
+    OffsetDateTime submittedAt,          // only populated when pending=true OR visible=true
+    OffsetDateTime revealedAt,           // only populated when visible=true
+    ReviewResponseDto response           // nullable; the reviewee's one response if any
+) { }
+```
+
+`flagCount` is NOT exposed publicly — admin-only (Epic 10 adds the admin DTO).
+
+---
+
+## 5. Blind-reveal state machine
+
+### 5.1 State transitions
+
+```
+[no review]
+    │
+    │ party A submits
+    ↓
+[A submitted, pending]
+    │
+    ├── party B submits before day 14 ───→ REVEAL BOTH (synchronous, inside submit tx)
+    │
+    ├── day 14 passes, B never submits ──→ REVEAL A ONLY (scheduler)
+    │                                       ∧ submission endpoint returns 422 for late attempts
+    │
+    └── both submit simultaneously ──────→ REVEAL BOTH (the second commit wins the lock; the first just inserted)
+```
+
+### 5.2 Scheduler — `BlindReviewRevealTask`
+
+- Spring `@Scheduled(cron = "0 0 * * * *")` — top of every hour.
+- Query:
+  ```sql
+  SELECT r.id FROM reviews r
+  JOIN auctions a ON a.id = r.auction_id
+  JOIN escrows e ON e.auction_id = a.id
+  WHERE r.visible = false
+    AND e.state = 'COMPLETED'
+    AND e.completed_at + INTERVAL '14 days' < :now
+  ORDER BY r.id
+  LIMIT 500
+  ```
+- For each id: call `ReviewService.reveal(reviewId)` in its own transaction.
+- Idempotent: `reveal()` is a no-op if `visible=true` already. Safe to re-run after a partial failure.
+- Per-auction lock through `AuctionRepository.findByIdForUpdate(auctionId)` inside `reveal()` to serialise against a simultaneous submit-and-reveal race.
+- Budget check: scans for reviews > 14d old + escrow COMPLETED + not visible. Expected volume: single-digit per hour in MVP. Hard ceiling `LIMIT 500` to prevent runaway batches; logged if hit.
+
+### 5.3 `ReviewService.reveal(reviewId)`
+
+```java
+@Transactional
+public void reveal(Long reviewId) {
+    Review r = reviewRepo.findByIdForUpdate(reviewId).orElseThrow();
+    if (Boolean.TRUE.equals(r.getVisible())) return;  // idempotent
+
+    r.setVisible(true);
+    r.setRevealedAt(clock.instant().atOffset(UTC));
+    reviewRepo.save(r);
+
+    recomputeAggregates(r.getReviewee(), r.getReviewedRole());
+
+    final ReviewRevealedEnvelope env = ReviewRevealedEnvelope.of(r);
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+            @Override public void afterCommit() { broadcastPublisher.publishReviewRevealed(env); }
+        });
+}
+```
+
+### 5.4 `ReviewService.recomputeAggregates(User reviewee, ReviewedRole role)`
+
+```java
+private void recomputeAggregates(User reviewee, ReviewedRole role) {
+    if (role == ReviewedRole.SELLER) {
+        var agg = reviewRepo.computeSellerAggregate(reviewee.getId());
+        reviewee.setAvgSellerRating(agg.avg());           // null if count=0
+        reviewee.setTotalSellerReviews(agg.count());
+    } else {
+        var agg = reviewRepo.computeBuyerAggregate(reviewee.getId());
+        reviewee.setAvgBuyerRating(agg.avg());
+        reviewee.setTotalBuyerReviews(agg.count());
+    }
+    userRepo.save(reviewee);
+}
+```
+
+`ReviewRepository` custom JPQL:
+```java
+@Query("select new com.slparcelauctions.backend.review.Aggregate(" +
+       "  avg(r.rating), count(r)) " +
+       "from Review r " +
+       "where r.reviewee.id = :revieweeId " +
+       "  and r.reviewedRole = 'SELLER' " +
+       "  and r.visible = true")
+Aggregate computeSellerAggregate(@Param("revieweeId") Long revieweeId);
+```
+
+(Analogous `computeBuyerAggregate`.)
+
+`Aggregate` is a tiny Java record `(BigDecimal avg, int count)`; the JPQL returns `Double`/`Long` which we normalise.
+
+### 5.5 Submit-path simultaneous reveal
+
+Inside `ReviewService.submit`:
+
+```java
+@Transactional
+public ReviewDto submit(Long auctionId, User caller, ReviewSubmitRequest req) {
+    // ... eligibility checks + persist new review (visible=false) ...
+    Review mine = reviewRepo.save(Review.builder()...build());
+
+    // Check for counterparty's prior submission. If present, reveal both atomically.
+    Optional<Review> theirs = reviewRepo.findByAuctionIdAndReviewerId(
+            auctionId, counterpartyId);
+    if (theirs.isPresent() && !theirs.get().getVisible()) {
+        reveal(mine.getId());          // reveals mine + recomputes my reviewee's aggregates
+        reveal(theirs.get().getId());  // reveals theirs + recomputes their reviewee's aggregates
+    }
+    return ReviewDto.pendingFor(caller, mine);
+}
+```
+
+`reveal()` calls are nested into the same transaction; the `afterCommit` WS envelope fires once per revealed review.
+
+---
+
+## 6. Completion-rate pipeline
+
+### 6.1 The three counters
+
+| Counter | Incremented where | Notes |
+|---|---|---|
+| `completedSales` | `TerminalCommandService.handleEscrowPayoutSuccess` — inside the same tx that flips `escrow.state=COMPLETED` | Incremented on the **seller** only |
+| `cancelledWithBids` | `CancellationService.cancel` — when `from == ACTIVE && hadBids` (already exists) | Sub-spec 1 does **not** change this path |
+| `escrowExpiredUnfulfilled` | `EscrowService.expireTransfer` — inside the same tx that flips `escrow.state=EXPIRED` after a TRANSFER_PENDING timeout | Incremented on the **seller** only. `expirePayment` (buyer-fault) does NOT touch this counter. |
+
+All three are atomic integer increments on the `User` row, guarded by the same `@Transactional` boundary that owns the triggering state transition.
+
+### 6.2 Derivation at read time
+
+`SellerCompletionRateMapper.compute()` is the sole derivation point. It takes three integers and returns `BigDecimal | null`. No column is stored on `User` for `completion_rate`. The three counters are the source of truth; the mapper is the lens.
+
+### 6.3 Where completion rate surfaces
+
+- `UserProfileResponse` (via `UserController.getPublicProfile`): add `completionRate` field, populate via mapper.
+- `PublicAuctionResponse.sellerStats` (auction detail): already present, already wired through the mapper — update the mapper call to add the third argument.
+- `SellerSummaryDto` (search/listing cards): NOT present today (only `averageRating` + `reviewCount`). We add an optional `completionRate` field to `SellerSummaryDto` but do NOT render it on listing cards for MVP (cards already have enough density); the summary card on the auction detail page and the profile are the surfaces that show it.
+
+### 6.4 "New Seller" threshold
+
+- Derived at read time as `completedSales < 3` — not stored as a flag.
+- `UserProfileResponse.isNewSeller` (new field) exposes it.
+- Listing cards already read `seller.completedSales` and render `<NewSellerBadge>` client-side, but `SellerSummaryDto` does NOT currently carry `completedSales`. We add it.
+
+---
+
+## 7. WebSocket integration
+
+### 7.1 New envelope
+
+`ReviewRevealedEnvelope` joins the `AuctionEnvelope | EscrowEnvelope` union (broadcast on `/topic/auction/{id}`):
+
+```java
+public record ReviewRevealedEnvelope(
+    String type,          // always "REVIEW_REVEALED"
+    Long auctionId,
+    Long reviewId,
+    Long reviewerId,
+    Long revieweeId,
+    ReviewedRole reviewedRole,
+    OffsetDateTime revealedAt
+) implements AuctionTopicEnvelope {
+    public static ReviewRevealedEnvelope of(Review r) { ... }
+}
+```
+
+Frontend type addition to `types/auction.ts`:
+
+```typescript
+type ReviewRevealedEnvelope = AuctionEnvelopeBase & {
+  type: "REVIEW_REVEALED";
+  reviewId: number;
+  reviewerId: number;
+  revieweeId: number;
+  reviewedRole: "SELLER" | "BUYER";
+  revealedAt: string;
+};
+
+export type AuctionTopicEnvelope =
+  | AuctionEnvelope
+  | EscrowEnvelope
+  | ReviewRevealedEnvelope;
+```
+
+### 7.2 Client handling
+
+`EscrowPageClient` subscribes to `/topic/auction/{id}` already. Extend the envelope handler:
+
+```ts
+if (env.type === "REVIEW_REVEALED") {
+    queryClient.invalidateQueries({ queryKey: ["reviews", "auction", auctionId] });
+}
+```
+
+No new topic, no new subscription. Cheapest possible integration.
+
+### 7.3 No broadcast on submit (pending)
+
+A bare submit (no counterparty review yet, not revealed) does NOT broadcast anything. Per Q9, we don't leak "the other party has submitted." The reviewer's own client refreshes its own review locally via the mutation's `onSuccess` — no WS needed.
+
+---
+
+## 8. Frontend surfaces
+
+### 8.1 `ReviewPanel` on escrow page
+
+Rendered in `EscrowPageClient` below `<EscrowStepCard>` when `escrow.state === "COMPLETED"`. One component, five internal states derived from props:
+
+| State key | When | UI |
+|---|---|---|
+| `submit` | `canReview=true` and no `myPendingReview` | `<StarSelector>` + textarea (500-char counter) + "Submit review" button |
+| `pending` | `myPendingReview` exists, `visible=false` | "Submitted — you'll see [counterparty]'s review when they submit theirs or on [windowClosesAt date]." Plus a read-only display of the viewer's own text + rating. |
+| `revealed-both` | `reviews` array contains both seller-side and buyer-side reviews | Two `<ReviewCard>`s side-by-side (desktop) / stacked (mobile) with a "Respond" button on the viewer's own received review (if no response yet) |
+| `revealed-one` | `reviews` array has one entry, `canReview=false`, `windowClosesAt` in the past | One `<ReviewCard>`; if viewer's side never submitted, show subtle "Your review window closed." |
+| `window-closed-none` | `canReview=false`, `reviews` empty, `windowClosesAt` in the past | "The review window for this auction has closed." |
+
+The panel uses `useAuctionReviews(auctionId)` (React Query). On `REVIEW_REVEALED` WS event, the query invalidates and refetches; the panel re-renders into the new state.
+
+### 8.2 `ProfileReviewTabs` on profile page
+
+Replaces the existing "No reviews yet" `<EmptyState>` in `PublicProfileView.tsx`. Tabs: "As Seller" (default active) / "As Buyer". Each tab has its own `ReviewList` with independent pagination state. URL-synced tab via a `?tab=seller|buyer` query param so deep-links work.
+
+Inside each tab:
+- `<RatingSummary>` at top (partial-star + "4.7" + "· 23 reviews")
+- `<ReviewList>` — paginated (10/page), newest first, empty-state "No reviews as [seller|buyer] yet" when count = 0
+
+`<ReviewCard>` shape:
+- Reviewer avatar + display name + date (relative, "3 weeks ago", absolute in title attr)
+- `<RatingStars>` — 5 stars, filled to the review's rating (no partial; it's an integer 1-5)
+- Text (if present) — pre-wrapped (`white-space: pre-wrap`) so newlines render, everything else escaped
+- Link to auction ("Aurora Parcel · L$ 12,345") using `auctionTitle` + numeric bid display, `href="/auction/{auctionId}"`
+- Reviewee's response (if present) — visually nested / indented, labeled "Seller response" or "Buyer response" based on reviewedRole
+- Small "Flag" button → opens `<FlagModal>`
+- On the viewer's own-profile reviews (`session.user.id === revieweeId`), a "Respond" button when no response exists → opens `<RespondModal>`
+
+### 8.3 Partial-star rendering (`<RatingSummary>`)
+
+Current `ReputationStars` renders one filled star + numeric. Upgrade to five SVG stars, filled proportionally to the rating value. Ratings ≤ 0 / null render "No ratings yet". Ratings > 0 render the partial-star row.
+
+Implementation sketch:
+
+```tsx
+function Star({ fillRatio }: { fillRatio: number }) {
+  // fillRatio in [0, 1]; uses a <linearGradient> with two stops
+  // at fillRatio * 100% to produce left-to-right partial fills.
+}
+
+function RatingSummary({ rating, reviewCount, size = "md" }: ...) {
+  if (rating === null || reviewCount === 0) {
+    return <span className="text-body-sm text-on-surface-variant">No ratings yet</span>;
+  }
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex">
+        {[0, 1, 2, 3, 4].map(i =>
+          <Star key={i} fillRatio={Math.max(0, Math.min(1, rating - i))} />)}
+      </div>
+      <span className="text-title-md font-bold">{rating.toFixed(1)}</span>
+      <span className="text-body-sm text-on-surface-variant">
+        ({reviewCount} review{reviewCount === 1 ? "" : "s"})
+      </span>
+    </div>
+  );
+}
+```
+
+`ReputationStars` is retained for backwards compatibility during migration but becomes a thin wrapper around `RatingSummary` with identical props.
+
+### 8.4 `PendingReviewsSection` on dashboard
+
+Lives in the verified-dashboard overview. Renders only if `pendingReviews.length > 0`. Shape:
+
+```
+┌──────────────────────────────────────────────┐
+│ Pending reviews                              │
+│ ─────────────────────────────────────────── │
+│ [photo] Aurora Parcel · Seller              │
+│         Leave a review for Alice             │
+│         Closes in 3 days                     │
+│         [Leave a review →]  ← /auction/1234/escrow#review-panel
+│                                              │
+│ [photo] Lakeview Shore · Buyer              │
+│         Leave a review for Bob               │
+│         Closes in 12 days                    │
+│         [Leave a review →]                   │
+└──────────────────────────────────────────────┘
+```
+
+CTA links jump to the escrow page with `#review-panel` hash; `ReviewPanel` is given an `id="review-panel"` so the browser's native scroll-into-view handles the jump. Dashboard query: `useQuery(["pending-reviews"], fetchPendingReviews)`. Invalidated when any review is submitted.
+
+### 8.5 `FlagModal`
+
+Opens from any `<ReviewCard>`'s flag button. Headless UI Dialog. Form:
+- Radio group with 5 options: Spam, Abusive, Off-topic, False information, Other
+- Textarea (optional when reason ≠ OTHER, required when reason = OTHER, max 500 chars with live counter)
+- Submit button → `POST /api/v1/reviews/{id}/flag`
+- Success state: "Thanks — this review has been flagged for admin review." → auto-close after 2s
+- Error state: duplicate-flag 409 → "You've already flagged this review."
+
+### 8.6 `RespondModal`
+
+Opens from any `<ReviewCard>` where `session.user.id === review.revieweeId` and no response exists. Headless UI Dialog. Form:
+- Textarea (required, non-empty, max 500 chars, live counter)
+- Submit button → `POST /api/v1/reviews/{id}/respond`
+- Success state: modal closes; `<ReviewCard>` re-renders with the response nested below
+- Error state: 409 (already responded) → refresh the card and close
+
+### 8.7 `StarSelector`
+
+Interactive 1-5 star picker used inside `ReviewPanel` submit state.
+- Five star buttons, arrow-key and number-key (1-5) accessible, `role="radiogroup"` ARIA
+- Hover preview fills stars left-to-right up to the hovered index
+- Click sets the rating
+- Keyboard: Home → 1, End → 5, ArrowLeft/Right decrement/increment with wraparound
+- Clear affordance: selected rating stays visible after mouseleave
+
+### 8.8 Listing-card / auction-detail seller card
+
+No direct component changes. The existing `ListingCard` already reads `seller.averageRating` and `seller.reviewCount`. The only wire-up is the backend: ensure `SellerSummaryDto` (from Epic 07 search path) is populated using the freshly-maintained `User.avgSellerRating` / `User.totalSellerReviews` — which is automatic because the aggregate columns are the read source and sub-spec 1 is where those columns finally start being written.
+
+---
+
+## 9. Eligibility & edge cases
+
+| Scenario | Behavior |
+|---|---|
+| Escrow state is not COMPLETED (PENDING / DISPUTED / EXPIRED / FROZEN) | `POST /auctions/{id}/reviews` → 422 `ReviewIneligibleException`. Panel shows nothing. |
+| Escrow COMPLETED but viewer is anonymous | Panel shows read-only reviews (if any) but no form. |
+| Escrow COMPLETED and viewer is seller/winner, already submitted | Panel shows pending state with their own text. No resubmit, no edit. |
+| Escrow COMPLETED and viewer is seller/winner, window closed | Panel shows "review window has closed" + any revealed reviews. No form. |
+| Escrow COMPLETED and viewer is a bidder who did NOT win | Panel shows revealed reviews only (they are not a party). No form. |
+| Auction has no escrow row (e.g., ended-no-bids / reserve-not-met) | Panel shows nothing; auction never qualifies for review. |
+| Both parties submit simultaneously (race) | The `findByIdForUpdate` lock on the escrow row inside submit serialises them. The second commit sees the first's row and triggers the simultaneous-reveal branch; the first's insert simply enters the pending state. |
+| Seller reviews themselves (e.g., bought their own parcel via sock puppet) | Prevented by eligibility check — they'd have to be both seller and winner, but `revieweeId = other party ≠ self` is enforced. If sellerId == winnerId (shouldn't happen, Epic 04 guards against self-bid), submit is rejected. |
+| Review flag by the author | 403. |
+| Duplicate flag by same user | 409 `ReviewFlagAlreadyExistsException`. |
+| Response submitted by non-reviewee | 403. |
+| Duplicate response | 409 `ReviewResponseAlreadyExistsException`. |
+
+---
+
+## 10. Review text rendering
+
+- **Storage:** UTF-8 string, ≤ 500 chars. No HTML parsing or sanitisation on write (defense in depth is at render).
+- **Rendering:** plain text with `white-space: pre-wrap` so newlines render. No Markdown. No auto-linking. Rendered into a `<p>` or `<blockquote>`; React auto-escapes string children, so we cannot accidentally inject HTML.
+- **Newline cap:** no hard cap, but the 500-char cap makes this a non-issue in practice.
+- **Empty text:** text is optional on reviews (just the rating is enough); required on responses (no empty responses).
+
+---
+
+## 11. Security & authz
+
+- All write endpoints require JWT. Read endpoints are public except `GET /users/me/pending-reviews`.
+- Ownership validation is inside the service layer (not a filter), so it's visible in tests:
+  - `submit`: caller ∈ {sellerId, winnerId}
+  - `respond`: caller == review.revieweeId
+  - `flag`: caller ≠ review.reviewerId
+  - `pending-reviews`: scoped to caller via `@AuthenticationPrincipal`
+- Rate-limit pre-existing config on bid-placement also covers review endpoints (Redis-backed). Sub-spec 1 reuses without new rules.
+- Reviewee and reviewer identities exposed in DTOs — this is deliberate: reviews are a public trust signal, not pseudonymous.
+- `flagCount` is NOT in `ReviewDto`. Sub-spec 1 adds a field but does not expose it via public endpoints; Epic 10's admin DTO will read it directly.
+
+---
+
+## 12. Testing strategy
+
+### 12.1 Backend
+
+| Layer | Coverage |
+|---|---|
+| Unit (service) | `ReviewService.submit` across all eligibility paths; simultaneous-reveal path; `reveal()` idempotency; aggregate recompute correctness; `BlindReviewRevealTask` scanning; `SellerCompletionRateMapper` three-arg boundary cases |
+| Slice (`@WebMvcTest`) | All 6 endpoints: happy path, auth failures (401/403), validation failures (422), duplicates (409), idempotent reveal |
+| Integration (`@SpringBootTest` + Testcontainers) | End-to-end: create auction → escrow COMPLETED → both submit → aggregates updated → WS envelope fires → day-14 scheduler idempotent |
+
+Key test — **race**: two concurrent `submit` calls on the same auction (different reviewers). Assert exactly one reveal happens, both aggregates land, WS envelope fires twice (once per revealed review).
+
+Key test — **formula B** coverage: build fixture users with representative counter mixes (`completed=10, cancelled=1, expired=0` → 91%; `completed=0, cancelled=0, expired=0` → null; etc.) and assert `SellerCompletionRateMapper.compute` output.
+
+### 12.2 Frontend
+
+| File | Coverage |
+|---|---|
+| `ReviewPanel.test.tsx` | All 5 states render correctly. State transitions on `canReview`, `myPendingReview`, `reviews` changes. WS-invalidation path: simulate envelope → assert query invalidated. |
+| `ReviewCard.test.tsx` | Reviewer display, partial-star, response nesting, flag button gating (hidden for authors), respond button gating (shown only to reviewee on own profile). Dark-mode assertions. |
+| `RatingSummary.test.tsx` | Partial-star fill ratios across rating values (0, 0.5, 3.7, 5.0). "No ratings yet" empty state. Dark-mode. |
+| `StarSelector.test.tsx` | Click, hover, keyboard (arrows, Home/End, 1-5). ARIA radiogroup. |
+| `FlagModal.test.tsx` | Reason radio group, elaboration required on OTHER, submit/cancel, 409 handling. |
+| `RespondModal.test.tsx` | Non-empty validation, submit, 409 handling. |
+| `PendingReviewsSection.test.tsx` | Renders only when items > 0. Item rendering. Link-hash behavior. |
+| `ProfileReviewTabs.test.tsx` | Tab switching, independent pagination, URL-sync, default-active "As Seller". |
+| `useReviews.test.tsx` | All React Query hooks: auction reviews, user reviews, pending reviews, submit mutation, respond mutation, flag mutation. Cache invalidation on mutation success. |
+
+MSW 2 with `onUnhandledRequest: "error"` for all tests.
+
+---
+
+## 13. Task breakdown
+
+Six tasks, executed sequentially via `superpowers:subagent-driven-development`.
+
+**Task 1 — Backend: Review domain + submit endpoint**
+- Entity trio (`Review`, `ReviewResponse`, `ReviewFlag`) + enums
+- Repositories with custom aggregate JPQL
+- `ReviewService.submit` with eligibility + simultaneous-reveal
+- `POST /auctions/{id}/reviews` endpoint + exception handler + 201/422/409 mapping
+- `User.escrowExpiredUnfulfilled` column added
+- `SellerCompletionRateMapper` extended to 3-arg + all callers updated
+- `TerminalCommandService.handleEscrowPayoutSuccess` — add `seller.completedSales++`
+- `EscrowService.expireTransfer` — add `seller.escrowExpiredUnfulfilled++`
+- Unit + slice tests for submit, eligibility, simultaneous-reveal, expireTransfer counter increment
+
+**Task 2 — Backend: Reveal scheduler, aggregates, list endpoints**
+- `BlindReviewRevealTask` hourly cron
+- `ReviewService.reveal` + `recomputeAggregates`
+- `ReviewRevealedEnvelope` + broadcast publisher wiring
+- `GET /auctions/{id}/reviews` (public + own-pending for parties)
+- `GET /users/{id}/reviews` (paginated)
+- `GET /users/me/pending-reviews`
+- Unit + slice + integration tests
+
+**Task 3 — Backend: Response + flag endpoints**
+- `ReviewResponse` + `ReviewResponseRepository` (already scaffolded in Task 1 entity; wire service path here)
+- `POST /reviews/{id}/respond`
+- `POST /reviews/{id}/flag` + `ReviewFlagReason` cross-field validator
+- `review.flagCount++` on flag
+- Exception handler additions
+- Tests
+
+**Task 4 — Frontend: Primitives + hooks + API client**
+- `RatingSummary` (partial-star SVG) + `ReputationStars` becomes thin wrapper
+- `StarSelector`
+- `ReviewCard` (with reviewer avatar/name/date/stars/text/response/flag/auction-link)
+- `RespondModal` + `FlagModal`
+- `lib/api/reviews.ts` (6 functions)
+- `hooks/useReviews.ts` (6 hooks with optimistic updates on flag/respond)
+- `types/review.ts` (mirror backend DTOs)
+- Component + hook tests with MSW 2
+
+**Task 5 — Frontend: ReviewPanel + escrow page wiring**
+- `ReviewPanel` with all 5 states
+- Wire into `EscrowPageClient`: render when `escrow.state === "COMPLETED"`
+- Extend `AuctionTopicEnvelope` union with `REVIEW_REVEALED`
+- Escrow page client: handle `REVIEW_REVEALED` by invalidating `["reviews", "auction", auctionId]`
+- Tests (state matrix, WS invalidation, hash-scroll anchor)
+
+**Task 6 — Frontend: Profile tabs + dashboard pending section**
+- `ProfileReviewTabs` replaces empty-state in `PublicProfileView`
+- `ReviewList` with pagination + URL-sync tab param
+- `PendingReviewsSection` + dashboard wiring
+- Resolve DEFERRED_WORK: "Partial-star rendering for ReputationStars" + "Recent reviews section on public profile"
+- Tests
+
+Cross-cutting (rolled into whichever task naturally touches each):
+- `types/auction.ts` envelope union extension (Task 5)
+- `SellerSummaryDto.completedSales` field addition (Task 1 — minor)
+
+---
+
+## 14. DEFERRED_WORK ledger changes
+
+**Resolve** (delete from ledger on sub-spec completion):
+- "Partial-star rendering for ReputationStars"
+- "Recent reviews section on public profile"
+
+**Add** (if any surface isn't fully shipped):
+- None expected. Sub-spec 1 covers the full reviews surface.
+
+**Noted out-of-scope for sub-spec 1** (either pre-existing deferred entries or sub-spec 2 scope):
+- Cancellation penalty ladder → Epic 08 sub-spec 2
+- 48h post-cancel ownership watcher → Epic 08 sub-spec 2
+- Admin fraud-flag review queue → Epic 10
+- Notifications on review reveal / receive / respond → Epic 09
+- `flagCount` public exposure (admin DTO) → Epic 10
+
+---
+
+## 15. Out of scope (explicit)
+
+- Email or SL-IM notifications on any review event — Epic 09 owns.
+- Distribution bar charts (5★/4★/3★/2★/1★ breakdown) — polish, not MVP.
+- Rating decay / time-weighting — simple arithmetic mean for MVP.
+- Reviewer-identity snapshotting (preserving display name at time of review) — live-join from current `User` row.
+- Response editing or deletion — one-shot, no revisions.
+- Review editing — one-shot, no revisions (per Epic spec).
+- Self-review prevention beyond the implicit check (seller ≠ winner) — edge case not worth dedicated guarding.
+- Moderation auto-hide on flag threshold — Epic 10.
+- Admin review-management UI — Epic 10.
+
+---
+
+## 16. Open questions
+
+None. All design questions resolved in brainstorm Q1–Q9.
+
+---
+
+## 17. File inventory
+
+### Backend new (≈ 28 files)
+
+```
+review/
+  Review.java
+  ReviewResponse.java
+  ReviewFlag.java
+  ReviewedRole.java
+  ReviewFlagReason.java
+  ReviewRepository.java
+  ReviewResponseRepository.java
+  ReviewFlagRepository.java
+  ReviewService.java
+  ReviewController.java
+  UserReviewsController.java
+  BlindReviewRevealTask.java
+  ReviewRevealedEnvelope.java
+  Aggregate.java              (record for JPQL projection)
+  dto/ReviewDto.java
+  dto/ReviewResponseDto.java
+  dto/ReviewSubmitRequest.java
+  dto/ReviewResponseSubmitRequest.java
+  dto/ReviewFlagRequest.java
+  dto/ReviewListPage.java     (typed alias of PagedResponse)
+  dto/PendingReviewDto.java
+  dto/AuctionReviewsResponse.java  (for GET /auctions/{id}/reviews)
+  exception/ReviewNotFoundException.java
+  exception/ReviewIneligibleException.java
+  exception/ReviewAlreadySubmittedException.java
+  exception/ReviewWindowClosedException.java
+  exception/ReviewResponseAlreadyExistsException.java
+  exception/ReviewFlagAlreadyExistsException.java
+  exception/ReviewExceptionHandler.java
+  exception/ElaborationRequiredWhenOtherValidator.java  (JSR-303 custom)
+  exception/ElaborationRequiredWhenOther.java           (annotation)
+```
+
+### Backend modified
+
+- `user/User.java` — add `escrowExpiredUnfulfilled` column
+- `user/SellerCompletionRateMapper.java` — 3-arg signature
+- `user/dto/UserProfileResponse.java` — add `completionRate`, `isNewSeller`
+- `auction/AuctionDtoMapper.java` — pass 3rd arg to mapper
+- `auction/dto/PublicAuctionResponse.java` — (javadoc only)
+- `auction/search/SellerSummaryDto.java` — add `completedSales` field
+- `auction/search/AuctionSearchResultMapper.java` — populate new field
+- `escrow/EscrowService.java` — `expireTransfer` increments seller's `escrowExpiredUnfulfilled`
+- `escrow/command/TerminalCommandService.java` — `handleEscrowPayoutSuccess` increments seller's `completedSales`
+- `escrow/broadcast/*` — add `publishReviewRevealed` method
+- `config/SecurityConfig.java` — permit GET `/users/{id}/reviews`, `/auctions/{id}/reviews`; require auth on POST reviews/flag/respond
+
+### Frontend new (≈ 20 files)
+
+```
+components/reviews/
+  ReviewPanel.tsx
+  ReviewPanel.test.tsx
+  ReviewCard.tsx
+  ReviewCard.test.tsx
+  ReviewList.tsx
+  ReviewList.test.tsx
+  RatingSummary.tsx
+  RatingSummary.test.tsx
+  StarSelector.tsx
+  StarSelector.test.tsx
+  RespondModal.tsx
+  RespondModal.test.tsx
+  FlagModal.tsx
+  FlagModal.test.tsx
+  PendingReviewsSection.tsx
+  PendingReviewsSection.test.tsx
+  ProfileReviewTabs.tsx
+  ProfileReviewTabs.test.tsx
+hooks/
+  useReviews.ts
+  useReviews.test.tsx
+lib/api/
+  reviews.ts
+  reviews.test.ts
+types/
+  review.ts
+```
+
+### Frontend modified
+
+- `components/user/ReputationStars.tsx` — thin wrapper around `RatingSummary`
+- `components/user/PublicProfileView.tsx` — replace empty-state with `<ProfileReviewTabs>`
+- `app/auction/[id]/escrow/EscrowPageClient.tsx` — append `<ReviewPanel>` on COMPLETED + `REVIEW_REVEALED` invalidation
+- `app/dashboard/(verified)/overview/page.tsx` — append `<PendingReviewsSection>`
+- `types/auction.ts` — extend `AuctionTopicEnvelope` union
+
+### Docs
+
+- `docs/implementation/DEFERRED_WORK.md` — remove two entries (see §14)
+- This spec and its companion plan
+
+---
+
+## 18. Timeline estimate
+
+Six tasks, roughly symmetric in size. Prior sub-spec benchmark (Epic 07 sub-2) shipped 6 tasks + 1 post-review fix in about 17 commits.
+
+**Expected shape:**
+- Tasks 1-3 (backend): entity + service + 6 endpoints + scheduler + integration. ~8-10 commits.
+- Tasks 4-6 (frontend): primitives + panel + tabs + dashboard. ~6-8 commits.
+- Plus per-task spec-review + code-quality review fixup commits.
+
+Total: ~16-20 commits, single PR to `dev`.

--- a/frontend/src/app/auction/[id]/AuctionDetailClient.tsx
+++ b/frontend/src/app/auction/[id]/AuctionDetailClient.tsx
@@ -155,6 +155,21 @@ export function AuctionDetailClient({ initialAuction, initialBidPage }: Props) {
 
   const handleEnvelope = useCallback(
     (env: AuctionTopicEnvelope) => {
+      // REVIEW_REVEALED envelopes piggy-back on the same topic (Epic 08
+      // sub-spec 1 §7.2) but carry none of the auction-level fields the
+      // detail page reads (no {@code serverTime}, no bid state). Handle
+      // them first so the {@code env.serverTime} read below never fires
+      // against a REVIEW_REVEALED payload. The invalidation refreshes the
+      // seller-card rating once the escrow-page ReviewPanel reveals a
+      // review — the {@code useAuctionReviews} query key mirrors the one
+      // used by {@code EscrowPageClient}.
+      if (env.type === "REVIEW_REVEALED") {
+        queryClient.invalidateQueries({
+          queryKey: ["reviews", "auction", String(id)],
+        });
+        return;
+      }
+
       // Refine the server-time offset on every envelope so the countdown
       // stays accurate even if the user's clock drifts mid-session.
       serverTimeOffsetRef.current =
@@ -198,16 +213,25 @@ export function AuctionDetailClient({ initialAuction, initialBidPage }: Props) {
           // `finalBidAmount`, `winnerUserId` live only on the
           // SellerAuctionResponse shape; the cache is typed wide enough to
           // admit them on the public shape too. Task 6's AuctionEndedPanel
-          // reads them back.
-          return {
-            ...prev,
-            status: "ENDED",
-            endsAt: env.endsAt,
-            endOutcome: env.endOutcome,
-            finalBidAmount: env.finalBid,
-            winnerUserId: env.winnerUserId,
-            bidderCount: env.bidCount,
-          };
+          // reads them back. The explicit {@code type === "AUCTION_ENDED"}
+          // narrows the union down past the non-type-guard
+          // {@code startsWith("ESCROW_")} early-return above so TypeScript
+          // can see we only read AUCTION_ENDED fields here.
+          if (env.type === "AUCTION_ENDED") {
+            return {
+              ...prev,
+              status: "ENDED",
+              endsAt: env.endsAt,
+              endOutcome: env.endOutcome,
+              finalBidAmount: env.finalBid,
+              winnerUserId: env.winnerUserId,
+              bidderCount: env.bidCount,
+            };
+          }
+          // Any other envelope type (ESCROW_*, REVIEW_REVEALED) is already
+          // handled by the early-returns above and never reaches this
+          // callback — leave the cache untouched as a defensive fallback.
+          return prev;
         },
       );
 

--- a/frontend/src/app/auction/[id]/escrow/EscrowPageClient.test.tsx
+++ b/frontend/src/app/auction/[id]/escrow/EscrowPageClient.test.tsx
@@ -112,6 +112,62 @@ describe("EscrowPageClient", () => {
     expect(screen.getByText(/escrow · winner/i)).toBeInTheDocument();
   });
 
+  it("invalidates the reviews query on REVIEW_REVEALED envelope", async () => {
+    server.use(
+      http.get("*/api/v1/auctions/7/escrow", () =>
+        HttpResponse.json(
+          fakeEscrow({
+            auctionId: 7,
+            state: "COMPLETED",
+            completedAt: "2026-04-18T12:00:00Z",
+          }),
+        ),
+      ),
+    );
+    let reviewsFetchCount = 0;
+    server.use(
+      http.get("*/api/v1/auctions/7/reviews", () => {
+        reviewsFetchCount += 1;
+        return HttpResponse.json({
+          reviews: [],
+          myPendingReview: null,
+          canReview: true,
+          windowClosesAt: "2026-05-10T00:00:00Z",
+        });
+      }),
+    );
+
+    renderWithProviders(
+      <EscrowPageClient auctionId={7} sellerId={42} />,
+      { auth: "authenticated", authUser: winnerUser },
+    );
+
+    // ReviewPanel renders once escrow lands in COMPLETED; the panel's
+    // useAuctionReviews hook fires the first GET.
+    await waitFor(() => expect(reviewsFetchCount).toBeGreaterThan(0));
+    const initial = reviewsFetchCount;
+
+    const handler = subscribeMock.mock.calls[0]?.[1] as (
+      env: unknown,
+    ) => void;
+    expect(handler).toBeDefined();
+    act(() => {
+      handler({
+        type: "REVIEW_REVEALED",
+        auctionId: 7,
+        reviewId: 1,
+        reviewerId: 999,
+        revieweeId: 42,
+        reviewedRole: "SELLER",
+        revealedAt: "2026-04-20T10:00:00Z",
+      });
+    });
+
+    // The handler branch invalidates ["reviews","auction","7"], which
+    // refetches the panel's envelope — assert on the second GET.
+    await waitFor(() => expect(reviewsFetchCount).toBeGreaterThan(initial));
+  });
+
   it("invalidates cache on ESCROW_FUNDED envelope and refetches", async () => {
     let callCount = 0;
     server.use(

--- a/frontend/src/app/auction/[id]/escrow/EscrowPageClient.tsx
+++ b/frontend/src/app/auction/[id]/escrow/EscrowPageClient.tsx
@@ -19,6 +19,7 @@ import { EscrowPageError } from "@/components/escrow/EscrowPageError";
 import { EscrowPageEmpty } from "@/components/escrow/EscrowPageEmpty";
 import { EscrowStepper } from "@/components/escrow/EscrowStepper";
 import { EscrowStepCard } from "@/components/escrow/EscrowStepCard";
+import { ReviewPanel } from "@/components/reviews/ReviewPanel";
 import { ReconnectingBanner } from "@/components/auction/ReconnectingBanner";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 
@@ -95,6 +96,14 @@ export function EscrowPageClient({ auctionId, sellerId }: EscrowPageClientProps)
         // authoritative state.
         if (env.type.startsWith("ESCROW_")) {
           queryClient.invalidateQueries({ queryKey: escrowKey(auctionId) });
+        } else if (env.type === "REVIEW_REVEALED") {
+          // Epic 08 sub-spec 1 §7.2: refresh the {@code useAuctionReviews}
+          // envelope so the ReviewPanel transitions from pending → revealed
+          // (or revealed-one → revealed-both) without a page reload. The
+          // query key mirrors {@code reviewsKeys.auction} in useReviews.ts.
+          queryClient.invalidateQueries({
+            queryKey: ["reviews", "auction", String(auctionId)],
+          });
         }
       },
       [auctionId, queryClient],
@@ -148,6 +157,9 @@ export function EscrowPageClient({ auctionId, sellerId }: EscrowPageClientProps)
           <EscrowPageHeader escrow={escrow} role={role} />
           <EscrowStepper escrow={escrow} />
           <EscrowStepCard escrow={escrow} role={role} />
+          {escrow.state === "COMPLETED" && (
+            <ReviewPanel auctionId={auctionId} isParty />
+          )}
         </>
       )}
       <ReconnectingBanner state={connectionState} />

--- a/frontend/src/app/dashboard/(verified)/overview/page.tsx
+++ b/frontend/src/app/dashboard/(verified)/overview/page.tsx
@@ -1,7 +1,21 @@
 "use client";
 
+import { PendingReviewsSection } from "@/components/reviews/PendingReviewsSection";
 import { VerifiedOverview } from "@/components/user/VerifiedOverview";
 
+/**
+ * Verified-dashboard landing page. Renders the time-bound
+ * {@link PendingReviewsSection} at the top — reviewing a completed sale is
+ * a higher-priority CTA than identity / profile maintenance because the
+ * review window closes. The section collapses to {@code null} when the
+ * viewer has no pending reviews, so established users see their normal
+ * identity / profile layout unchanged.
+ */
 export default function OverviewPage() {
-  return <VerifiedOverview />;
+  return (
+    <div className="flex flex-col gap-8">
+      <PendingReviewsSection />
+      <VerifiedOverview />
+    </div>
+  );
 }

--- a/frontend/src/app/dev/listing-card-demo/page.tsx
+++ b/frontend/src/app/dev/listing-card-demo/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { ListingCard } from "@/components/auction/ListingCard";
 import type { AuctionSearchResultDto } from "@/types/search";
 
@@ -48,20 +49,25 @@ const sample: AuctionSearchResultDto = {
 };
 
 export default function ListingCardDemo() {
+  // ListingCard transitively reads useSearchParams via useSavedAuctions,
+  // so the Next.js 16 prerender needs a Suspense boundary to bail out
+  // cleanly. Fallback is invisible — the demo is client-rendered anyway.
   return (
-    <div className="p-8 grid grid-cols-1 md:grid-cols-3 gap-6 max-w-6xl mx-auto">
-      <section>
-        <h2 className="text-title-lg font-bold mb-3">default</h2>
-        <ListingCard listing={sample} variant="default" />
-      </section>
-      <section>
-        <h2 className="text-title-lg font-bold mb-3">compact</h2>
-        <ListingCard listing={sample} variant="compact" />
-      </section>
-      <section className="md:col-span-2">
-        <h2 className="text-title-lg font-bold mb-3">featured</h2>
-        <ListingCard listing={sample} variant="featured" />
-      </section>
-    </div>
+    <Suspense fallback={null}>
+      <div className="p-8 grid grid-cols-1 md:grid-cols-3 gap-6 max-w-6xl mx-auto">
+        <section>
+          <h2 className="text-title-lg font-bold mb-3">default</h2>
+          <ListingCard listing={sample} variant="default" />
+        </section>
+        <section>
+          <h2 className="text-title-lg font-bold mb-3">compact</h2>
+          <ListingCard listing={sample} variant="compact" />
+        </section>
+        <section className="md:col-span-2">
+          <h2 className="text-title-lg font-bold mb-3">featured</h2>
+          <ListingCard listing={sample} variant="featured" />
+        </section>
+      </div>
+    </Suspense>
   );
 }

--- a/frontend/src/app/saved/page.tsx
+++ b/frontend/src/app/saved/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { SavedPageContent } from "./SavedPageContent";
 
 export const metadata: Metadata = {
@@ -9,8 +11,15 @@ export const metadata: Metadata = {
 /**
  * {@code /saved} — the URL-synced companion to the Curator Tray drawer.
  * Server component shell; the authenticated-only state + URL-synced
- * query live in {@link SavedPageContent}.
+ * query live in {@link SavedPageContent}. The {@link Suspense} boundary
+ * is required so the Next.js 16 prerender can bail out on the
+ * {@code useSearchParams} read inside the client body without failing
+ * the build.
  */
 export default function SavedPage() {
-  return <SavedPageContent />;
+  return (
+    <Suspense fallback={<LoadingSpinner label="Loading saved parcels..." />}>
+      <SavedPageContent />
+    </Suspense>
+  );
 }

--- a/frontend/src/components/reviews/FlagModal.test.tsx
+++ b/frontend/src/components/reviews/FlagModal.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/msw/server";
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/test/render";
+import { FlagModal } from "./FlagModal";
+
+describe("FlagModal", () => {
+  it("renders the 5 reason radios", () => {
+    renderWithProviders(<FlagModal reviewId={5} open onClose={() => {}} />, {
+      auth: "authenticated",
+    });
+    for (const code of ["SPAM", "ABUSIVE", "OFF_TOPIC", "FALSE_INFO", "OTHER"]) {
+      expect(screen.getByTestId(`flag-modal-reason-${code}`)).toBeInTheDocument();
+    }
+  });
+
+  it("keeps submit disabled until a reason is picked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<FlagModal reviewId={5} open onClose={() => {}} />, {
+      auth: "authenticated",
+    });
+    expect(screen.getByTestId("flag-modal-submit")).toBeDisabled();
+    await user.click(screen.getByTestId("flag-modal-reason-SPAM"));
+    expect(screen.getByTestId("flag-modal-submit")).not.toBeDisabled();
+  });
+
+  it("requires elaboration when reason is OTHER", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<FlagModal reviewId={5} open onClose={() => {}} />, {
+      auth: "authenticated",
+    });
+    await user.click(screen.getByTestId("flag-modal-reason-OTHER"));
+    expect(screen.getByTestId("flag-modal-submit")).toBeDisabled();
+    await user.type(
+      screen.getByTestId("flag-modal-elaboration"),
+      "Because reasons",
+    );
+    expect(screen.getByTestId("flag-modal-submit")).not.toBeDisabled();
+  });
+
+  it("submits with the selected reason and closes on success", async () => {
+    const onClose = vi.fn();
+    let capturedBody: unknown = null;
+    server.use(
+      http.post("*/api/v1/reviews/:id/flag", async ({ request }) => {
+        capturedBody = await request.json();
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<FlagModal reviewId={5} open onClose={onClose} />, {
+      auth: "authenticated",
+    });
+    await user.click(screen.getByTestId("flag-modal-reason-SPAM"));
+    await user.click(screen.getByTestId("flag-modal-submit"));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(capturedBody).toEqual({ reason: "SPAM" });
+  });
+
+  it("includes elaboration in the payload when provided", async () => {
+    const onClose = vi.fn();
+    let capturedBody: unknown = null;
+    server.use(
+      http.post("*/api/v1/reviews/:id/flag", async ({ request }) => {
+        capturedBody = await request.json();
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<FlagModal reviewId={5} open onClose={onClose} />, {
+      auth: "authenticated",
+    });
+    await user.click(screen.getByTestId("flag-modal-reason-OTHER"));
+    await user.type(
+      screen.getByTestId("flag-modal-elaboration"),
+      "Explains the thing",
+    );
+    await user.click(screen.getByTestId("flag-modal-submit"));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(capturedBody).toEqual({
+      reason: "OTHER",
+      elaboration: "Explains the thing",
+    });
+  });
+
+  it("closes on 409 duplicate-flag", async () => {
+    const onClose = vi.fn();
+    server.use(
+      http.post("*/api/v1/reviews/:id/flag", () =>
+        HttpResponse.json({ status: 409 }, { status: 409 }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<FlagModal reviewId={5} open onClose={onClose} />, {
+      auth: "authenticated",
+    });
+    await user.click(screen.getByTestId("flag-modal-reason-SPAM"));
+    await user.click(screen.getByTestId("flag-modal-submit"));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/components/reviews/FlagModal.tsx
+++ b/frontend/src/components/reviews/FlagModal.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
+import { Button } from "@/components/ui/Button";
+import { FormError } from "@/components/ui/FormError";
+import { ApiError, isApiError } from "@/lib/api";
+import { cn } from "@/lib/cn";
+import { useFlagReview } from "@/hooks/useReviews";
+import type { ReviewFlagReason } from "@/types/review";
+
+const MAX_LEN = 500;
+
+const REASONS: Array<{ code: ReviewFlagReason; label: string }> = [
+  { code: "SPAM", label: "Spam" },
+  { code: "ABUSIVE", label: "Abusive" },
+  { code: "OFF_TOPIC", label: "Off-topic" },
+  { code: "FALSE_INFO", label: "False information" },
+  { code: "OTHER", label: "Other" },
+];
+
+export interface FlagModalProps {
+  reviewId: number;
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Modal form for any non-author to flag a review. Reason is a radio group
+ * (radiogroup pattern → arrow-key navigation from the browser's native
+ * radio handling); elaboration is a 500-char textarea, required iff
+ * {@code reason === "OTHER"} (mirrors the backend
+ * {@code ElaborationRequiredWhenOtherValidator} so the 422 path stays a
+ * fallback). 409 duplicate-flag is handled in {@link useFlagReview} via
+ * toast.
+ */
+export function FlagModal({ reviewId, open, onClose }: FlagModalProps) {
+  const [reason, setReason] = useState<ReviewFlagReason | null>(null);
+  const [elaboration, setElaboration] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const mutation = useFlagReview(reviewId);
+
+  // Local state resets on unmount — callers (ReviewCard) mount this modal
+  // only when {@code open} is true so a cancel-then-reopen sequence starts
+  // from a clean slate without a reset effect.
+
+  const overLimit = elaboration.length > MAX_LEN;
+  const elaborationRequired = reason === "OTHER";
+  const elaborationMissing =
+    elaborationRequired && elaboration.trim().length === 0;
+  const canSubmit =
+    reason !== null && !overLimit && !elaborationMissing && !mutation.isPending;
+
+  const submit = async () => {
+    if (!canSubmit || reason === null) return;
+    setError(null);
+    const trimmed = elaboration.trim();
+    try {
+      await mutation.mutateAsync({
+        reason,
+        ...(trimmed.length > 0 ? { elaboration: trimmed } : {}),
+      });
+      onClose();
+    } catch (e) {
+      if (isApiError(e) && e.status === 409) {
+        // Hook fires the "Already flagged" toast; we still close so the UI
+        // resets.
+        onClose();
+        return;
+      }
+      if (e instanceof ApiError) {
+        setError(
+          e.problem.detail ?? e.problem.title ?? "Could not flag this review.",
+        );
+        return;
+      }
+      setError("Could not flag this review. Please try again.");
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} className="relative z-50">
+      <div
+        className="fixed inset-0 bg-inverse-surface/40 backdrop-blur-sm"
+        aria-hidden="true"
+      />
+      <div className="fixed inset-0 flex items-center justify-center p-4">
+        <DialogPanel
+          data-testid="flag-modal"
+          className="w-full max-w-md flex flex-col gap-4 rounded-default bg-surface-container-low p-6"
+        >
+          <DialogTitle className="text-title-lg text-on-surface">
+            Flag this review
+          </DialogTitle>
+          <p className="text-body-sm text-on-surface-variant">
+            Tell us why this review needs moderator attention. Flagging is
+            confidential — the reviewer is not notified.
+          </p>
+          <FormError message={error ?? undefined} />
+
+          <fieldset
+            className="flex flex-col gap-2"
+            data-testid="flag-modal-reasons"
+          >
+            <legend className="text-label-md font-medium text-on-surface">
+              Reason
+            </legend>
+            {REASONS.map((r) => (
+              <label
+                key={r.code}
+                className="flex items-center gap-2 text-body-md text-on-surface"
+              >
+                <input
+                  type="radio"
+                  name={`flag-reason-${reviewId}`}
+                  value={r.code}
+                  checked={reason === r.code}
+                  onChange={() => setReason(r.code)}
+                  className="size-4 accent-primary"
+                  data-testid={`flag-modal-reason-${r.code}`}
+                />
+                <span>{r.label}</span>
+              </label>
+            ))}
+          </fieldset>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-label-md text-on-surface">
+              {elaborationRequired
+                ? "Please elaborate (required)"
+                : "Additional details (optional)"}
+            </span>
+            <textarea
+              rows={4}
+              value={elaboration}
+              onChange={(e) => setElaboration(e.target.value)}
+              placeholder="What should the moderator know?"
+              data-testid="flag-modal-elaboration"
+              className="w-full resize-y rounded-default bg-surface-container-low px-4 py-3 text-on-surface placeholder:text-on-surface-variant ring-1 ring-outline-variant transition-all focus:outline-none focus:ring-primary"
+            />
+          </label>
+          <div
+            data-testid="flag-modal-counter"
+            className={cn(
+              "self-end text-label-sm",
+              overLimit ? "text-error" : "text-on-surface-variant",
+            )}
+          >
+            {elaboration.length} / {MAX_LEN}
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="secondary"
+              onClick={onClose}
+              disabled={mutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={submit}
+              disabled={!canSubmit}
+              loading={mutation.isPending}
+              data-testid="flag-modal-submit"
+            >
+              Flag review
+            </Button>
+          </div>
+        </DialogPanel>
+      </div>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/reviews/FlagModal.tsx
+++ b/frontend/src/components/reviews/FlagModal.tsx
@@ -3,8 +3,7 @@
 import { useState } from "react";
 import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
 import { Button } from "@/components/ui/Button";
-import { FormError } from "@/components/ui/FormError";
-import { ApiError, isApiError } from "@/lib/api";
+import { isApiError } from "@/lib/api";
 import { cn } from "@/lib/cn";
 import { useFlagReview } from "@/hooks/useReviews";
 import type { ReviewFlagReason } from "@/types/review";
@@ -37,7 +36,6 @@ export interface FlagModalProps {
 export function FlagModal({ reviewId, open, onClose }: FlagModalProps) {
   const [reason, setReason] = useState<ReviewFlagReason | null>(null);
   const [elaboration, setElaboration] = useState("");
-  const [error, setError] = useState<string | null>(null);
   const mutation = useFlagReview(reviewId);
 
   // Local state resets on unmount — callers (ReviewCard) mount this modal
@@ -53,7 +51,6 @@ export function FlagModal({ reviewId, open, onClose }: FlagModalProps) {
 
   const submit = async () => {
     if (!canSubmit || reason === null) return;
-    setError(null);
     const trimmed = elaboration.trim();
     try {
       await mutation.mutateAsync({
@@ -68,13 +65,8 @@ export function FlagModal({ reviewId, open, onClose }: FlagModalProps) {
         onClose();
         return;
       }
-      if (e instanceof ApiError) {
-        setError(
-          e.problem.detail ?? e.problem.title ?? "Could not flag this review.",
-        );
-        return;
-      }
-      setError("Could not flag this review. Please try again.");
+      // Non-409 errors surface via the hook's toast; leave the modal open
+      // with the form preserved so the user can retry.
     }
   };
 
@@ -96,7 +88,6 @@ export function FlagModal({ reviewId, open, onClose }: FlagModalProps) {
             Tell us why this review needs moderator attention. Flagging is
             confidential — the reviewer is not notified.
           </p>
-          <FormError message={error ?? undefined} />
 
           <fieldset
             className="flex flex-col gap-2"

--- a/frontend/src/components/reviews/PendingReviewsSection.test.tsx
+++ b/frontend/src/components/reviews/PendingReviewsSection.test.tsx
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, screen, waitFor } from "@/test/render";
+import { server } from "@/test/msw/server";
+import type { PendingReviewDto } from "@/types/review";
+import {
+  PendingReviewsSection,
+  formatWindowRemaining,
+} from "./PendingReviewsSection";
+
+function makePending(
+  overrides: Partial<PendingReviewDto> = {},
+): PendingReviewDto {
+  return {
+    auctionId: 1234,
+    title: "Aurora Parcel",
+    primaryPhotoUrl: null,
+    counterpartyId: 7,
+    counterpartyDisplayName: "Alice",
+    counterpartyAvatarUrl: null,
+    escrowCompletedAt: "2026-04-18T00:00:00Z",
+    windowClosesAt: "2026-05-02T00:00:00Z",
+    hoursRemaining: 72,
+    viewerRole: "SELLER",
+    ...overrides,
+  };
+}
+
+describe("formatWindowRemaining", () => {
+  it("returns days when ≥ 24h remain", () => {
+    expect(formatWindowRemaining(72)).toBe("Closes in 3 days");
+    expect(formatWindowRemaining(24)).toBe("Closes in 1 day");
+  });
+
+  it("returns hours when < 24h remain", () => {
+    expect(formatWindowRemaining(23)).toBe("Closes in 23 hours");
+    expect(formatWindowRemaining(1)).toBe("Closes in 1 hour");
+  });
+
+  it("collapses to 'Closes soon' when < 1h remain", () => {
+    expect(formatWindowRemaining(0)).toBe("Closes soon");
+    expect(formatWindowRemaining(-1)).toBe("Closes soon");
+  });
+
+  it("floors fractional hours before choosing the unit", () => {
+    expect(formatWindowRemaining(23.9)).toBe("Closes in 23 hours");
+    expect(formatWindowRemaining(48.5)).toBe("Closes in 2 days");
+  });
+});
+
+describe("PendingReviewsSection", () => {
+  it("renders nothing when the list is empty", async () => {
+    server.use(
+      http.get("*/api/v1/users/me/pending-reviews", () =>
+        HttpResponse.json([]),
+      ),
+    );
+
+    renderWithProviders(<PendingReviewsSection />, {
+      auth: "authenticated",
+    });
+
+    // Wait a tick for the query to resolve before asserting the
+    // nothing-rendered contract.
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("pending-reviews-section"),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText("Pending reviews")).not.toBeInTheDocument();
+  });
+
+  it("renders one row per pending review with CTA link and window copy", async () => {
+    server.use(
+      http.get("*/api/v1/users/me/pending-reviews", () =>
+        HttpResponse.json([
+          makePending({ auctionId: 1234, hoursRemaining: 72, viewerRole: "SELLER" }),
+          makePending({
+            auctionId: 5678,
+            title: "Lakeview Shore",
+            counterpartyDisplayName: "Bob",
+            hoursRemaining: 12,
+            viewerRole: "BUYER",
+          }),
+        ]),
+      ),
+    );
+
+    renderWithProviders(<PendingReviewsSection />, { auth: "authenticated" });
+
+    expect(await screen.findByText("Pending reviews")).toBeInTheDocument();
+    const rows = screen.getAllByTestId("pending-review-row");
+    expect(rows).toHaveLength(2);
+
+    // First row — SELLER, 3 days remaining
+    expect(screen.getByText("Aurora Parcel")).toBeInTheDocument();
+    expect(
+      screen.getByText("Leave a review for Alice"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Closes in 3 days")).toBeInTheDocument();
+    expect(screen.getByText("· Seller")).toBeInTheDocument();
+
+    // Second row — BUYER, 12 hours remaining
+    expect(screen.getByText("Lakeview Shore")).toBeInTheDocument();
+    expect(screen.getByText("Leave a review for Bob")).toBeInTheDocument();
+    expect(screen.getByText("Closes in 12 hours")).toBeInTheDocument();
+    expect(screen.getByText("· Buyer")).toBeInTheDocument();
+  });
+
+  it("links each CTA to the escrow page's #review-panel anchor", async () => {
+    server.use(
+      http.get("*/api/v1/users/me/pending-reviews", () =>
+        HttpResponse.json([makePending({ auctionId: 42 })]),
+      ),
+    );
+
+    renderWithProviders(<PendingReviewsSection />, { auth: "authenticated" });
+
+    const cta = await screen.findByTestId("pending-review-cta");
+    expect(cta).toHaveAttribute("href", "/auction/42/escrow#review-panel");
+  });
+
+  it("renders nothing when the request fails", async () => {
+    server.use(
+      http.get("*/api/v1/users/me/pending-reviews", () =>
+        HttpResponse.json({ status: 500 }, { status: 500 }),
+      ),
+    );
+
+    renderWithProviders(<PendingReviewsSection />, {
+      auth: "authenticated",
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("pending-reviews-section"),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText("Pending reviews")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/reviews/PendingReviewsSection.tsx
+++ b/frontend/src/components/reviews/PendingReviewsSection.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import Link from "next/link";
+import { Avatar } from "@/components/ui/Avatar";
+import { Card } from "@/components/ui/Card";
+import { ArrowRight } from "@/components/ui/icons";
+import { cn } from "@/lib/cn";
+import { usePendingReviews } from "@/hooks/useReviews";
+import type { PendingReviewDto } from "@/types/review";
+
+/**
+ * "Closes in N days" when ≥ 24h left, otherwise "Closes in N hours". The
+ * backend already sorts most-urgent-first so the UI does not round-trip
+ * timestamps; {@code hoursRemaining} is the single source of truth.
+ *
+ * @param hoursRemaining whole hours until the review window closes
+ */
+export function formatWindowRemaining(hoursRemaining: number): string {
+  const hours = Math.max(0, Math.floor(hoursRemaining));
+  if (hours === 0) {
+    return "Closes soon";
+  }
+  if (hours < 24) {
+    return `Closes in ${hours} hour${hours === 1 ? "" : "s"}`;
+  }
+  const days = Math.floor(hours / 24);
+  return `Closes in ${days} day${days === 1 ? "" : "s"}`;
+}
+
+/**
+ * Role-label for the row header — maps backend enum to the spec §8.4 copy
+ * ("Aurora Parcel · Seller"). The viewer's role is embedded in the DTO so
+ * one "pending reviews" list cleanly covers both seller-side and
+ * buyer-side rows.
+ */
+function roleLabel(role: PendingReviewDto["viewerRole"]): string {
+  return role === "SELLER" ? "Seller" : "Buyer";
+}
+
+function PendingReviewRow({ item }: { item: PendingReviewDto }) {
+  const href = `/auction/${item.auctionId}/escrow#review-panel`;
+  return (
+    <li
+      className="flex flex-col gap-3 rounded-default bg-surface-container-low p-4 ring-1 ring-outline-variant sm:flex-row sm:items-center"
+      data-testid="pending-review-row"
+      data-auction-id={item.auctionId}
+    >
+      <div
+        className={cn(
+          "relative h-20 w-full shrink-0 overflow-hidden rounded-default bg-surface-container sm:w-28",
+        )}
+      >
+        {item.primaryPhotoUrl && (
+          // eslint-disable-next-line @next/next/no-img-element -- Deferred: swap to next/image when backend returns image dimensions + a stable remotePatterns list for SL CDN hosts is agreed upon. Matches the ListingCard deferral.
+          <img
+            src={item.primaryPhotoUrl}
+            alt=""
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+        )}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <div className="flex items-baseline gap-2">
+          <span className="truncate text-title-md font-bold text-on-surface">
+            {item.title}
+          </span>
+          <span className="text-label-sm text-on-surface-variant">
+            · {roleLabel(item.viewerRole)}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 text-body-sm text-on-surface-variant">
+          <Avatar
+            src={item.counterpartyAvatarUrl ?? undefined}
+            alt={item.counterpartyDisplayName}
+            name={item.counterpartyDisplayName}
+            size="xs"
+          />
+          <span className="truncate">
+            Leave a review for {item.counterpartyDisplayName}
+          </span>
+        </div>
+        <p
+          className="text-label-sm text-on-surface-variant"
+          data-testid="pending-review-window"
+        >
+          {formatWindowRemaining(item.hoursRemaining)}
+        </p>
+      </div>
+      <Link
+        href={href}
+        className="inline-flex items-center gap-1 self-start rounded-default bg-primary px-3 py-2 text-label-md text-on-primary transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary sm:self-center"
+        data-testid="pending-review-cta"
+      >
+        Leave a review
+        <ArrowRight className="size-4" aria-hidden="true" />
+      </Link>
+    </li>
+  );
+}
+
+/**
+ * Dashboard "Pending reviews" card. Short-circuits to {@code null} when
+ * there is nothing for the viewer to review so the dashboard is not
+ * permanently burdened with an empty card. Each row deep-links to the
+ * escrow page's {@code #review-panel} anchor — {@link ReviewPanel} carries
+ * that id so the browser's native scroll handles the jump.
+ */
+export function PendingReviewsSection({ className }: { className?: string } = {}) {
+  const { data, isPending, isError } = usePendingReviews();
+
+  // Loading / error collapse to nothing — the section is additive and the
+  // rest of the dashboard does not depend on it, so a failed fetch should
+  // not poison the page. A toast is raised by the mutation hooks that
+  // invalidate this query; no surface-level copy is required here.
+  if (isPending || isError) return null;
+  if (data.length === 0) return null;
+
+  return (
+    <Card className={className} data-testid="pending-reviews-section">
+      <Card.Header>
+        <h2 className="text-title-md font-bold">Pending reviews</h2>
+      </Card.Header>
+      <Card.Body>
+        <ul className="flex flex-col gap-3">
+          {data.map((item) => (
+            <PendingReviewRow key={item.auctionId} item={item} />
+          ))}
+        </ul>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/frontend/src/components/reviews/ProfileReviewTabs.test.tsx
+++ b/frontend/src/components/reviews/ProfileReviewTabs.test.tsx
@@ -1,0 +1,247 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/test/render";
+import { server } from "@/test/msw/server";
+import type { ReviewDto, ReviewedRole } from "@/types/review";
+import { ProfileReviewTabs } from "./ProfileReviewTabs";
+
+// --- next/navigation mock with mutable state -------------------------------
+//
+// The tab component reads useSearchParams and writes via router.replace. We
+// back both with a module-scoped URLSearchParams so tests can seed the
+// initial query and assert on the resulting push.
+
+const replaceMock = vi.fn();
+let currentParams = new URLSearchParams();
+
+function setParams(init: string) {
+  currentParams = new URLSearchParams(init);
+}
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: replaceMock, push: vi.fn() }),
+  usePathname: () => "/users/42",
+  useSearchParams: () => currentParams,
+}));
+
+function makeReview(id: number, role: ReviewedRole): ReviewDto {
+  return {
+    id,
+    auctionId: id * 10,
+    auctionTitle: `Parcel #${id}`,
+    auctionPrimaryPhotoUrl: null,
+    reviewerId: 100 + id,
+    reviewerDisplayName: `Reviewer ${id}`,
+    reviewerAvatarUrl: null,
+    revieweeId: 42,
+    reviewedRole: role,
+    rating: 5,
+    text: `Review ${id} for role ${role}`,
+    visible: true,
+    pending: false,
+    submittedAt: "2026-04-18T12:00:00Z",
+    revealedAt: "2026-04-19T12:00:00Z",
+    response: null,
+  };
+}
+
+/**
+ * Register one handler that branches on the {@code role} query param so the
+ * same test can cover both tabs without re-registering mid-test.
+ */
+function registerReviewHandler(options: {
+  sellerReviews?: ReviewDto[];
+  buyerReviews?: ReviewDto[];
+  sellerTotalPages?: number;
+  buyerTotalPages?: number;
+}) {
+  const {
+    sellerReviews = [],
+    buyerReviews = [],
+    sellerTotalPages = 1,
+    buyerTotalPages = 1,
+  } = options;
+  server.use(
+    http.get("*/api/v1/users/:id/reviews", ({ request }) => {
+      const url = new URL(request.url);
+      const role = url.searchParams.get("role") as ReviewedRole | null;
+      const page = Number(url.searchParams.get("page") ?? "0");
+      if (role === "BUYER") {
+        return HttpResponse.json({
+          content: buyerReviews,
+          totalElements: buyerReviews.length,
+          totalPages: buyerTotalPages,
+          number: page,
+          size: 10,
+        });
+      }
+      return HttpResponse.json({
+        content: sellerReviews,
+        totalElements: sellerReviews.length,
+        totalPages: sellerTotalPages,
+        number: page,
+        size: 10,
+      });
+    }),
+  );
+}
+
+describe("ProfileReviewTabs", () => {
+  beforeEach(() => {
+    replaceMock.mockClear();
+    setParams("");
+  });
+
+  it("renders both tabs and defaults to 'As Seller' active", async () => {
+    registerReviewHandler({ sellerReviews: [makeReview(1, "SELLER")] });
+
+    renderWithProviders(
+      <ProfileReviewTabs
+        userId={42}
+        avgSellerRating={4.5}
+        avgBuyerRating={4.8}
+        totalSellerReviews={3}
+        totalBuyerReviews={2}
+      />,
+      { auth: "anonymous" },
+    );
+
+    const sellerTab = await screen.findByTestId("profile-review-tab-seller");
+    const buyerTab = screen.getByTestId("profile-review-tab-buyer");
+    expect(sellerTab).toHaveAttribute("aria-selected", "true");
+    expect(buyerTab).toHaveAttribute("aria-selected", "false");
+    // Seller review is rendered under the active tab.
+    await waitFor(() =>
+      expect(screen.getByText("Reviewer 1")).toBeInTheDocument(),
+    );
+  });
+
+  it("syncs tab selection to the URL via ?tab=buyer", async () => {
+    registerReviewHandler({
+      sellerReviews: [makeReview(1, "SELLER")],
+      buyerReviews: [makeReview(2, "BUYER")],
+    });
+
+    renderWithProviders(
+      <ProfileReviewTabs
+        userId={42}
+        avgSellerRating={4.5}
+        avgBuyerRating={4.8}
+        totalSellerReviews={3}
+        totalBuyerReviews={2}
+      />,
+      { auth: "anonymous" },
+    );
+
+    const buyerTab = await screen.findByTestId("profile-review-tab-buyer");
+    await userEvent.click(buyerTab);
+
+    await waitFor(() => expect(replaceMock).toHaveBeenCalled());
+    const last = replaceMock.mock.calls.at(-1)?.[0] as string;
+    expect(last).toContain("tab=buyer");
+  });
+
+  it("activates the buyer tab from ?tab=buyer initial URL", async () => {
+    setParams("tab=buyer");
+    registerReviewHandler({
+      buyerReviews: [makeReview(7, "BUYER")],
+    });
+
+    renderWithProviders(
+      <ProfileReviewTabs
+        userId={42}
+        avgSellerRating={4.5}
+        avgBuyerRating={4.8}
+        totalSellerReviews={3}
+        totalBuyerReviews={2}
+      />,
+      { auth: "anonymous" },
+    );
+
+    const buyerTab = await screen.findByTestId("profile-review-tab-buyer");
+    expect(buyerTab).toHaveAttribute("aria-selected", "true");
+    await waitFor(() =>
+      expect(screen.getByText("Reviewer 7")).toBeInTheDocument(),
+    );
+  });
+
+  it("tracks independent page state per tab via sellerPage/buyerPage URL keys", async () => {
+    registerReviewHandler({
+      sellerReviews: [makeReview(1, "SELLER")],
+      sellerTotalPages: 3,
+    });
+
+    renderWithProviders(
+      <ProfileReviewTabs
+        userId={42}
+        avgSellerRating={4.5}
+        avgBuyerRating={4.8}
+        totalSellerReviews={30}
+        totalBuyerReviews={0}
+      />,
+      { auth: "anonymous" },
+    );
+
+    await screen.findByText("Reviewer 1");
+    // Click page 2 in the seller pagination — should sync sellerPage=1
+    await userEvent.click(screen.getByRole("button", { name: /page 2/i }));
+    await waitFor(() => expect(replaceMock).toHaveBeenCalled());
+    const last = replaceMock.mock.calls.at(-1)?.[0] as string;
+    expect(last).toContain("sellerPage=1");
+    // The buyerPage key is untouched — switching tabs preserves its state.
+    expect(last).not.toContain("buyerPage");
+  });
+
+  it("renders an empty-state per role when no reviews exist", async () => {
+    registerReviewHandler({
+      sellerReviews: [],
+      buyerReviews: [],
+      sellerTotalPages: 0,
+      buyerTotalPages: 0,
+    });
+
+    renderWithProviders(
+      <ProfileReviewTabs
+        userId={42}
+        avgSellerRating={null}
+        avgBuyerRating={null}
+        totalSellerReviews={0}
+        totalBuyerReviews={0}
+      />,
+      { auth: "anonymous" },
+    );
+
+    expect(
+      await screen.findByText("No reviews as seller yet"),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces the RatingSummary at the top of each tab", async () => {
+    registerReviewHandler({
+      sellerReviews: [makeReview(1, "SELLER")],
+    });
+
+    renderWithProviders(
+      <ProfileReviewTabs
+        userId={42}
+        avgSellerRating={4.7}
+        avgBuyerRating={4.8}
+        totalSellerReviews={23}
+        totalBuyerReviews={10}
+      />,
+      { auth: "anonymous" },
+    );
+
+    // The active seller panel shows the 4.7 / 23 reviews summary.
+    expect(
+      await screen.findByRole("img", {
+        name: /4\.7 out of 5 stars, 23 reviews/i,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/reviews/ProfileReviewTabs.tsx
+++ b/frontend/src/components/reviews/ProfileReviewTabs.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { Tab, TabGroup, TabList, TabPanel, TabPanels } from "@headlessui/react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useCallback, useMemo } from "react";
+import { cn } from "@/lib/cn";
+import { RatingSummary } from "./RatingSummary";
+import { ReviewList } from "./ReviewList";
+
+/**
+ * URL-synced key for the active tab. The backend enum is SELLER/BUYER but
+ * the URL uses the lowercase variant for friendliness. Kept as a map here
+ * rather than a {@code .toLowerCase()} call so TypeScript catches any
+ * typo at the call site.
+ */
+const TAB_SLUGS = ["seller", "buyer"] as const;
+type TabSlug = (typeof TAB_SLUGS)[number];
+
+/**
+ * Parse a raw {@code ?tab=…} value into one of our two slugs. Invalid
+ * values fall back to "seller" (the default active tab per spec §8.2) so
+ * malformed deep-links don't break the surface.
+ */
+function parseTab(raw: string | null): TabSlug {
+  if (raw === "buyer") return "buyer";
+  return "seller";
+}
+
+/**
+ * Parse a raw {@code ?page=…} value into a 0-indexed non-negative integer.
+ * Garbage values collapse to 0 so the fallback is "first page" rather than
+ * "error".
+ */
+function parsePage(raw: string | null): number {
+  if (!raw) return 0;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0) return 0;
+  return n;
+}
+
+export interface ProfileReviewTabsProps {
+  userId: number;
+  avgSellerRating: number | null;
+  avgBuyerRating: number | null;
+  totalSellerReviews: number;
+  totalBuyerReviews: number;
+  className?: string;
+}
+
+function ProfileReviewTabsContent({
+  userId,
+  avgSellerRating,
+  avgBuyerRating,
+  totalSellerReviews,
+  totalBuyerReviews,
+  className,
+}: ProfileReviewTabsProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const activeTab = parseTab(searchParams?.get("tab") ?? null);
+  // Per-tab page keys so switching tabs preserves each tab's pagination
+  // state. `sellerPage` / `buyerPage` live in the URL so deep-links work.
+  const sellerPage = parsePage(searchParams?.get("sellerPage") ?? null);
+  const buyerPage = parsePage(searchParams?.get("buyerPage") ?? null);
+
+  const syncParam = useCallback(
+    (key: string, value: string | null) => {
+      const next = new URLSearchParams(searchParams?.toString() ?? "");
+      if (value === null || value === "") {
+        next.delete(key);
+      } else {
+        next.set(key, value);
+      }
+      const qs = next.toString();
+      const url = qs ? `${pathname}?${qs}` : pathname;
+      router.replace(url, { scroll: false });
+    },
+    [pathname, router, searchParams],
+  );
+
+  const handleTabChange = useCallback(
+    (index: number) => {
+      const nextSlug = TAB_SLUGS[index] ?? "seller";
+      // Default tab omits the param to keep URLs tidy for the common case.
+      syncParam("tab", nextSlug === "seller" ? null : nextSlug);
+    },
+    [syncParam],
+  );
+
+  const handleSellerPageChange = useCallback(
+    (page: number) => {
+      syncParam("sellerPage", page === 0 ? null : String(page));
+    },
+    [syncParam],
+  );
+
+  const handleBuyerPageChange = useCallback(
+    (page: number) => {
+      syncParam("buyerPage", page === 0 ? null : String(page));
+    },
+    [syncParam],
+  );
+
+  const selectedIndex = useMemo(
+    () => TAB_SLUGS.indexOf(activeTab),
+    [activeTab],
+  );
+
+  return (
+    <TabGroup
+      selectedIndex={selectedIndex}
+      onChange={handleTabChange}
+      className={cn("flex flex-col gap-4", className)}
+    >
+      <TabList
+        aria-label="Reviews by role"
+        className="flex gap-1 border-b border-outline-variant"
+      >
+        <Tab
+          data-testid="profile-review-tab-seller"
+          className={({ selected }) =>
+            cn(
+              "px-4 py-2 text-label-lg transition-colors focus:outline-none",
+              selected
+                ? "text-primary border-b-2 border-primary"
+                : "text-on-surface-variant hover:text-on-surface",
+            )
+          }
+        >
+          As Seller
+        </Tab>
+        <Tab
+          data-testid="profile-review-tab-buyer"
+          className={({ selected }) =>
+            cn(
+              "px-4 py-2 text-label-lg transition-colors focus:outline-none",
+              selected
+                ? "text-primary border-b-2 border-primary"
+                : "text-on-surface-variant hover:text-on-surface",
+            )
+          }
+        >
+          As Buyer
+        </Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel
+          data-testid="profile-review-panel-seller"
+          className="flex flex-col gap-4 focus:outline-none"
+        >
+          <RatingSummary
+            rating={avgSellerRating}
+            reviewCount={totalSellerReviews}
+            size="md"
+          />
+          <ReviewList
+            userId={userId}
+            role="SELLER"
+            page={sellerPage}
+            onPageChange={handleSellerPageChange}
+          />
+        </TabPanel>
+        <TabPanel
+          data-testid="profile-review-panel-buyer"
+          className="flex flex-col gap-4 focus:outline-none"
+        >
+          <RatingSummary
+            rating={avgBuyerRating}
+            reviewCount={totalBuyerReviews}
+            size="md"
+          />
+          <ReviewList
+            userId={userId}
+            role="BUYER"
+            page={buyerPage}
+            onPageChange={handleBuyerPageChange}
+          />
+        </TabPanel>
+      </TabPanels>
+    </TabGroup>
+  );
+}
+
+/**
+ * Tabbed profile reviews section. Two tabs ("As Seller" default / "As
+ * Buyer") each hosting an independently paginated {@link ReviewList}. Tab
+ * selection and per-tab page state sync to the URL via
+ * {@code ?tab=seller|buyer}, {@code ?sellerPage=N}, {@code ?buyerPage=N}
+ * so deep-links and browser history work.
+ *
+ * <p>The inner component reads {@code useSearchParams}, which requires a
+ * {@code <Suspense>} boundary in Next.js 16 to keep the static-prerender
+ * pipeline from bailing. The wrapper owns the boundary so any caller can
+ * drop {@code <ProfileReviewTabs>} into a server component without
+ * thinking about it.
+ */
+export function ProfileReviewTabs(props: ProfileReviewTabsProps) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex flex-col gap-4">
+          <div className="h-10 border-b border-outline-variant" />
+          <div className="h-32" aria-hidden="true" />
+        </div>
+      }
+    >
+      <ProfileReviewTabsContent {...props} />
+    </Suspense>
+  );
+}

--- a/frontend/src/components/reviews/RatingSummary.test.tsx
+++ b/frontend/src/components/reviews/RatingSummary.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { renderWithProviders, screen } from "@/test/render";
+import { RatingSummary, starFillRatios } from "./RatingSummary";
+
+describe("RatingSummary", () => {
+  it("renders 'No ratings yet' when rating is null", () => {
+    renderWithProviders(<RatingSummary rating={null} reviewCount={0} />);
+    expect(screen.getByText("No ratings yet")).toBeInTheDocument();
+    expect(screen.queryAllByTestId("rating-star")).toHaveLength(0);
+  });
+
+  it("renders 'No ratings yet' when reviewCount is 0 even with a positive rating", () => {
+    // Guard against the backend briefly returning an AVG but 0 reviews during
+    // a race — the empty state is the correct UX.
+    renderWithProviders(<RatingSummary rating={4.5} reviewCount={0} />);
+    expect(screen.getByText("No ratings yet")).toBeInTheDocument();
+  });
+
+  it("renders five stars and the numeric average", () => {
+    renderWithProviders(<RatingSummary rating={4.2} reviewCount={12} />);
+    expect(screen.getAllByTestId("rating-star")).toHaveLength(5);
+    expect(screen.getByText("4.2")).toBeInTheDocument();
+    expect(screen.getByText("(12 reviews)")).toBeInTheDocument();
+  });
+
+  it("uses singular 'review' when count is 1", () => {
+    renderWithProviders(<RatingSummary rating={5.0} reviewCount={1} />);
+    expect(screen.getByText("(1 review)")).toBeInTheDocument();
+  });
+
+  it("omits the count when hideCountText is set", () => {
+    renderWithProviders(
+      <RatingSummary rating={5.0} reviewCount={1} hideCountText />,
+    );
+    expect(screen.queryByText(/review/)).not.toBeInTheDocument();
+  });
+
+  it("produces the correct per-star fill ratios across rating values", () => {
+    expect(starFillRatios(0)).toEqual([0, 0, 0, 0, 0]);
+    expect(starFillRatios(2.5)).toEqual([1, 1, 0.5, 0, 0]);
+    expect(starFillRatios(5.0)).toEqual([1, 1, 1, 1, 1]);
+    // 4.2 - 4 drifts with floating-point subtraction; assert with tolerance.
+    const fourPointTwo = starFillRatios(4.2);
+    expect(fourPointTwo.slice(0, 4)).toEqual([1, 1, 1, 1]);
+    expect(fourPointTwo[4]).toBeCloseTo(0.2, 10);
+  });
+
+  it("exposes the fill ratio via data-fill for partial stars", () => {
+    renderWithProviders(<RatingSummary rating={2.5} reviewCount={3} />);
+    const stars = screen.getAllByTestId("rating-star");
+    expect(stars[0].getAttribute("data-fill")).toBe("1.00");
+    expect(stars[2].getAttribute("data-fill")).toBe("0.50");
+    expect(stars[4].getAttribute("data-fill")).toBe("0.00");
+  });
+
+  it("renders in dark mode without hardcoded colors", () => {
+    const { container } = renderWithProviders(
+      <RatingSummary rating={3.5} reviewCount={2} />,
+      { theme: "dark", forceTheme: true },
+    );
+    // Gradient stops use CSS var tokens, not hex literals.
+    const html = container.innerHTML;
+    expect(html).toMatch(/var\(--color-primary\)/);
+    expect(html).toMatch(/var\(--color-surface-variant\)/);
+    expect(html).not.toMatch(/#[0-9a-fA-F]{3,6}/);
+  });
+
+  it("generates unique gradient ids across two summary instances", () => {
+    const { container } = renderWithProviders(
+      <>
+        <RatingSummary rating={4.0} reviewCount={1} />
+        <RatingSummary rating={4.0} reviewCount={1} />
+      </>,
+    );
+    const gradients = container.querySelectorAll("linearGradient");
+    const ids = Array.from(gradients).map((g) => g.getAttribute("id"));
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/frontend/src/components/reviews/RatingSummary.tsx
+++ b/frontend/src/components/reviews/RatingSummary.tsx
@@ -1,0 +1,157 @@
+import { useId } from "react";
+import { cn } from "@/lib/cn";
+
+/**
+ * Three display sizes for {@link RatingSummary}. The {@code star} / {@code text}
+ * / {@code count} slots map to Tailwind typography + sizing tokens so every
+ * caller picks a consistent pair — a tiny listing-card rating stays readable
+ * and the hero rating stays prominent without ad-hoc class overrides.
+ */
+type Size = "sm" | "md" | "lg";
+
+const SIZE_MAP: Record<
+  Size,
+  { star: string; text: string; count: string }
+> = {
+  sm: { star: "size-3.5", text: "text-label-md", count: "text-label-sm" },
+  md: { star: "size-4", text: "text-title-md font-bold", count: "text-body-sm" },
+  lg: { star: "size-5", text: "text-title-lg font-bold", count: "text-body-md" },
+};
+
+export interface RatingSummaryProps {
+  /** The average rating in [0, 5]. {@code null} → "No ratings yet". */
+  rating: number | null;
+  /** Number of reviews behind the average. 0 → "No ratings yet". */
+  reviewCount: number;
+  size?: Size;
+  /**
+   * When {@code true}, omits the "(12 reviews)" suffix. Used inside
+   * {@link ReviewCard} where the single-review rating gets a date stamp
+   * instead of a count.
+   */
+  hideCountText?: boolean;
+  className?: string;
+}
+
+interface PartialStarProps {
+  /**
+   * How full the star should draw, clamped to {@code [0, 1]}. Values
+   * between drive a {@code <linearGradient>} whose two stops sit at
+   * {@code fillRatio * 100%} to produce a sharp left-to-right split.
+   */
+  fillRatio: number;
+  className?: string;
+  /**
+   * Gradient id. Must be unique per star instance — multiple stars on one
+   * page with a duplicate id collapse to the first gradient's fill. Caller
+   * supplies a deterministic prefix (via {@code useId()}) plus the star
+   * index.
+   */
+  gradientId: string;
+}
+
+/**
+ * Star SVG with a two-stop linear gradient driving the partial fill. The
+ * filled portion uses {@code --color-primary}; the empty portion uses
+ * {@code --color-surface-variant}. Design-system tokens only — no dark
+ * variants because both theme tokens adapt automatically.
+ */
+function PartialStar({ fillRatio, className, gradientId }: PartialStarProps) {
+  const clamped = Math.max(0, Math.min(1, fillRatio));
+  const pct = clamped * 100;
+  const offset = `${pct}%`;
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      aria-hidden="true"
+      className={className}
+      data-testid="rating-star"
+      data-fill={clamped.toFixed(2)}
+    >
+      <defs>
+        <linearGradient id={gradientId}>
+          <stop
+            offset={offset}
+            style={{ stopColor: "var(--color-primary)" }}
+          />
+          <stop
+            offset={offset}
+            style={{ stopColor: "var(--color-surface-variant)" }}
+          />
+        </linearGradient>
+      </defs>
+      <path
+        d="M10 1l2.78 5.64 6.22.9-4.5 4.39 1.06 6.2L10 15.27l-5.56 2.86 1.06-6.2L1 7.54l6.22-.9L10 1z"
+        fill={`url(#${gradientId})`}
+        stroke="currentColor"
+        strokeWidth="0.5"
+        className="text-primary"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Compute the partial-star fill ratios for every position given a numeric
+ * rating. Exported for test coverage of the math across boundary values
+ * (0, 2.5, 4.2, 5.0) without having to scrape the DOM.
+ */
+export function starFillRatios(rating: number): number[] {
+  return [0, 1, 2, 3, 4].map((i) => Math.max(0, Math.min(1, rating - i)));
+}
+
+/**
+ * Five-star rating display with partial fills. Empty state ({@code rating
+ * === null} or {@code reviewCount === 0}) collapses to "No ratings yet".
+ * Uses {@link useId} for the gradient-id prefix so duplicate mounts on the
+ * same page don't collide — each {@link PartialStar} suffixes the shared
+ * prefix with its index.
+ */
+export function RatingSummary({
+  rating,
+  reviewCount,
+  size = "md",
+  hideCountText,
+  className,
+}: RatingSummaryProps) {
+  const reactId = useId();
+  const sz = SIZE_MAP[size];
+
+  if (rating === null || rating <= 0 || reviewCount === 0) {
+    return (
+      <span
+        className={cn(sz.count, "text-on-surface-variant", className)}
+        data-testid="rating-empty"
+      >
+        No ratings yet
+      </span>
+    );
+  }
+
+  const numeric = Number(rating);
+  const ratios = starFillRatios(numeric);
+  return (
+    <div
+      className={cn("flex items-center gap-2", className)}
+      role="img"
+      aria-label={`${numeric.toFixed(1)} out of 5 stars, ${reviewCount} review${reviewCount === 1 ? "" : "s"}`}
+    >
+      <div className="flex gap-0.5">
+        {ratios.map((fill, i) => (
+          <PartialStar
+            key={i}
+            fillRatio={fill}
+            className={sz.star}
+            gradientId={`${reactId}-star-${i}`}
+          />
+        ))}
+      </div>
+      <span className={sz.text}>{numeric.toFixed(1)}</span>
+      {!hideCountText && (
+        <span className={cn(sz.count, "text-on-surface-variant")}>
+          ({reviewCount} review{reviewCount === 1 ? "" : "s"})
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/reviews/RespondModal.test.tsx
+++ b/frontend/src/components/reviews/RespondModal.test.tsx
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/msw/server";
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/test/render";
+import { RespondModal } from "./RespondModal";
+
+describe("RespondModal", () => {
+  it("does not render when open=false", () => {
+    renderWithProviders(
+      <RespondModal reviewId={5} open={false} onClose={() => {}} />,
+      { auth: "authenticated" },
+    );
+    expect(screen.queryByTestId("respond-modal")).not.toBeInTheDocument();
+  });
+
+  it("disables submit until the textarea has non-whitespace content", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <RespondModal reviewId={5} open onClose={() => {}} />,
+      { auth: "authenticated" },
+    );
+    const submit = screen.getByTestId("respond-modal-submit");
+    expect(submit).toBeDisabled();
+    await user.type(
+      screen.getByTestId("respond-modal-textarea"),
+      "   ",
+    );
+    expect(submit).toBeDisabled();
+    await user.type(
+      screen.getByTestId("respond-modal-textarea"),
+      "Thanks!",
+    );
+    expect(submit).not.toBeDisabled();
+  });
+
+  it("shows a live character counter", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <RespondModal reviewId={5} open onClose={() => {}} />,
+      { auth: "authenticated" },
+    );
+    await user.type(screen.getByTestId("respond-modal-textarea"), "hi");
+    expect(screen.getByTestId("respond-modal-counter").textContent).toContain(
+      "2 / 500",
+    );
+  });
+
+  it("submits and closes on success", async () => {
+    const onClose = vi.fn();
+    server.use(
+      http.post("*/api/v1/reviews/:id/respond", () =>
+        HttpResponse.json(
+          { id: 99, text: "ok", createdAt: "2026-04-22T00:00:00Z" },
+          { status: 201 },
+        ),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(
+      <RespondModal reviewId={5} open onClose={onClose} />,
+      { auth: "authenticated" },
+    );
+    await user.type(
+      screen.getByTestId("respond-modal-textarea"),
+      "Thanks!",
+    );
+    await user.click(screen.getByTestId("respond-modal-submit"));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("closes on 409 duplicate-response even though the mutation errors", async () => {
+    const onClose = vi.fn();
+    server.use(
+      http.post("*/api/v1/reviews/:id/respond", () =>
+        HttpResponse.json({ status: 409 }, { status: 409 }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(
+      <RespondModal reviewId={5} open onClose={onClose} />,
+      { auth: "authenticated" },
+    );
+    await user.type(
+      screen.getByTestId("respond-modal-textarea"),
+      "Thanks!",
+    );
+    await user.click(screen.getByTestId("respond-modal-submit"));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/components/reviews/RespondModal.tsx
+++ b/frontend/src/components/reviews/RespondModal.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
+import { Button } from "@/components/ui/Button";
+import { FormError } from "@/components/ui/FormError";
+import { ApiError, isApiError } from "@/lib/api";
+import { cn } from "@/lib/cn";
+import { useRespondToReview } from "@/hooks/useReviews";
+
+const MAX_LEN = 500;
+
+export interface RespondModalProps {
+  reviewId: number;
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Modal form for the reviewee to post a single response to a revealed
+ * review. One-shot (no editing, spec §15) — on success the cache
+ * invalidation in {@link useRespondToReview} drives the card re-render
+ * with the nested response pill. 409 "already responded" is handled in the
+ * hook (via toast); we still close the modal here so the stale local state
+ * does not linger.
+ */
+export function RespondModal({ reviewId, open, onClose }: RespondModalProps) {
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const mutation = useRespondToReview(reviewId);
+
+  // Local state resets automatically when the modal unmounts — callers
+  // (ReviewCard, ReviewPanel) should mount us only when {@code open} is
+  // true so a cancelled-then-reopened modal starts with a fresh
+  // textarea.
+
+  const trimmed = text.trim();
+  const overLimit = text.length > MAX_LEN;
+  const canSubmit = trimmed.length > 0 && !overLimit && !mutation.isPending;
+
+  const submit = async () => {
+    if (!canSubmit) return;
+    setError(null);
+    try {
+      await mutation.mutateAsync({ text: trimmed });
+      onClose();
+    } catch (e) {
+      if (isApiError(e) && e.status === 409) {
+        // Hook already fires the toast; close so the caller refetches and
+        // renders the (already-submitted) response.
+        onClose();
+        return;
+      }
+      if (e instanceof ApiError) {
+        setError(e.problem.detail ?? e.problem.title ?? "Could not respond.");
+        return;
+      }
+      setError("Could not respond. Please try again.");
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} className="relative z-50">
+      <div
+        className="fixed inset-0 bg-inverse-surface/40 backdrop-blur-sm"
+        aria-hidden="true"
+      />
+      <div className="fixed inset-0 flex items-center justify-center p-4">
+        <DialogPanel
+          data-testid="respond-modal"
+          className="w-full max-w-md flex flex-col gap-4 rounded-default bg-surface-container-low p-6"
+        >
+          <DialogTitle className="text-title-lg text-on-surface">
+            Respond to this review
+          </DialogTitle>
+          <p className="text-body-sm text-on-surface-variant">
+            Your response appears publicly beneath the review. You can only
+            respond once — no edits.
+          </p>
+          <FormError message={error ?? undefined} />
+          <label className="flex flex-col gap-1">
+            <span className="sr-only">Response text</span>
+            <textarea
+              rows={5}
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              placeholder="Say something constructive…"
+              data-testid="respond-modal-textarea"
+              className="w-full resize-y rounded-default bg-surface-container-low px-4 py-3 text-on-surface placeholder:text-on-surface-variant ring-1 ring-outline-variant transition-all focus:outline-none focus:ring-primary"
+            />
+          </label>
+          <div
+            data-testid="respond-modal-counter"
+            className={cn(
+              "self-end text-label-sm",
+              overLimit ? "text-error" : "text-on-surface-variant",
+            )}
+          >
+            {text.length} / {MAX_LEN}
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="secondary"
+              onClick={onClose}
+              disabled={mutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={submit}
+              disabled={!canSubmit}
+              loading={mutation.isPending}
+              data-testid="respond-modal-submit"
+            >
+              Post response
+            </Button>
+          </div>
+        </DialogPanel>
+      </div>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/reviews/RespondModal.tsx
+++ b/frontend/src/components/reviews/RespondModal.tsx
@@ -3,8 +3,7 @@
 import { useState } from "react";
 import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
 import { Button } from "@/components/ui/Button";
-import { FormError } from "@/components/ui/FormError";
-import { ApiError, isApiError } from "@/lib/api";
+import { isApiError } from "@/lib/api";
 import { cn } from "@/lib/cn";
 import { useRespondToReview } from "@/hooks/useReviews";
 
@@ -26,7 +25,6 @@ export interface RespondModalProps {
  */
 export function RespondModal({ reviewId, open, onClose }: RespondModalProps) {
   const [text, setText] = useState("");
-  const [error, setError] = useState<string | null>(null);
   const mutation = useRespondToReview(reviewId);
 
   // Local state resets automatically when the modal unmounts — callers
@@ -40,7 +38,6 @@ export function RespondModal({ reviewId, open, onClose }: RespondModalProps) {
 
   const submit = async () => {
     if (!canSubmit) return;
-    setError(null);
     try {
       await mutation.mutateAsync({ text: trimmed });
       onClose();
@@ -51,11 +48,8 @@ export function RespondModal({ reviewId, open, onClose }: RespondModalProps) {
         onClose();
         return;
       }
-      if (e instanceof ApiError) {
-        setError(e.problem.detail ?? e.problem.title ?? "Could not respond.");
-        return;
-      }
-      setError("Could not respond. Please try again.");
+      // Non-409 errors surface via the hook's toast; leave the modal open
+      // with the textarea preserved so the user can retry.
     }
   };
 
@@ -77,7 +71,6 @@ export function RespondModal({ reviewId, open, onClose }: RespondModalProps) {
             Your response appears publicly beneath the review. You can only
             respond once — no edits.
           </p>
-          <FormError message={error ?? undefined} />
           <label className="flex flex-col gap-1">
             <span className="sr-only">Response text</span>
             <textarea

--- a/frontend/src/components/reviews/ReviewCard.test.tsx
+++ b/frontend/src/components/reviews/ReviewCard.test.tsx
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { renderWithProviders, screen } from "@/test/render";
+import { mockUser } from "@/test/msw/fixtures";
+import type { ReviewDto } from "@/types/review";
+import { ReviewCard } from "./ReviewCard";
+
+function makeReview(overrides: Partial<ReviewDto> = {}): ReviewDto {
+  return {
+    id: 1,
+    auctionId: 10,
+    auctionTitle: "Aurora Parcel",
+    auctionPrimaryPhotoUrl: null,
+    reviewerId: 100,
+    reviewerDisplayName: "Alice",
+    reviewerAvatarUrl: null,
+    revieweeId: 200,
+    reviewedRole: "SELLER",
+    rating: 5,
+    text: "Great seller, would buy again.\nTwo newlines.",
+    visible: true,
+    pending: false,
+    submittedAt: "2026-04-18T12:00:00Z",
+    revealedAt: "2026-04-19T12:00:00Z",
+    response: null,
+    ...overrides,
+  };
+}
+
+describe("ReviewCard", () => {
+  it("renders reviewer name, rating stars, and review text", () => {
+    renderWithProviders(<ReviewCard review={makeReview()} />, {
+      auth: "anonymous",
+    });
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getAllByTestId("rating-star")).toHaveLength(5);
+    expect(screen.getByTestId("review-card-text").textContent).toContain(
+      "Great seller",
+    );
+  });
+
+  it("renders text with whitespace-pre-wrap so newlines show", () => {
+    renderWithProviders(<ReviewCard review={makeReview()} />, {
+      auth: "anonymous",
+    });
+    const text = screen.getByTestId("review-card-text");
+    expect(text.className).toMatch(/whitespace-pre-wrap/);
+  });
+
+  it("renders an auction link by default and hides it when hideAuctionLink is set", () => {
+    const { rerender } = renderWithProviders(
+      <ReviewCard review={makeReview()} />,
+      { auth: "anonymous" },
+    );
+    const link = screen.getByTestId("review-card-auction-link");
+    expect(link).toHaveAttribute("href", "/auction/10");
+    expect(link.textContent).toContain("Aurora Parcel");
+    rerender(<ReviewCard review={makeReview()} hideAuctionLink />);
+    expect(
+      screen.queryByTestId("review-card-auction-link"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the flag button for the review's author", () => {
+    // mockUser.id === 100, which matches reviewerId. The author can't flag
+    // themselves.
+    renderWithProviders(
+      <ReviewCard review={makeReview({ reviewerId: mockUser.id })} />,
+      { auth: "authenticated" },
+    );
+    expect(screen.queryByTestId("review-card-flag")).not.toBeInTheDocument();
+  });
+
+  it("shows the flag button for non-authors", () => {
+    renderWithProviders(
+      <ReviewCard review={makeReview({ reviewerId: 999, revieweeId: 888 })} />,
+      { auth: "authenticated" },
+    );
+    expect(screen.getByTestId("review-card-flag")).toBeInTheDocument();
+  });
+
+  it("hides the flag button for anonymous viewers", () => {
+    renderWithProviders(<ReviewCard review={makeReview()} />, {
+      auth: "anonymous",
+    });
+    expect(screen.queryByTestId("review-card-flag")).not.toBeInTheDocument();
+  });
+
+  it("shows the respond button only when viewer is reviewee AND no response exists", () => {
+    // Viewer is the reviewee (reviewedRole=SELLER so viewer is the seller)
+    // and no response posted yet → button shows.
+    const reviewee = makeReview({ revieweeId: mockUser.id, response: null });
+    renderWithProviders(<ReviewCard review={reviewee} />, {
+      auth: "authenticated",
+    });
+    expect(screen.getByTestId("review-card-respond")).toBeInTheDocument();
+  });
+
+  it("hides the respond button when a response already exists", () => {
+    const reviewed = makeReview({
+      revieweeId: mockUser.id,
+      response: {
+        id: 99,
+        text: "Thanks",
+        createdAt: "2026-04-19T13:00:00Z",
+      },
+    });
+    renderWithProviders(<ReviewCard review={reviewed} />, {
+      auth: "authenticated",
+    });
+    expect(
+      screen.queryByTestId("review-card-respond"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the response section with 'Seller response' label for SELLER reviews", () => {
+    const r = makeReview({
+      reviewedRole: "SELLER",
+      response: {
+        id: 99,
+        text: "Thanks, enjoy the parcel!",
+        createdAt: "2026-04-19T13:00:00Z",
+      },
+    });
+    renderWithProviders(<ReviewCard review={r} />, { auth: "anonymous" });
+    const response = screen.getByTestId("review-card-response");
+    expect(response.textContent).toContain("Seller response");
+    expect(response.textContent).toContain("Thanks, enjoy the parcel!");
+  });
+
+  it("labels the response as 'Buyer response' for BUYER reviews", () => {
+    const r = makeReview({
+      reviewedRole: "BUYER",
+      response: {
+        id: 99,
+        text: "Cheers",
+        createdAt: "2026-04-19T13:00:00Z",
+      },
+    });
+    renderWithProviders(<ReviewCard review={r} />, { auth: "anonymous" });
+    expect(screen.getByTestId("review-card-response").textContent).toContain(
+      "Buyer response",
+    );
+  });
+
+  it("renders an absolute timestamp in the time tag's title attribute", () => {
+    renderWithProviders(<ReviewCard review={makeReview()} />, {
+      auth: "anonymous",
+    });
+    const time = screen.getByText(
+      (_, el) => el?.tagName === "TIME" && el.getAttribute("datetime") === "2026-04-18T12:00:00Z",
+    );
+    expect(time).toHaveAttribute("title");
+    expect(time.getAttribute("title")?.length).toBeGreaterThan(0);
+  });
+
+  it("renders in dark mode without hardcoded hex colors", () => {
+    const { container } = renderWithProviders(
+      <ReviewCard review={makeReview()} />,
+      { theme: "dark", forceTheme: true, auth: "anonymous" },
+    );
+    expect(container.innerHTML).not.toMatch(/#[0-9a-fA-F]{6}/);
+  });
+});

--- a/frontend/src/components/reviews/ReviewCard.tsx
+++ b/frontend/src/components/reviews/ReviewCard.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Avatar } from "@/components/ui/Avatar";
+import { Button } from "@/components/ui/Button";
+import { CornerDownRight, Flag } from "@/components/ui/icons";
+import { useAuth } from "@/lib/auth";
+import { cn } from "@/lib/cn";
+import { formatAbsoluteTime, formatRelativeTime } from "@/lib/time/relativeTime";
+import type { ReviewDto } from "@/types/review";
+import { FlagModal } from "./FlagModal";
+import { RatingSummary } from "./RatingSummary";
+import { RespondModal } from "./RespondModal";
+
+export interface ReviewCardProps {
+  review: ReviewDto;
+  /**
+   * When {@code true}, the auction-link pill below the review text is
+   * hidden — useful on the escrow page where the review is already in
+   * auction context.
+   */
+  hideAuctionLink?: boolean;
+  className?: string;
+}
+
+/**
+ * Label for the reviewee's response pill — mirrors the role of the
+ * reviewee, not the reviewer (spec §8.2). A SELLER review is authored by
+ * the buyer about the seller, so the response comes from the seller and
+ * reads "Seller response".
+ */
+function responseLabel(reviewedRole: ReviewDto["reviewedRole"]): string {
+  return reviewedRole === "SELLER" ? "Seller response" : "Buyer response";
+}
+
+export function ReviewCard({
+  review,
+  hideAuctionLink,
+  className,
+}: ReviewCardProps) {
+  const { status, user } = useAuth();
+  const viewerId = status === "authenticated" ? user.id : null;
+  const [flagOpen, setFlagOpen] = useState(false);
+  const [respondOpen, setRespondOpen] = useState(false);
+
+  const viewerIsAuthor = viewerId !== null && viewerId === review.reviewerId;
+  const viewerIsReviewee = viewerId !== null && viewerId === review.revieweeId;
+  const canRespond = viewerIsReviewee && review.response === null;
+  const canFlag = viewerId !== null && !viewerIsAuthor;
+
+  const rating = review.rating ?? 0;
+  const submittedAt = review.submittedAt ?? review.revealedAt;
+
+  return (
+    <article
+      data-testid="review-card"
+      data-review-id={review.id}
+      className={cn(
+        "flex flex-col gap-3 rounded-default bg-surface-container-low p-4 ring-1 ring-outline-variant",
+        className,
+      )}
+    >
+      <header className="flex items-start gap-3">
+        <Avatar
+          src={review.reviewerAvatarUrl ?? undefined}
+          alt={review.reviewerDisplayName}
+          name={review.reviewerDisplayName}
+          size="sm"
+        />
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+            <span className="text-body-md font-medium text-on-surface">
+              {review.reviewerDisplayName}
+            </span>
+            {submittedAt && (
+              <time
+                dateTime={submittedAt}
+                title={formatAbsoluteTime(submittedAt)}
+                className="text-label-sm text-on-surface-variant"
+              >
+                {formatRelativeTime(submittedAt)}
+              </time>
+            )}
+          </div>
+          <div className="mt-1">
+            <RatingSummary
+              rating={rating > 0 ? rating : null}
+              reviewCount={rating > 0 ? 1 : 0}
+              size="sm"
+              hideCountText
+            />
+          </div>
+        </div>
+        {canFlag && (
+          <button
+            type="button"
+            onClick={() => setFlagOpen(true)}
+            className="inline-flex shrink-0 items-center gap-1 rounded-default px-2 py-1 text-label-sm text-on-surface-variant transition-colors hover:text-on-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            aria-label="Flag this review"
+            data-testid="review-card-flag"
+          >
+            <Flag className="size-3.5" aria-hidden="true" />
+            <span>Flag</span>
+          </button>
+        )}
+      </header>
+
+      {review.text && (
+        <p
+          className="whitespace-pre-wrap text-body-md text-on-surface"
+          data-testid="review-card-text"
+        >
+          {review.text}
+        </p>
+      )}
+
+      {!hideAuctionLink && (
+        <Link
+          href={`/auction/${review.auctionId}`}
+          className="inline-flex w-fit items-center gap-1 rounded-default bg-surface-container px-3 py-1 text-label-sm text-on-surface-variant transition-colors hover:text-primary"
+          data-testid="review-card-auction-link"
+        >
+          <span className="truncate">{review.auctionTitle}</span>
+        </Link>
+      )}
+
+      {review.response && (
+        <div
+          className="ml-6 flex flex-col gap-1 rounded-default bg-surface-container px-3 py-2"
+          data-testid="review-card-response"
+        >
+          <div className="flex items-center gap-1 text-label-sm font-medium text-on-surface-variant">
+            <CornerDownRight className="size-3.5" aria-hidden="true" />
+            <span>{responseLabel(review.reviewedRole)}</span>
+            <time
+              dateTime={review.response.createdAt}
+              title={formatAbsoluteTime(review.response.createdAt)}
+              className="text-label-sm text-on-surface-variant"
+            >
+              · {formatRelativeTime(review.response.createdAt)}
+            </time>
+          </div>
+          <p className="whitespace-pre-wrap text-body-md text-on-surface">
+            {review.response.text}
+          </p>
+        </div>
+      )}
+
+      {canRespond && (
+        <div className="flex justify-end">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setRespondOpen(true)}
+            data-testid="review-card-respond"
+          >
+            Respond
+          </Button>
+        </div>
+      )}
+
+      {flagOpen && (
+        <FlagModal
+          reviewId={review.id}
+          open={flagOpen}
+          onClose={() => setFlagOpen(false)}
+        />
+      )}
+      {respondOpen && (
+        <RespondModal
+          reviewId={review.id}
+          open={respondOpen}
+          onClose={() => setRespondOpen(false)}
+        />
+      )}
+    </article>
+  );
+}

--- a/frontend/src/components/reviews/ReviewList.test.tsx
+++ b/frontend/src/components/reviews/ReviewList.test.tsx
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, screen, userEvent, waitFor } from "@/test/render";
+import { server } from "@/test/msw/server";
+import type { ReviewDto } from "@/types/review";
+import { ReviewList } from "./ReviewList";
+
+function makeReview(id: number, overrides: Partial<ReviewDto> = {}): ReviewDto {
+  return {
+    id,
+    auctionId: id * 10,
+    auctionTitle: `Parcel #${id}`,
+    auctionPrimaryPhotoUrl: null,
+    reviewerId: 100 + id,
+    reviewerDisplayName: `Reviewer ${id}`,
+    reviewerAvatarUrl: null,
+    revieweeId: 42,
+    reviewedRole: "SELLER",
+    rating: 5,
+    text: `Review text ${id}`,
+    visible: true,
+    pending: false,
+    submittedAt: "2026-04-18T12:00:00Z",
+    revealedAt: "2026-04-19T12:00:00Z",
+    response: null,
+    ...overrides,
+  };
+}
+
+describe("ReviewList", () => {
+  it("renders a card per review from the paged response", async () => {
+    server.use(
+      http.get("*/api/v1/users/:id/reviews", () =>
+        HttpResponse.json({
+          content: [makeReview(1), makeReview(2), makeReview(3)],
+          totalElements: 3,
+          totalPages: 1,
+          number: 0,
+          size: 10,
+        }),
+      ),
+    );
+
+    renderWithProviders(
+      <ReviewList userId={42} role="SELLER" page={0} onPageChange={() => {}} />,
+      { auth: "anonymous" },
+    );
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId("review-card")).toHaveLength(3),
+    );
+  });
+
+  it("renders the seller-specific empty state when there are no reviews", async () => {
+    server.use(
+      http.get("*/api/v1/users/:id/reviews", () =>
+        HttpResponse.json({
+          content: [],
+          totalElements: 0,
+          totalPages: 0,
+          number: 0,
+          size: 10,
+        }),
+      ),
+    );
+
+    renderWithProviders(
+      <ReviewList userId={42} role="SELLER" page={0} onPageChange={() => {}} />,
+      { auth: "anonymous" },
+    );
+
+    expect(
+      await screen.findByText("No reviews as seller yet"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the buyer-specific empty state when there are no reviews", async () => {
+    server.use(
+      http.get("*/api/v1/users/:id/reviews", () =>
+        HttpResponse.json({
+          content: [],
+          totalElements: 0,
+          totalPages: 0,
+          number: 0,
+          size: 10,
+        }),
+      ),
+    );
+
+    renderWithProviders(
+      <ReviewList userId={42} role="BUYER" page={0} onPageChange={() => {}} />,
+      { auth: "anonymous" },
+    );
+
+    expect(
+      await screen.findByText("No reviews as buyer yet"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders pagination when totalPages > 1 and fires onPageChange on click", async () => {
+    server.use(
+      http.get("*/api/v1/users/:id/reviews", () =>
+        HttpResponse.json({
+          content: [makeReview(1)],
+          totalElements: 25,
+          totalPages: 3,
+          number: 0,
+          size: 10,
+        }),
+      ),
+    );
+
+    const onPageChange = vi.fn();
+    renderWithProviders(
+      <ReviewList
+        userId={42}
+        role="SELLER"
+        page={0}
+        onPageChange={onPageChange}
+      />,
+      { auth: "anonymous" },
+    );
+
+    await screen.findByTestId("review-list-seller");
+    await userEvent.click(screen.getByRole("button", { name: /page 2/i }));
+    expect(onPageChange).toHaveBeenCalledWith(1);
+  });
+
+  it("omits pagination when only one page of results", async () => {
+    server.use(
+      http.get("*/api/v1/users/:id/reviews", () =>
+        HttpResponse.json({
+          content: [makeReview(1)],
+          totalElements: 1,
+          totalPages: 1,
+          number: 0,
+          size: 10,
+        }),
+      ),
+    );
+
+    renderWithProviders(
+      <ReviewList userId={42} role="SELLER" page={0} onPageChange={() => {}} />,
+      { auth: "anonymous" },
+    );
+
+    await screen.findByTestId("review-list-seller");
+    expect(
+      screen.queryByRole("navigation", { name: /pagination/i }),
+    ).toBeNull();
+  });
+
+  it("renders an error state when the request fails", async () => {
+    server.use(
+      http.get("*/api/v1/users/:id/reviews", () =>
+        HttpResponse.json({ status: 500 }, { status: 500 }),
+      ),
+    );
+
+    renderWithProviders(
+      <ReviewList userId={42} role="SELLER" page={0} onPageChange={() => {}} />,
+      { auth: "anonymous" },
+    );
+
+    expect(
+      await screen.findByText("Could not load reviews"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/reviews/ReviewList.tsx
+++ b/frontend/src/components/reviews/ReviewList.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { AlertCircle, MessageSquare } from "@/components/ui/icons";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { Pagination } from "@/components/ui/Pagination";
+import { useUserReviews } from "@/hooks/useReviews";
+import type { ReviewedRole } from "@/types/review";
+import { ReviewCard } from "./ReviewCard";
+
+export interface ReviewListProps {
+  userId: number;
+  role: ReviewedRole;
+  /** 0-indexed current page. */
+  page: number;
+  onPageChange: (page: number) => void;
+}
+
+/**
+ * Paginated list of {@link ReviewCard} for one user + role. Loading,
+ * error, and role-specific empty states live here so {@link
+ * ProfileReviewTabs} can focus on tab routing. Page number is driven by
+ * the caller (URL-synced) so switching tabs preserves each tab's
+ * independent pagination.
+ */
+export function ReviewList({ userId, role, page, onPageChange }: ReviewListProps) {
+  const { data, isPending, isError } = useUserReviews(userId, role, page);
+
+  if (isPending) {
+    return (
+      <div className="flex justify-center py-8">
+        <LoadingSpinner label="Loading reviews..." />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <EmptyState
+        icon={AlertCircle}
+        headline="Could not load reviews"
+        description="Please try again in a moment."
+      />
+    );
+  }
+
+  if (data.content.length === 0) {
+    return (
+      <EmptyState
+        icon={MessageSquare}
+        headline={
+          role === "SELLER"
+            ? "No reviews as seller yet"
+            : "No reviews as buyer yet"
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4" data-testid={`review-list-${role.toLowerCase()}`}>
+      <ul className="flex flex-col gap-3">
+        {data.content.map((review) => (
+          <li key={review.id}>
+            <ReviewCard review={review} />
+          </li>
+        ))}
+      </ul>
+      {data.totalPages > 1 && (
+        <Pagination
+          page={data.number}
+          totalPages={data.totalPages}
+          onPageChange={onPageChange}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/reviews/ReviewPanel.test.tsx
+++ b/frontend/src/components/reviews/ReviewPanel.test.tsx
@@ -1,0 +1,445 @@
+import { describe, expect, it, vi } from "vitest";
+import { act, type ReactElement, type ReactNode } from "react";
+import { http, HttpResponse } from "msw";
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "next-themes";
+import { ToastProvider } from "@/components/ui/Toast";
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/test/render";
+import { server } from "@/test/msw/server";
+import type { AuthUser } from "@/lib/auth/session";
+import type { AuctionReviewsResponse, ReviewDto } from "@/types/review";
+import {
+  deriveReviewPanelState,
+  ReviewPanel,
+} from "./ReviewPanel";
+
+// --------------------------------------------------------------------------
+// Fixtures
+// --------------------------------------------------------------------------
+
+const partyUser: AuthUser = {
+  id: 42,
+  email: "party@example.com",
+  displayName: "Party",
+  slAvatarUuid: null,
+  verified: true,
+};
+
+function makeReview(overrides: Partial<ReviewDto> = {}): ReviewDto {
+  return {
+    id: 1,
+    auctionId: 7,
+    auctionTitle: "Aurora Parcel",
+    auctionPrimaryPhotoUrl: null,
+    reviewerId: 42,
+    reviewerDisplayName: "Party",
+    reviewerAvatarUrl: null,
+    revieweeId: 77,
+    reviewedRole: "SELLER",
+    rating: 5,
+    text: "Smooth transaction.",
+    visible: true,
+    pending: false,
+    submittedAt: "2026-04-18T12:00:00Z",
+    revealedAt: "2026-04-19T12:00:00Z",
+    response: null,
+    ...overrides,
+  };
+}
+
+function stubEnvelope(
+  envelope: AuctionReviewsResponse,
+  { auctionId = 7 }: { auctionId?: number } = {},
+) {
+  server.use(
+    http.get(`*/api/v1/auctions/${auctionId}/reviews`, () =>
+      HttpResponse.json(envelope),
+    ),
+  );
+}
+
+// --------------------------------------------------------------------------
+// Pure helper tests
+// --------------------------------------------------------------------------
+
+describe("deriveReviewPanelState", () => {
+  const NOW = new Date("2026-05-01T12:00:00Z");
+  const future = "2026-05-10T00:00:00Z";
+  const past = "2026-04-20T00:00:00Z";
+
+  it("returns loading when envelope is undefined", () => {
+    expect(deriveReviewPanelState(undefined, true, NOW)).toBe("loading");
+  });
+
+  it("returns submit when canReview is true", () => {
+    expect(
+      deriveReviewPanelState(
+        {
+          reviews: [],
+          myPendingReview: null,
+          canReview: true,
+          windowClosesAt: future,
+        },
+        true,
+        NOW,
+      ),
+    ).toBe("submit");
+  });
+
+  it("returns pending when myPendingReview is set", () => {
+    expect(
+      deriveReviewPanelState(
+        {
+          reviews: [],
+          myPendingReview: makeReview({ visible: false, pending: true }),
+          canReview: false,
+          windowClosesAt: future,
+        },
+        true,
+        NOW,
+      ),
+    ).toBe("pending");
+  });
+
+  it("returns revealed-both when reviews.length >= 2", () => {
+    expect(
+      deriveReviewPanelState(
+        {
+          reviews: [makeReview({ id: 1 }), makeReview({ id: 2 })],
+          myPendingReview: null,
+          canReview: false,
+          windowClosesAt: past,
+        },
+        true,
+        NOW,
+      ),
+    ).toBe("revealed-both");
+  });
+
+  it("returns revealed-one when reviews.length === 1", () => {
+    expect(
+      deriveReviewPanelState(
+        {
+          reviews: [makeReview()],
+          myPendingReview: null,
+          canReview: false,
+          windowClosesAt: past,
+        },
+        true,
+        NOW,
+      ),
+    ).toBe("revealed-one");
+  });
+
+  it("returns window-closed-none for parties with elapsed windowClosesAt and no reviews", () => {
+    expect(
+      deriveReviewPanelState(
+        {
+          reviews: [],
+          myPendingReview: null,
+          canReview: false,
+          windowClosesAt: past,
+        },
+        true,
+        NOW,
+      ),
+    ).toBe("window-closed-none");
+  });
+
+  it("returns read-only for non-parties even when the window is closed", () => {
+    expect(
+      deriveReviewPanelState(
+        {
+          reviews: [],
+          myPendingReview: null,
+          canReview: false,
+          windowClosesAt: past,
+        },
+        false,
+        NOW,
+      ),
+    ).toBe("read-only");
+  });
+});
+
+// --------------------------------------------------------------------------
+// Rendering tests — one per derived state
+// --------------------------------------------------------------------------
+
+describe("ReviewPanel", () => {
+  it("renders the hash-scroll id on the panel root", async () => {
+    stubEnvelope({
+      reviews: [],
+      myPendingReview: null,
+      canReview: true,
+      windowClosesAt: "2026-05-10T00:00:00Z",
+    });
+    renderWithProviders(<ReviewPanel auctionId={7} isParty />, {
+      auth: "authenticated",
+      authUser: partyUser,
+    });
+    const panel = await screen.findByTestId("review-panel");
+    expect(panel).toHaveAttribute("id", "review-panel");
+  });
+
+  it("renders the submit state when canReview=true and no pending review", async () => {
+    stubEnvelope({
+      reviews: [],
+      myPendingReview: null,
+      canReview: true,
+      windowClosesAt: "2026-05-10T00:00:00Z",
+    });
+    renderWithProviders(<ReviewPanel auctionId={7} isParty />, {
+      auth: "authenticated",
+      authUser: partyUser,
+    });
+    expect(
+      await screen.findByTestId("review-panel-submit"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("review-panel-submit-button"),
+    ).toBeDisabled();
+  });
+
+  it("enables submit once a rating is selected", async () => {
+    stubEnvelope({
+      reviews: [],
+      myPendingReview: null,
+      canReview: true,
+      windowClosesAt: "2026-05-10T00:00:00Z",
+    });
+    const user = userEvent.setup();
+    renderWithProviders(<ReviewPanel auctionId={7} isParty />, {
+      auth: "authenticated",
+      authUser: partyUser,
+    });
+    await screen.findByTestId("review-panel-submit");
+    await user.click(screen.getByTestId("star-selector-4"));
+    expect(
+      screen.getByTestId("review-panel-submit-button"),
+    ).not.toBeDisabled();
+  });
+
+  it("POSTs the review on submit click", async () => {
+    stubEnvelope({
+      reviews: [],
+      myPendingReview: null,
+      canReview: true,
+      windowClosesAt: "2026-05-10T00:00:00Z",
+    });
+    const submitSpy = vi.fn();
+    server.use(
+      http.post("*/api/v1/auctions/7/reviews", async ({ request }) => {
+        submitSpy(await request.json());
+        return HttpResponse.json(
+          makeReview({ visible: false, pending: true, rating: 4 }),
+        );
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<ReviewPanel auctionId={7} isParty />, {
+      auth: "authenticated",
+      authUser: partyUser,
+    });
+    await screen.findByTestId("review-panel-submit");
+    await user.click(screen.getByTestId("star-selector-4"));
+    await user.type(
+      screen.getByTestId("review-panel-submit-text"),
+      "Great seller",
+    );
+    await user.click(screen.getByTestId("review-panel-submit-button"));
+    await waitFor(() => expect(submitSpy).toHaveBeenCalledOnce());
+    expect(submitSpy).toHaveBeenCalledWith({
+      rating: 4,
+      text: "Great seller",
+    });
+  });
+
+  it("renders the pending state with the viewer's own rating + text", async () => {
+    const pending = makeReview({
+      id: 99,
+      rating: 4,
+      text: "Line one.\nLine two.",
+      visible: false,
+      pending: true,
+    });
+    stubEnvelope({
+      reviews: [],
+      myPendingReview: pending,
+      canReview: false,
+      windowClosesAt: "2026-05-10T00:00:00Z",
+    });
+    renderWithProviders(<ReviewPanel auctionId={7} isParty />, {
+      auth: "authenticated",
+      authUser: partyUser,
+    });
+    expect(
+      await screen.findByTestId("review-panel-pending"),
+    ).toBeInTheDocument();
+    const text = screen.getByTestId("review-panel-pending-text");
+    expect(text.textContent).toContain("Line one.");
+    expect(text.className).toMatch(/whitespace-pre-wrap/);
+  });
+
+  it("renders revealed-both when there are two visible reviews", async () => {
+    stubEnvelope({
+      reviews: [
+        makeReview({ id: 1, reviewerId: 42, reviewerDisplayName: "Party" }),
+        makeReview({
+          id: 2,
+          reviewerId: 77,
+          reviewerDisplayName: "Other",
+          reviewedRole: "BUYER",
+        }),
+      ],
+      myPendingReview: null,
+      canReview: false,
+      windowClosesAt: "2026-04-15T00:00:00Z",
+    });
+    renderWithProviders(<ReviewPanel auctionId={7} isParty />, {
+      auth: "authenticated",
+      authUser: partyUser,
+    });
+    expect(
+      await screen.findByTestId("review-panel-revealed"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByTestId("review-card")).toHaveLength(2);
+  });
+
+  it("renders revealed-one with the window-closed note when the viewer never submitted", async () => {
+    stubEnvelope({
+      reviews: [makeReview({ id: 1, reviewerId: 77 })],
+      myPendingReview: null,
+      canReview: false,
+      windowClosesAt: "2026-04-15T00:00:00Z",
+    });
+    renderWithProviders(<ReviewPanel auctionId={7} isParty />, {
+      auth: "authenticated",
+      authUser: partyUser,
+    });
+    expect(
+      await screen.findByTestId("review-panel-revealed"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByTestId("review-card")).toHaveLength(1);
+    expect(
+      screen.getByTestId("review-panel-window-closed-note"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders window-closed-none for a party viewer past the window with no reviews", async () => {
+    stubEnvelope({
+      reviews: [],
+      myPendingReview: null,
+      canReview: false,
+      windowClosesAt: "2020-01-01T00:00:00Z",
+    });
+    renderWithProviders(<ReviewPanel auctionId={7} isParty />, {
+      auth: "authenticated",
+      authUser: partyUser,
+    });
+    expect(
+      await screen.findByTestId("review-panel-window-closed"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the read-only fallback for anonymous viewers when there are no reviews", async () => {
+    stubEnvelope({
+      reviews: [],
+      myPendingReview: null,
+      canReview: false,
+      windowClosesAt: "2020-01-01T00:00:00Z",
+    });
+    renderWithProviders(<ReviewPanel auctionId={7} isParty={false} />, {
+      auth: "anonymous",
+    });
+    expect(
+      await screen.findByTestId("review-panel-readonly"),
+    ).toBeInTheDocument();
+  });
+
+  it("refetches the envelope when the query is invalidated", async () => {
+    // Simulate the WS-driven invalidation path by flipping the mock
+    // response on the second call — the assertion is that the panel
+    // re-renders into the new state after invalidation, without any
+    // page reload.
+    let callCount = 0;
+    server.use(
+      http.get("*/api/v1/auctions/7/reviews", () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return HttpResponse.json({
+            reviews: [],
+            myPendingReview: makeReview({ visible: false, pending: true }),
+            canReview: false,
+            windowClosesAt: "2026-05-10T00:00:00Z",
+          });
+        }
+        return HttpResponse.json({
+          reviews: [
+            makeReview({ id: 1, reviewerId: 42 }),
+            makeReview({ id: 2, reviewerId: 77 }),
+          ],
+          myPendingReview: null,
+          canReview: false,
+          windowClosesAt: "2026-05-10T00:00:00Z",
+        });
+      }),
+    );
+    const { queryClient } = renderWithInspectableClient(
+      <ReviewPanel auctionId={7} isParty />,
+      partyUser,
+    );
+    await screen.findByTestId("review-panel-pending");
+    await act(async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["reviews", "auction", "7"],
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("review-panel-revealed")).toBeInTheDocument();
+    });
+  });
+});
+
+// --------------------------------------------------------------------------
+// Helper — render with an accessible QueryClient handle so the test can
+// drive invalidations directly (simulating the WS handler's behaviour).
+// Mirrors the internals of {@code renderWithProviders} so the test can
+// reach the QueryClient without widening the shared helper's public API.
+// --------------------------------------------------------------------------
+
+function renderWithInspectableClient(
+  ui: ReactElement,
+  authUser: AuthUser,
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  queryClient.setQueryData(["auth", "session"], authUser);
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <ThemeProvider
+        attribute="class"
+        defaultTheme="light"
+        enableSystem={false}
+      >
+        <QueryClientProvider client={queryClient}>
+          <ToastProvider>{children}</ToastProvider>
+        </QueryClientProvider>
+      </ThemeProvider>
+    );
+  }
+
+  render(ui, { wrapper: Wrapper });
+  return { queryClient };
+}

--- a/frontend/src/components/reviews/ReviewPanel.tsx
+++ b/frontend/src/components/reviews/ReviewPanel.tsx
@@ -1,0 +1,383 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/Button";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { cn } from "@/lib/cn";
+import { formatAbsoluteTime } from "@/lib/time/relativeTime";
+import { useAuth } from "@/lib/auth";
+import { useAuctionReviews, useSubmitReview } from "@/hooks/useReviews";
+import type {
+  AuctionReviewsResponse,
+  ReviewDto,
+} from "@/types/review";
+import { RatingSummary } from "./RatingSummary";
+import { ReviewCard } from "./ReviewCard";
+import { StarSelector } from "./StarSelector";
+
+/**
+ * Derived state keys for {@link ReviewPanel}, mirroring spec §8.1 one-to-one
+ * plus two viewer-scoped additions (`loading` for the in-flight envelope
+ * fetch and `read-only` for anonymous / non-party viewers who land here via
+ * the escrow-page link).
+ */
+export type ReviewPanelState =
+  | "loading"
+  | "submit"
+  | "pending"
+  | "revealed-both"
+  | "revealed-one"
+  | "window-closed-none"
+  | "read-only";
+
+/**
+ * Spec §10: review text cap. Kept in sync with the backend DTO bean-validation
+ * rule (see {@code ReviewSubmitRequest.text}). Mirrors the 500-char cap used
+ * on the flag + respond modals so the UX feels consistent across the surface.
+ */
+const MAX_TEXT_LEN = 500;
+
+/**
+ * Pure state-derivation helper. Exported for unit tests — the component
+ * itself memoises the call inside {@link ReviewPanel}. {@code isPartyAuthed}
+ * is {@code true} when the viewer is logged in AND is either the buyer or
+ * the seller for this auction (escrow page's auth + role gate upstream).
+ * Anonymous or non-party viewers follow the {@code read-only} branch even
+ * when {@code windowClosesAt} has elapsed — the "window closed" copy is
+ * seller-/buyer-facing only.
+ */
+export function deriveReviewPanelState(
+  envelope: AuctionReviewsResponse | undefined,
+  isPartyAuthed: boolean,
+  now: Date,
+): ReviewPanelState {
+  if (!envelope) return "loading";
+  const { canReview, myPendingReview, reviews, windowClosesAt } = envelope;
+  const windowClosed =
+    windowClosesAt !== null && new Date(windowClosesAt) < now;
+  if (canReview) return "submit";
+  if (myPendingReview) return "pending";
+  if (reviews.length >= 2) return "revealed-both";
+  if (reviews.length === 1) return "revealed-one";
+  if (isPartyAuthed && windowClosed) return "window-closed-none";
+  return "read-only";
+}
+
+export interface ReviewPanelProps {
+  auctionId: number;
+  /**
+   * When {@code true}, the viewer is the seller or the winner on this
+   * auction — the escrow-page client enforces this upstream via the
+   * server-side authz gate. Drives the read-only fallback vs. window-
+   * closed copy in {@link deriveReviewPanelState}.
+   */
+  isParty: boolean;
+  className?: string;
+}
+
+/**
+ * Escrow-page review surface, rendered beneath {@code EscrowStepCard} once
+ * escrow reaches {@code COMPLETED}. Fetches the viewer-scoped review
+ * envelope via {@link useAuctionReviews} and collapses it into one of the
+ * five spec-defined states (spec §8.1) plus a loading spinner and a
+ * read-only fallback.
+ *
+ * <p>The {@code id="review-panel"} on the root element is load-bearing —
+ * the dashboard pending-reviews card deep-links here via
+ * {@code /auction/{id}/escrow#review-panel} and the browser's native
+ * hash-scroll lands on the panel.
+ */
+export function ReviewPanel({
+  auctionId,
+  isParty,
+  className,
+}: ReviewPanelProps) {
+  const { data: envelope, isLoading } = useAuctionReviews(auctionId);
+  const session = useAuth();
+  const isPartyAuthed = isParty && session.status === "authenticated";
+
+  // Re-derive only when the envelope changes. {@code Date.now()} is fine —
+  // the state transitions on windowClosesAt elapse only matter at grain of
+  // minutes, and re-mounts from the WS-invalidation refetch carry a fresh
+  // {@code now}.
+  const state = useMemo<ReviewPanelState>(
+    () => deriveReviewPanelState(envelope, isPartyAuthed, new Date()),
+    [envelope, isPartyAuthed],
+  );
+
+  return (
+    <section
+      id="review-panel"
+      data-testid="review-panel"
+      data-state={state}
+      aria-labelledby="review-panel-heading"
+      className={cn(
+        "flex flex-col gap-4 rounded-default bg-surface-container-low p-6 ring-1 ring-outline-variant",
+        className,
+      )}
+    >
+      <header className="flex items-baseline justify-between">
+        <h2
+          id="review-panel-heading"
+          className="text-title-lg font-bold text-on-surface"
+        >
+          Reviews
+        </h2>
+        {envelope && envelope.reviews.length > 0 && (
+          <span className="text-label-md text-on-surface-variant">
+            {envelope.reviews.length} of 2 submitted
+          </span>
+        )}
+      </header>
+
+      {(state === "loading" || isLoading) && (
+        <div
+          data-testid="review-panel-loading"
+          className="flex min-h-[6rem] items-center justify-center"
+        >
+          <LoadingSpinner label="Loading reviews..." />
+        </div>
+      )}
+
+      {state === "submit" && envelope && (
+        <SubmitState auctionId={auctionId} envelope={envelope} />
+      )}
+
+      {state === "pending" && envelope?.myPendingReview && (
+        <PendingState
+          review={envelope.myPendingReview}
+          windowClosesAt={envelope.windowClosesAt}
+        />
+      )}
+
+      {(state === "revealed-both" || state === "revealed-one") && envelope && (
+        <RevealedState
+          envelope={envelope}
+          viewerId={
+            session.status === "authenticated" ? session.user.id : null
+          }
+        />
+      )}
+
+      {state === "window-closed-none" && (
+        <p
+          data-testid="review-panel-window-closed"
+          className="text-body-md text-on-surface-variant"
+        >
+          The review window for this auction has closed.
+        </p>
+      )}
+
+      {state === "read-only" && (!envelope || envelope.reviews.length === 0) && (
+        <p
+          data-testid="review-panel-readonly"
+          className="text-body-md text-on-surface-variant"
+        >
+          No reviews have been published for this auction yet.
+        </p>
+      )}
+    </section>
+  );
+}
+
+// --------------------------------------------------------------------------
+// Internal sub-states. Kept inline — each one is small enough that splitting
+// would cost more than the one-shot compose saves, and the shared props
+// (envelope / auctionId) flow naturally from the outer hook.
+// --------------------------------------------------------------------------
+
+function SubmitState({
+  auctionId,
+  envelope,
+}: {
+  auctionId: number;
+  envelope: AuctionReviewsResponse;
+}) {
+  const mutation = useSubmitReview(auctionId);
+  const [rating, setRating] = useState<number | null>(null);
+  const [text, setText] = useState("");
+
+  const overLimit = text.length > MAX_TEXT_LEN;
+  const trimmed = text.trim();
+  const canSubmit =
+    rating !== null && !overLimit && !mutation.isPending;
+
+  const submit = async () => {
+    if (!canSubmit || rating === null) return;
+    try {
+      await mutation.mutateAsync({
+        rating,
+        ...(trimmed.length > 0 ? { text: trimmed } : {}),
+      });
+      // Cache invalidation in the hook drives the panel's next state — no
+      // local optimism required.
+    } catch {
+      // Hook's {@code onError} already surfaced a toast.
+    }
+  };
+
+  return (
+    <div
+      data-testid="review-panel-submit"
+      className="flex flex-col gap-4"
+    >
+      <p className="text-body-md text-on-surface">
+        How was the other party? Your review stays hidden until they submit
+        theirs or on{" "}
+        <time
+          dateTime={envelope.windowClosesAt ?? undefined}
+          className="font-medium"
+        >
+          {envelope.windowClosesAt
+            ? formatAbsoluteTime(envelope.windowClosesAt)
+            : "the window close"}
+        </time>
+        .
+      </p>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-label-md font-medium text-on-surface">
+          Rating
+        </span>
+        <StarSelector
+          value={rating}
+          onChange={setRating}
+          disabled={mutation.isPending}
+        />
+      </div>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-label-md font-medium text-on-surface">
+          Your review (optional)
+        </span>
+        <textarea
+          rows={4}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          disabled={mutation.isPending}
+          placeholder="Share what went well — or what didn't."
+          data-testid="review-panel-submit-text"
+          className="w-full resize-y rounded-default bg-surface-container-low px-4 py-3 text-on-surface placeholder:text-on-surface-variant ring-1 ring-outline-variant transition-all focus:outline-none focus:ring-primary"
+        />
+      </label>
+
+      <div className="flex items-center justify-between gap-4">
+        <span
+          data-testid="review-panel-submit-counter"
+          className={cn(
+            "text-label-sm",
+            overLimit ? "text-error" : "text-on-surface-variant",
+          )}
+        >
+          {text.length} / {MAX_TEXT_LEN}
+        </span>
+        <Button
+          onClick={submit}
+          disabled={!canSubmit}
+          loading={mutation.isPending}
+          data-testid="review-panel-submit-button"
+        >
+          Submit review
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function PendingState({
+  review,
+  windowClosesAt,
+}: {
+  review: ReviewDto;
+  windowClosesAt: string | null;
+}) {
+  const rating = review.rating ?? 0;
+  return (
+    <div
+      data-testid="review-panel-pending"
+      className="flex flex-col gap-3"
+    >
+      <p className="text-body-md text-on-surface">
+        Your review has been submitted. It will appear when the other party
+        submits theirs
+        {windowClosesAt ? (
+          <>
+            {" "}or on{" "}
+            <time
+              dateTime={windowClosesAt}
+              title={formatAbsoluteTime(windowClosesAt)}
+              className="font-medium"
+            >
+              {formatAbsoluteTime(windowClosesAt)}
+            </time>
+            .
+          </>
+        ) : (
+          <>.</>
+        )}
+      </p>
+
+      <div
+        className="flex flex-col gap-2 rounded-default bg-surface-container px-4 py-3"
+        data-testid="review-panel-pending-card"
+      >
+        <div className="flex items-center justify-between">
+          <span className="text-label-md font-medium text-on-surface-variant">
+            Your submission
+          </span>
+          <RatingSummary
+            rating={rating > 0 ? rating : null}
+            reviewCount={rating > 0 ? 1 : 0}
+            size="sm"
+            hideCountText
+          />
+        </div>
+        {review.text && (
+          <p
+            className="whitespace-pre-wrap text-body-md text-on-surface"
+            data-testid="review-panel-pending-text"
+          >
+            {review.text}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RevealedState({
+  envelope,
+  viewerId,
+}: {
+  envelope: AuctionReviewsResponse;
+  viewerId: number | null;
+}) {
+  const reviews = envelope.reviews;
+  // Spec §8.1 notes: on revealed-one, if the viewer never submitted a
+  // review, show a subtle "your review window closed" note. Detect that
+  // by the absence of a row authored by the viewer in {@code reviews}.
+  const viewerAuthored =
+    viewerId !== null &&
+    reviews.some((r) => r.reviewerId === viewerId);
+  const showWindowClosedNote =
+    reviews.length === 1 && viewerId !== null && !viewerAuthored;
+
+  return (
+    <div
+      data-testid="review-panel-revealed"
+      className="flex flex-col gap-4 md:grid md:grid-cols-2"
+    >
+      {reviews.map((r) => (
+        <ReviewCard key={r.id} review={r} hideAuctionLink />
+      ))}
+      {showWindowClosedNote && (
+        <p
+          data-testid="review-panel-window-closed-note"
+          className="text-body-sm text-on-surface-variant md:col-span-2"
+        >
+          Your review window closed.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/reviews/StarSelector.test.tsx
+++ b/frontend/src/components/reviews/StarSelector.test.tsx
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import {
+  fireEvent,
+  renderWithProviders,
+  screen,
+  userEvent,
+} from "@/test/render";
+import { StarSelector } from "./StarSelector";
+
+function Controlled({
+  initial = null,
+  onChange,
+}: {
+  initial?: number | null;
+  onChange?: (v: number) => void;
+}) {
+  const [value, setValue] = useState<number | null>(initial);
+  return (
+    <StarSelector
+      value={value}
+      onChange={(v) => {
+        setValue(v);
+        onChange?.(v);
+      }}
+    />
+  );
+}
+
+describe("StarSelector", () => {
+  it("renders 5 stars wrapped in role=radiogroup", () => {
+    renderWithProviders(<StarSelector value={null} onChange={() => {}} />);
+    expect(screen.getByRole("radiogroup")).toBeInTheDocument();
+    expect(screen.getAllByRole("radio")).toHaveLength(5);
+  });
+
+  it("marks the selected star with aria-checked=true", () => {
+    renderWithProviders(<StarSelector value={4} onChange={() => {}} />);
+    const radios = screen.getAllByRole("radio");
+    expect(radios[3]).toHaveAttribute("aria-checked", "true");
+    expect(radios[0]).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("fires onChange with the clicked value", async () => {
+    const onChange = vi.fn();
+    renderWithProviders(<Controlled onChange={onChange} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByLabelText("3 stars"));
+    expect(onChange).toHaveBeenCalledWith(3);
+  });
+
+  it("fills stars up to the hovered index without changing value", async () => {
+    const onChange = vi.fn();
+    renderWithProviders(<StarSelector value={null} onChange={onChange} />);
+    const star3 = screen.getByTestId("star-selector-3");
+    fireEvent.mouseEnter(star3);
+    expect(screen.getByTestId("star-selector-1")).toHaveAttribute(
+      "data-filled",
+      "true",
+    );
+    expect(screen.getByTestId("star-selector-3")).toHaveAttribute(
+      "data-filled",
+      "true",
+    );
+    expect(screen.getByTestId("star-selector-4")).toHaveAttribute(
+      "data-filled",
+      "false",
+    );
+    // No click, so onChange must not fire.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps the selected fill after mouse leave", () => {
+    renderWithProviders(<StarSelector value={2} onChange={() => {}} />);
+    const group = screen.getByRole("radiogroup");
+    // Hover 5 then leave — fill must collapse back to the selected value (2).
+    fireEvent.mouseEnter(screen.getByTestId("star-selector-5"));
+    fireEvent.mouseLeave(group);
+    expect(screen.getByTestId("star-selector-2")).toHaveAttribute(
+      "data-filled",
+      "true",
+    );
+    expect(screen.getByTestId("star-selector-3")).toHaveAttribute(
+      "data-filled",
+      "false",
+    );
+  });
+
+  it("increments on ArrowRight and decrements on ArrowLeft with wraparound", () => {
+    const onChange = vi.fn();
+    const { rerender } = renderWithProviders(
+      <StarSelector value={3} onChange={onChange} />,
+    );
+    const star3 = screen.getByTestId("star-selector-3");
+    fireEvent.keyDown(star3, { key: "ArrowRight" });
+    expect(onChange).toHaveBeenLastCalledWith(4);
+
+    rerender(<StarSelector value={5} onChange={onChange} />);
+    fireEvent.keyDown(screen.getByTestId("star-selector-5"), {
+      key: "ArrowRight",
+    });
+    expect(onChange).toHaveBeenLastCalledWith(1);
+
+    rerender(<StarSelector value={1} onChange={onChange} />);
+    fireEvent.keyDown(screen.getByTestId("star-selector-1"), {
+      key: "ArrowLeft",
+    });
+    expect(onChange).toHaveBeenLastCalledWith(5);
+  });
+
+  it("jumps to 1 on Home and 5 on End", () => {
+    const onChange = vi.fn();
+    renderWithProviders(<StarSelector value={3} onChange={onChange} />);
+    const star3 = screen.getByTestId("star-selector-3");
+    fireEvent.keyDown(star3, { key: "Home" });
+    expect(onChange).toHaveBeenLastCalledWith(1);
+    fireEvent.keyDown(star3, { key: "End" });
+    expect(onChange).toHaveBeenLastCalledWith(5);
+  });
+
+  it("jumps directly on number keys 1-5", () => {
+    const onChange = vi.fn();
+    renderWithProviders(<StarSelector value={3} onChange={onChange} />);
+    const star3 = screen.getByTestId("star-selector-3");
+    fireEvent.keyDown(star3, { key: "4" });
+    expect(onChange).toHaveBeenLastCalledWith(4);
+    fireEvent.keyDown(star3, { key: "2" });
+    expect(onChange).toHaveBeenLastCalledWith(2);
+  });
+
+  it("ignores keys when disabled", () => {
+    const onChange = vi.fn();
+    renderWithProviders(
+      <StarSelector value={3} onChange={onChange} disabled />,
+    );
+    const star3 = screen.getByTestId("star-selector-3");
+    fireEvent.keyDown(star3, { key: "ArrowRight" });
+    fireEvent.click(star3);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps exactly one star in the tab sequence (the selected one)", () => {
+    renderWithProviders(<StarSelector value={2} onChange={() => {}} />);
+    const radios = screen.getAllByRole("radio");
+    const tabStops = radios.filter(
+      (el) => (el as HTMLButtonElement).tabIndex === 0,
+    );
+    expect(tabStops).toHaveLength(1);
+    expect(tabStops[0]).toHaveAttribute("aria-label", "2 stars");
+  });
+
+  it("makes the first star the tab stop when nothing is selected", () => {
+    renderWithProviders(<StarSelector value={null} onChange={() => {}} />);
+    const radios = screen.getAllByRole("radio");
+    expect((radios[0] as HTMLButtonElement).tabIndex).toBe(0);
+    expect((radios[1] as HTMLButtonElement).tabIndex).toBe(-1);
+  });
+
+  it("renders in dark mode using design-system token classes", () => {
+    const { container } = renderWithProviders(
+      <StarSelector value={3} onChange={() => {}} />,
+      { theme: "dark", forceTheme: true },
+    );
+    expect(container.innerHTML).not.toMatch(/#[0-9a-fA-F]{3,6}/);
+  });
+});

--- a/frontend/src/components/reviews/StarSelector.tsx
+++ b/frontend/src/components/reviews/StarSelector.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import {
+  useCallback,
+  useId,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
+import { cn } from "@/lib/cn";
+
+/**
+ * Interactive 1-5 rating picker. Each star is a {@code role="radio"} inside
+ * a {@code role="radiogroup"} container. The component is controlled —
+ * caller owns {@code value}, we fire {@code onChange} on click, number-key,
+ * Home/End, and ArrowLeft/Right. Hover preview is local state and does not
+ * reach {@code onChange}, so mousing in and out without clicking leaves
+ * {@code value} untouched (spec §8.7 "Clear affordance: selected rating
+ * stays visible after mouseleave").
+ *
+ * The gradient-free solid star approach matches what the spec asks for —
+ * the rating in a submit form is always an integer 1-5, so we flip between
+ * fully-filled (selected or hovered) and fully-empty (unselected) with
+ * {@code text-primary} and {@code text-surface-variant} tokens rather than
+ * reusing {@link RatingSummary}'s {@code <linearGradient>} machinery.
+ */
+
+export interface StarSelectorProps {
+  /** Current rating in {@code [1, 5]}. {@code null} means nothing picked yet. */
+  value: number | null;
+  onChange: (value: number) => void;
+  /** Accessible label for the whole radiogroup. Required for SR users. */
+  label?: string;
+  disabled?: boolean;
+  size?: "md" | "lg";
+  className?: string;
+}
+
+const SIZE_CLASS: Record<NonNullable<StarSelectorProps["size"]>, string> = {
+  md: "size-7",
+  lg: "size-8",
+};
+
+// Solid-star path — identical geometry to RatingSummary so both readouts
+// line up visually. We draw it once; the surrounding button picks the fill
+// color based on hover/selected state.
+const STAR_PATH =
+  "M10 1l2.78 5.64 6.22.9-4.5 4.39 1.06 6.2L10 15.27l-5.56 2.86 1.06-6.2L1 7.54l6.22-.9L10 1z";
+
+function wrap(index: number): number {
+  // Wrap 0 → 5 and 6 → 1 so ArrowLeft on the first star jumps to 5 and
+  // ArrowRight on the fifth star jumps to 1 (spec §8.7).
+  if (index < 1) return 5;
+  if (index > 5) return 1;
+  return index;
+}
+
+export function StarSelector({
+  value,
+  onChange,
+  label = "Rating",
+  disabled,
+  size = "lg",
+  className,
+}: StarSelectorProps) {
+  const groupId = useId();
+  const [hover, setHover] = useState<number | null>(null);
+  const buttonsRef = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const focusStar = useCallback((idx: number) => {
+    const btn = buttonsRef.current[idx - 1];
+    btn?.focus();
+  }, []);
+
+  const select = useCallback(
+    (next: number) => {
+      if (disabled) return;
+      onChange(next);
+      focusStar(next);
+    },
+    [disabled, onChange, focusStar],
+  );
+
+  const handleKey = useCallback(
+    (e: KeyboardEvent<HTMLButtonElement>, current: number) => {
+      if (disabled) return;
+      // Number keys 1-5 jump directly — matches spec §8.7.
+      if (/^[1-5]$/.test(e.key)) {
+        e.preventDefault();
+        select(Number.parseInt(e.key, 10));
+        return;
+      }
+      switch (e.key) {
+        case "ArrowLeft":
+        case "ArrowDown":
+          e.preventDefault();
+          select(wrap(current - 1));
+          break;
+        case "ArrowRight":
+        case "ArrowUp":
+          e.preventDefault();
+          select(wrap(current + 1));
+          break;
+        case "Home":
+          e.preventDefault();
+          select(1);
+          break;
+        case "End":
+          e.preventDefault();
+          select(5);
+          break;
+        default:
+          break;
+      }
+    },
+    [disabled, select],
+  );
+
+  const onStarClick = (starValue: number) => (e: MouseEvent) => {
+    e.preventDefault();
+    select(starValue);
+  };
+
+  const active = hover ?? value ?? 0;
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={label}
+      aria-disabled={disabled || undefined}
+      id={groupId}
+      className={cn("inline-flex items-center gap-1", className)}
+      data-testid="star-selector"
+      onMouseLeave={() => setHover(null)}
+    >
+      {[1, 2, 3, 4, 5].map((starValue) => {
+        const filled = starValue <= active;
+        const checked = value === starValue;
+        // Exactly one star in the group is tab-stop: the selected one, or
+        // the first when nothing is selected yet. Matches the WAI-ARIA
+        // radiogroup pattern where arrow keys cycle focus inside.
+        const isTabStop = checked || (value === null && starValue === 1);
+        return (
+          <button
+            key={starValue}
+            type="button"
+            ref={(el) => {
+              buttonsRef.current[starValue - 1] = el;
+            }}
+            role="radio"
+            aria-checked={checked}
+            aria-label={`${starValue} star${starValue === 1 ? "" : "s"}`}
+            disabled={disabled}
+            tabIndex={isTabStop ? 0 : -1}
+            onClick={onStarClick(starValue)}
+            onKeyDown={(e) => handleKey(e, value ?? starValue)}
+            onMouseEnter={() => !disabled && setHover(starValue)}
+            className={cn(
+              "rounded-default p-1 transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+              disabled && "opacity-50 cursor-not-allowed",
+            )}
+            data-testid={`star-selector-${starValue}`}
+            data-filled={filled}
+          >
+            <svg
+              viewBox="0 0 20 20"
+              aria-hidden="true"
+              className={cn(
+                SIZE_CLASS[size],
+                filled ? "text-primary" : "text-surface-variant",
+              )}
+            >
+              <path
+                d={STAR_PATH}
+                fill="currentColor"
+                stroke="currentColor"
+                strokeWidth="0.5"
+              />
+            </svg>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/icons.ts
+++ b/frontend/src/components/ui/icons.ts
@@ -65,3 +65,6 @@ export { FileX } from "lucide-react";
 
 // Epic 07 sub-spec 2 additions (browse/search UI — heart overlay on ListingCard)
 export { Heart } from "lucide-react";
+
+// Epic 08 sub-spec 1 additions (reviews & reputation — flag/respond)
+export { Flag, CornerDownRight } from "lucide-react";

--- a/frontend/src/components/user/PublicProfileView.test.tsx
+++ b/frontend/src/components/user/PublicProfileView.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
 import { renderWithProviders, screen, waitFor } from "@/test/render";
 import { server } from "@/test/msw/server";
 import { userHandlers } from "@/test/msw/handlers";
@@ -8,6 +9,25 @@ import {
   mockUnverifiedPublicProfile,
 } from "@/test/msw/fixtures";
 import { PublicProfileView } from "./PublicProfileView";
+
+/**
+ * The new {@link ProfileReviewTabs} fires a user-reviews request as soon
+ * as the profile resolves — MSW is configured with
+ * {@code onUnhandledRequest: "error"}, so every test needs a catch-all
+ * reviews handler that returns an empty page. Tests that exercise the
+ * reviews surface override this.
+ */
+function mockEmptyUserReviews() {
+  return http.get("*/api/v1/users/:id/reviews", () =>
+    HttpResponse.json({
+      content: [],
+      totalElements: 0,
+      totalPages: 0,
+      number: 0,
+      size: 10,
+    }),
+  );
+}
 
 const mockNotFound = vi.fn();
 vi.mock("next/navigation", () => ({
@@ -23,7 +43,10 @@ describe("PublicProfileView", () => {
   });
 
   it("renders verified user with badge and SL identity", async () => {
-    server.use(userHandlers.publicProfileSuccess(mockPublicProfile));
+    server.use(
+      userHandlers.publicProfileSuccess(mockPublicProfile),
+      mockEmptyUserReviews(),
+    );
 
     renderWithProviders(<PublicProfileView userId={42} />);
 
@@ -36,6 +59,7 @@ describe("PublicProfileView", () => {
   it("renders unverified user with Unverified chip and no SL identity", async () => {
     server.use(
       userHandlers.publicProfileSuccess(mockUnverifiedPublicProfile),
+      mockEmptyUserReviews(),
     );
 
     renderWithProviders(<PublicProfileView userId={44} />);
@@ -58,6 +82,7 @@ describe("PublicProfileView", () => {
   it("shows NewSellerBadge when completedSales < 3", async () => {
     server.use(
       userHandlers.publicProfileSuccess(mockNewSellerPublicProfile),
+      mockEmptyUserReviews(),
     );
 
     renderWithProviders(<PublicProfileView userId={43} />);
@@ -70,11 +95,36 @@ describe("PublicProfileView", () => {
   });
 
   it("hides NewSellerBadge for established seller", async () => {
-    server.use(userHandlers.publicProfileSuccess(mockPublicProfile));
+    server.use(
+      userHandlers.publicProfileSuccess(mockPublicProfile),
+      mockEmptyUserReviews(),
+    );
 
     renderWithProviders(<PublicProfileView userId={42} />);
 
     expect(await screen.findByText("Verified Tester")).toBeInTheDocument();
     expect(screen.queryByText("New Seller")).not.toBeInTheDocument();
+  });
+
+  it("renders the ProfileReviewTabs instead of the legacy empty-state", async () => {
+    server.use(
+      userHandlers.publicProfileSuccess(mockPublicProfile),
+      mockEmptyUserReviews(),
+    );
+
+    renderWithProviders(<PublicProfileView userId={42} />);
+
+    await screen.findByText("Verified Tester");
+    expect(
+      await screen.findByTestId("profile-review-tab-seller"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("profile-review-tab-buyer")).toBeInTheDocument();
+    // The legacy placeholder copy must not appear.
+    expect(screen.queryByText("No reviews yet")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        /Reviews will appear here once this user completes transactions/,
+      ),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/user/PublicProfileView.tsx
+++ b/frontend/src/components/user/PublicProfileView.tsx
@@ -2,12 +2,13 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { notFound } from "next/navigation";
-import { AlertCircle, BadgeCheck, MessageSquare } from "@/components/ui/icons";
+import { AlertCircle, BadgeCheck } from "@/components/ui/icons";
 import { Avatar } from "@/components/ui/Avatar";
 import { Card } from "@/components/ui/Card";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { StatusBadge } from "@/components/ui/StatusBadge";
+import { ProfileReviewTabs } from "@/components/reviews/ProfileReviewTabs";
 import { isApiError } from "@/lib/api";
 import { userApi } from "@/lib/user/api";
 import { ActiveListingsSection } from "./ActiveListingsSection";
@@ -111,16 +112,18 @@ export function PublicProfileView({ userId }: PublicProfileViewProps) {
         </Card.Body>
       </Card>
 
-      {/* Placeholder: Reviews */}
+      {/* Reviews (Epic 08 sub-spec 1 §8.2) */}
       <Card>
         <Card.Header>
           <h2 className="text-title-md font-bold">Reviews</h2>
         </Card.Header>
         <Card.Body>
-          <EmptyState
-            icon={MessageSquare}
-            headline="No reviews yet"
-            description="Reviews will appear here once this user completes transactions."
+          <ProfileReviewTabs
+            userId={profile.id}
+            avgSellerRating={profile.avgSellerRating}
+            avgBuyerRating={profile.avgBuyerRating}
+            totalSellerReviews={profile.totalSellerReviews}
+            totalBuyerReviews={profile.totalBuyerReviews}
           />
         </Card.Body>
       </Card>

--- a/frontend/src/components/user/ReputationStars.test.tsx
+++ b/frontend/src/components/user/ReputationStars.test.tsx
@@ -29,4 +29,20 @@ describe("ReputationStars", () => {
     expect(screen.getByText("5.0")).toBeInTheDocument();
     expect(screen.getByText("(1 review)")).toBeInTheDocument();
   });
+
+  it("accepts a string rating (BigDecimal wire shape) and parses it", () => {
+    renderWithProviders(<ReputationStars rating="4.3" reviewCount={5} />);
+    expect(screen.getByText("4.3")).toBeInTheDocument();
+    // Five stars rendered by the underlying RatingSummary primitive.
+    expect(screen.getAllByTestId("rating-star")).toHaveLength(5);
+  });
+
+  it("delegates to RatingSummary's partial-star rendering", () => {
+    renderWithProviders(<ReputationStars rating={3.5} reviewCount={2} />);
+    // 3.5 → [1, 1, 1, 0.5, 0]
+    const stars = screen.getAllByTestId("rating-star");
+    expect(stars[2].getAttribute("data-fill")).toBe("1.00");
+    expect(stars[3].getAttribute("data-fill")).toBe("0.50");
+    expect(stars[4].getAttribute("data-fill")).toBe("0.00");
+  });
 });

--- a/frontend/src/components/user/ReputationStars.tsx
+++ b/frontend/src/components/user/ReputationStars.tsx
@@ -1,12 +1,33 @@
-import { Star } from "@/components/ui/icons";
+import { RatingSummary } from "@/components/reviews/RatingSummary";
 
-type ReputationStarsProps = {
-  rating: number | null;
+/**
+ * Backwards-compat wrapper around the new {@link RatingSummary} primitive
+ * (Epic 08 sub-spec 1 §8.3). Existing callsites — public profile,
+ * listing-card seller strip — pass their existing props here and the
+ * partial-star renderer takes care of the rest.
+ *
+ * A {@code label} is the only feature this wrapper adds on top of
+ * {@code RatingSummary}: the section-header strip above the stars is a
+ * profile-view convention that isn't worth polluting the primitive with.
+ */
+export interface ReputationStarsProps {
+  /**
+   * Numeric rating. BigDecimal serializes as a string on the wire in some
+   * legacy endpoints — the component normalizes before forwarding so
+   * callers can pass either shape.
+   */
+  rating: number | string | null;
   reviewCount: number;
   label?: string;
-};
+}
 
-export function ReputationStars({ rating, reviewCount, label }: ReputationStarsProps) {
+export function ReputationStars({
+  rating,
+  reviewCount,
+  label,
+}: ReputationStarsProps) {
+  const normalized =
+    typeof rating === "string" ? Number.parseFloat(rating) : rating;
   return (
     <div className="flex flex-col gap-1">
       {label && (
@@ -14,17 +35,7 @@ export function ReputationStars({ rating, reviewCount, label }: ReputationStarsP
           {label}
         </span>
       )}
-      {rating === null ? (
-        <p className="text-body-md text-on-surface-variant">No ratings yet</p>
-      ) : (
-        <div className="flex items-center gap-2">
-          <Star className="size-5 fill-primary text-primary" strokeWidth={1.5} />
-          <span className="text-title-md font-bold">{rating.toFixed(1)}</span>
-          <span className="text-body-sm text-on-surface-variant">
-            ({reviewCount} review{reviewCount === 1 ? "" : "s"})
-          </span>
-        </div>
-      )}
+      <RatingSummary rating={normalized} reviewCount={reviewCount} size="md" />
     </div>
   );
 }

--- a/frontend/src/hooks/useReviews.test.tsx
+++ b/frontend/src/hooks/useReviews.test.tsx
@@ -1,0 +1,271 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { makeWrapper } from "@/test/render";
+import { server } from "@/test/msw/server";
+import {
+  reviewsKeys,
+  useAuctionReviews,
+  useFlagReview,
+  usePendingReviews,
+  useRespondToReview,
+  useSubmitReview,
+  useUserReviews,
+} from "./useReviews";
+
+// ---------- Read hooks ----------
+
+describe("useAuctionReviews", () => {
+  it("fetches the envelope and returns it in query.data", async () => {
+    server.use(
+      http.get("*/api/v1/auctions/:id/reviews", () =>
+        HttpResponse.json({
+          reviews: [],
+          myPendingReview: null,
+          canReview: true,
+          windowClosesAt: "2026-05-01T00:00:00Z",
+        }),
+      ),
+    );
+
+    const { result } = renderHook(() => useAuctionReviews(10), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.canReview).toBe(true);
+  });
+
+  it("does not fetch when auctionId is non-positive", async () => {
+    let called = false;
+    server.use(
+      http.get("*/api/v1/auctions/:id/reviews", () => {
+        called = true;
+        return HttpResponse.json({});
+      }),
+    );
+
+    const { result } = renderHook(() => useAuctionReviews(0), {
+      wrapper: makeWrapper(),
+    });
+
+    // Give React Query a tick to decide whether to fire
+    await new Promise((r) => setTimeout(r, 20));
+    expect(called).toBe(false);
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+});
+
+describe("useUserReviews", () => {
+  it("fetches a paged response for the given role", async () => {
+    let captured: URL | null = null;
+    server.use(
+      http.get("*/api/v1/users/:id/reviews", ({ request }) => {
+        captured = new URL(request.url);
+        return HttpResponse.json({
+          content: [],
+          totalElements: 0,
+          totalPages: 0,
+          number: 0,
+          size: 10,
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useUserReviews(7, "SELLER", 1), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(captured!.searchParams.get("role")).toBe("SELLER");
+    expect(captured!.searchParams.get("page")).toBe("1");
+  });
+});
+
+describe("usePendingReviews", () => {
+  it("fetches the list for the authenticated user", async () => {
+    server.use(
+      http.get("*/api/v1/users/me/pending-reviews", () =>
+        HttpResponse.json([]),
+      ),
+    );
+
+    const { result } = renderHook(() => usePendingReviews(), {
+      wrapper: makeWrapper({ auth: "authenticated" }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(Array.isArray(result.current.data)).toBe(true);
+  });
+});
+
+// ---------- Mutations ----------
+
+describe("useSubmitReview", () => {
+  it("invalidates the auction envelope and pending list on success", async () => {
+    server.use(
+      http.post("*/api/v1/auctions/:id/reviews", () =>
+        HttpResponse.json(
+          {
+            id: 1,
+            auctionId: 10,
+            auctionTitle: "t",
+            auctionPrimaryPhotoUrl: null,
+            reviewerId: 42,
+            reviewerDisplayName: "A",
+            reviewerAvatarUrl: null,
+            revieweeId: 7,
+            reviewedRole: "SELLER",
+            rating: 5,
+            text: "ok",
+            visible: false,
+            pending: true,
+            submittedAt: "2026-04-20T00:00:00Z",
+            revealedAt: null,
+            response: null,
+          },
+          { status: 201 },
+        ),
+      ),
+    );
+
+    const wrapper = makeWrapper();
+    const { result } = renderHook(() => useSubmitReview(10), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ rating: 5, text: "ok" });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("surfaces a toast on error", async () => {
+    server.use(
+      http.post("*/api/v1/auctions/:id/reviews", () =>
+        HttpResponse.json({ status: 500 }, { status: 500 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useSubmitReview(10), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      await result.current
+        .mutateAsync({ rating: 5 })
+        .catch(() => {
+          /* handled via toast */
+        });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useRespondToReview", () => {
+  it("posts the response and returns the created DTO", async () => {
+    server.use(
+      http.post("*/api/v1/reviews/:id/respond", () =>
+        HttpResponse.json(
+          { id: 99, text: "Thanks!", createdAt: "2026-04-22T00:00:00Z" },
+          { status: 201 },
+        ),
+      ),
+    );
+
+    const { result } = renderHook(() => useRespondToReview(5), {
+      wrapper: makeWrapper(),
+    });
+
+    let response;
+    await act(async () => {
+      response = await result.current.mutateAsync({ text: "Thanks!" });
+    });
+
+    expect(response).toEqual({
+      id: 99,
+      text: "Thanks!",
+      createdAt: "2026-04-22T00:00:00Z",
+    });
+  });
+
+  it("marks isError on 409 duplicate", async () => {
+    server.use(
+      http.post("*/api/v1/reviews/:id/respond", () =>
+        HttpResponse.json({ status: 409 }, { status: 409 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useRespondToReview(5), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      await result.current
+        .mutateAsync({ text: "Thanks!" })
+        .catch(() => {
+          /* handled via toast */
+        });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useFlagReview", () => {
+  it("resolves on 204 and marks isSuccess", async () => {
+    server.use(
+      http.post("*/api/v1/reviews/:id/flag", () =>
+        HttpResponse.json(null, { status: 204 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useFlagReview(5), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ reason: "SPAM" });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("surfaces the 409 duplicate path on isError", async () => {
+    server.use(
+      http.post("*/api/v1/reviews/:id/flag", () =>
+        HttpResponse.json({ status: 409 }, { status: 409 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useFlagReview(5), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      await result.current
+        .mutateAsync({ reason: "SPAM" })
+        .catch(() => {
+          /* handled via toast */
+        });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+// ---------- Key factory ----------
+
+describe("reviewsKeys", () => {
+  it("produces stable, scoped cache keys", () => {
+    expect(reviewsKeys.auction(10)).toEqual(["reviews", "auction", "10"]);
+    expect(reviewsKeys.user(7, "SELLER", 2)).toEqual([
+      "reviews",
+      "user",
+      "7",
+      "SELLER",
+      2,
+    ]);
+    expect(reviewsKeys.pending).toEqual(["reviews", "pending"]);
+  });
+});

--- a/frontend/src/hooks/useReviews.ts
+++ b/frontend/src/hooks/useReviews.ts
@@ -112,11 +112,15 @@ export function useSubmitReview(
           "It appears when the other party submits theirs or on day 14.",
       });
     },
-    onError: () =>
+    onError: (err) => {
+      const already = err instanceof ApiError && err.status === 409;
       toast.error({
-        title: "Could not submit review",
-        description: "Please try again.",
-      }),
+        title: already ? "Already reviewed" : "Could not submit review",
+        description: already
+          ? "You've already submitted a review for this auction."
+          : "Please try again.",
+      });
+    },
   });
 }
 

--- a/frontend/src/hooks/useReviews.ts
+++ b/frontend/src/hooks/useReviews.ts
@@ -1,0 +1,178 @@
+"use client";
+
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { ApiError } from "@/lib/api";
+import {
+  flagReview,
+  getAuctionReviews,
+  getPendingReviews,
+  getUserReviews,
+  respondToReview,
+  submitReview,
+} from "@/lib/api/reviews";
+import { useToast } from "@/components/ui/Toast";
+import type { Page } from "@/types/page";
+import type {
+  AuctionReviewsResponse,
+  PendingReviewDto,
+  ReviewDto,
+  ReviewFlagRequest,
+  ReviewResponseDto,
+  ReviewResponseSubmitRequest,
+  ReviewSubmitRequest,
+  ReviewedRole,
+} from "@/types/review";
+
+/**
+ * React Query keys for the reviews domain. Exported so tests (and future
+ * WebSocket envelope handlers) can invalidate without reaching into the
+ * hook internals.
+ */
+export const reviewsKeys = {
+  /** Top-level prefix. Use for wholesale invalidation on mutations. */
+  all: ["reviews"] as const,
+  auction: (auctionId: number | string) =>
+    ["reviews", "auction", String(auctionId)] as const,
+  user: (userId: number | string, role: ReviewedRole, page: number) =>
+    ["reviews", "user", String(userId), role, page] as const,
+  userAll: (userId: number | string) =>
+    ["reviews", "user", String(userId)] as const,
+  pending: ["reviews", "pending"] as const,
+};
+
+/**
+ * Read hook for the escrow-page ReviewPanel's one-shot envelope. Gated on
+ * a positive numeric auctionId so the panel can render during an SSR pass
+ * without triggering a stray fetch before the dynamic segment has
+ * hydrated.
+ */
+export function useAuctionReviews(
+  auctionId: number,
+): UseQueryResult<AuctionReviewsResponse> {
+  return useQuery<AuctionReviewsResponse>({
+    queryKey: reviewsKeys.auction(auctionId),
+    queryFn: () => getAuctionReviews(auctionId),
+    enabled: Number.isFinite(auctionId) && auctionId > 0,
+  });
+}
+
+/**
+ * Paged profile-tab read — one tab per role. The pagination state lives in
+ * the caller (URL-synced in Task 6) so tab switches reset the page cleanly.
+ */
+export function useUserReviews(
+  userId: number,
+  role: ReviewedRole,
+  page: number,
+): UseQueryResult<Page<ReviewDto>> {
+  return useQuery<Page<ReviewDto>>({
+    queryKey: reviewsKeys.user(userId, role, page),
+    queryFn: () => getUserReviews(userId, role, { page }),
+    enabled: Number.isFinite(userId) && userId > 0,
+  });
+}
+
+/**
+ * Dashboard "pending reviews" list. Refetches every submit so the card
+ * disappears as soon as the user catches up.
+ */
+export function usePendingReviews(): UseQueryResult<PendingReviewDto[]> {
+  return useQuery<PendingReviewDto[]>({
+    queryKey: reviewsKeys.pending,
+    queryFn: getPendingReviews,
+  });
+}
+
+/**
+ * Mutation for submitting a blind review. On success, invalidate the
+ * auction envelope (so the pending-state card flips in) and the pending
+ * list (so the dashboard card disappears). Toasts are fired here so
+ * every callsite — ReviewPanel, future SL-deeplink — gets the same UX
+ * without duplicating copy.
+ */
+export function useSubmitReview(
+  auctionId: number,
+): UseMutationResult<ReviewDto, unknown, ReviewSubmitRequest> {
+  const qc = useQueryClient();
+  const toast = useToast();
+  return useMutation<ReviewDto, unknown, ReviewSubmitRequest>({
+    mutationFn: (body) => submitReview(auctionId, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: reviewsKeys.auction(auctionId) });
+      qc.invalidateQueries({ queryKey: reviewsKeys.pending });
+      toast.success({
+        title: "Review submitted",
+        description:
+          "It appears when the other party submits theirs or on day 14.",
+      });
+    },
+    onError: () =>
+      toast.error({
+        title: "Could not submit review",
+        description: "Please try again.",
+      }),
+  });
+}
+
+/**
+ * Mutation for the reviewee's response. Invalidates the whole reviews
+ * subtree because the responded-to review might be on the auction page,
+ * the reviewee's profile, or both.
+ */
+export function useRespondToReview(
+  reviewId: number,
+): UseMutationResult<ReviewResponseDto, unknown, ReviewResponseSubmitRequest> {
+  const qc = useQueryClient();
+  const toast = useToast();
+  return useMutation<ReviewResponseDto, unknown, ReviewResponseSubmitRequest>({
+    mutationFn: (body) => respondToReview(reviewId, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: reviewsKeys.all });
+      toast.success({ title: "Response posted" });
+    },
+    onError: (err) => {
+      const already = err instanceof ApiError && err.status === 409;
+      toast.error({
+        title: already ? "Already responded" : "Could not post response",
+        description: already
+          ? "You've already responded to this review."
+          : "Please try again.",
+      });
+    },
+  });
+}
+
+/**
+ * Mutation for flagging a review. No cache invalidation — flag count is
+ * admin-only (§11), so from the caller's point of view the toast is the
+ * whole UX. 409 → "already flagged" copy; everything else → generic
+ * error.
+ */
+export function useFlagReview(
+  reviewId: number,
+): UseMutationResult<void, unknown, ReviewFlagRequest> {
+  const toast = useToast();
+  return useMutation<void, unknown, ReviewFlagRequest>({
+    mutationFn: (body) => flagReview(reviewId, body),
+    onSuccess: () =>
+      toast.success({
+        title: "Review flagged",
+        description: "Thanks — our team will review it shortly.",
+      }),
+    onError: (err) => {
+      const already = err instanceof ApiError && err.status === 409;
+      toast.error({
+        title: already ? "Already flagged" : "Could not flag review",
+        description: already
+          ? "You've already flagged this review."
+          : "Please try again.",
+      });
+    },
+  });
+}

--- a/frontend/src/lib/api/reviews.test.ts
+++ b/frontend/src/lib/api/reviews.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/msw/server";
+import type { Page } from "@/types/page";
+import type {
+  AuctionReviewsResponse,
+  PendingReviewDto,
+  ReviewDto,
+  ReviewResponseDto,
+} from "@/types/review";
+import {
+  flagReview,
+  getAuctionReviews,
+  getPendingReviews,
+  getUserReviews,
+  respondToReview,
+  submitReview,
+} from "./reviews";
+
+// ---------- Fixture builders ----------
+
+function reviewDto(overrides: Partial<ReviewDto> = {}): ReviewDto {
+  return {
+    id: 1,
+    auctionId: 10,
+    auctionTitle: "Aurora Parcel",
+    auctionPrimaryPhotoUrl: "/api/v1/auctions/10/photos/1/bytes",
+    reviewerId: 42,
+    reviewerDisplayName: "Alice",
+    reviewerAvatarUrl: "/api/v1/users/42/avatar/256",
+    revieweeId: 7,
+    reviewedRole: "SELLER",
+    rating: 5,
+    text: "Great seller",
+    visible: true,
+    pending: false,
+    submittedAt: "2026-04-20T12:00:00Z",
+    revealedAt: "2026-04-21T12:00:00Z",
+    response: null,
+    ...overrides,
+  };
+}
+
+function pendingReviewDto(
+  overrides: Partial<PendingReviewDto> = {},
+): PendingReviewDto {
+  return {
+    auctionId: 10,
+    title: "Aurora Parcel",
+    primaryPhotoUrl: null,
+    counterpartyId: 7,
+    counterpartyDisplayName: "Bob",
+    counterpartyAvatarUrl: null,
+    escrowCompletedAt: "2026-04-10T00:00:00Z",
+    windowClosesAt: "2026-04-24T00:00:00Z",
+    hoursRemaining: 72,
+    viewerRole: "BUYER",
+    ...overrides,
+  };
+}
+
+function pageOf<T>(content: T[], overrides: Partial<Page<T>> = {}): Page<T> {
+  return {
+    content,
+    totalElements: content.length,
+    totalPages: 1,
+    number: 0,
+    size: 10,
+    ...overrides,
+  };
+}
+
+// ---------- getAuctionReviews ----------
+
+describe("getAuctionReviews", () => {
+  it("GETs /api/v1/auctions/{id}/reviews and returns the envelope", async () => {
+    let captured: URL | null = null;
+    const envelope: AuctionReviewsResponse = {
+      reviews: [reviewDto()],
+      myPendingReview: null,
+      canReview: false,
+      windowClosesAt: null,
+    };
+    server.use(
+      http.get("*/api/v1/auctions/:id/reviews", ({ request }) => {
+        captured = new URL(request.url);
+        return HttpResponse.json(envelope);
+      }),
+    );
+
+    const result = await getAuctionReviews(10);
+
+    expect(captured).not.toBeNull();
+    expect(captured!.pathname).toBe("/api/v1/auctions/10/reviews");
+    expect(result.reviews).toHaveLength(1);
+    expect(result.canReview).toBe(false);
+  });
+});
+
+// ---------- submitReview ----------
+
+describe("submitReview", () => {
+  it("POSTs { rating, text } and returns the created ReviewDto", async () => {
+    let capturedBody: unknown = null;
+    let capturedMethod = "";
+    server.use(
+      http.post("*/api/v1/auctions/:id/reviews", async ({ request }) => {
+        capturedMethod = request.method;
+        capturedBody = await request.json();
+        return HttpResponse.json(reviewDto({ visible: false, pending: true }), {
+          status: 201,
+        });
+      }),
+    );
+
+    const result = await submitReview(10, { rating: 5, text: "ok" });
+
+    expect(capturedMethod).toBe("POST");
+    expect(capturedBody).toEqual({ rating: 5, text: "ok" });
+    expect(result.pending).toBe(true);
+  });
+});
+
+// ---------- getUserReviews ----------
+
+describe("getUserReviews", () => {
+  it("sends role/page/size by default (page=0, size=10)", async () => {
+    let captured: URL | null = null;
+    server.use(
+      http.get("*/api/v1/users/:id/reviews", ({ request }) => {
+        captured = new URL(request.url);
+        return HttpResponse.json(pageOf([reviewDto()]));
+      }),
+    );
+
+    const result = await getUserReviews(7, "SELLER");
+
+    expect(captured!.pathname).toBe("/api/v1/users/7/reviews");
+    expect(captured!.searchParams.get("role")).toBe("SELLER");
+    expect(captured!.searchParams.get("page")).toBe("0");
+    expect(captured!.searchParams.get("size")).toBe("10");
+    expect(result.content).toHaveLength(1);
+  });
+
+  it("honors explicit page and size overrides", async () => {
+    let captured: URL | null = null;
+    server.use(
+      http.get("*/api/v1/users/:id/reviews", ({ request }) => {
+        captured = new URL(request.url);
+        return HttpResponse.json(pageOf([], { number: 2, size: 5 }));
+      }),
+    );
+
+    await getUserReviews(7, "BUYER", { page: 2, size: 5 });
+
+    expect(captured!.searchParams.get("role")).toBe("BUYER");
+    expect(captured!.searchParams.get("page")).toBe("2");
+    expect(captured!.searchParams.get("size")).toBe("5");
+  });
+});
+
+// ---------- getPendingReviews ----------
+
+describe("getPendingReviews", () => {
+  it("GETs /api/v1/users/me/pending-reviews and returns the list", async () => {
+    server.use(
+      http.get("*/api/v1/users/me/pending-reviews", () =>
+        HttpResponse.json([pendingReviewDto()]),
+      ),
+    );
+
+    const result = await getPendingReviews();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].auctionId).toBe(10);
+  });
+});
+
+// ---------- respondToReview ----------
+
+describe("respondToReview", () => {
+  it("POSTs { text } and returns the created ReviewResponseDto", async () => {
+    let capturedBody: unknown = null;
+    const response: ReviewResponseDto = {
+      id: 99,
+      text: "Thanks!",
+      createdAt: "2026-04-22T00:00:00Z",
+    };
+    server.use(
+      http.post("*/api/v1/reviews/:id/respond", async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(response, { status: 201 });
+      }),
+    );
+
+    const result = await respondToReview(5, { text: "Thanks!" });
+
+    expect(capturedBody).toEqual({ text: "Thanks!" });
+    expect(result.id).toBe(99);
+  });
+});
+
+// ---------- flagReview ----------
+
+describe("flagReview", () => {
+  it("POSTs { reason, elaboration } and resolves to void on 204", async () => {
+    let capturedBody: unknown = null;
+    server.use(
+      http.post("*/api/v1/reviews/:id/flag", async ({ request }) => {
+        capturedBody = await request.json();
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await flagReview(5, { reason: "SPAM" });
+
+    expect(capturedBody).toEqual({ reason: "SPAM" });
+  });
+
+  it("passes elaboration through for OTHER reasons", async () => {
+    let capturedBody: unknown = null;
+    server.use(
+      http.post("*/api/v1/reviews/:id/flag", async ({ request }) => {
+        capturedBody = await request.json();
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await flagReview(5, { reason: "OTHER", elaboration: "Explains it" });
+
+    expect(capturedBody).toEqual({
+      reason: "OTHER",
+      elaboration: "Explains it",
+    });
+  });
+});

--- a/frontend/src/lib/api/reviews.ts
+++ b/frontend/src/lib/api/reviews.ts
@@ -1,0 +1,101 @@
+import { api } from "@/lib/api";
+import type { Page } from "@/types/page";
+import type {
+  AuctionReviewsResponse,
+  PendingReviewDto,
+  ReviewDto,
+  ReviewFlagRequest,
+  ReviewResponseDto,
+  ReviewResponseSubmitRequest,
+  ReviewSubmitRequest,
+  ReviewedRole,
+} from "@/types/review";
+
+/**
+ * Review read/write client. Mirrors {@code ReviewController} and
+ * {@code UserReviewsController} endpoints. Reads are public (anonymous
+ * callers get the pre-reveal shape); writes bubble the standard
+ * {@code ApiError} surface — 401/403/409/422 — on the documented codes.
+ */
+
+/**
+ * GET /api/v1/auctions/{auctionId}/reviews — returns the envelope the
+ * escrow-page {@code ReviewPanel} needs to pick one of its five states.
+ * Public endpoint; anonymous callers see revealed reviews only.
+ */
+export function getAuctionReviews(
+  auctionId: number | string,
+): Promise<AuctionReviewsResponse> {
+  return api.get<AuctionReviewsResponse>(
+    `/api/v1/auctions/${auctionId}/reviews`,
+  );
+}
+
+/**
+ * POST /api/v1/auctions/{auctionId}/reviews — submit the caller's blind
+ * review. 422 {@code ReviewIneligibleException} if escrow is not
+ * COMPLETED or the window has closed; 409 if the caller already submitted.
+ */
+export function submitReview(
+  auctionId: number | string,
+  body: ReviewSubmitRequest,
+): Promise<ReviewDto> {
+  return api.post<ReviewDto>(`/api/v1/auctions/${auctionId}/reviews`, body);
+}
+
+export type GetUserReviewsParams = {
+  page?: number;
+  size?: number;
+};
+
+const DEFAULT_USER_REVIEWS_SIZE = 10;
+
+/**
+ * GET /api/v1/users/{userId}/reviews — public, paginated, newest-first.
+ * The {@code role} query param is required by the backend — callers must
+ * pick SELLER or BUYER; there is no combined "all" endpoint for sub-spec 1.
+ */
+export function getUserReviews(
+  userId: number | string,
+  role: ReviewedRole,
+  params: GetUserReviewsParams = {},
+): Promise<Page<ReviewDto>> {
+  const page = params.page ?? 0;
+  const size = params.size ?? DEFAULT_USER_REVIEWS_SIZE;
+  return api.get<Page<ReviewDto>>(`/api/v1/users/${userId}/reviews`, {
+    params: { role, page, size },
+  });
+}
+
+/**
+ * GET /api/v1/users/me/pending-reviews — requires JWT. The backend sorts
+ * most-urgent-first; the UI preserves that order.
+ */
+export function getPendingReviews(): Promise<PendingReviewDto[]> {
+  return api.get<PendingReviewDto[]>("/api/v1/users/me/pending-reviews");
+}
+
+/**
+ * POST /api/v1/reviews/{reviewId}/respond — reviewee-only. 409 if a
+ * response already exists.
+ */
+export function respondToReview(
+  reviewId: number | string,
+  body: ReviewResponseSubmitRequest,
+): Promise<ReviewResponseDto> {
+  return api.post<ReviewResponseDto>(
+    `/api/v1/reviews/${reviewId}/respond`,
+    body,
+  );
+}
+
+/**
+ * POST /api/v1/reviews/{reviewId}/flag — any authenticated non-author. 409
+ * on duplicate flag; 204 on success (returned as {@code void}).
+ */
+export async function flagReview(
+  reviewId: number | string,
+  body: ReviewFlagRequest,
+): Promise<void> {
+  await api.post<void>(`/api/v1/reviews/${reviewId}/flag`, body);
+}

--- a/frontend/src/types/auction.ts
+++ b/frontend/src/types/auction.ts
@@ -325,13 +325,44 @@ export interface AuctionEndedEnvelope {
 export type AuctionEnvelope = BidSettlementEnvelope | AuctionEndedEnvelope;
 
 /**
+ * WebSocket envelope broadcast on {@code /topic/auction/{auctionId}} when a
+ * review flips from {@code visible=false} to {@code visible=true} — either
+ * via the simultaneous-reveal branch in {@code ReviewService.submit} or the
+ * hourly {@code BlindReviewRevealTask} scheduler sweep (Epic 08 sub-spec 1
+ * §7).
+ *
+ * <p>Subscribers should invalidate their {@code useAuctionReviews(auctionId)}
+ * query and refetch through the authenticated GET — the payload deliberately
+ * omits the rating/text fields so public subscribers can't read review
+ * content via the topic. No {@code serverTime} field: the backend
+ * {@code ReviewRevealedEnvelope} record carries only the discriminators
+ * needed to drive the client-side invalidation.
+ */
+export interface ReviewRevealedEnvelope {
+  type: "REVIEW_REVEALED";
+  auctionId: number;
+  reviewId: number;
+  reviewerId: number;
+  revieweeId: number;
+  reviewedRole: "SELLER" | "BUYER";
+  revealedAt: string;
+}
+
+/**
  * Every envelope type that can arrive on `/topic/auction/{id}`.
  * {@code AuctionDetailClient} and {@code EscrowPageClient} both subscribe
  * with this union; handlers discriminate on {@code type}. Re-exports the
  * nine escrow variants from `./escrow` via the imported EscrowEnvelope so
- * subscribers only need a single discriminator switch.
+ * subscribers only need a single discriminator switch. The review envelope
+ * lives on the same topic (Epic 08 sub-spec 1 §7) — subscribers that don't
+ * care about reviews should short-circuit on {@code type === "REVIEW_REVEALED"}
+ * before reading any envelope-specific field, since review envelopes do not
+ * carry {@code serverTime}.
  */
-export type AuctionTopicEnvelope = AuctionEnvelope | EscrowEnvelope;
+export type AuctionTopicEnvelope =
+  | AuctionEnvelope
+  | EscrowEnvelope
+  | ReviewRevealedEnvelope;
 
 /**
  * POST /api/v1/auctions/{id}/bids response body. Returns the just-committed

--- a/frontend/src/types/review.ts
+++ b/frontend/src/types/review.ts
@@ -1,0 +1,121 @@
+// Wire-shape mirrors of the backend review DTOs. Kept intentionally flat and
+// un-opinionated so the lib/api layer can JSON.parse straight into these
+// interfaces without any custom mapping. The Java side (see
+// {@code backend/.../review/dto/ReviewDto.java} and siblings) is the source of
+// truth — if the backend adds a field, add it here too.
+
+/**
+ * Which side of the transaction is being reviewed. A SELLER review is the
+ * buyer's feedback about the seller; a BUYER review is the seller's feedback
+ * about the buyer. The role is embedded in every {@link ReviewDto} for cheap
+ * filtering on the client without a second round-trip.
+ */
+export type ReviewedRole = "SELLER" | "BUYER";
+
+/**
+ * Five reason codes a flagger can pick from the {@code FlagModal} radio
+ * group. {@code OTHER} mandates a non-empty elaboration server-side (see
+ * {@code ElaborationRequiredWhenOtherValidator}); the UI enforces the same
+ * rule before submit so the 422 path is the fallback, not the norm.
+ */
+export type ReviewFlagReason =
+  | "SPAM"
+  | "ABUSIVE"
+  | "OFF_TOPIC"
+  | "FALSE_INFO"
+  | "OTHER";
+
+/**
+ * Reviewee's reply to a revealed review. One-shot: no editing, no deletion
+ * (spec §15). Absent when the reviewee hasn't responded yet or was never
+ * entitled (flag target, self-response, …).
+ */
+export interface ReviewResponseDto {
+  id: number;
+  text: string;
+  createdAt: string;
+}
+
+/**
+ * Shape of one review row. Every field that depends on visibility (text,
+ * rating, submittedAt) is nullable — the backend returns {@code null} until
+ * the row is revealed to the viewer (§8.1). The {@code pending} boolean is a
+ * viewer-specific hint: {@code true} means the viewer is this review's
+ * author and the counterparty hasn't submitted yet.
+ */
+export interface ReviewDto {
+  id: number;
+  auctionId: number;
+  auctionTitle: string;
+  auctionPrimaryPhotoUrl: string | null;
+  reviewerId: number;
+  reviewerDisplayName: string;
+  reviewerAvatarUrl: string | null;
+  revieweeId: number;
+  reviewedRole: ReviewedRole;
+  rating: number | null;
+  text: string | null;
+  visible: boolean;
+  pending: boolean;
+  submittedAt: string | null;
+  revealedAt: string | null;
+  response: ReviewResponseDto | null;
+}
+
+/**
+ * Envelope returned by {@code GET /api/v1/auctions/{id}/reviews}. Collapses
+ * the five {@code ReviewPanel} states into one round-trip: {@code reviews}
+ * contains any revealed rows, {@code myPendingReview} is the viewer's own
+ * hidden submission (if any), {@code canReview}/{@code windowClosesAt}
+ * describe whether the form should render.
+ */
+export interface AuctionReviewsResponse {
+  reviews: ReviewDto[];
+  myPendingReview: ReviewDto | null;
+  canReview: boolean;
+  windowClosesAt: string | null;
+}
+
+/**
+ * One entry in {@code GET /api/v1/users/me/pending-reviews}. Sorted most-
+ * urgent-first by the backend, so the dashboard renders in order without
+ * client-side sort (see backend commit {@code 2c7e125}).
+ */
+export interface PendingReviewDto {
+  auctionId: number;
+  title: string;
+  primaryPhotoUrl: string | null;
+  counterpartyId: number;
+  counterpartyDisplayName: string;
+  counterpartyAvatarUrl: string | null;
+  escrowCompletedAt: string;
+  windowClosesAt: string;
+  hoursRemaining: number;
+  viewerRole: ReviewedRole;
+}
+
+/**
+ * POST body for {@code /api/v1/auctions/{id}/reviews}. {@code text} is
+ * optional — rating-only reviews are allowed (spec §10).
+ */
+export interface ReviewSubmitRequest {
+  rating: number;
+  text?: string;
+}
+
+/**
+ * POST body for {@code /api/v1/reviews/{id}/respond}. {@code text} is
+ * required and non-empty; the service rejects blank strings.
+ */
+export interface ReviewResponseSubmitRequest {
+  text: string;
+}
+
+/**
+ * POST body for {@code /api/v1/reviews/{id}/flag}. {@code elaboration} is
+ * required iff {@code reason === "OTHER"}.
+ */
+export interface ReviewFlagRequest {
+  reason: ReviewFlagReason;
+  elaboration?: string;
+}


### PR DESCRIPTION
## Summary

Ships the blind-reveal reviews backend, reputation aggregation pipeline, and every public review UI surface end-to-end. Covers Epic 08 Tasks 01 + 02 + 04 (review service, reputation aggregation, reviews UI). Cancellation penalties + 48h post-cancel ownership watcher are deferred to sub-spec 2.

**Spec:** [`docs/superpowers/specs/2026-04-24-epic-08-sub-1-reviews-reputation.md`](./docs/superpowers/specs/2026-04-24-epic-08-sub-1-reviews-reputation.md)
**Plan:** [`docs/superpowers/plans/2026-04-24-epic-08-sub-1-reviews-reputation.md`](./docs/superpowers/plans/2026-04-24-epic-08-sub-1-reviews-reputation.md)

## What ships

### Backend
- New `review` package: `Review` / `ReviewResponse` / `ReviewFlag` entities + `ReviewedRole` / `ReviewFlagReason` enums + 3 repositories + `Aggregate` projection (no Flyway migrations — JPA `ddl-auto: update`).
- Six REST endpoints:
  - `POST /api/v1/auctions/{id}/reviews` — submit (eligibility-checked, 14-day window, 422/409 mapping)
  - `GET /api/v1/auctions/{id}/reviews` — public + own-pending enrichment for authenticated party
  - `POST /api/v1/reviews/{id}/respond` — one response per review (409 on duplicate, 403 on non-reviewee)
  - `POST /api/v1/reviews/{id}/flag` — enum reason + optional elaboration (required when `OTHER`); `flagCount++` side effect; one flag per user per review
  - `GET /api/v1/users/{id}/reviews?role=...&page&size` — `PagedResponse<ReviewDto>`, sorted `revealedAt DESC`
  - `GET /api/v1/users/me/pending-reviews` — sorted most-urgent-first
- `BlindReviewRevealTask` — hourly cron (`@ConditionalOnProperty`), batch limit 500, idempotent reveal.
- `ReviewService.reveal` — pessimistic lock, idempotent early-return on already-visible, full AVG+COUNT recompute on reveal. Simultaneous-reveal path inside `submit` flips both rows + recomputes both aggregates atomically when the second party submits.
- `ReviewRevealedEnvelope` published on `/topic/auction/{id}` after commit.
- `User.escrowExpiredUnfulfilled` (new column) + `SellerCompletionRateMapper.compute(int, int, int)` extended to formula B: `completedSales / (completedSales + cancelledWithBids + escrowExpiredUnfulfilled)`. All callers updated.
- `TerminalCommandService.handleEscrowPayoutSuccess` increments `seller.completedSales` (was a dormant column).
- `EscrowService.expireTransfer` increments `seller.escrowExpiredUnfulfilled` (NOT `expirePayment` — buyer-fault correctly excluded).
- `SellerSummaryDto.completedSales` field added; `UserProfileResponse` extended with `completionRate` + `isNewSeller`.

### Frontend
- New `components/reviews/` package: `RatingSummary` (partial-star SVG with `<linearGradient>`, `useId()` for SSR-safe IDs), `StarSelector` (interactive 1-5, full keyboard a11y, `role="radiogroup"`), `ReviewCard`, `FlagModal`, `RespondModal`, `ReviewPanel` (7 derived states), `ReviewList`, `ProfileReviewTabs`, `PendingReviewsSection`.
- 6 React Query hooks in `useReviews.ts` (caching + invalidation + 409-specific toast copy).
- `lib/api/reviews.ts` — 6 API functions; `types/review.ts` mirrors backend DTOs.
- `ReviewPanel` mounts on `/auction/{id}/escrow` when escrow `state === "COMPLETED"`. WS handler invalidates `["reviews", "auction", auctionId]` on `REVIEW_REVEALED`.
- `ProfileReviewTabs` replaces the legacy "No reviews yet" empty-state in `PublicProfileView`. URL-synced `?tab=seller|buyer` + per-tab pagination via `?sellerPage` / `?buyerPage`.
- `PendingReviewsSection` on dashboard overview — links to `/auction/{id}/escrow#review-panel` for hash-scroll into the panel.
- `ReputationStars` refactored to a thin wrapper over `RatingSummary` (resolves the 3-epics-deferred partial-star rendering ledger entry).

### Build fix bonus
- `AuctionDetailClient.tsx` — fixed pre-existing TypeScript narrowing bug in the WS envelope union switch that was blocking `npm run build`.
- Two pre-existing Suspense-boundary issues on `/saved` and `/dev/listing-card-demo` that were masked by the TS failure — wrapped in `<Suspense>` boundaries.

## DEFERRED_WORK ledger changes

**Resolved (deleted):**
- _Partial-star rendering for ReputationStars_ (Epic 02 sub-spec 2b)
- _Recent reviews section on public profile_ (Epic 02 sub-spec 2b)

**Out of scope for sub-spec 1** (carried forward, in expected epics):
- Cancellation penalty ladder + suspension enforcement → Epic 08 sub-spec 2
- 48h post-cancel ownership watcher → Epic 08 sub-spec 2
- Email / SL-IM notifications on review events → Epic 09
- Admin review moderation queue + auto-hide thresholds → Epic 10
- Public `flagCount` exposure (admin DTO) → Epic 10

## Test plan

- [x] Backend: `cd backend && ./mvnw test` — 993 tests pass; 4 pre-existing failures unchanged on this branch (libwebp native-load on arm64 Mac × 3, parcel-tags `permitAll` mismatch × 1)
- [x] Frontend: `cd frontend && npm test -- --run` — 1149 tests pass across 190 files
- [x] Frontend lint: `cd frontend && npm run lint` — clean
- [x] Frontend build: `cd frontend && npm run build` — passing (21 static pages prerendered)
- [ ] Manual: post-completion escrow flow → submit review on both sides → both reveal in real time via WS
- [ ] Manual: only one party submits → wait 14 days → scheduler reveals (or simulate via `BlindReviewRevealTask.run()`)
- [ ] Manual: `/users/{id}` profile shows tabbed reviews with partial-star rating
- [ ] Manual: `/dashboard/overview` Pending reviews card → CTA → review panel hash-scroll

## Commits

13 commits — 2 docs + 11 implementation, organized per task with spec-review and code-quality-review fixup commits where issues surfaced.