### PR TITLE
Epic 08 sub-spec 2 — Cancellation Penalties & Anti-Circumvention

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/Auction.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/Auction.java
@@ -100,6 +100,19 @@ public class Auction {
     @Column(name = "last_ownership_check_at")
     private OffsetDateTime lastOwnershipCheckAt;
 
+    /**
+     * Watch-window deadline for the post-cancellation ownership probe (Epic 08
+     * sub-spec 2 §6). Set when an {@code ACTIVE}-with-bids auction is
+     * cancelled, to {@code now + slpa.cancellation.post-cancel-watch-hours}
+     * (default 48h). The ownership monitor scans for cancelled auctions whose
+     * watch window is still open and raises a {@code CANCEL_AND_SELL} fraud
+     * flag if the parcel ownership flips to a non-seller avatar within the
+     * window. {@code null} for cancellations that don't qualify (pre-active,
+     * or active-without-bids).
+     */
+    @Column(name = "post_cancel_watch_until")
+    private OffsetDateTime postCancelWatchUntil;
+
     @Builder.Default
     @Column(name = "consecutive_world_api_failures", nullable = false, columnDefinition = "integer NOT NULL DEFAULT 0")
     private Integer consecutiveWorldApiFailures = 0;

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionRepository.java
@@ -78,21 +78,38 @@ public interface AuctionRepository extends JpaRepository<Auction, Long>, JpaSpec
     Optional<Auction> findByIdForDetail(@Param("id") Long id);
 
     /**
-     * Returns the IDs of ACTIVE auctions whose {@code lastOwnershipCheckAt} is
-     * either null (never checked — happens on fresh activation when the
-     * jitter-seeded timestamp lands before the cutoff) or at/before the cutoff.
-     * Sorted oldest-first so the longest-stale listings are dispatched first.
-     * Nulls sort first so fresh ACTIVE transitions that missed the jitter
-     * window still participate in the next sweep. See
-     * {@code OwnershipMonitorScheduler} for the cutoff derivation.
+     * Returns the IDs of auctions due for an ownership check. Two paths share
+     * the {@code lastOwnershipCheckAt < cutoff} cadence gate so the polling
+     * frequency is uniform across both:
+     * <ul>
+     *   <li><b>ACTIVE auctions</b> — the live ownership-monitor flow. A null
+     *       {@code lastOwnershipCheckAt} qualifies (fresh ACTIVE transitions
+     *       that missed the jitter window still get picked up).</li>
+     *   <li><b>CANCELLED auctions inside their post-cancel watch window</b> —
+     *       Epic 08 sub-spec 2 §6. {@code postCancelWatchUntil} is set on
+     *       cancel-with-bids and points {@code now + watch-hours} into the
+     *       future; rows whose window has expired are excluded by the
+     *       {@code postCancelWatchUntil > :now} predicate. The watch window
+     *       gets cleared once a {@code CANCEL_AND_SELL} flag is raised so a
+     *       single auction can flag at most once during the window.</li>
+     * </ul>
+     *
+     * <p>Sort is oldest-first within each branch so the longest-stale
+     * listings are dispatched first; nulls sort first.
      */
     @Query("""
             SELECT a.id FROM Auction a
-            WHERE a.status = com.slparcelauctions.backend.auction.AuctionStatus.ACTIVE
-              AND (a.lastOwnershipCheckAt IS NULL OR a.lastOwnershipCheckAt <= :cutoff)
+            WHERE (a.status = com.slparcelauctions.backend.auction.AuctionStatus.ACTIVE
+                    AND (a.lastOwnershipCheckAt IS NULL OR a.lastOwnershipCheckAt <= :cutoff))
+               OR (a.status = com.slparcelauctions.backend.auction.AuctionStatus.CANCELLED
+                    AND a.postCancelWatchUntil IS NOT NULL
+                    AND a.postCancelWatchUntil > :now
+                    AND (a.lastOwnershipCheckAt IS NULL OR a.lastOwnershipCheckAt <= :cutoff))
             ORDER BY a.lastOwnershipCheckAt ASC NULLS FIRST
             """)
-    List<Long> findDueForOwnershipCheck(@Param("cutoff") OffsetDateTime cutoff);
+    List<Long> findDueForOwnershipCheck(
+            @Param("cutoff") OffsetDateTime cutoff,
+            @Param("now") OffsetDateTime now);
 
     /**
      * Acquires a {@code PESSIMISTIC_WRITE} (i.e. {@code SELECT ... FOR UPDATE})

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionService.java
@@ -1,6 +1,8 @@
 package com.slparcelauctions.backend.auction;
 
 import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -19,6 +21,8 @@ import com.slparcelauctions.backend.auction.dto.AuctionCreateRequest;
 import com.slparcelauctions.backend.auction.dto.AuctionUpdateRequest;
 import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
 import com.slparcelauctions.backend.auction.exception.InvalidAuctionStateException;
+import com.slparcelauctions.backend.auction.exception.SellerSuspendedException;
+import com.slparcelauctions.backend.auction.exception.SuspensionReason;
 import com.slparcelauctions.backend.parcel.Parcel;
 import com.slparcelauctions.backend.parcel.ParcelRepository;
 import com.slparcelauctions.backend.parceltag.ParcelTag;
@@ -41,6 +45,7 @@ public class AuctionService {
     private final ParcelRepository parcelRepo;
     private final UserRepository userRepo;
     private final ParcelTagRepository tagRepo;
+    private final Clock clock;
 
     @Value("${slpa.commission.default-rate:0.05}")
     private BigDecimal defaultCommissionRate;
@@ -54,6 +59,18 @@ public class AuctionService {
 
         User seller = userRepo.findById(sellerId)
                 .orElseThrow(() -> new IllegalStateException("Authenticated user not found: " + sellerId));
+
+        // Listing-creation suspension gate (Epic 08 sub-spec 2 §7.7). Order is
+        // most-restrictive-first: a permanent ban shadows a timed suspension,
+        // which shadows an outstanding penalty balance. The first match
+        // surfaces as the {@code code} on the 403 ProblemDetail so the
+        // frontend can branch on the discriminator without parsing the
+        // human-readable detail.
+        SuspensionReason suspended = checkCanCreateListing(seller);
+        if (suspended != null) {
+            throw new SellerSuspendedException(suspended);
+        }
+
         Parcel parcel = parcelRepo.findById(req.parcelId())
                 .orElseThrow(() -> new IllegalArgumentException("Parcel not found: " + req.parcelId()));
 
@@ -213,6 +230,26 @@ public class AuctionService {
             }
         }
         return new PageImpl<>(ordered, pageable, idsPage.getTotalElements());
+    }
+
+    /**
+     * Returns the most-restrictive {@link SuspensionReason} that bars the
+     * caller from creating a new listing, or {@code null} if no condition
+     * applies. Order matters: ban → timed → penalty. See Epic 08 sub-spec 2
+     * §7.7.
+     */
+    private SuspensionReason checkCanCreateListing(User u) {
+        if (Boolean.TRUE.equals(u.getBannedFromListing())) {
+            return SuspensionReason.PERMANENT_BAN;
+        }
+        if (u.getListingSuspensionUntil() != null
+                && OffsetDateTime.now(clock).isBefore(u.getListingSuspensionUntil())) {
+            return SuspensionReason.TIMED_SUSPENSION;
+        }
+        if (u.getPenaltyBalanceOwed() != null && u.getPenaltyBalanceOwed() > 0L) {
+            return SuspensionReason.PENALTY_OWED;
+        }
+        return null;
     }
 
     private Set<ParcelTag> resolveTags(Set<String> codes) {

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLog.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLog.java
@@ -8,6 +8,8 @@ import com.slparcelauctions.backend.user.User;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -51,6 +53,24 @@ public class CancellationLog {
 
     @Column(length = 500)
     private String reason;
+
+    /**
+     * Snapshot of the ladder consequence selected at the moment of this
+     * cancellation. Immutable historical fact — never recomputed. Nullable
+     * because pre-sub-spec-2 rows have no kind. See spec §4.3.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "penalty_kind", length = 30)
+    private CancellationOffenseKind penaltyKind;
+
+    /**
+     * Snapshot of the L$ debt added by this cancellation. Populated when
+     * {@code penaltyKind} is {@code PENALTY} or {@code PENALTY_AND_30D};
+     * {@code null} for {@code NONE}, {@code WARNING}, and
+     * {@code PERMANENT_BAN}. Pre-sub-spec-2 rows are also {@code null}.
+     */
+    @Column(name = "penalty_amount_l")
+    private Long penaltyAmountL;
 
     @CreationTimestamp
     @Column(name = "cancelled_at", nullable = false, updatable = false)

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLogRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLogRepository.java
@@ -26,12 +26,14 @@ public interface CancellationLogRepository extends JpaRepository<CancellationLog
 
     /**
      * Paginated cancellation history for one seller, hydrated with the
-     * referenced auction (and its parcel) so the DTO mapper can pick a primary
-     * photo URL without an N+1 lazy fetch storm. Sorting is supplied by the
-     * caller via {@link Pageable} — the controller pins
+     * referenced auction (its parcel and photos) so the DTO mapper can pick a
+     * primary photo URL without an N+1 lazy fetch storm. The {@code auction.photos}
+     * collection is the only to-many in the graph, so Hibernate batches the
+     * fetch via a single LEFT JOIN without Cartesian explosion. Sorting is
+     * supplied by the caller via {@link Pageable} — the controller pins
      * {@code Sort.by("cancelledAt").descending()} per spec §7.4.
      */
-    @EntityGraph(attributePaths = {"auction", "auction.parcel"})
+    @EntityGraph(attributePaths = {"auction", "auction.parcel", "auction.photos"})
     Page<CancellationLog> findBySellerId(Long sellerId, Pageable pageable);
 
     /**

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLogRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLogRepository.java
@@ -1,5 +1,10 @@
 package com.slparcelauctions.backend.auction;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,4 +23,30 @@ public interface CancellationLogRepository extends JpaRepository<CancellationLog
     @Query("SELECT count(c) FROM CancellationLog c "
             + "WHERE c.seller.id = :sellerId AND c.hadBids = true")
     long countPriorOffensesWithBids(@Param("sellerId") Long sellerId);
+
+    /**
+     * Paginated cancellation history for one seller, hydrated with the
+     * referenced auction (and its parcel) so the DTO mapper can pick a primary
+     * photo URL without an N+1 lazy fetch storm. Sorting is supplied by the
+     * caller via {@link Pageable} — the controller pins
+     * {@code Sort.by("cancelledAt").descending()} per spec §7.4.
+     */
+    @EntityGraph(attributePaths = {"auction", "auction.parcel"})
+    Page<CancellationLog> findBySellerId(Long sellerId, Pageable pageable);
+
+    /**
+     * Most-recent cancellation log rows for a given auction, newest first.
+     * Used by the post-cancel ownership watcher (Epic 08 sub-spec 2 §6.3) to
+     * derive the {@code hoursSinceCancellation} evidence field — computed
+     * from the latest row's {@code cancelledAt} rather than
+     * {@code postCancelWatchUntil - 48h} so the math is robust even if the
+     * watch-window length is reconfigured. Callers should pass
+     * {@code PageRequest.of(0, 1)} and read the first element; the return
+     * type is {@code List} (not {@code Optional}) because Spring Data
+     * rejects {@code Optional} on JPQL queries that take a {@link Pageable}.
+     */
+    @Query("SELECT c FROM CancellationLog c WHERE c.auction.id = :auctionId "
+            + "ORDER BY c.cancelledAt DESC")
+    List<CancellationLog> findLatestByAuctionId(
+            @Param("auctionId") Long auctionId, Pageable pageable);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLogRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLogRepository.java
@@ -1,6 +1,21 @@
 package com.slparcelauctions.backend.auction;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CancellationLogRepository extends JpaRepository<CancellationLog, Long> {
+
+    /**
+     * Count of prior cancelled-with-bids log rows for a seller. Drives the
+     * ladder index in {@code CancellationService.cancel} — the call MUST run
+     * BEFORE the new log row is inserted (off-by-one trap). Result indices:
+     * 0 → WARNING, 1 → PENALTY, 2 → PENALTY_AND_30D, 3+ → PERMANENT_BAN.
+     * The seller-row pessimistic lock acquired earlier in the same
+     * transaction prevents two concurrent cancellations from racing on this
+     * count.
+     */
+    @Query("SELECT count(c) FROM CancellationLog c "
+            + "WHERE c.seller.id = :sellerId AND c.hadBids = true")
+    long countPriorOffensesWithBids(@Param("sellerId") Long sellerId);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationOffenseKind.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationOffenseKind.java
@@ -1,0 +1,29 @@
+package com.slparcelauctions.backend.auction;
+
+/**
+ * Discriminator for the consequence applied at a single cancellation event.
+ * Stored on {@link CancellationLog} as a snapshot — historical fact, not a
+ * derivation of what would be computed today. The decision uses live query
+ * of prior log rows; the record is immutable. See spec §4.3.
+ *
+ * <ul>
+ *   <li>{@code NONE} — pre-live cancellation or active-without-bids; no
+ *       penalty applied.</li>
+ *   <li>{@code WARNING} — first cancelled-with-bids offense; logged only,
+ *       no debt or suspension.</li>
+ *   <li>{@code PENALTY} — second cancelled-with-bids offense; debits the
+ *       configured second-offense L$ amount (default 1000).</li>
+ *   <li>{@code PENALTY_AND_30D} — third cancelled-with-bids offense; debits
+ *       the configured third-offense L$ amount (default 2500) and stamps a
+ *       30-day listing suspension.</li>
+ *   <li>{@code PERMANENT_BAN} — fourth-or-later cancelled-with-bids offense;
+ *       sets {@code User.bannedFromListing = true}.</li>
+ * </ul>
+ */
+public enum CancellationOffenseKind {
+    NONE,
+    WARNING,
+    PENALTY,
+    PENALTY_AND_30D,
+    PERMANENT_BAN
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationPenaltyProperties.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationPenaltyProperties.java
@@ -1,0 +1,31 @@
+package com.slparcelauctions.backend.auction;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Configuration for the cancellation-penalty ladder (Epic 08 sub-spec 2 §2).
+ * Bound to {@code slpa.cancellation.*}. The ladder fires only on cancellations
+ * of {@code ACTIVE} auctions that already have at least one bid; the
+ * {@code post-cancel-watch-hours} window arms the ownership watcher for the
+ * same path.
+ *
+ * <p>Registered via {@code CancellationPenaltyConfig} —
+ * the project uses {@code @EnableConfigurationProperties} rather than
+ * {@code @ConfigurationPropertiesScan}.
+ */
+@ConfigurationProperties(prefix = "slpa.cancellation")
+@Validated
+public record CancellationPenaltyProperties(
+        @NotNull @Valid Penalty penalty,
+        @Min(1) int postCancelWatchHours) {
+
+    public record Penalty(
+            @Min(1) long secondOffenseL,
+            @Min(1) long thirdOffenseL,
+            @Min(1) int thirdOffenseSuspensionDays) {}
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationService.java
@@ -6,7 +6,11 @@ import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import com.slparcelauctions.backend.auction.broadcast.AuctionBroadcastPublisher;
+import com.slparcelauctions.backend.auction.dto.AuctionCancelledEnvelope;
 import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
 import com.slparcelauctions.backend.auction.exception.InvalidAuctionStateException;
 import com.slparcelauctions.backend.bot.BotMonitorLifecycleService;
@@ -29,6 +33,15 @@ import lombok.extern.slf4j.Slf4j;
  * loser sees whichever status the winner committed (ACTIVE → CANCELLED or
  * ACTIVE → ENDED) and surfaces a {@link InvalidAuctionStateException}. See
  * {@code BidCancelRaceTest} for the pin.
+ *
+ * <p><strong>Penalty ladder (Epic 08 sub-spec 2).</strong> When an
+ * {@code ACTIVE} auction with bids is cancelled, the seller's prior
+ * cancelled-with-bids count drives a four-step ladder
+ * (see {@link CancellationOffenseKind}). The seller row is pessimistically
+ * locked BEFORE the count read so two concurrent cancellations on the same
+ * seller serialise and observe distinct ladder indices. The selected
+ * {@link CancellationOffenseKind} and L$ amount are snapshotted onto the
+ * {@link CancellationLog} row as immutable historical fact.
  */
 @Service
 @RequiredArgsConstructor
@@ -47,6 +60,8 @@ public class CancellationService {
     private final ListingFeeRefundRepository refundRepo;
     private final UserRepository userRepo;
     private final BotMonitorLifecycleService monitorLifecycle;
+    private final AuctionBroadcastPublisher broadcastPublisher;
+    private final CancellationPenaltyProperties penaltyProps;
     private final Clock clock;
 
     @Transactional
@@ -64,15 +79,82 @@ public class CancellationService {
 
         AuctionStatus from = a.getStatus();
         boolean hadBids = a.getBidCount() != null && a.getBidCount() > 0;
+        boolean activeWithBids = from == AuctionStatus.ACTIVE && hadBids;
 
-        // Cancellation log
+        // Pessimistic lock on the seller row — must precede the COUNT so two
+        // concurrent cancellations on the same seller serialise here and
+        // observe distinct prior-offense counts. Pre-active and active-without-
+        // bids cancellations also acquire the lock to keep the path uniform;
+        // the lock is cheap and avoids branching that would matter only on
+        // the cold path.
+        User seller = userRepo.findByIdForUpdate(a.getSeller().getId())
+                .orElseThrow(); // FK guarantees existence
+
+        // Pre-INSERT count → ladder index → consequence snapshot. Indices are
+        // clamped at 3 so the 4th-and-beyond offenses all snapshot
+        // PERMANENT_BAN. This call MUST run before saving the new log row
+        // (off-by-one trap).
+        CancellationOffenseKind kind;
+        Long amountL;
+        if (activeWithBids) {
+            long prior = logRepo.countPriorOffensesWithBids(seller.getId());
+            int index = (int) Math.min(prior, 3L);
+            switch (index) {
+                case 0 -> {
+                    kind = CancellationOffenseKind.WARNING;
+                    amountL = null;
+                }
+                case 1 -> {
+                    kind = CancellationOffenseKind.PENALTY;
+                    amountL = penaltyProps.penalty().secondOffenseL();
+                }
+                case 2 -> {
+                    kind = CancellationOffenseKind.PENALTY_AND_30D;
+                    amountL = penaltyProps.penalty().thirdOffenseL();
+                }
+                default -> {
+                    kind = CancellationOffenseKind.PERMANENT_BAN;
+                    amountL = null;
+                }
+            }
+        } else {
+            kind = CancellationOffenseKind.NONE;
+            amountL = null;
+        }
+
+        // Snapshot the consequence onto the log row — immutable historical
+        // fact, never recomputed from live state.
         logRepo.save(CancellationLog.builder()
                 .auction(a)
-                .seller(a.getSeller())
+                .seller(seller)
                 .cancelledFromStatus(from.name())
                 .hadBids(hadBids)
                 .reason(reason)
+                .penaltyKind(kind)
+                .penaltyAmountL(amountL)
                 .build());
+
+        // Apply consequence + arm the post-cancel ownership-watcher window.
+        if (activeWithBids) {
+            seller.setCancelledWithBids(seller.getCancelledWithBids() + 1);
+            OffsetDateTime now = OffsetDateTime.now(clock);
+            switch (kind) {
+                case PENALTY -> seller.setPenaltyBalanceOwed(
+                        seller.getPenaltyBalanceOwed() + amountL);
+                case PENALTY_AND_30D -> {
+                    seller.setPenaltyBalanceOwed(
+                            seller.getPenaltyBalanceOwed() + amountL);
+                    seller.setListingSuspensionUntil(
+                            now.plusDays(penaltyProps.penalty().thirdOffenseSuspensionDays()));
+                }
+                case PERMANENT_BAN -> seller.setBannedFromListing(true);
+                default -> {
+                    // WARNING / NONE — log only, no consequence.
+                }
+            }
+            userRepo.save(seller);
+            a.setPostCancelWatchUntil(now.plusHours(penaltyProps.postCancelWatchHours()));
+        }
 
         // Refund record if fee was paid and this is a pre-live cancellation
         if (Boolean.TRUE.equals(a.getListingFeePaid())
@@ -85,17 +167,30 @@ public class CancellationService {
             log.info("Listing fee refund (PENDING) created for auction {}", a.getId());
         }
 
-        // cancelled_with_bids counter on ACTIVE cancellations with bids
-        if (from == AuctionStatus.ACTIVE && hadBids) {
-            User seller = a.getSeller();
-            seller.setCancelledWithBids(seller.getCancelledWithBids() + 1);
-            userRepo.save(seller);
-        }
-
         a.setStatus(AuctionStatus.CANCELLED);
         Auction saved = auctionRepo.save(a);
         monitorLifecycle.onAuctionClosed(saved);
-        log.info("Auction {} cancelled from {} (hadBids={})", a.getId(), from, hadBids);
+        log.info("Auction {} cancelled from {} (hadBids={}, kind={})",
+                a.getId(), from, hadBids, kind);
+
+        // Register the WS broadcast for afterCommit only — never inside the
+        // tx. Subscribers must never observe a cancellation that rolls back
+        // on a late DB failure. Mirrors the pattern used by ReviewService.
+        AuctionCancelledEnvelope envelope = AuctionCancelledEnvelope.of(
+                saved, hadBids, OffsetDateTime.now(clock));
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            broadcastPublisher.publishCancelled(envelope);
+                        }
+                    });
+        } else {
+            // Slice tests / non-tx callers — fire immediately.
+            broadcastPublisher.publishCancelled(envelope);
+        }
+
         return saved;
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationStatusController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationStatusController.java
@@ -1,0 +1,47 @@
+package com.slparcelauctions.backend.auction;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.auction.dto.CancellationHistoryDto;
+import com.slparcelauctions.backend.auction.dto.CancellationStatusResponse;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.common.PagedResponse;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Read-only endpoints backing the cancel modal and the seller's cancellation
+ * history view (Epic 08 sub-spec 2 §7.3 / §7.4). Both paths require a JWT —
+ * see SecurityConfig — and read the caller off the
+ * {@link AuthPrincipal} (FOOTGUNS §B.1: never use {@code UserDetails}).
+ */
+@RestController
+@RequestMapping("/api/v1/users/me")
+@RequiredArgsConstructor
+public class CancellationStatusController {
+
+    private final CancellationStatusService service;
+
+    @GetMapping("/cancellation-status")
+    public CancellationStatusResponse status(
+            @AuthenticationPrincipal AuthPrincipal principal) {
+        return service.statusFor(principal.userId());
+    }
+
+    @GetMapping("/cancellation-history")
+    public PagedResponse<CancellationHistoryDto> history(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        // PageRequest size is clamped at the service layer
+        // (CancellationStatusService.MAX_PAGE_SIZE = 50) so a caller
+        // requesting size=9999 still gets a 50-row page.
+        return PagedResponse.from(
+                service.historyFor(principal.userId(), PageRequest.of(page, size)));
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationStatusService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationStatusService.java
@@ -1,0 +1,122 @@
+package com.slparcelauctions.backend.auction;
+
+import java.util.Comparator;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.auction.dto.CancellationHistoryDto;
+import com.slparcelauctions.backend.auction.dto.CancellationStatusResponse;
+import com.slparcelauctions.backend.auction.dto.NextConsequenceDto;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserNotFoundException;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Read-only service for the seller-facing cancellation surfaces (Epic 08
+ * sub-spec 2 §7.3 / §7.4). Two responsibilities:
+ * <ul>
+ *   <li>{@link #statusFor(Long)} — assembles the cancel-modal preview: prior
+ *       offense count, current suspension state, and the next-consequence
+ *       derivation using the same ladder logic as
+ *       {@link CancellationService}. The next-consequence preview is purely
+ *       hypothetical ("what would happen IF this cancel had bids") so the
+ *       kind is never {@link CancellationOffenseKind#NONE}.</li>
+ *   <li>{@link #historyFor(Long, Pageable)} — paginated read of
+ *       {@link CancellationLog} rows for the caller, sorted
+ *       {@code cancelledAt DESC}. Page size is clamped at 50 to prevent
+ *       abuse.</li>
+ * </ul>
+ *
+ * <p>Photo-URL resolution mirrors the convention from {@code AuctionPhotoResponse}
+ * — first sort-order photo via the byte-proxy URL, falling back to the parcel's
+ * snapshot when no listing photos exist.
+ */
+@Service
+@RequiredArgsConstructor
+public class CancellationStatusService {
+
+    /** Page size cap so callers can't request unbounded history pages. */
+    static final int MAX_PAGE_SIZE = 50;
+
+    private final CancellationLogRepository logRepo;
+    private final UserRepository userRepo;
+    private final AuctionPhotoRepository photoRepo;
+    private final CancellationPenaltyProperties penaltyProps;
+
+    @Transactional(readOnly = true)
+    public CancellationStatusResponse statusFor(Long userId) {
+        User u = userRepo.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        long prior = logRepo.countPriorOffensesWithBids(userId);
+        // Indices 0..3 → WARNING, PENALTY, PENALTY_AND_30D, PERMANENT_BAN.
+        // Anything beyond 3 collapses onto PERMANENT_BAN — a banned account
+        // shouldn't be hitting this preview at all (the gate already blocks
+        // listing creation), but the ladder math stays well-defined.
+        int index = (int) Math.min(prior, 3L);
+        CancellationOffenseKind nextKind;
+        Long nextAmount;
+        switch (index) {
+            case 0 -> {
+                nextKind = CancellationOffenseKind.WARNING;
+                nextAmount = null;
+            }
+            case 1 -> {
+                nextKind = CancellationOffenseKind.PENALTY;
+                nextAmount = penaltyProps.penalty().secondOffenseL();
+            }
+            case 2 -> {
+                nextKind = CancellationOffenseKind.PENALTY_AND_30D;
+                nextAmount = penaltyProps.penalty().thirdOffenseL();
+            }
+            default -> {
+                nextKind = CancellationOffenseKind.PERMANENT_BAN;
+                nextAmount = null;
+            }
+        }
+
+        return new CancellationStatusResponse(
+                prior,
+                new CancellationStatusResponse.CurrentSuspension(
+                        u.getPenaltyBalanceOwed(),
+                        u.getListingSuspensionUntil(),
+                        u.getBannedFromListing()),
+                NextConsequenceDto.from(nextKind, nextAmount));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CancellationHistoryDto> historyFor(Long userId, Pageable page) {
+        // Caller's Sort is ignored — spec §7.4 pins cancelledAt DESC. Size
+        // is clamped at MAX_PAGE_SIZE on the way in.
+        Pageable sorted = PageRequest.of(
+                page.getPageNumber(),
+                Math.min(page.getPageSize(), MAX_PAGE_SIZE),
+                Sort.by(Sort.Direction.DESC, "cancelledAt"));
+        Page<CancellationLog> logs = logRepo.findBySellerId(userId, sorted);
+        return logs.map(log -> CancellationHistoryDto.from(
+                log, resolvePrimaryPhotoUrl(log.getAuction())));
+    }
+
+    private String resolvePrimaryPhotoUrl(Auction auction) {
+        // Listing photos live on a separate table; query them via the repo
+        // rather than relying on the lazy {@code Auction.photos} collection
+        // (which is read-only inverse and not always hydrated under
+        // {@code spring.jpa.open-in-view=false}). Pick the first sort-order
+        // and project to the byte-proxy URL the rest of the app uses.
+        List<AuctionPhoto> photos = photoRepo.findByAuctionIdOrderBySortOrderAsc(auction.getId());
+        return photos.stream()
+                .min(Comparator.comparing(AuctionPhoto::getSortOrder))
+                .map(p -> "/api/v1/auctions/" + auction.getId() + "/photos/" + p.getId() + "/bytes")
+                .orElseGet(() -> auction.getParcel() == null
+                        ? null
+                        : auction.getParcel().getSnapshotUrl());
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationStatusService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationStatusService.java
@@ -1,7 +1,6 @@
 package com.slparcelauctions.backend.auction;
 
 import java.util.Comparator;
-import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -48,7 +47,6 @@ public class CancellationStatusService {
 
     private final CancellationLogRepository logRepo;
     private final UserRepository userRepo;
-    private final AuctionPhotoRepository photoRepo;
     private final CancellationPenaltyProperties penaltyProps;
 
     @Transactional(readOnly = true)
@@ -106,13 +104,11 @@ public class CancellationStatusService {
     }
 
     private String resolvePrimaryPhotoUrl(Auction auction) {
-        // Listing photos live on a separate table; query them via the repo
-        // rather than relying on the lazy {@code Auction.photos} collection
-        // (which is read-only inverse and not always hydrated under
-        // {@code spring.jpa.open-in-view=false}). Pick the first sort-order
+        // Photos are eagerly hydrated by the {@code @EntityGraph} on
+        // {@link CancellationLogRepository#findBySellerId} (one LEFT JOIN per
+        // page, not per row), so we read straight off the entity collection
         // and project to the byte-proxy URL the rest of the app uses.
-        List<AuctionPhoto> photos = photoRepo.findByAuctionIdOrderBySortOrderAsc(auction.getId());
-        return photos.stream()
+        return auction.getPhotos().stream()
                 .min(Comparator.comparing(AuctionPhoto::getSortOrder))
                 .map(p -> "/api/v1/auctions/" + auction.getId() + "/photos/" + p.getId() + "/bytes")
                 .orElseGet(() -> auction.getParcel() == null

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/broadcast/AuctionBroadcastPublisher.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/broadcast/AuctionBroadcastPublisher.java
@@ -1,5 +1,7 @@
 package com.slparcelauctions.backend.auction.broadcast;
 
+import com.slparcelauctions.backend.auction.dto.AuctionCancelledEnvelope;
+
 /**
  * Abstraction over the WebSocket broadcast layer. Bid-placement, proxy, and
  * auction-end services depend on this interface and never touch STOMP
@@ -30,4 +32,13 @@ public interface AuctionBroadcastPublisher {
      * that end the auction. Never called from Task 2's core bid path.
      */
     void publishEnded(AuctionEndedEnvelope envelope);
+
+    /**
+     * Publishes an {@link AuctionCancelledEnvelope} when an auction
+     * transitions to {@code CANCELLED}. Invoked from
+     * {@code CancellationService.cancel}'s afterCommit callback so
+     * subscribers never observe a cancellation that rolls back. Closes the
+     * deferred-ledger "Cancellation WS broadcast" entry (Epic 08 sub-spec 2).
+     */
+    void publishCancelled(AuctionCancelledEnvelope envelope);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/broadcast/NoOpAuctionBroadcastPublisher.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/broadcast/NoOpAuctionBroadcastPublisher.java
@@ -4,6 +4,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.slparcelauctions.backend.auction.dto.AuctionCancelledEnvelope;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -38,6 +40,12 @@ public class NoOpAuctionBroadcastPublisher {
             public void publishEnded(AuctionEndedEnvelope envelope) {
                 log.debug("no-op publishEnded: auctionId={}, outcome={}",
                         envelope.auctionId(), envelope.endOutcome());
+            }
+
+            @Override
+            public void publishCancelled(AuctionCancelledEnvelope envelope) {
+                log.debug("no-op publishCancelled: auctionId={}, hadBids={}",
+                        envelope.auctionId(), envelope.hadBids());
             }
         };
     }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/broadcast/StompAuctionBroadcastPublisher.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/broadcast/StompAuctionBroadcastPublisher.java
@@ -4,6 +4,8 @@ import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
+import com.slparcelauctions.backend.auction.dto.AuctionCancelledEnvelope;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -74,6 +76,19 @@ public class StompAuctionBroadcastPublisher implements AuctionBroadcastPublisher
             messagingTemplate.convertAndSend(destination, envelope);
         } catch (MessagingException e) {
             log.warn("Failed to publish AUCTION_ENDED for auction {}: {}",
+                    envelope.auctionId(), e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void publishCancelled(AuctionCancelledEnvelope envelope) {
+        String destination = "/topic/auction/" + envelope.auctionId();
+        log.info("Publishing AUCTION_CANCELLED to {}: hadBids={}, cancelledAt={}",
+                destination, envelope.hadBids(), envelope.cancelledAt());
+        try {
+            messagingTemplate.convertAndSend(destination, envelope);
+        } catch (MessagingException e) {
+            log.warn("Failed to publish AUCTION_CANCELLED for auction {}: {}",
                     envelope.auctionId(), e.getMessage(), e);
         }
     }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/config/CancellationPenaltyConfig.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/config/CancellationPenaltyConfig.java
@@ -1,0 +1,18 @@
+package com.slparcelauctions.backend.auction.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import com.slparcelauctions.backend.auction.CancellationPenaltyProperties;
+
+/**
+ * Registers {@link CancellationPenaltyProperties} as a configuration-properties
+ * bean. Mirrors the pattern used by
+ * {@code com.slparcelauctions.backend.escrow.config.EscrowPropertiesConfig} —
+ * the project uses {@code @EnableConfigurationProperties} rather than
+ * {@code @ConfigurationPropertiesScan}.
+ */
+@Configuration
+@EnableConfigurationProperties(CancellationPenaltyProperties.class)
+public class CancellationPenaltyConfig {
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/dto/AuctionCancelledEnvelope.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/dto/AuctionCancelledEnvelope.java
@@ -1,0 +1,33 @@
+package com.slparcelauctions.backend.auction.dto;
+
+import java.time.OffsetDateTime;
+
+import com.slparcelauctions.backend.auction.Auction;
+
+/**
+ * WebSocket payload broadcast to {@code /topic/auction/{auctionId}} when an
+ * auction transitions to {@code CANCELLED}. Closes the deferred-ledger
+ * "Cancellation WS broadcast" entry by folding {@code AUCTION_CANCELLED} into
+ * Epic 08 sub-spec 2. Subscribers route on {@code type} alongside
+ * {@code BID_SETTLEMENT} / {@code AUCTION_ENDED} / {@code REVIEW_REVEALED}
+ * from a single subscription.
+ *
+ * <p>The publisher is invoked from a
+ * {@code TransactionSynchronization.afterCommit} callback registered inside
+ * {@code CancellationService.cancel}, so subscribers never observe a
+ * cancellation that rolls back on a late DB failure.
+ */
+public record AuctionCancelledEnvelope(
+        String type,
+        Long auctionId,
+        OffsetDateTime cancelledAt,
+        Boolean hadBids) {
+
+    public static AuctionCancelledEnvelope of(Auction auction, boolean hadBids, OffsetDateTime cancelledAt) {
+        return new AuctionCancelledEnvelope(
+                "AUCTION_CANCELLED",
+                auction.getId(),
+                cancelledAt,
+                hadBids);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/dto/CancellationHistoryDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/dto/CancellationHistoryDto.java
@@ -1,0 +1,52 @@
+package com.slparcelauctions.backend.auction.dto;
+
+import java.time.OffsetDateTime;
+
+import com.slparcelauctions.backend.auction.CancellationLog;
+import com.slparcelauctions.backend.auction.CancellationOffenseKind;
+
+/**
+ * Single row in the seller's paginated cancellation history (Epic 08 sub-spec 2
+ * §7.4). All fields are read directly from the snapshotted
+ * {@link CancellationLog} columns — no live recomputation against today's
+ * ladder. {@link #penaltyApplied} is null when the log row's
+ * {@code penaltyKind} is {@link CancellationOffenseKind#NONE} (pre-active or
+ * active-without-bids cancellation, or a pre-sub-spec-2 row); the frontend
+ * renders a "No penalty" badge in that case.
+ */
+public record CancellationHistoryDto(
+        Long auctionId,
+        String auctionTitle,
+        String primaryPhotoUrl,
+        String cancelledFromStatus,
+        Boolean hadBids,
+        String reason,
+        OffsetDateTime cancelledAt,
+        PenaltyApplied penaltyApplied) {
+
+    public record PenaltyApplied(
+            CancellationOffenseKind kind,
+            Long amountL) {}
+
+    /**
+     * Builds the DTO from the persisted log row plus the resolved primary
+     * photo URL. The log carries the snapshotted kind/amount; the resolver
+     * upstream picks the auction's first-sort-order photo or falls back to
+     * the parcel snapshot.
+     */
+    public static CancellationHistoryDto from(CancellationLog log, String primaryPhotoUrl) {
+        PenaltyApplied applied = (log.getPenaltyKind() == null
+                || log.getPenaltyKind() == CancellationOffenseKind.NONE)
+                ? null
+                : new PenaltyApplied(log.getPenaltyKind(), log.getPenaltyAmountL());
+        return new CancellationHistoryDto(
+                log.getAuction().getId(),
+                log.getAuction().getTitle(),
+                primaryPhotoUrl,
+                log.getCancelledFromStatus(),
+                log.getHadBids(),
+                log.getReason(),
+                log.getCancelledAt(),
+                applied);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/dto/CancellationStatusResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/dto/CancellationStatusResponse.java
@@ -1,0 +1,31 @@
+package com.slparcelauctions.backend.auction.dto;
+
+import java.time.OffsetDateTime;
+
+/**
+ * {@code GET /api/v1/users/me/cancellation-status} response shape (Epic 08
+ * sub-spec 2 §7.3). Three concerns:
+ * <ul>
+ *   <li>{@link #priorOffensesWithBids} — count of historical
+ *       cancelled-with-bids logs for this seller, drives the ladder index in
+ *       the cancel modal preview.</li>
+ *   <li>{@link #currentSuspension} — current account state mirroring the
+ *       three new {@code User} columns (penalty balance, suspension expiry,
+ *       permanent ban). Echoed here so the dashboard banner has the data on
+ *       a single fetch.</li>
+ *   <li>{@link #nextConsequenceIfBidsPresent} — preview of what the next
+ *       cancel WOULD trigger if the auction had bids. Never
+ *       {@link com.slparcelauctions.backend.auction.CancellationOffenseKind#NONE}
+ *       since the question is hypothetical — see {@link NextConsequenceDto}.</li>
+ * </ul>
+ */
+public record CancellationStatusResponse(
+        long priorOffensesWithBids,
+        CurrentSuspension currentSuspension,
+        NextConsequenceDto nextConsequenceIfBidsPresent) {
+
+    public record CurrentSuspension(
+            Long penaltyBalanceOwed,
+            OffsetDateTime listingSuspensionUntil,
+            Boolean bannedFromListing) {}
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/dto/NextConsequenceDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/dto/NextConsequenceDto.java
@@ -1,0 +1,31 @@
+package com.slparcelauctions.backend.auction.dto;
+
+import com.slparcelauctions.backend.auction.CancellationOffenseKind;
+
+/**
+ * Cancel-modal preview row — what would happen IF the seller cancels an
+ * {@code ACTIVE}-with-bids auction right now (Epic 08 sub-spec 2 §7.3). Because
+ * the query is hypothetical ("if bids were present"), {@link #kind} is never
+ * {@link CancellationOffenseKind#NONE} — even a clean record (0 prior
+ * offenses) yields {@link CancellationOffenseKind#WARNING}. The boolean
+ * convenience flags ({@link #suspends30Days}, {@link #permanentBan}) are
+ * derived from {@link #kind} so the frontend can render badges off a single
+ * field without re-deriving.
+ *
+ * <p>{@link #amountL} is null for {@code WARNING} and {@code PERMANENT_BAN}
+ * (no L$ change) and populated for {@code PENALTY} / {@code PENALTY_AND_30D}.
+ */
+public record NextConsequenceDto(
+        CancellationOffenseKind kind,
+        Long amountL,
+        Boolean suspends30Days,
+        Boolean permanentBan) {
+
+    public static NextConsequenceDto from(CancellationOffenseKind kind, Long amountL) {
+        return new NextConsequenceDto(
+                kind,
+                amountL,
+                kind == CancellationOffenseKind.PENALTY_AND_30D,
+                kind == CancellationOffenseKind.PERMANENT_BAN);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/exception/AuctionExceptionHandler.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/exception/AuctionExceptionHandler.java
@@ -237,6 +237,33 @@ public class AuctionExceptionHandler {
         return pd;
     }
 
+    /**
+     * Listing-creation suspension gate (Epic 08 sub-spec 2 §7.7). 403 (not
+     * 422) because the resource is forbidden until the user resolves the
+     * underlying state — pay penalty at terminal, wait out suspension, or
+     * (in the ban case) admin intervention. The {@code code} property
+     * carries the {@link SuspensionReason} enum value as a String so the
+     * frontend can branch on the discriminator without parsing detail copy.
+     */
+    @ExceptionHandler(SellerSuspendedException.class)
+    public ProblemDetail handleSellerSuspended(
+            SellerSuspendedException e, HttpServletRequest req) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.FORBIDDEN);
+        pd.setType(URI.create("https://slpa.example/problems/seller-suspended"));
+        pd.setTitle("Listing creation suspended");
+        pd.setInstance(URI.create(req.getRequestURI()));
+        pd.setProperty("code", e.getReason().name());
+        pd.setDetail(switch (e.getReason()) {
+            case PENALTY_OWED ->
+                    "You have an outstanding penalty balance. Pay at any SLPA terminal to resume listing.";
+            case TIMED_SUSPENSION ->
+                    "Your listing privileges are temporarily suspended.";
+            case PERMANENT_BAN ->
+                    "Your listing privileges have been permanently suspended.";
+        });
+        return pd;
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ProblemDetail handleIllegalArgument(IllegalArgumentException e, HttpServletRequest req) {
         ProblemDetail pd = ProblemDetail.forStatusAndDetail(

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/exception/SellerSuspendedException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/exception/SellerSuspendedException.java
@@ -1,0 +1,21 @@
+package com.slparcelauctions.backend.auction.exception;
+
+import lombok.Getter;
+
+/**
+ * Thrown by {@code AuctionService.create} when the seller's account state
+ * forbids creating a new listing — see Epic 08 sub-spec 2 §7.7 for the gate
+ * order and {@link SuspensionReason} for the discriminator. Mapped to a
+ * {@code 403 application/problem+json} response with the enum value carried as
+ * the {@code code} property by {@link AuctionExceptionHandler}.
+ */
+@Getter
+public class SellerSuspendedException extends RuntimeException {
+
+    private final SuspensionReason reason;
+
+    public SellerSuspendedException(SuspensionReason reason) {
+        super("Seller is suspended from listing: " + reason);
+        this.reason = reason;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/exception/SuspensionReason.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/exception/SuspensionReason.java
@@ -1,0 +1,16 @@
+package com.slparcelauctions.backend.auction.exception;
+
+/**
+ * Enumerates the reasons a seller can be barred from creating a new listing
+ * (Epic 08 sub-spec 2 §7.7). Order is significant: the gate evaluates the most
+ * restrictive condition first ({@code PERMANENT_BAN} → {@code TIMED_SUSPENSION}
+ * → {@code PENALTY_OWED}) and surfaces the first match. The enum value rides
+ * along on the {@code SellerSuspendedException} and is serialised as the
+ * {@code code} property on the 403 ProblemDetail so the frontend can branch on
+ * it without parsing the human-readable detail.
+ */
+public enum SuspensionReason {
+    PENALTY_OWED,
+    TIMED_SUSPENSION,
+    PERMANENT_BAN
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/fraud/FraudFlagReason.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/fraud/FraudFlagReason.java
@@ -63,5 +63,12 @@ public enum FraudFlagReason {
      * (default 3). Seller has revoked bot access — treated as fraud on
      * active auctions; the escrow flow uses markReviewRequired instead.
      */
-    BOT_ACCESS_REVOKED
+    BOT_ACCESS_REVOKED,
+    /**
+     * Raised by the post-cancel ownership watcher (Epic 08 sub-spec 2 §6) when
+     * a CANCELLED auction's parcel ownership flips to a non-seller avatar
+     * within {@code slpa.cancellation.post-cancel-watch-hours} of cancellation
+     * (default 48h). Strong signal of an off-platform deal.
+     */
+    CANCEL_AND_SELL
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/OwnershipCheckTask.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/OwnershipCheckTask.java
@@ -4,6 +4,7 @@ import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,6 +12,8 @@ import org.springframework.transaction.annotation.Transactional;
 import com.slparcelauctions.backend.auction.Auction;
 import com.slparcelauctions.backend.auction.AuctionRepository;
 import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.CancellationLog;
+import com.slparcelauctions.backend.auction.CancellationLogRepository;
 import com.slparcelauctions.backend.sl.SlWorldApiClient;
 import com.slparcelauctions.backend.sl.dto.ParcelMetadata;
 import com.slparcelauctions.backend.sl.exception.ExternalApiTimeoutException;
@@ -54,6 +57,7 @@ public class OwnershipCheckTask {
     private final AuctionRepository auctionRepo;
     private final SlWorldApiClient worldApi;
     private final SuspensionService suspensionService;
+    private final CancellationLogRepository cancellationLogRepo;
     private final Clock clock;
 
     @Async
@@ -69,9 +73,18 @@ public class OwnershipCheckTask {
             log.debug("Ownership check skipped: auction {} not found", auctionId);
             return;
         }
-        if (auction.getStatus() != AuctionStatus.ACTIVE) {
+        // Two valid paths: ACTIVE (live ownership monitor) and CANCELLED with
+        // an open post-cancel watch window (Epic 08 sub-spec 2 §6). Anything
+        // else short-circuits — covers the race where status moves between
+        // scheduler dispatch and async execution.
+        AuctionStatus status = auction.getStatus();
+        boolean activePath = status == AuctionStatus.ACTIVE;
+        boolean cancelledWatchPath = status == AuctionStatus.CANCELLED
+                && auction.getPostCancelWatchUntil() != null
+                && OffsetDateTime.now(clock).isBefore(auction.getPostCancelWatchUntil());
+        if (!activePath && !cancelledWatchPath) {
             log.debug("Ownership check skipped: auction {} status={}",
-                    auctionId, auction.getStatus());
+                    auctionId, status);
             return;
         }
 
@@ -87,16 +100,47 @@ public class OwnershipCheckTask {
             }
             UUID expected = auction.getSeller().getSlAvatarUuid();
             UUID actual = result.ownerUuid();
-            if (expected != null && expected.equals(actual) && "agent".equalsIgnoreCase(result.ownerType())) {
+            boolean ownerMatches = expected != null
+                    && expected.equals(actual)
+                    && "agent".equalsIgnoreCase(result.ownerType());
+            if (ownerMatches) {
                 auction.setLastOwnershipCheckAt(OffsetDateTime.now(clock));
                 auction.setConsecutiveWorldApiFailures(0);
                 auctionRepo.save(auction);
                 log.debug("Ownership check OK for auction {} (owner={})", auctionId, actual);
+                return;
+            }
+
+            if (cancelledWatchPath) {
+                // Post-cancel mismatch — raise the CANCEL_AND_SELL flag. Clear
+                // {@code postCancelWatchUntil} on the same row so subsequent
+                // ticks during the original window don't re-flag the same
+                // cancellation. The flag carries the rich evidence map per
+                // spec §6.3 so admin reviewers can score temporal proximity.
+                suspensionService.raiseCancelAndSellFlag(auction, actual,
+                        resolveCancelledAt(auction));
+                auction.setLastOwnershipCheckAt(OffsetDateTime.now(clock));
+                auction.setPostCancelWatchUntil(null);
+                auctionRepo.save(auction);
             } else {
+                // ACTIVE mismatch — existing flow. SuspensionService handles
+                // the status flip (ACTIVE → SUSPENDED), the fraud-flag write,
+                // and removes the auction from the watcher query naturally
+                // since the status is no longer ACTIVE.
                 suspensionService.suspendForOwnershipChange(auction, result);
             }
         } catch (ParcelNotFoundInSlException e) {
-            suspensionService.suspendForDeletedParcel(auction);
+            // Both paths route a deleted parcel through the existing
+            // suspension service — for the CANCELLED path the auction is
+            // already cancelled, so this is best-effort logging. The flag
+            // helps the admin dashboard tie a deleted-parcel signal to the
+            // post-cancel window.
+            if (activePath) {
+                suspensionService.suspendForDeletedParcel(auction);
+            } else {
+                log.warn("Post-cancel watcher: parcel {} no longer exists in-world for auction {}",
+                        parcelUuid, auctionId);
+            }
         } catch (ExternalApiTimeoutException e) {
             handleTimeout(auction, e.getMessage());
         } catch (RuntimeException e) {
@@ -107,6 +151,20 @@ public class OwnershipCheckTask {
             // unexpected. Log with stack trace and let the next sweep retry.
             log.error("Unexpected error checking auction {}: {}", auctionId, e.getMessage(), e);
         }
+    }
+
+    /**
+     * Resolves the cancellation timestamp from the most recent
+     * {@link CancellationLog} for the auction. Drives the
+     * {@code hoursSinceCancellation} evidence field — computing from the log
+     * row (not {@code postCancelWatchUntil - watchHours}) keeps the math
+     * robust if the watch-window length is reconfigured between cancel and
+     * flag.
+     */
+    private OffsetDateTime resolveCancelledAt(Auction auction) {
+        java.util.List<CancellationLog> latest =
+                cancellationLogRepo.findLatestByAuctionId(auction.getId(), PageRequest.of(0, 1));
+        return latest.isEmpty() ? null : latest.get(0).getCancelledAt();
     }
 
     private void handleTimeout(Auction auction, String detail) {

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/OwnershipMonitorScheduler.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/OwnershipMonitorScheduler.java
@@ -49,9 +49,15 @@ public class OwnershipMonitorScheduler {
 
     @Scheduled(fixedDelayString = "${slpa.ownership-monitor.scheduler-frequency:PT30S}")
     public void dispatchDueChecks() {
-        OffsetDateTime cutoff = OffsetDateTime.now(clock)
-                .minusMinutes(props.getCheckIntervalMinutes());
-        List<Long> dueIds = auctionRepo.findDueForOwnershipCheck(cutoff);
+        // {@code now} is passed alongside {@code cutoff} so the post-cancel
+        // watch-window predicate ({@code postCancelWatchUntil > :now}) and the
+        // cadence gate ({@code lastOwnershipCheckAt < :cutoff}) are evaluated
+        // against the same wall-clock instant — the two values are derived
+        // from one {@link Clock#instant()} read so a slow scheduler tick can
+        // not see different "now"s on the two predicates.
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        OffsetDateTime cutoff = now.minusMinutes(props.getCheckIntervalMinutes());
+        List<Long> dueIds = auctionRepo.findDueForOwnershipCheck(cutoff, now);
         if (dueIds.isEmpty()) {
             return;
         }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/SuspensionService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/SuspensionService.java
@@ -4,6 +4,7 @@ import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -104,6 +105,64 @@ public class SuspensionService {
 
         log.warn("Auction {} SUSPENDED: parcel {} no longer exists in-world",
                 auction.getId(), auction.getParcel().getSlParcelUuid());
+    }
+
+    /**
+     * Raises a {@link FraudFlagReason#CANCEL_AND_SELL} flag for a CANCELLED
+     * auction whose parcel ownership has flipped to a non-seller avatar
+     * within the post-cancel watch window (Epic 08 sub-spec 2 §6). Unlike
+     * {@link #suspendForOwnershipChange}, the auction is already CANCELLED
+     * so no status transition or {@code monitorLifecycle} hook fires — the
+     * flag is for admin review only. The caller is responsible for clearing
+     * {@code postCancelWatchUntil} on the auction (preventing re-flag on
+     * subsequent ticks during the original watch window).
+     *
+     * <p>Evidence shape per spec §6.3: snapshot of cancelledAt, expected
+     * vs observed owner UUIDs, an exact {@code hoursSinceCancellation}
+     * decimal so admin reviewers can score temporal proximity, plus the
+     * parcel/auction descriptors for at-a-glance context.
+     */
+    @Transactional
+    public void raiseCancelAndSellFlag(
+            Auction auction,
+            UUID observedOwnerKey,
+            OffsetDateTime cancelledAt) {
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        UUID expectedSeller = auction.getSeller().getSlAvatarUuid();
+
+        Map<String, Object> ev = new HashMap<>();
+        ev.put("cancelledAt", cancelledAt == null ? null : cancelledAt.toString());
+        ev.put("expectedSellerKey", expectedSeller == null ? null : expectedSeller.toString());
+        ev.put("observedOwnerKey", observedOwnerKey == null ? null : observedOwnerKey.toString());
+        // Decimal hours so the admin UI can display "4.2h" / "31.7h" without
+        // re-deriving from raw timestamps. Null if the cancellation log is
+        // missing — should not happen on a CANCELLED auction with an open
+        // watch window, but the JSON schema is permissive.
+        if (cancelledAt != null) {
+            double hours = (now.toEpochSecond() - cancelledAt.toEpochSecond()) / 3600.0;
+            ev.put("hoursSinceCancellation", hours);
+        } else {
+            ev.put("hoursSinceCancellation", null);
+        }
+        ev.put("parcelRegion", auction.getParcel().getRegionName());
+        // The Parcel entity carries no SL-side "local id" today — surface the
+        // database id as a stable handle so admin tools can join back to the
+        // parcel without leaking SL implementation details. If a future SL
+        // local-id column lands on Parcel, swap this projection in place.
+        ev.put("parcelLocalId", auction.getParcel().getId());
+        ev.put("auctionTitle", auction.getTitle());
+
+        fraudFlagRepo.save(FraudFlag.builder()
+                .auction(auction)
+                .parcel(auction.getParcel())
+                .reason(FraudFlagReason.CANCEL_AND_SELL)
+                .detectedAt(now)
+                .evidenceJson(ev)
+                .resolved(false)
+                .build());
+
+        log.warn("Auction {} CANCEL_AND_SELL flag raised: expectedSeller={}, observedOwner={}, hoursSince={}",
+                auction.getId(), expectedSeller, observedOwnerKey, ev.get("hoursSinceCancellation"));
     }
 
     /**

--- a/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
@@ -161,6 +161,17 @@ public class SecurityConfig {
                         // added in-place without disturbing the POST rule.
                         // FOOTGUNS §B.5: this MUST sit before the
                         // /api/v1/** catch-all (first-match-wins).
+                        // Cancellation preview + history (Epic 08 sub-spec 2
+                        // Task 2). Both are seller-private — JWT required so
+                        // CancellationStatusController can read the caller's
+                        // userId off the AuthPrincipal. The /me/* paths sit
+                        // BEFORE the /api/v1/users/{id}-style wildcards above
+                        // because matcher order is first-match-wins
+                        // (FOOTGUNS §B.5) and well above the /api/v1/**
+                        // catch-all so the contract is explicit at this
+                        // surface.
+                        .requestMatchers(HttpMethod.GET, "/api/v1/users/me/cancellation-status").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/users/me/cancellation-history").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auctions/*/reviews").authenticated()
                         // Review read endpoints (Epic 08 sub-spec 1 Task 2).
                         // GET /auctions/{id}/reviews and

--- a/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
@@ -94,6 +94,17 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/sl/escrow/payment").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/sl/escrow/payout-result").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/sl/listing-fee/payment").permitAll()
+                        // Cancellation-penalty terminal endpoints (Epic 08 sub-spec 2
+                        // Tasks 3 §7.5 / §7.6). Same trust model as the escrow
+                        // terminal endpoints above: permitAll at the HTTP layer,
+                        // SlHeaderValidator inside PenaltyTerminalController is the
+                        // actual security boundary (X-SecondLife-Shard +
+                        // X-SecondLife-Owner-Key). LSL scripts cannot present a
+                        // JWT, so this is the only viable trust gate for terminal
+                        // traffic. FOOTGUNS §B.5: MUST sit before the /api/v1/**
+                        // catch-all (first-match-wins).
+                        .requestMatchers(HttpMethod.POST, "/api/v1/sl/penalty-lookup").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/sl/penalty-payment").permitAll()
                         // --- New in Epic 02 sub-spec 2a ---
                         // Public avatar proxy. Must come before the /api/v1/** catch-all
                         // and before /api/v1/users/{id} (also public). FOOTGUNS section B.5

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowTransactionType.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowTransactionType.java
@@ -6,5 +6,11 @@ public enum EscrowTransactionType {
     AUCTION_ESCROW_REFUND,
     AUCTION_ESCROW_COMMISSION,
     LISTING_FEE_PAYMENT,
-    LISTING_FEE_REFUND
+    LISTING_FEE_REFUND,
+    /**
+     * Penalty payment from a seller at a SLPA terminal, paying down their
+     * {@code User.penaltyBalanceOwed} debt accrued from cancelled-with-bids
+     * offenses (Epic 08 sub-spec 2 §4.6).
+     */
+    LISTING_PENALTY_PAYMENT
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowTransactionTypeCheckConstraintInitializer.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowTransactionTypeCheckConstraintInitializer.java
@@ -1,0 +1,34 @@
+package com.slparcelauctions.backend.escrow;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import com.slparcelauctions.backend.common.EnumCheckConstraintSync;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Refreshes the {@code escrow_transactions_type_check} constraint on
+ * startup so new values added to {@link EscrowTransactionType} do not
+ * require a manual DDL edit. Added when Epic 08 sub-spec 2 introduced
+ * {@link EscrowTransactionType#LISTING_PENALTY_PAYMENT} — without this
+ * initializer, the original CHECK constraint (created by Hibernate at
+ * first boot before {@code LISTING_PENALTY_PAYMENT} existed) rejects
+ * the new value with {@code violates check constraint
+ * "escrow_transactions_type_check"}. See {@link EnumCheckConstraintSync}
+ * and FOOTGUNS §F.51 for the rationale.
+ */
+@Component
+@RequiredArgsConstructor
+public class EscrowTransactionTypeCheckConstraintInitializer {
+
+    private final JdbcTemplate jdbc;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void refresh() {
+        new EnumCheckConstraintSync(jdbc)
+                .sync("escrow_transactions", "type", EscrowTransactionType.class);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/sl/PenaltyTerminalController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/sl/PenaltyTerminalController.java
@@ -1,0 +1,60 @@
+package com.slparcelauctions.backend.sl;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.sl.dto.PenaltyLookupRequest;
+import com.slparcelauctions.backend.sl.dto.PenaltyLookupResponse;
+import com.slparcelauctions.backend.sl.dto.PenaltyPaymentRequest;
+import com.slparcelauctions.backend.sl.dto.PenaltyPaymentResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * In-world LSL terminal endpoints for cancellation-penalty payment
+ * (Epic 08 sub-spec 2 §7.5 / §7.6). Mirrors the trust model of
+ * {@link SlVerificationController} and the escrow terminal endpoints:
+ * the paths are {@code permitAll} at the Spring Security layer and the
+ * actual security boundary is {@link SlHeaderValidator} validating the
+ * SL-grid-injected {@code X-SecondLife-Shard} +
+ * {@code X-SecondLife-Owner-Key} headers inside the handler. LSL
+ * scripts cannot present a JWT (avatars have no web session), so this
+ * is the only viable trust gate for terminal traffic.
+ *
+ * <p>{@code /penalty-lookup} is a read-only debt query —
+ * {@link PenaltyTerminalService#lookup} returns the outstanding balance
+ * or 404 if the avatar is unknown / owes nothing. {@code /penalty-payment}
+ * applies a partial-or-full payment with idempotency on
+ * {@code slTransactionId}; benign retries return the current balance,
+ * overpayment beyond the outstanding balance returns 422.
+ */
+@RestController
+@RequestMapping("/api/v1/sl")
+@RequiredArgsConstructor
+public class PenaltyTerminalController {
+
+    private final PenaltyTerminalService service;
+    private final SlHeaderValidator headerValidator;
+
+    @PostMapping("/penalty-lookup")
+    public PenaltyLookupResponse lookup(
+            @RequestHeader(value = "X-SecondLife-Shard", required = false) String shard,
+            @RequestHeader(value = "X-SecondLife-Owner-Key", required = false) String ownerKey,
+            @Valid @RequestBody PenaltyLookupRequest req) {
+        headerValidator.validate(shard, ownerKey);
+        return service.lookup(req.slAvatarUuid());
+    }
+
+    @PostMapping("/penalty-payment")
+    public PenaltyPaymentResponse pay(
+            @RequestHeader(value = "X-SecondLife-Shard", required = false) String shard,
+            @RequestHeader(value = "X-SecondLife-Owner-Key", required = false) String ownerKey,
+            @Valid @RequestBody PenaltyPaymentRequest req) {
+        headerValidator.validate(shard, ownerKey);
+        return service.pay(req);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/sl/PenaltyTerminalService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/sl/PenaltyTerminalService.java
@@ -1,0 +1,161 @@
+package com.slparcelauctions.backend.sl;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.escrow.EscrowTransaction;
+import com.slparcelauctions.backend.escrow.EscrowTransactionRepository;
+import com.slparcelauctions.backend.escrow.EscrowTransactionStatus;
+import com.slparcelauctions.backend.escrow.EscrowTransactionType;
+import com.slparcelauctions.backend.sl.dto.PenaltyLookupResponse;
+import com.slparcelauctions.backend.sl.dto.PenaltyPaymentRequest;
+import com.slparcelauctions.backend.sl.dto.PenaltyPaymentResponse;
+import com.slparcelauctions.backend.sl.exception.PenaltyOverpaymentException;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserNotFoundException;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Domain service backing the SL terminal penalty endpoints (Epic 08
+ * sub-spec 2 §7.5 / §7.6). Two operations:
+ *
+ * <ul>
+ *   <li>{@link #lookup(UUID)} — read-only debt query. 404 if the avatar
+ *       is unknown OR the user owes nothing.</li>
+ *   <li>{@link #pay(PenaltyPaymentRequest)} — apply a partial-or-full
+ *       payment. Idempotent on {@code slTransactionId}: a benign retry
+ *       returns the current balance without writing a second ledger
+ *       row. The non-idempotent path acquires a {@code PESSIMISTIC_WRITE}
+ *       lock on the {@code User} row before reading the outstanding
+ *       balance so two concurrent terminal sessions on the same seller
+ *       serialise on the database side.</li>
+ * </ul>
+ *
+ * <p>Idempotency lookup intentionally happens BEFORE the pessimistic
+ * lock — a replay of an already-applied transaction must short-circuit
+ * without competing for the write lock, otherwise two retried payments
+ * for the same {@code slTransactionId} could each block waiting for the
+ * other. The trade-off is a tiny race window where two non-replay
+ * payments could see "no prior row" and both proceed to the lock; that
+ * is exactly the case the lock + balance check exists to handle, and
+ * the second writer either succeeds (if its amount fits the now-reduced
+ * balance) or hits {@link PenaltyOverpaymentException}.
+ *
+ * <p>Ledger row shape mirrors the existing {@code AUCTION_ESCROW_COMMISSION}
+ * convention: {@code payer} is the locked {@link User}, {@code payee} is
+ * {@code null} (the platform side has no User entity), and the type is
+ * {@link EscrowTransactionType#LISTING_PENALTY_PAYMENT}.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PenaltyTerminalService {
+
+    private final UserRepository userRepo;
+    private final EscrowTransactionRepository ledgerRepo;
+    private final Clock clock;
+
+    @Transactional(readOnly = true)
+    public PenaltyLookupResponse lookup(UUID slAvatarUuid) {
+        User u = userRepo.findBySlAvatarUuid(slAvatarUuid)
+                .orElseThrow(() -> new UserNotFoundException(
+                        "No SLPA user found for avatar " + slAvatarUuid));
+
+        long balance = currentBalance(u);
+        if (balance == 0L) {
+            // Spec §7.5: zero-balance lookups are 404 so the terminal can
+            // render a single "no debt" branch without inspecting the
+            // numeric body. Distinguishing "unknown avatar" from "user
+            // exists but owes nothing" would only be useful to an
+            // attacker probing the user table.
+            throw new UserNotFoundException(
+                    "No outstanding penalty balance for avatar " + slAvatarUuid);
+        }
+        return new PenaltyLookupResponse(u.getId(), u.getDisplayName(), balance);
+    }
+
+    @Transactional
+    public PenaltyPaymentResponse pay(PenaltyPaymentRequest req) {
+        // Resolve avatar UUID → user id via a projection query so the
+        // full User entity is not hydrated into the persistence context
+        // before the lock is acquired. Hibernate's session cache would
+        // otherwise return the pre-lock entity instance for the
+        // subsequent findByIdForUpdate call with stale field values —
+        // silently defeating the lock for the read path. See
+        // UserRepository.findIdBySlAvatarUuid javadoc.
+        Long userId = userRepo.findIdBySlAvatarUuid(req.slAvatarUuid())
+                .orElseThrow(() -> new UserNotFoundException(
+                        "No SLPA user found for avatar " + req.slAvatarUuid()));
+
+        // Idempotency check happens BEFORE the pessimistic lock so a
+        // benign terminal-side retry never competes for a write lock
+        // (and never double-debits). Type-scoped on
+        // LISTING_PENALTY_PAYMENT so a hypothetical slTransactionId
+        // collision with another transaction kind cannot mask a real
+        // payment.
+        Optional<EscrowTransaction> existing = ledgerRepo
+                .findFirstBySlTransactionIdAndType(
+                        req.slTransactionId(),
+                        EscrowTransactionType.LISTING_PENALTY_PAYMENT);
+        if (existing.isPresent()) {
+            // Replay path — no need for the lock. Re-read the balance
+            // off a fresh entity (not cached) so the response reflects
+            // any committed concurrent payment from a different
+            // slTransactionId.
+            User snapshot = userRepo.findById(userId)
+                    .orElseThrow(() -> new UserNotFoundException(userId));
+            log.info("Idempotent replay of penalty payment slTxn={} user={} terminal={}",
+                    req.slTransactionId(), userId, req.terminalId());
+            return new PenaltyPaymentResponse(currentBalance(snapshot));
+        }
+
+        // Acquire the write lock and re-read the balance under the lock
+        // so two concurrent non-replay payments on the same user
+        // serialise. The second writer either commits a smaller-or-fits
+        // amount or hits the overpayment guard below.
+        User locked = userRepo.findByIdForUpdate(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        long balance = currentBalance(locked);
+        if (req.amount() > balance) {
+            throw new PenaltyOverpaymentException(req.amount(), balance);
+        }
+
+        long newBalance = balance - req.amount();
+        locked.setPenaltyBalanceOwed(newBalance);
+        userRepo.save(locked);
+
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        ledgerRepo.save(EscrowTransaction.builder()
+                .type(EscrowTransactionType.LISTING_PENALTY_PAYMENT)
+                .status(EscrowTransactionStatus.COMPLETED)
+                .amount(req.amount())
+                .payer(locked)
+                .payee(null)
+                .slTransactionId(req.slTransactionId())
+                .terminalId(req.terminalId())
+                .completedAt(now)
+                .build());
+
+        log.info("Penalty payment recorded: user={} amount=L${} remaining=L${} terminal={} slTxn={}",
+                locked.getId(), req.amount(), newBalance, req.terminalId(), req.slTransactionId());
+
+        return new PenaltyPaymentResponse(newBalance);
+    }
+
+    private static long currentBalance(User u) {
+        // The column carries a NOT NULL DEFAULT 0 on the entity, but
+        // legacy rows or in-memory test fixtures may still expose a null
+        // — coerce defensively rather than NPE on a hot terminal call.
+        Long balance = u.getPenaltyBalanceOwed();
+        return balance == null ? 0L : balance;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/sl/SlExceptionHandler.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/sl/SlExceptionHandler.java
@@ -15,6 +15,7 @@ import com.slparcelauctions.backend.auction.exception.InvalidAuctionStateExcepti
 import com.slparcelauctions.backend.auction.exception.ParcelAlreadyListedException;
 import com.slparcelauctions.backend.sl.exception.AvatarAlreadyLinkedException;
 import com.slparcelauctions.backend.sl.exception.InvalidSlHeadersException;
+import com.slparcelauctions.backend.sl.exception.PenaltyOverpaymentException;
 import com.slparcelauctions.backend.verification.exception.AlreadyVerifiedException;
 import com.slparcelauctions.backend.verification.exception.CodeCollisionException;
 import com.slparcelauctions.backend.verification.exception.CodeNotFoundException;
@@ -156,6 +157,33 @@ public class SlExceptionHandler {
         pd.setTitle("Parcel already listed");
         pd.setInstance(URI.create(req.getRequestURI()));
         pd.setProperty("code", "SL_PARCEL_ALREADY_LISTED");
+        return pd;
+    }
+
+    /**
+     * Penalty payment exceeds the seller's outstanding balance
+     * (Epic 08 sub-spec 2 §7.6). 422 because the request is well-formed
+     * and authenticated but cannot be applied without driving the
+     * balance negative — the LSL terminal should refund the excess
+     * L$ in-world. Both {@code requested} and {@code available} surface
+     * on the ProblemDetail so the in-world script can render an
+     * accurate message ("you tried to pay L${requested} but only owe
+     * L${available}").
+     */
+    @ExceptionHandler(PenaltyOverpaymentException.class)
+    public ProblemDetail handlePenaltyOverpayment(
+            PenaltyOverpaymentException e, HttpServletRequest req) {
+        log.warn("Penalty overpayment rejected: requested=L${} available=L${} path={}",
+                e.getRequested(), e.getAvailable(), req.getRequestURI());
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(
+                HttpStatus.UNPROCESSABLE_ENTITY,
+                "Payment amount exceeds outstanding penalty balance.");
+        pd.setType(URI.create("https://slpa.example/problems/sl/penalty-overpayment"));
+        pd.setTitle("Penalty overpayment");
+        pd.setInstance(URI.create(req.getRequestURI()));
+        pd.setProperty("code", "SL_PENALTY_OVERPAYMENT");
+        pd.setProperty("requested", e.getRequested());
+        pd.setProperty("available", e.getAvailable());
         return pd;
     }
 

--- a/backend/src/main/java/com/slparcelauctions/backend/sl/dto/PenaltyLookupRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/sl/dto/PenaltyLookupRequest.java
@@ -1,0 +1,19 @@
+package com.slparcelauctions.backend.sl.dto;
+
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Body of {@code POST /api/v1/sl/penalty-lookup} — the in-world terminal
+ * asks "does this avatar owe a cancellation penalty?". Spec §7.5.
+ *
+ * <p>{@code slAvatarUuid} is the avatar that walked up to the terminal;
+ * {@code terminalId} is the terminal's own object UUID, recorded in logs
+ * for forensics but not stored on a ledger row (lookup is read-only).
+ */
+public record PenaltyLookupRequest(
+        @NotNull UUID slAvatarUuid,
+        @NotBlank String terminalId
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/sl/dto/PenaltyLookupResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/sl/dto/PenaltyLookupResponse.java
@@ -1,0 +1,14 @@
+package com.slparcelauctions.backend.sl.dto;
+
+/**
+ * Body of a successful {@code POST /api/v1/sl/penalty-lookup} response.
+ * Spec §7.5: returned only when an SLPA user with this avatar UUID has a
+ * non-zero {@code penaltyBalanceOwed}; otherwise the controller returns
+ * 404 (no debt found / unknown avatar) so the terminal can render a clean
+ * "no penalty" message without branching on the body shape.
+ */
+public record PenaltyLookupResponse(
+        Long userId,
+        String displayName,
+        Long penaltyBalanceOwed
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/sl/dto/PenaltyPaymentRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/sl/dto/PenaltyPaymentRequest.java
@@ -1,0 +1,24 @@
+package com.slparcelauctions.backend.sl.dto;
+
+import java.util.UUID;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Body of {@code POST /api/v1/sl/penalty-payment} — the in-world terminal
+ * posts after pulling L$ from the seller's avatar. Spec §7.6.
+ *
+ * <p>{@code slTransactionId} is the SL grid's own transaction id, used as
+ * the idempotency key on the {@code escrow_transactions} ledger so a
+ * benign terminal-side retry returns the current balance instead of
+ * double-debiting. {@code amount} is the L$ paid (partial payments are
+ * allowed; overpayment beyond the outstanding balance returns 422).
+ */
+public record PenaltyPaymentRequest(
+        @NotNull UUID slAvatarUuid,
+        @NotBlank String slTransactionId,
+        @NotNull @Min(1) Long amount,
+        @NotBlank String terminalId
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/sl/dto/PenaltyPaymentResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/sl/dto/PenaltyPaymentResponse.java
@@ -1,0 +1,11 @@
+package com.slparcelauctions.backend.sl.dto;
+
+/**
+ * Body of a successful {@code POST /api/v1/sl/penalty-payment} response.
+ * Spec §7.6: {@code remainingBalance} is the new
+ * {@code User.penaltyBalanceOwed} after the payment was applied (or the
+ * unchanged value on idempotent replay of a previously recorded
+ * {@code slTransactionId}). Suspension stays active until this value
+ * reaches zero.
+ */
+public record PenaltyPaymentResponse(Long remainingBalance) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/sl/exception/PenaltyOverpaymentException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/sl/exception/PenaltyOverpaymentException.java
@@ -1,0 +1,26 @@
+package com.slparcelauctions.backend.sl.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Thrown by {@code PenaltyTerminalService.pay} when the requested
+ * payment {@code amount} exceeds the seller's outstanding
+ * {@code penaltyBalanceOwed}. Spec §7.6: the service refuses to drive
+ * the balance negative — the terminal should refund the excess L$
+ * in-world. Maps to HTTP 422 via
+ * {@link com.slparcelauctions.backend.sl.SlExceptionHandler}.
+ *
+ * <p>{@code requested} is the L$ the terminal tried to apply;
+ * {@code available} is the seller's current outstanding balance at the
+ * moment the lock was acquired. Both are surfaced on the ProblemDetail
+ * so the LSL script can tell the avatar "you tried to pay L${requested}
+ * but only owe L${available}".
+ */
+@Getter
+@RequiredArgsConstructor
+public class PenaltyOverpaymentException extends RuntimeException {
+
+    private final long requested;
+    private final long available;
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/user/User.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/User.java
@@ -123,6 +123,45 @@ public class User {
     @Column(name = "listing_suspension_until")
     private OffsetDateTime listingSuspensionUntil;
 
+    /**
+     * Outstanding penalty debt in L$ owed by this seller from cancelled-with-
+     * bids offenses on the cancellation ladder (Epic 08 sub-spec 2 §2). Pay-at-
+     * terminal model: while this is &gt; 0 the seller is suspended from creating
+     * new listings; payment at any SLPA terminal pays it down to zero, at which
+     * point the suspension lifts. Incremented atomically inside
+     * {@code CancellationService.cancel} when the ladder selects
+     * {@code PENALTY} or {@code PENALTY_AND_30D}; decremented by
+     * {@code PenaltyTerminalService} on payment receipt.
+     *
+     * <p>The {@code columnDefinition} supplies a SQL-side default so
+     * Hibernate's {@code ddl-auto: update} can add this NOT NULL column to
+     * existing rows on local dev databases without failing. The
+     * {@code @Builder.Default} handles the Java-side default for newly-
+     * constructed entities.
+     */
+    @Builder.Default
+    @Column(name = "penalty_balance_owed", nullable = false,
+            columnDefinition = "bigint not null default 0")
+    private Long penaltyBalanceOwed = 0L;
+
+    /**
+     * Permanent listing ban flag. Set to {@code true} on the seller's 4th+
+     * cancelled-with-bids offense by {@code CancellationService.cancel} when
+     * the ladder selects {@code PERMANENT_BAN}. Once set, listing creation is
+     * permanently denied — there is no automatic clear path; admins must
+     * intervene. See spec §2 (ladder) and §7.7 (gate semantics).
+     *
+     * <p>The {@code columnDefinition} supplies a SQL-side default so
+     * Hibernate's {@code ddl-auto: update} can add this NOT NULL column to
+     * existing rows on local dev databases without failing. The
+     * {@code @Builder.Default} handles the Java-side default for newly-
+     * constructed entities.
+     */
+    @Builder.Default
+    @Column(name = "banned_from_listing", nullable = false,
+            columnDefinition = "boolean not null default false")
+    private Boolean bannedFromListing = false;
+
     @Builder.Default
     @Column(name = "email_verified", nullable = false)
     private Boolean emailVerified = false;

--- a/backend/src/main/java/com/slparcelauctions/backend/user/UserNotFoundException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/UserNotFoundException.java
@@ -7,4 +7,13 @@ public class UserNotFoundException extends ResourceNotFoundException {
     public UserNotFoundException(Long id) {
         super("User not found: id=" + id);
     }
+
+    /**
+     * Free-form message constructor used by avatar-keyed lookups
+     * (e.g. {@code PenaltyTerminalService} resolving by SL avatar UUID).
+     * Maps to HTTP 404 via the global handler.
+     */
+    public UserNotFoundException(String message) {
+        super(message);
+    }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java
@@ -4,7 +4,12 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.LockModeType;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -16,4 +21,17 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     boolean existsBySlAvatarUuid(UUID slAvatarUuid);
+
+    /**
+     * Acquires a {@code PESSIMISTIC_WRITE} (i.e. {@code SELECT ... FOR UPDATE})
+     * row lock on the user inside the caller's transaction. Used by the
+     * cancellation flow so two concurrent cancellations on the same seller
+     * serialise on the User row before reading
+     * {@code CancellationLogRepository#countPriorOffensesWithBids} —
+     * preventing two callers from each seeing the same prior count and
+     * landing on the same ladder index.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT u FROM User u WHERE u.id = :id")
+    Optional<User> findByIdForUpdate(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java
@@ -34,4 +34,18 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT u FROM User u WHERE u.id = :id")
     Optional<User> findByIdForUpdate(@Param("id") Long id);
+
+    /**
+     * Projection lookup that returns only the user id for an SL avatar
+     * UUID, avoiding hydration of the full {@link User} entity into the
+     * persistence context. Used by the SL terminal penalty endpoints
+     * (Epic 08 sub-spec 2 §7.5 / §7.6) where the subsequent
+     * {@link #findByIdForUpdate(Long)} call must read the freshly
+     * locked row's state — Hibernate's session cache would otherwise
+     * return the pre-lock entity instance with stale field values
+     * and the lock would silently degrade to a no-op for the read
+     * path.
+     */
+    @Query("SELECT u.id FROM User u WHERE u.slAvatarUuid = :slAvatarUuid")
+    Optional<Long> findIdBySlAvatarUuid(@Param("slAvatarUuid") UUID slAvatarUuid);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/user/dto/UserResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/dto/UserResponse.java
@@ -24,6 +24,16 @@ public record UserResponse(
         Boolean emailVerified,
         Map<String, Object> notifyEmail,
         Map<String, Object> notifySlIm,
+        // Listing-suspension state (Epic 08 sub-spec 2 §7.2). Mirrors the
+        // three new User columns so the dashboard banner can render the
+        // current penalty/suspension/ban state from the same /me payload
+        // without an extra round-trip. Each field is independently
+        // populated — a banned account may still owe L$, etc. — and the
+        // frontend collapses them into a single banner per
+        // SuspensionReason ordering.
+        Long penaltyBalanceOwed,
+        OffsetDateTime listingSuspensionUntil,
+        Boolean bannedFromListing,
         OffsetDateTime createdAt,
         OffsetDateTime updatedAt) {
 
@@ -45,6 +55,9 @@ public record UserResponse(
                 user.getEmailVerified(),
                 user.getNotifyEmail(),
                 user.getNotifySlIm(),
+                user.getPenaltyBalanceOwed(),
+                user.getListingSuspensionUntil(),
+                user.getBannedFromListing(),
                 user.getCreatedAt(),
                 user.getUpdatedAt());
     }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -124,6 +124,19 @@ slpa:
     amount-lindens: 100
   commission:
     default-rate: 0.05
+  cancellation:
+    # Epic 08 sub-spec 2 §2 — cancellation-penalty ladder. Applied only when
+    # an ACTIVE auction with at least one bid is cancelled. Walking the ladder
+    # is keyed off the seller's count of prior cancelled-with-bids log rows.
+    penalty:
+      second-offense-l: 1000
+      third-offense-l: 2500
+      third-offense-suspension-days: 30
+    # Sub-spec 2 §6 — post-cancel ownership watcher window. The ownership
+    # monitor scans cancelled auctions whose watch deadline is still in the
+    # future and raises CANCEL_AND_SELL if the parcel ownership flips to a
+    # non-seller avatar within the window.
+    post-cancel-watch-hours: 48
   photos:
     max-per-listing: 10
     max-bytes: 2097152

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionControllerIntegrationTest.java
@@ -125,6 +125,67 @@ class AuctionControllerIntegrationTest {
     }
 
     @Test
+    void create_whenSellerOwesPenalty_returns403WithCodePenaltyOwed() throws Exception {
+        // Epic 08 sub-spec 2 §7.7 — suspension gate on listing creation.
+        // Mark the seller as owing a penalty balance and assert the create
+        // path 403s with the right ProblemDetail code.
+        User seller = userRepository.findById(sellerId).orElseThrow();
+        seller.setPenaltyBalanceOwed(1000L);
+        userRepository.save(seller);
+
+        AuctionCreateRequest req = new AuctionCreateRequest(
+                sellerParcel.getId(), "Test listing", 1000L, null, null,
+                168, false, null, null, null);
+
+        mockMvc.perform(post("/api/v1/auctions")
+                .header("Authorization", "Bearer " + sellerAccessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("PENALTY_OWED"))
+                .andExpect(jsonPath("$.title").value("Listing creation suspended"));
+    }
+
+    @Test
+    void create_whenSellerTimedSuspended_returns403WithCodeTimedSuspension() throws Exception {
+        User seller = userRepository.findById(sellerId).orElseThrow();
+        seller.setListingSuspensionUntil(OffsetDateTime.now().plusDays(20));
+        userRepository.save(seller);
+
+        AuctionCreateRequest req = new AuctionCreateRequest(
+                sellerParcel.getId(), "Test listing", 1000L, null, null,
+                168, false, null, null, null);
+
+        mockMvc.perform(post("/api/v1/auctions")
+                .header("Authorization", "Bearer " + sellerAccessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("TIMED_SUSPENSION"));
+    }
+
+    @Test
+    void create_whenSellerBanned_returns403WithCodePermanentBan() throws Exception {
+        // Ban shadows penalty + timed — the gate evaluates ban first.
+        User seller = userRepository.findById(sellerId).orElseThrow();
+        seller.setBannedFromListing(true);
+        seller.setListingSuspensionUntil(OffsetDateTime.now().plusDays(20));
+        seller.setPenaltyBalanceOwed(2500L);
+        userRepository.save(seller);
+
+        AuctionCreateRequest req = new AuctionCreateRequest(
+                sellerParcel.getId(), "Test listing", 1000L, null, null,
+                168, false, null, null, null);
+
+        mockMvc.perform(post("/api/v1/auctions")
+                .header("Authorization", "Bearer " + sellerAccessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("PERMANENT_BAN"));
+    }
+
+    @Test
     void create_asUnverifiedUser_returns403() throws Exception {
         AuctionCreateRequest req = new AuctionCreateRequest(
                 sellerParcel.getId(), "Test listing", 1000L, null, null,

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionRepositoryOwnershipCheckTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionRepositoryOwnershipCheckTest.java
@@ -77,7 +77,7 @@ class AuctionRepositoryOwnershipCheckTest {
         // 6) ENDED (excluded regardless of timestamp)
         Auction ended = auctionRepo.save(build(seller, p6, AuctionStatus.ENDED, now.minusHours(5)));
 
-        List<Long> due = auctionRepo.findDueForOwnershipCheck(cutoff);
+        List<Long> due = auctionRepo.findDueForOwnershipCheck(cutoff, now);
 
         assertThat(due).containsExactlyInAnyOrder(
                 stale.getId(), veryStale.getId(), neverChecked.getId());
@@ -86,6 +86,52 @@ class AuctionRepositoryOwnershipCheckTest {
         // Ordering: null (NULLS FIRST), then oldest timestamp, then newer.
         assertThat(due).containsExactly(
                 neverChecked.getId(), veryStale.getId(), stale.getId());
+    }
+
+    @Test
+    void findDueForOwnershipCheck_includesPostCancelWatched_excludesExpired() {
+        // Epic 08 sub-spec 2 §6 — a CANCELLED auction with an open watch
+        // window should be returned alongside ACTIVE due rows; one whose
+        // watch window has expired must NOT.
+        User seller = userRepo.save(User.builder()
+                .email("watch-seller-" + UUID.randomUUID() + "@example.com")
+                .passwordHash("$2a$10$dummy.hash.value.for.test.only.aaaaaaaaaaaaaaaaaaaa")
+                .displayName("Watch Seller")
+                .verified(true)
+                .slAvatarUuid(UUID.randomUUID())
+                .build());
+
+        Parcel pa = parcelRepo.save(buildParcel());
+        Parcel pb = parcelRepo.save(buildParcel());
+        Parcel pc = parcelRepo.save(buildParcel());
+
+        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime cutoff = now.minusMinutes(30);
+
+        // ACTIVE, due — should be picked up.
+        Auction active = auctionRepo.save(buildWithWatch(seller, pa,
+                AuctionStatus.ACTIVE, now.minusHours(1), null));
+        // CANCELLED with open post-cancel watch — should be picked up.
+        Auction watched = buildWithWatch(seller, pb,
+                AuctionStatus.CANCELLED, now.minusHours(1), now.plusHours(24));
+        watched = auctionRepo.save(watched);
+        // CANCELLED with expired post-cancel watch — must be excluded even
+        // though lastOwnershipCheckAt is stale.
+        Auction expired = buildWithWatch(seller, pc,
+                AuctionStatus.CANCELLED, now.minusHours(1), now.minusHours(1));
+        expired = auctionRepo.save(expired);
+
+        List<Long> due = auctionRepo.findDueForOwnershipCheck(cutoff, now);
+
+        assertThat(due).contains(active.getId(), watched.getId());
+        assertThat(due).doesNotContain(expired.getId());
+    }
+
+    private Auction buildWithWatch(User seller, Parcel parcel, AuctionStatus status,
+                                   OffsetDateTime lastCheck, OffsetDateTime watchUntil) {
+        Auction a = build(seller, parcel, status, lastCheck);
+        a.setPostCancelWatchUntil(watchUntil);
+        return a;
     }
 
     private Parcel buildParcel() {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionServiceTest.java
@@ -7,7 +7,10 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -19,8 +22,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import com.slparcelauctions.backend.auction.exception.SellerSuspendedException;
+import com.slparcelauctions.backend.auction.exception.SuspensionReason;
 
 import com.slparcelauctions.backend.auction.dto.AuctionCreateRequest;
 import com.slparcelauctions.backend.auction.dto.AuctionUpdateRequest;
@@ -40,6 +47,7 @@ class AuctionServiceTest {
     @Mock ParcelRepository parcelRepo;
     @Mock UserRepository userRepo;
     @Mock ParcelTagRepository tagRepo;
+    @Spy Clock clock = Clock.fixed(Instant.parse("2026-04-24T10:00:00Z"), ZoneOffset.UTC);
 
     @InjectMocks AuctionService service;
 
@@ -182,6 +190,90 @@ class AuctionServiceTest {
         Auction updated = service.update(1L, 42L, req);
 
         assertThat(updated.getTitle()).isEqualTo("Renamed listing");
+    }
+
+    // -------------------------------------------------------------------------
+    // create(): suspension gate — Epic 08 sub-spec 2 §7.7
+    //
+    // Order is most-restrictive-first: ban → timed → penalty. The first
+    // matching condition surfaces as the SellerSuspendedException's reason
+    // and rides the 403 ProblemDetail's "code" property.
+    // -------------------------------------------------------------------------
+
+    @Test
+    void create_throwsPenaltyOwed_whenPenaltyBalancePositive() {
+        seller.setPenaltyBalanceOwed(500L);
+        AuctionCreateRequest req = minimalCreateRequest("Test listing");
+
+        SellerSuspendedException ex = org.junit.jupiter.api.Assertions.assertThrows(
+                SellerSuspendedException.class,
+                () -> service.create(42L, req));
+
+        assertThat(ex.getReason()).isEqualTo(SuspensionReason.PENALTY_OWED);
+    }
+
+    @Test
+    void create_throwsTimedSuspension_whenSuspensionUntilFuture() {
+        seller.setListingSuspensionUntil(OffsetDateTime.now(clock).plusDays(5));
+        AuctionCreateRequest req = minimalCreateRequest("Test listing");
+
+        SellerSuspendedException ex = org.junit.jupiter.api.Assertions.assertThrows(
+                SellerSuspendedException.class,
+                () -> service.create(42L, req));
+
+        assertThat(ex.getReason()).isEqualTo(SuspensionReason.TIMED_SUSPENSION);
+    }
+
+    @Test
+    void create_succeeds_whenSuspensionUntilInPast() {
+        // Boundary: an expired suspension does not gate the create.
+        seller.setListingSuspensionUntil(OffsetDateTime.now(clock).minusSeconds(1));
+        AuctionCreateRequest req = minimalCreateRequest("Test listing");
+
+        Auction created = service.create(42L, req);
+
+        assertThat(created.getStatus()).isEqualTo(AuctionStatus.DRAFT);
+    }
+
+    @Test
+    void create_throwsPermanentBan_whenBannedFromListingTrue() {
+        seller.setBannedFromListing(true);
+        AuctionCreateRequest req = minimalCreateRequest("Test listing");
+
+        SellerSuspendedException ex = org.junit.jupiter.api.Assertions.assertThrows(
+                SellerSuspendedException.class,
+                () -> service.create(42L, req));
+
+        assertThat(ex.getReason()).isEqualTo(SuspensionReason.PERMANENT_BAN);
+    }
+
+    @Test
+    void create_throwsBan_evenWhenAlsoSuspendedAndOwesPenalty() {
+        // Order: ban → timed → penalty. The most-restrictive match wins.
+        seller.setBannedFromListing(true);
+        seller.setListingSuspensionUntil(OffsetDateTime.now(clock).plusDays(5));
+        seller.setPenaltyBalanceOwed(500L);
+        AuctionCreateRequest req = minimalCreateRequest("Test listing");
+
+        SellerSuspendedException ex = org.junit.jupiter.api.Assertions.assertThrows(
+                SellerSuspendedException.class,
+                () -> service.create(42L, req));
+
+        assertThat(ex.getReason()).isEqualTo(SuspensionReason.PERMANENT_BAN);
+    }
+
+    @Test
+    void create_throwsTimed_whenAlsoOwesPenalty() {
+        // Timed beats penalty when both are set (and ban isn't).
+        seller.setListingSuspensionUntil(OffsetDateTime.now(clock).plusDays(5));
+        seller.setPenaltyBalanceOwed(500L);
+        AuctionCreateRequest req = minimalCreateRequest("Test listing");
+
+        SellerSuspendedException ex = org.junit.jupiter.api.Assertions.assertThrows(
+                SellerSuspendedException.class,
+                () -> service.create(42L, req));
+
+        assertThat(ex.getReason()).isEqualTo(SuspensionReason.TIMED_SUSPENSION);
     }
 
     private AuctionCreateRequest minimalCreateRequest(String title) {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationServiceLadderTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationServiceLadderTest.java
@@ -1,0 +1,293 @@
+package com.slparcelauctions.backend.auction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.HashSet;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.slparcelauctions.backend.auction.broadcast.AuctionBroadcastPublisher;
+import com.slparcelauctions.backend.auction.dto.AuctionCancelledEnvelope;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Boundary coverage for the cancellation-penalty ladder
+ * (Epic 08 sub-spec 2 §2). Each test pins a single ladder index and
+ * asserts the snapshot on the {@link CancellationLog} row plus the live
+ * consequence applied to {@link User} (debt, suspension, ban) and
+ * {@link Auction#getPostCancelWatchUntil()}. The {@code countPriorOffensesWithBids}
+ * stub drives the ladder index — the test deliberately runs against the
+ * real {@link CancellationService#cancel} so the COUNT-before-INSERT
+ * ordering and the snapshot semantics are both exercised.
+ */
+@ExtendWith(MockitoExtension.class)
+class CancellationServiceLadderTest {
+
+    @Mock AuctionRepository auctionRepo;
+    @Mock CancellationLogRepository logRepo;
+    @Mock ListingFeeRefundRepository refundRepo;
+    @Mock UserRepository userRepo;
+    @Mock com.slparcelauctions.backend.bot.BotMonitorLifecycleService monitorLifecycle;
+    @Mock AuctionBroadcastPublisher broadcastPublisher;
+
+    CancellationService service;
+
+    private User seller;
+    private Parcel parcel;
+    private Clock fixed;
+    private OffsetDateTime now;
+    private CancellationPenaltyProperties penaltyProps;
+
+    @BeforeEach
+    void setUp() {
+        fixed = Clock.fixed(Instant.parse("2026-04-16T12:00:00Z"), ZoneOffset.UTC);
+        now = OffsetDateTime.now(fixed);
+        penaltyProps = new CancellationPenaltyProperties(
+                new CancellationPenaltyProperties.Penalty(1000L, 2500L, 30),
+                48);
+        service = new CancellationService(
+                auctionRepo, logRepo, refundRepo, userRepo, monitorLifecycle,
+                broadcastPublisher, penaltyProps, fixed);
+        seller = User.builder().id(42L).email("s@example.com")
+                .cancelledWithBids(0)
+                .penaltyBalanceOwed(0L)
+                .bannedFromListing(false)
+                .build();
+        parcel = Parcel.builder().id(100L).build();
+        lenient().when(auctionRepo.save(any(Auction.class))).thenAnswer(inv -> inv.getArgument(0));
+        lenient().when(userRepo.findByIdForUpdate(42L)).thenReturn(Optional.of(seller));
+    }
+
+    private Auction cancel(Auction a, String reason) {
+        lenient().when(auctionRepo.findByIdForUpdate(anyLong())).thenReturn(Optional.of(a));
+        return service.cancel(a.getId(), reason);
+    }
+
+    private CancellationLog capturedLog() {
+        ArgumentCaptor<CancellationLog> cap = ArgumentCaptor.forClass(CancellationLog.class);
+        verify(logRepo).save(cap.capture());
+        return cap.getValue();
+    }
+
+    // -------------------------------------------------------------------------
+    // Ladder boundaries on ACTIVE-with-bids cancellations
+    // -------------------------------------------------------------------------
+
+    @Test
+    void cancel_activeWithBids_zeroPriorOffenses_writesWarningKind() {
+        when(logRepo.countPriorOffensesWithBids(42L)).thenReturn(0L);
+        Auction a = activeWithBids();
+
+        cancel(a, "first");
+
+        CancellationLog log = capturedLog();
+        assertThat(log.getPenaltyKind()).isEqualTo(CancellationOffenseKind.WARNING);
+        assertThat(log.getPenaltyAmountL()).isNull();
+        assertThat(seller.getPenaltyBalanceOwed()).isZero();
+        assertThat(seller.getListingSuspensionUntil()).isNull();
+        assertThat(seller.getBannedFromListing()).isFalse();
+        assertThat(a.getPostCancelWatchUntil()).isEqualTo(now.plusHours(48));
+    }
+
+    @Test
+    void cancel_activeWithBids_onePriorOffense_writesPenaltyKindAndDebits1000() {
+        when(logRepo.countPriorOffensesWithBids(42L)).thenReturn(1L);
+        Auction a = activeWithBids();
+
+        cancel(a, "second");
+
+        CancellationLog log = capturedLog();
+        assertThat(log.getPenaltyKind()).isEqualTo(CancellationOffenseKind.PENALTY);
+        assertThat(log.getPenaltyAmountL()).isEqualTo(1000L);
+        assertThat(seller.getPenaltyBalanceOwed()).isEqualTo(1000L);
+        assertThat(seller.getListingSuspensionUntil()).isNull();
+        assertThat(seller.getBannedFromListing()).isFalse();
+        assertThat(a.getPostCancelWatchUntil()).isEqualTo(now.plusHours(48));
+    }
+
+    @Test
+    void cancel_activeWithBids_twoPriorOffenses_writesPenaltyAnd30dAndDebits2500AndSuspends() {
+        when(logRepo.countPriorOffensesWithBids(42L)).thenReturn(2L);
+        Auction a = activeWithBids();
+
+        cancel(a, "third");
+
+        CancellationLog log = capturedLog();
+        assertThat(log.getPenaltyKind()).isEqualTo(CancellationOffenseKind.PENALTY_AND_30D);
+        assertThat(log.getPenaltyAmountL()).isEqualTo(2500L);
+        assertThat(seller.getPenaltyBalanceOwed()).isEqualTo(2500L);
+        assertThat(seller.getListingSuspensionUntil())
+                .isCloseTo(now.plusDays(30),
+                        new org.assertj.core.data.TemporalUnitWithinOffset(1, ChronoUnit.SECONDS));
+        assertThat(seller.getBannedFromListing()).isFalse();
+    }
+
+    @Test
+    void cancel_activeWithBids_threePriorOffenses_writesPermanentBan() {
+        when(logRepo.countPriorOffensesWithBids(42L)).thenReturn(3L);
+        seller.setPenaltyBalanceOwed(3500L);
+        OffsetDateTime priorSuspension = now.minusDays(5);
+        seller.setListingSuspensionUntil(priorSuspension);
+        Auction a = activeWithBids();
+
+        cancel(a, "fourth");
+
+        CancellationLog log = capturedLog();
+        assertThat(log.getPenaltyKind()).isEqualTo(CancellationOffenseKind.PERMANENT_BAN);
+        assertThat(log.getPenaltyAmountL()).isNull();
+        assertThat(seller.getBannedFromListing()).isTrue();
+        // Existing debt + suspension are not modified by the PERMANENT_BAN branch.
+        assertThat(seller.getPenaltyBalanceOwed()).isEqualTo(3500L);
+        assertThat(seller.getListingSuspensionUntil()).isEqualTo(priorSuspension);
+    }
+
+    @Test
+    void cancel_activeWithBids_fivePriorOffenses_stillWritesPermanentBan() {
+        when(logRepo.countPriorOffensesWithBids(42L)).thenReturn(5L);
+        seller.setBannedFromListing(true); // already banned
+        Auction a = activeWithBids();
+
+        cancel(a, "sixth");
+
+        CancellationLog log = capturedLog();
+        assertThat(log.getPenaltyKind()).isEqualTo(CancellationOffenseKind.PERMANENT_BAN);
+        // Idempotent — already true.
+        assertThat(seller.getBannedFromListing()).isTrue();
+    }
+
+    @Test
+    void cancel_activeWithBids_existingPenaltyBalance_addsToIt() {
+        when(logRepo.countPriorOffensesWithBids(42L)).thenReturn(2L);
+        seller.setPenaltyBalanceOwed(1000L); // already owes from a prior PENALTY
+        Auction a = activeWithBids();
+
+        cancel(a, "third while owing");
+
+        // 1000 (existing) + 2500 (third-offense) = 3500
+        assertThat(seller.getPenaltyBalanceOwed()).isEqualTo(3500L);
+    }
+
+    // -------------------------------------------------------------------------
+    // Non-laddered paths
+    // -------------------------------------------------------------------------
+
+    @Test
+    void cancel_activeWithoutBids_writesNoneKind() {
+        Auction a = build(AuctionStatus.ACTIVE, true, 0);
+        a.setEndsAt(now.plusHours(10));
+
+        cancel(a, "no bids yet");
+
+        CancellationLog log = capturedLog();
+        assertThat(log.getPenaltyKind()).isEqualTo(CancellationOffenseKind.NONE);
+        assertThat(log.getPenaltyAmountL()).isNull();
+        // Seller fields untouched.
+        assertThat(seller.getCancelledWithBids()).isZero();
+        assertThat(seller.getPenaltyBalanceOwed()).isZero();
+        assertThat(seller.getListingSuspensionUntil()).isNull();
+        assertThat(seller.getBannedFromListing()).isFalse();
+        // Watcher window NOT armed.
+        assertThat(a.getPostCancelWatchUntil()).isNull();
+        // Counter increment + ladder count must NOT run.
+        verify(userRepo, never()).save(any());
+        verify(logRepo, never()).countPriorOffensesWithBids(anyLong());
+    }
+
+    @Test
+    void cancel_preActiveStatus_writesNoneKindAndQueuesRefund() {
+        Auction a = build(AuctionStatus.DRAFT_PAID, true, 0);
+        a.setListingFeeAmt(100L);
+
+        cancel(a, "changed mind");
+
+        CancellationLog log = capturedLog();
+        assertThat(log.getPenaltyKind()).isEqualTo(CancellationOffenseKind.NONE);
+        assertThat(log.getPenaltyAmountL()).isNull();
+        verify(refundRepo).save(any(ListingFeeRefund.class));
+        assertThat(a.getPostCancelWatchUntil()).isNull();
+        verify(logRepo, never()).countPriorOffensesWithBids(anyLong());
+    }
+
+    // -------------------------------------------------------------------------
+    // WS broadcast — afterCommit registration
+    // -------------------------------------------------------------------------
+
+    @Test
+    void cancel_publishesAuctionCancelledEnvelope() {
+        when(logRepo.countPriorOffensesWithBids(42L)).thenReturn(0L);
+        Auction a = activeWithBids();
+
+        cancel(a, "broadcast me");
+
+        ArgumentCaptor<AuctionCancelledEnvelope> cap =
+                ArgumentCaptor.forClass(AuctionCancelledEnvelope.class);
+        // No tx active → service publishes synchronously (mirrors ReviewService).
+        verify(broadcastPublisher).publishCancelled(cap.capture());
+        AuctionCancelledEnvelope env = cap.getValue();
+        assertThat(env.type()).isEqualTo("AUCTION_CANCELLED");
+        assertThat(env.auctionId()).isEqualTo(a.getId());
+        assertThat(env.hadBids()).isTrue();
+        assertThat(env.cancelledAt()).isEqualTo(now);
+    }
+
+    @Test
+    void cancel_activeWithoutBids_publishesEnvelopeWithHadBidsFalse() {
+        Auction a = build(AuctionStatus.ACTIVE, true, 0);
+        a.setEndsAt(now.plusHours(10));
+
+        cancel(a, "no bids");
+
+        ArgumentCaptor<AuctionCancelledEnvelope> cap =
+                ArgumentCaptor.forClass(AuctionCancelledEnvelope.class);
+        verify(broadcastPublisher).publishCancelled(cap.capture());
+        assertThat(cap.getValue().hadBids()).isFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private Auction activeWithBids() {
+        Auction a = build(AuctionStatus.ACTIVE, true, 5);
+        a.setEndsAt(now.plusHours(10));
+        return a;
+    }
+
+    private Auction build(AuctionStatus status, boolean listingFeePaid, int bidCount) {
+        return Auction.builder()
+                .title("Test listing")
+                .id(1L).seller(seller).parcel(parcel).status(status)
+                .verificationMethod(VerificationMethod.UUID_ENTRY)
+                .startingBid(1000L).durationHours(168)
+                .snipeProtect(false)
+                .listingFeePaid(listingFeePaid)
+                .currentBid(0L).bidCount(bidCount)
+                .commissionRate(new BigDecimal("0.05"))
+                .agentFeeRate(BigDecimal.ZERO)
+                .tags(new HashSet<>())
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+    }
+
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationServiceTest.java
@@ -23,6 +23,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.slparcelauctions.backend.auction.broadcast.AuctionBroadcastPublisher;
 import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
 import com.slparcelauctions.backend.auction.exception.InvalidAuctionStateException;
 import com.slparcelauctions.backend.parcel.Parcel;
@@ -37,21 +38,32 @@ class CancellationServiceTest {
     @Mock ListingFeeRefundRepository refundRepo;
     @Mock UserRepository userRepo;
     @Mock com.slparcelauctions.backend.bot.BotMonitorLifecycleService monitorLifecycle;
+    @Mock AuctionBroadcastPublisher broadcastPublisher;
 
     CancellationService service;
 
     private User seller;
     private Parcel parcel;
     private Clock fixed;
+    private CancellationPenaltyProperties penaltyProps;
 
     @BeforeEach
     void setUp() {
         fixed = Clock.fixed(Instant.parse("2026-04-16T12:00:00Z"), ZoneOffset.UTC);
+        penaltyProps = new CancellationPenaltyProperties(
+                new CancellationPenaltyProperties.Penalty(1000L, 2500L, 30),
+                48);
         service = new CancellationService(
-                auctionRepo, logRepo, refundRepo, userRepo, monitorLifecycle, fixed);
-        seller = User.builder().id(42L).email("s@example.com").cancelledWithBids(0).build();
+                auctionRepo, logRepo, refundRepo, userRepo, monitorLifecycle,
+                broadcastPublisher, penaltyProps, fixed);
+        seller = User.builder().id(42L).email("s@example.com")
+                .cancelledWithBids(0)
+                .penaltyBalanceOwed(0L)
+                .bannedFromListing(false)
+                .build();
         parcel = Parcel.builder().id(100L).build();
         lenient().when(auctionRepo.save(any(Auction.class))).thenAnswer(inv -> inv.getArgument(0));
+        lenient().when(userRepo.findByIdForUpdate(42L)).thenReturn(Optional.of(seller));
     }
 
     /**

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationStatusControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationStatusControllerTest.java
@@ -1,0 +1,220 @@
+package com.slparcelauctions.backend.auction;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.slparcelauctions.backend.auction.dto.CancellationHistoryDto;
+import com.slparcelauctions.backend.auction.dto.CancellationStatusResponse;
+import com.slparcelauctions.backend.auction.dto.NextConsequenceDto;
+import com.slparcelauctions.backend.auction.exception.AuctionExceptionHandler;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.auth.test.WithMockAuthPrincipal;
+import com.slparcelauctions.backend.common.exception.GlobalExceptionHandler;
+
+/**
+ * Slice tests for {@link CancellationStatusController}. Filters off (the
+ * security filter chain is exercised separately); auth principal injected via
+ * {@code @WithMockAuthPrincipal} so the controller can read {@code userId}.
+ *
+ * <p>Coverage:
+ * <ul>
+ *   <li>cancellation-status response shape across all four ladder positions
+ *       (warning → penalty → penalty + 30d → permanent ban).</li>
+ *   <li>currentSuspension echoes the user's three new columns verbatim.</li>
+ *   <li>cancellation-history paginated response shape and size clamp.</li>
+ * </ul>
+ */
+@WebMvcTest(controllers = CancellationStatusController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({GlobalExceptionHandler.class, AuctionExceptionHandler.class})
+class CancellationStatusControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private CancellationStatusService service;
+    @MockitoBean private JwtService jwtService;
+
+    @Test
+    @WithMockAuthPrincipal(userId = 42L)
+    void status_zeroPriorOffenses_returnsWarningAsNextConsequence() throws Exception {
+        CancellationStatusResponse resp = new CancellationStatusResponse(
+                0L,
+                new CancellationStatusResponse.CurrentSuspension(0L, null, false),
+                NextConsequenceDto.from(CancellationOffenseKind.WARNING, null));
+        when(service.statusFor(42L)).thenReturn(resp);
+
+        mockMvc.perform(get("/api/v1/users/me/cancellation-status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.priorOffensesWithBids").value(0))
+                .andExpect(jsonPath("$.nextConsequenceIfBidsPresent.kind").value("WARNING"))
+                .andExpect(jsonPath("$.nextConsequenceIfBidsPresent.amountL").doesNotExist())
+                .andExpect(jsonPath("$.nextConsequenceIfBidsPresent.suspends30Days").value(false))
+                .andExpect(jsonPath("$.nextConsequenceIfBidsPresent.permanentBan").value(false))
+                .andExpect(jsonPath("$.currentSuspension.penaltyBalanceOwed").value(0))
+                .andExpect(jsonPath("$.currentSuspension.bannedFromListing").value(false));
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 42L)
+    void status_onePriorOffense_returnsPenaltyAsNext() throws Exception {
+        CancellationStatusResponse resp = new CancellationStatusResponse(
+                1L,
+                new CancellationStatusResponse.CurrentSuspension(0L, null, false),
+                NextConsequenceDto.from(CancellationOffenseKind.PENALTY, 1000L));
+        when(service.statusFor(42L)).thenReturn(resp);
+
+        mockMvc.perform(get("/api/v1/users/me/cancellation-status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.priorOffensesWithBids").value(1))
+                .andExpect(jsonPath("$.nextConsequenceIfBidsPresent.kind").value("PENALTY"))
+                .andExpect(jsonPath("$.nextConsequenceIfBidsPresent.amountL").value(1000))
+                .andExpect(jsonPath("$.nextConsequenceIfBidsPresent.suspends30Days").value(false))
+                .andExpect(jsonPath("$.nextConsequenceIfBidsPresent.permanentBan").value(false));
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 42L)
+    void status_twoPriorOffenses_returnsPenaltyAnd30dAsNext() throws Exception {
+        CancellationStatusResponse resp = new CancellationStatusResponse(
+                2L,
+                new CancellationStatusResponse.CurrentSuspension(1000L, null, false),
+                NextConsequenceDto.from(CancellationOffenseKind.PENALTY_AND_30D, 2500L));
+        when(service.statusFor(42L)).thenReturn(resp);
+
+        mockMvc.perform(get("/api/v1/users/me/cancellation-status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.priorOffensesWithBids").value(2))
+                .andExpect(jsonPath("$.nextConsequenceIfBidsPresent.kind").value("PENALTY_AND_30D"))
+                .andExpect(jsonPath("$.nextConsequenceIfBidsPresent.amountL").value(2500))
+                .andExpect(jsonPath("$.nextConsequenceIfBidsPresent.suspends30Days").value(true))
+                .andExpect(jsonPath("$.nextConsequenceIfBidsPresent.permanentBan").value(false));
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 42L)
+    void status_threePlusOffenses_returnsPermanentBanAsNext() throws Exception {
+        CancellationStatusResponse resp = new CancellationStatusResponse(
+                3L,
+                new CancellationStatusResponse.CurrentSuspension(2500L,
+                        OffsetDateTime.now().plusDays(20), false),
+                NextConsequenceDto.from(CancellationOffenseKind.PERMANENT_BAN, null));
+        when(service.statusFor(42L)).thenReturn(resp);
+
+        mockMvc.perform(get("/api/v1/users/me/cancellation-status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.priorOffensesWithBids").value(3))
+                .andExpect(jsonPath("$.nextConsequenceIfBidsPresent.kind").value("PERMANENT_BAN"))
+                .andExpect(jsonPath("$.nextConsequenceIfBidsPresent.amountL").doesNotExist())
+                .andExpect(jsonPath("$.nextConsequenceIfBidsPresent.suspends30Days").value(false))
+                .andExpect(jsonPath("$.nextConsequenceIfBidsPresent.permanentBan").value(true));
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 42L)
+    void status_currentSuspensionEchoesUserState() throws Exception {
+        OffsetDateTime suspendedUntil = OffsetDateTime.parse("2026-05-24T10:15:00Z");
+        CancellationStatusResponse resp = new CancellationStatusResponse(
+                2L,
+                new CancellationStatusResponse.CurrentSuspension(2500L, suspendedUntil, false),
+                NextConsequenceDto.from(CancellationOffenseKind.PENALTY_AND_30D, 2500L));
+        when(service.statusFor(42L)).thenReturn(resp);
+
+        mockMvc.perform(get("/api/v1/users/me/cancellation-status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.currentSuspension.penaltyBalanceOwed").value(2500))
+                .andExpect(jsonPath("$.currentSuspension.listingSuspensionUntil")
+                        .value("2026-05-24T10:15:00Z"))
+                .andExpect(jsonPath("$.currentSuspension.bannedFromListing").value(false));
+    }
+
+    // -------------------------------------------------------------------------
+    // History
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockAuthPrincipal(userId = 42L)
+    void history_returnsPagedResponse_shape() throws Exception {
+        OffsetDateTime cancelledAt = OffsetDateTime.parse("2026-04-20T10:15:00Z");
+        CancellationHistoryDto row = new CancellationHistoryDto(
+                1234L, "Aurora Parcel", "https://snap.example/1.png",
+                "ACTIVE", true, "Personal reasons.", cancelledAt,
+                new CancellationHistoryDto.PenaltyApplied(
+                        CancellationOffenseKind.PENALTY, 1000L));
+        Page<CancellationHistoryDto> page = new PageImpl<>(
+                List.of(row), PageRequest.of(0, 10), 1);
+        when(service.historyFor(eq(42L), any(Pageable.class))).thenReturn(page);
+
+        mockMvc.perform(get("/api/v1/users/me/cancellation-history"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].auctionId").value(1234))
+                .andExpect(jsonPath("$.content[0].auctionTitle").value("Aurora Parcel"))
+                .andExpect(jsonPath("$.content[0].cancelledFromStatus").value("ACTIVE"))
+                .andExpect(jsonPath("$.content[0].hadBids").value(true))
+                .andExpect(jsonPath("$.content[0].penaltyApplied.kind").value("PENALTY"))
+                .andExpect(jsonPath("$.content[0].penaltyApplied.amountL").value(1000))
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.totalPages").value(1))
+                .andExpect(jsonPath("$.number").value(0))
+                .andExpect(jsonPath("$.size").value(10));
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 42L)
+    void history_penaltyAppliedNullForNoneKind() throws Exception {
+        // No-bid cancellations and pre-active cancellations show "No penalty"
+        // — backend returns null in penaltyApplied so the frontend renders
+        // a neutral badge.
+        CancellationHistoryDto row = new CancellationHistoryDto(
+                999L, "Cool Parcel", null,
+                "DRAFT", false, "Changed my mind", OffsetDateTime.now(),
+                null);
+        Page<CancellationHistoryDto> page = new PageImpl<>(
+                List.of(row), PageRequest.of(0, 10), 1);
+        when(service.historyFor(eq(42L), any(Pageable.class))).thenReturn(page);
+
+        mockMvc.perform(get("/api/v1/users/me/cancellation-history"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].penaltyApplied").doesNotExist());
+    }
+
+    @Test
+    @WithMockAuthPrincipal(userId = 42L)
+    void history_forwardsPagingArgsToService() throws Exception {
+        Page<CancellationHistoryDto> empty = new PageImpl<>(
+                List.of(), PageRequest.of(2, 5), 0);
+        when(service.historyFor(eq(42L), any(Pageable.class))).thenReturn(empty);
+
+        mockMvc.perform(get("/api/v1/users/me/cancellation-history?page=2&size=5"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Pageable> pageableCap = ArgumentCaptor.forClass(Pageable.class);
+        verify(service).historyFor(eq(42L), pageableCap.capture());
+        Pageable received = pageableCap.getValue();
+        // Controller forwards raw page/size; service applies the size clamp.
+        // page=2&size=5 → service receives PageRequest(2, 5).
+        org.assertj.core.api.Assertions.assertThat(received.getPageNumber()).isEqualTo(2);
+        org.assertj.core.api.Assertions.assertThat(received.getPageSize()).isEqualTo(5);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationStatusServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationStatusServiceTest.java
@@ -1,0 +1,284 @@
+package com.slparcelauctions.backend.auction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import com.slparcelauctions.backend.auction.dto.CancellationHistoryDto;
+import com.slparcelauctions.backend.auction.dto.CancellationStatusResponse;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserNotFoundException;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Unit coverage for {@link CancellationStatusService}.
+ * <ul>
+ *   <li>Ladder index → next consequence mapping (matches
+ *       {@link CancellationService}'s authoritative logic).</li>
+ *   <li>currentSuspension echoes the user's three new columns verbatim.</li>
+ *   <li>History page-size clamp (>{@code MAX_PAGE_SIZE} → 50).</li>
+ *   <li>History sort always cancelledAt DESC regardless of caller's Sort.</li>
+ *   <li>{@code penaltyApplied} null when log row's kind is NONE.</li>
+ *   <li>Photo URL falls back to parcel snapshot when no listing photos.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+class CancellationStatusServiceTest {
+
+    private static final long USER_ID = 42L;
+
+    @Mock CancellationLogRepository logRepo;
+    @Mock UserRepository userRepo;
+    @Mock AuctionPhotoRepository photoRepo;
+
+    CancellationStatusService service;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        CancellationPenaltyProperties penalty = new CancellationPenaltyProperties(
+                new CancellationPenaltyProperties.Penalty(1000L, 2500L, 30),
+                48);
+        service = new CancellationStatusService(logRepo, userRepo, photoRepo, penalty);
+
+        user = User.builder()
+                .id(USER_ID)
+                .email("seller@example.com")
+                .passwordHash("x")
+                .penaltyBalanceOwed(0L)
+                .bannedFromListing(false)
+                .build();
+        lenient().when(userRepo.findById(USER_ID)).thenReturn(Optional.of(user));
+    }
+
+    @Test
+    void statusFor_zeroPrior_returnsWarning() {
+        when(logRepo.countPriorOffensesWithBids(USER_ID)).thenReturn(0L);
+
+        CancellationStatusResponse resp = service.statusFor(USER_ID);
+
+        assertThat(resp.priorOffensesWithBids()).isEqualTo(0L);
+        assertThat(resp.nextConsequenceIfBidsPresent().kind())
+                .isEqualTo(CancellationOffenseKind.WARNING);
+        assertThat(resp.nextConsequenceIfBidsPresent().amountL()).isNull();
+        assertThat(resp.nextConsequenceIfBidsPresent().suspends30Days()).isFalse();
+        assertThat(resp.nextConsequenceIfBidsPresent().permanentBan()).isFalse();
+    }
+
+    @Test
+    void statusFor_onePrior_returnsPenalty1000() {
+        when(logRepo.countPriorOffensesWithBids(USER_ID)).thenReturn(1L);
+
+        CancellationStatusResponse resp = service.statusFor(USER_ID);
+
+        assertThat(resp.nextConsequenceIfBidsPresent().kind())
+                .isEqualTo(CancellationOffenseKind.PENALTY);
+        assertThat(resp.nextConsequenceIfBidsPresent().amountL()).isEqualTo(1000L);
+    }
+
+    @Test
+    void statusFor_twoPrior_returnsPenaltyAnd30d() {
+        when(logRepo.countPriorOffensesWithBids(USER_ID)).thenReturn(2L);
+
+        CancellationStatusResponse resp = service.statusFor(USER_ID);
+
+        assertThat(resp.nextConsequenceIfBidsPresent().kind())
+                .isEqualTo(CancellationOffenseKind.PENALTY_AND_30D);
+        assertThat(resp.nextConsequenceIfBidsPresent().amountL()).isEqualTo(2500L);
+        assertThat(resp.nextConsequenceIfBidsPresent().suspends30Days()).isTrue();
+    }
+
+    @Test
+    void statusFor_threePrior_returnsPermanentBan() {
+        when(logRepo.countPriorOffensesWithBids(USER_ID)).thenReturn(3L);
+
+        CancellationStatusResponse resp = service.statusFor(USER_ID);
+
+        assertThat(resp.nextConsequenceIfBidsPresent().kind())
+                .isEqualTo(CancellationOffenseKind.PERMANENT_BAN);
+        assertThat(resp.nextConsequenceIfBidsPresent().permanentBan()).isTrue();
+        // Ban has no L$ amount.
+        assertThat(resp.nextConsequenceIfBidsPresent().amountL()).isNull();
+    }
+
+    @Test
+    void statusFor_manyPrior_clampsToPermanentBan() {
+        // Sanity — 12 prior offenses still reads as PERMANENT_BAN, not OOB.
+        when(logRepo.countPriorOffensesWithBids(USER_ID)).thenReturn(12L);
+
+        CancellationStatusResponse resp = service.statusFor(USER_ID);
+
+        assertThat(resp.nextConsequenceIfBidsPresent().kind())
+                .isEqualTo(CancellationOffenseKind.PERMANENT_BAN);
+    }
+
+    @Test
+    void statusFor_currentSuspensionEchoesUserColumns() {
+        OffsetDateTime suspendedUntil = OffsetDateTime.now().plusDays(20);
+        user.setPenaltyBalanceOwed(1000L);
+        user.setListingSuspensionUntil(suspendedUntil);
+        user.setBannedFromListing(false);
+        when(logRepo.countPriorOffensesWithBids(USER_ID)).thenReturn(1L);
+
+        CancellationStatusResponse resp = service.statusFor(USER_ID);
+
+        assertThat(resp.currentSuspension().penaltyBalanceOwed()).isEqualTo(1000L);
+        assertThat(resp.currentSuspension().listingSuspensionUntil()).isEqualTo(suspendedUntil);
+        assertThat(resp.currentSuspension().bannedFromListing()).isFalse();
+    }
+
+    @Test
+    void statusFor_unknownUser_throws() {
+        when(userRepo.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.statusFor(999L))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // historyFor
+    // -------------------------------------------------------------------------
+
+    @Test
+    void historyFor_clampsPageSizeAt50() {
+        when(logRepo.findBySellerId(eq(USER_ID), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 50), 0));
+
+        service.historyFor(USER_ID, PageRequest.of(0, 9999));
+
+        ArgumentCaptor<Pageable> cap = ArgumentCaptor.forClass(Pageable.class);
+        org.mockito.Mockito.verify(logRepo).findBySellerId(eq(USER_ID), cap.capture());
+        Pageable forwarded = cap.getValue();
+        assertThat(forwarded.getPageSize()).isEqualTo(50);
+    }
+
+    @Test
+    void historyFor_alwaysSortsByCancelledAtDesc_regardlessOfCallerSort() {
+        when(logRepo.findBySellerId(eq(USER_ID), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
+
+        service.historyFor(USER_ID,
+                PageRequest.of(0, 10, Sort.by("auction.id").ascending()));
+
+        ArgumentCaptor<Pageable> cap = ArgumentCaptor.forClass(Pageable.class);
+        org.mockito.Mockito.verify(logRepo).findBySellerId(eq(USER_ID), cap.capture());
+        Sort sort = cap.getValue().getSort();
+        Sort.Order order = sort.getOrderFor("cancelledAt");
+        assertThat(order).isNotNull();
+        assertThat(order.getDirection()).isEqualTo(Sort.Direction.DESC);
+    }
+
+    @Test
+    void historyFor_mapsLogRowsToDtos_penaltyAppliedNullWhenKindNone() {
+        Auction auction = Auction.builder()
+                .id(101L)
+                .title("Pre-active cancel")
+                .parcel(Parcel.builder().id(7L).snapshotUrl("https://snap.example/p7.png").build())
+                .build();
+        CancellationLog log = CancellationLog.builder()
+                .id(1L)
+                .auction(auction)
+                .seller(user)
+                .cancelledFromStatus("DRAFT")
+                .hadBids(false)
+                .penaltyKind(CancellationOffenseKind.NONE)
+                .penaltyAmountL(null)
+                .reason("Changed my mind")
+                .cancelledAt(OffsetDateTime.now())
+                .build();
+        when(logRepo.findBySellerId(eq(USER_ID), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(log), PageRequest.of(0, 10), 1));
+        when(photoRepo.findByAuctionIdOrderBySortOrderAsc(101L)).thenReturn(List.of());
+
+        Page<CancellationHistoryDto> page = service.historyFor(USER_ID, PageRequest.of(0, 10));
+
+        assertThat(page.getContent()).hasSize(1);
+        CancellationHistoryDto dto = page.getContent().get(0);
+        // No-bid cancellation → penaltyApplied is null per spec §7.4.
+        assertThat(dto.penaltyApplied()).isNull();
+        // No listing photos → falls back to parcel snapshot URL.
+        assertThat(dto.primaryPhotoUrl()).isEqualTo("https://snap.example/p7.png");
+        assertThat(dto.auctionTitle()).isEqualTo("Pre-active cancel");
+    }
+
+    @Test
+    void historyFor_mapsLogRowsToDtos_penaltyAppliedPopulatedWhenKindPenalty() {
+        Auction auction = Auction.builder()
+                .id(202L)
+                .title("Active cancel with bids")
+                .parcel(Parcel.builder().id(9L).build())
+                .build();
+        CancellationLog log = CancellationLog.builder()
+                .id(2L)
+                .auction(auction)
+                .seller(user)
+                .cancelledFromStatus("ACTIVE")
+                .hadBids(true)
+                .penaltyKind(CancellationOffenseKind.PENALTY)
+                .penaltyAmountL(1000L)
+                .reason("Personal reasons")
+                .cancelledAt(OffsetDateTime.now())
+                .build();
+        when(logRepo.findBySellerId(eq(USER_ID), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(log), PageRequest.of(0, 10), 1));
+        when(photoRepo.findByAuctionIdOrderBySortOrderAsc(202L)).thenReturn(List.of());
+
+        Page<CancellationHistoryDto> page = service.historyFor(USER_ID, PageRequest.of(0, 10));
+
+        CancellationHistoryDto dto = page.getContent().get(0);
+        assertThat(dto.penaltyApplied()).isNotNull();
+        assertThat(dto.penaltyApplied().kind()).isEqualTo(CancellationOffenseKind.PENALTY);
+        assertThat(dto.penaltyApplied().amountL()).isEqualTo(1000L);
+    }
+
+    @Test
+    void historyFor_resolvesPrimaryPhotoUrlFromAuctionPhoto() {
+        Auction auction = Auction.builder()
+                .id(303L)
+                .title("Photo'd auction")
+                .parcel(Parcel.builder().id(11L).snapshotUrl("ignored.png").build())
+                .build();
+        CancellationLog log = CancellationLog.builder()
+                .id(3L)
+                .auction(auction)
+                .seller(user)
+                .cancelledFromStatus("ACTIVE")
+                .hadBids(true)
+                .penaltyKind(CancellationOffenseKind.PENALTY)
+                .penaltyAmountL(1000L)
+                .cancelledAt(OffsetDateTime.now())
+                .build();
+        AuctionPhoto p1 = AuctionPhoto.builder().id(50L).auction(auction).sortOrder(1).build();
+        AuctionPhoto p2 = AuctionPhoto.builder().id(51L).auction(auction).sortOrder(0).build();
+        when(logRepo.findBySellerId(eq(USER_ID), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(log), PageRequest.of(0, 10), 1));
+        when(photoRepo.findByAuctionIdOrderBySortOrderAsc(303L)).thenReturn(List.of(p1, p2));
+
+        Page<CancellationHistoryDto> page = service.historyFor(USER_ID, PageRequest.of(0, 10));
+
+        // Picks the photo with the smallest sortOrder (p2 = sortOrder 0).
+        assertThat(page.getContent().get(0).primaryPhotoUrl())
+                .isEqualTo("/api/v1/auctions/303/photos/51/bytes");
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationStatusServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationStatusServiceTest.java
@@ -49,7 +49,6 @@ class CancellationStatusServiceTest {
 
     @Mock CancellationLogRepository logRepo;
     @Mock UserRepository userRepo;
-    @Mock AuctionPhotoRepository photoRepo;
 
     CancellationStatusService service;
 
@@ -60,7 +59,7 @@ class CancellationStatusServiceTest {
         CancellationPenaltyProperties penalty = new CancellationPenaltyProperties(
                 new CancellationPenaltyProperties.Penalty(1000L, 2500L, 30),
                 48);
-        service = new CancellationStatusService(logRepo, userRepo, photoRepo, penalty);
+        service = new CancellationStatusService(logRepo, userRepo, penalty);
 
         user = User.builder()
                 .id(USER_ID)
@@ -209,7 +208,8 @@ class CancellationStatusServiceTest {
                 .build();
         when(logRepo.findBySellerId(eq(USER_ID), any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of(log), PageRequest.of(0, 10), 1));
-        when(photoRepo.findByAuctionIdOrderBySortOrderAsc(101L)).thenReturn(List.of());
+        // Auction has no photos (default empty list on the builder) → falls back
+        // to the parcel snapshot URL via {@code auction.photos.isEmpty()}.
 
         Page<CancellationHistoryDto> page = service.historyFor(USER_ID, PageRequest.of(0, 10));
 
@@ -242,7 +242,6 @@ class CancellationStatusServiceTest {
                 .build();
         when(logRepo.findBySellerId(eq(USER_ID), any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of(log), PageRequest.of(0, 10), 1));
-        when(photoRepo.findByAuctionIdOrderBySortOrderAsc(202L)).thenReturn(List.of());
 
         Page<CancellationHistoryDto> page = service.historyFor(USER_ID, PageRequest.of(0, 10));
 
@@ -254,10 +253,15 @@ class CancellationStatusServiceTest {
 
     @Test
     void historyFor_resolvesPrimaryPhotoUrlFromAuctionPhoto() {
+        AuctionPhoto p1 = AuctionPhoto.builder().id(50L).sortOrder(1).build();
+        AuctionPhoto p2 = AuctionPhoto.builder().id(51L).sortOrder(0).build();
         Auction auction = Auction.builder()
                 .id(303L)
                 .title("Photo'd auction")
                 .parcel(Parcel.builder().id(11L).snapshotUrl("ignored.png").build())
+                // Order in the list is intentionally not sortOrder ASC — the
+                // service must pick the min(sortOrder) regardless.
+                .photos(new java.util.ArrayList<>(List.of(p1, p2)))
                 .build();
         CancellationLog log = CancellationLog.builder()
                 .id(3L)
@@ -269,11 +273,8 @@ class CancellationStatusServiceTest {
                 .penaltyAmountL(1000L)
                 .cancelledAt(OffsetDateTime.now())
                 .build();
-        AuctionPhoto p1 = AuctionPhoto.builder().id(50L).auction(auction).sortOrder(1).build();
-        AuctionPhoto p2 = AuctionPhoto.builder().id(51L).auction(auction).sortOrder(0).build();
         when(logRepo.findBySellerId(eq(USER_ID), any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of(log), PageRequest.of(0, 10), 1));
-        when(photoRepo.findByAuctionIdOrderBySortOrderAsc(303L)).thenReturn(List.of(p1, p2));
 
         Page<CancellationHistoryDto> page = service.historyFor(USER_ID, PageRequest.of(0, 10));
 

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/broadcast/CapturingAuctionBroadcastPublisher.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/broadcast/CapturingAuctionBroadcastPublisher.java
@@ -3,6 +3,8 @@ package com.slparcelauctions.backend.auction.broadcast;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import com.slparcelauctions.backend.auction.dto.AuctionCancelledEnvelope;
+
 /**
  * Test-support implementation of {@link AuctionBroadcastPublisher} that
  * stores every published envelope in thread-safe lists. Swap this into a
@@ -41,6 +43,7 @@ public class CapturingAuctionBroadcastPublisher implements AuctionBroadcastPubli
 
     public final List<BidSettlementEnvelope> settlements = new CopyOnWriteArrayList<>();
     public final List<AuctionEndedEnvelope> ended = new CopyOnWriteArrayList<>();
+    public final List<AuctionCancelledEnvelope> cancelled = new CopyOnWriteArrayList<>();
 
     @Override
     public void publishSettlement(BidSettlementEnvelope envelope) {
@@ -52,9 +55,15 @@ public class CapturingAuctionBroadcastPublisher implements AuctionBroadcastPubli
         ended.add(envelope);
     }
 
-    /** Clears both capture lists; useful in {@code @BeforeEach} hooks. */
+    @Override
+    public void publishCancelled(AuctionCancelledEnvelope envelope) {
+        cancelled.add(envelope);
+    }
+
+    /** Clears all capture lists; useful in {@code @BeforeEach} hooks. */
     public void reset() {
         settlements.clear();
         ended.clear();
+        cancelled.clear();
     }
 }

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/concurrency/CancelLadderRaceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/concurrency/CancelLadderRaceTest.java
@@ -1,0 +1,278 @@
+package com.slparcelauctions.backend.auction.concurrency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.CancellationLogRepository;
+import com.slparcelauctions.backend.auction.CancellationOffenseKind;
+import com.slparcelauctions.backend.auction.CancellationService;
+import com.slparcelauctions.backend.auction.VerificationMethod;
+import com.slparcelauctions.backend.auction.VerificationTier;
+import com.slparcelauctions.backend.auction.broadcast.AuctionBroadcastPublisher;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.parcel.ParcelRepository;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Epic 08 sub-spec 2 regression: two concurrent cancellations targeting two
+ * different auctions for the SAME seller must serialise on the seller-row
+ * pessimistic lock acquired inside {@link CancellationService#cancel}. The
+ * critical invariant is that the COUNT-before-INSERT ladder evaluation
+ * observes consistent prior-offense counts — without the seller-row lock,
+ * both transactions could read {@code countPriorOffensesWithBids = 0}
+ * concurrently and both snapshot the same ladder index (WARNING + WARNING),
+ * skipping the PENALTY rung.
+ *
+ * <p>Mirrors the harness style of {@link BidCancelRaceTest}: NOT
+ * {@code @Transactional}, so each thread runs its own transaction and the
+ * row lock actually contends. Both auctions are ACTIVE-with-bids so both
+ * cancellations qualify for the ladder.
+ *
+ * <p>Accepted orderings (post-serialisation, after both threads finish):
+ * <ol>
+ *   <li>One log row records {@code WARNING}, the other records
+ *       {@code PENALTY} (with {@code amountL = 1000}).</li>
+ *   <li>The seller's {@code penaltyBalanceOwed} is exactly {@code 1000}
+ *       (the PENALTY contributed) and {@code cancelledWithBids} is exactly
+ *       {@code 2}.</li>
+ * </ol>
+ * If the lock were missing, both threads could serialise as WARNING+WARNING
+ * (debt would be 0 — the spec violation we're guarding against).
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.auction-end.enabled=false",
+        "slpa.ownership-monitor.enabled=false",
+        "slpa.escrow.ownership-monitor-job.enabled=false"
+})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class CancelLadderRaceTest {
+
+    @Autowired CancellationService cancellationService;
+    @Autowired CancellationLogRepository cancellationLogRepository;
+    @Autowired AuctionRepository auctionRepository;
+    @Autowired ParcelRepository parcelRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired DataSource dataSource;
+
+    @MockitoBean AuctionBroadcastPublisher publisher;
+
+    private Long sellerId;
+    private Long parcelId1;
+    private Long parcelId2;
+    private Long auctionId1;
+    private Long auctionId2;
+
+    @AfterEach
+    void cleanup() throws Exception {
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var stmt = conn.createStatement()) {
+                if (auctionId1 != null) {
+                    stmt.execute("DELETE FROM cancellation_logs WHERE auction_id = " + auctionId1);
+                    stmt.execute("DELETE FROM bids WHERE auction_id = " + auctionId1);
+                    stmt.execute("DELETE FROM auction_tags WHERE auction_id = " + auctionId1);
+                    stmt.execute("DELETE FROM auctions WHERE id = " + auctionId1);
+                }
+                if (auctionId2 != null) {
+                    stmt.execute("DELETE FROM cancellation_logs WHERE auction_id = " + auctionId2);
+                    stmt.execute("DELETE FROM bids WHERE auction_id = " + auctionId2);
+                    stmt.execute("DELETE FROM auction_tags WHERE auction_id = " + auctionId2);
+                    stmt.execute("DELETE FROM auctions WHERE id = " + auctionId2);
+                }
+                if (parcelId1 != null) {
+                    stmt.execute("DELETE FROM parcels WHERE id = " + parcelId1);
+                }
+                if (parcelId2 != null) {
+                    stmt.execute("DELETE FROM parcels WHERE id = " + parcelId2);
+                }
+                if (sellerId != null) {
+                    stmt.execute("DELETE FROM users WHERE id = " + sellerId);
+                }
+            }
+        }
+        sellerId = null;
+        parcelId1 = null;
+        parcelId2 = null;
+        auctionId1 = null;
+        auctionId2 = null;
+    }
+
+    @Test
+    void cancel_concurrent_serializesViaSellerRowLock() throws Exception {
+        setup();
+
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch go = new CountDownLatch(1);
+        AtomicReference<Throwable> err1 = new AtomicReference<>();
+        AtomicReference<Throwable> err2 = new AtomicReference<>();
+
+        Runnable cancel1 = () -> {
+            ready.countDown();
+            try {
+                go.await();
+                cancellationService.cancel(auctionId1, "race-1");
+            } catch (Throwable t) {
+                err1.set(t);
+            }
+        };
+        Runnable cancel2 = () -> {
+            ready.countDown();
+            try {
+                go.await();
+                cancellationService.cancel(auctionId2, "race-2");
+            } catch (Throwable t) {
+                err2.set(t);
+            }
+        };
+
+        Thread t1 = new Thread(cancel1, "race-cancel-1");
+        Thread t2 = new Thread(cancel2, "race-cancel-2");
+        t1.setDaemon(true);
+        t2.setDaemon(true);
+        t1.start();
+        t2.start();
+
+        assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+        go.countDown();
+
+        t1.join(TimeUnit.SECONDS.toMillis(20));
+        t2.join(TimeUnit.SECONDS.toMillis(20));
+
+        assertThat(err1.get()).as("cancel-1 must not throw").isNull();
+        assertThat(err2.get()).as("cancel-2 must not throw").isNull();
+
+        // Both auctions cancelled.
+        assertThat(auctionRepository.findById(auctionId1).orElseThrow().getStatus())
+                .isEqualTo(AuctionStatus.CANCELLED);
+        assertThat(auctionRepository.findById(auctionId2).orElseThrow().getStatus())
+                .isEqualTo(AuctionStatus.CANCELLED);
+
+        // Counter incremented exactly twice.
+        User reloaded = userRepository.findById(sellerId).orElseThrow();
+        assertThat(reloaded.getCancelledWithBids())
+                .as("cancelled_with_bids must increment exactly twice")
+                .isEqualTo(2);
+
+        // The seller-row lock must serialise the COUNT, so the two log rows
+        // must record DISTINCT ladder kinds — one WARNING, one PENALTY. The
+        // PENALTY contributes 1000 L$ debt; WARNING contributes nothing.
+        long warningCount = cancellationLogRepository.findAll().stream()
+                .filter(l -> l.getSeller().getId().equals(sellerId))
+                .filter(l -> l.getPenaltyKind() == CancellationOffenseKind.WARNING)
+                .count();
+        long penaltyCount = cancellationLogRepository.findAll().stream()
+                .filter(l -> l.getSeller().getId().equals(sellerId))
+                .filter(l -> l.getPenaltyKind() == CancellationOffenseKind.PENALTY)
+                .count();
+        assertThat(warningCount)
+                .as("exactly one WARNING ladder snapshot must land")
+                .isEqualTo(1);
+        assertThat(penaltyCount)
+                .as("exactly one PENALTY ladder snapshot must land — without the seller-row lock both could land as WARNING")
+                .isEqualTo(1);
+
+        assertThat(reloaded.getPenaltyBalanceOwed())
+                .as("PENALTY contributes 1000 L$ debt; WARNING contributes nothing")
+                .isEqualTo(1000L);
+    }
+
+    private void setup() {
+        User seller = userRepository.save(User.builder()
+                .email("cancel-ladder-seller-" + UUID.randomUUID() + "@example.com")
+                .passwordHash("$2a$10$dummy.hash.value.for.test.only.aaaaaaaaaaaaaaaaaaaa")
+                .displayName("Cancel Ladder Seller")
+                .slAvatarUuid(UUID.randomUUID())
+                .verified(true)
+                .cancelledWithBids(0)
+                .penaltyBalanceOwed(0L)
+                .bannedFromListing(false)
+                .build());
+        Parcel parcel1 = parcelRepository.save(Parcel.builder()
+                .slParcelUuid(UUID.randomUUID())
+                .ownerUuid(seller.getSlAvatarUuid())
+                .ownerType("agent")
+                .regionName("CancelLadderRegion1")
+                .continentName("Sansara")
+                .areaSqm(1024)
+                .maturityRating("MODERATE")
+                .verified(true)
+                .verifiedAt(OffsetDateTime.now())
+                .build());
+        Parcel parcel2 = parcelRepository.save(Parcel.builder()
+                .slParcelUuid(UUID.randomUUID())
+                .ownerUuid(seller.getSlAvatarUuid())
+                .ownerType("agent")
+                .regionName("CancelLadderRegion2")
+                .continentName("Sansara")
+                .areaSqm(1024)
+                .maturityRating("MODERATE")
+                .verified(true)
+                .verifiedAt(OffsetDateTime.now())
+                .build());
+        OffsetDateTime now = OffsetDateTime.now();
+        Auction a1 = auctionRepository.save(Auction.builder()
+                .title("Race auction 1")
+                .parcel(parcel1).seller(seller)
+                .status(AuctionStatus.ACTIVE)
+                .verificationMethod(VerificationMethod.UUID_ENTRY)
+                .verificationTier(VerificationTier.SCRIPT)
+                .startingBid(1_000L).durationHours(168)
+                .snipeProtect(false)
+                .listingFeePaid(true).listingFeeAmt(0L)
+                .currentBid(1_500L).bidCount(1)
+                .consecutiveWorldApiFailures(0)
+                .startsAt(now.minusHours(1))
+                .endsAt(now.plusDays(1))
+                .originalEndsAt(now.plusDays(1))
+                .commissionRate(new BigDecimal("0.05"))
+                .agentFeeRate(BigDecimal.ZERO)
+                .build());
+        Auction a2 = auctionRepository.save(Auction.builder()
+                .title("Race auction 2")
+                .parcel(parcel2).seller(seller)
+                .status(AuctionStatus.ACTIVE)
+                .verificationMethod(VerificationMethod.UUID_ENTRY)
+                .verificationTier(VerificationTier.SCRIPT)
+                .startingBid(1_000L).durationHours(168)
+                .snipeProtect(false)
+                .listingFeePaid(true).listingFeeAmt(0L)
+                .currentBid(1_500L).bidCount(1)
+                .consecutiveWorldApiFailures(0)
+                .startsAt(now.minusHours(1))
+                .endsAt(now.plusDays(1))
+                .originalEndsAt(now.plusDays(1))
+                .commissionRate(new BigDecimal("0.05"))
+                .agentFeeRate(BigDecimal.ZERO)
+                .build());
+
+        this.sellerId = seller.getId();
+        this.parcelId1 = parcel1.getId();
+        this.parcelId2 = parcel2.getId();
+        this.auctionId1 = a1.getId();
+        this.auctionId2 = a2.getId();
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/exception/SellerSuspendedExceptionHandlerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/exception/SellerSuspendedExceptionHandlerTest.java
@@ -1,0 +1,66 @@
+package com.slparcelauctions.backend.auction.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * Unit coverage for the {@code SellerSuspendedException} → 403 ProblemDetail
+ * mapping in {@link AuctionExceptionHandler} (Epic 08 sub-spec 2 §7.7). The
+ * handler must:
+ * <ul>
+ *   <li>Set status 403 (not 422) — the resource is forbidden, not malformed.</li>
+ *   <li>Carry the {@link SuspensionReason} enum value as the {@code code}
+ *       property so the frontend can branch on it.</li>
+ *   <li>Pin the problem-type URI to the documented seller-suspended URL.</li>
+ *   <li>Set distinct {@code detail} copy per reason.</li>
+ * </ul>
+ */
+class SellerSuspendedExceptionHandlerTest {
+
+    private final AuctionExceptionHandler handler = new AuctionExceptionHandler();
+
+    @Test
+    void handlesPenaltyOwed_returns403WithCodePenaltyOwed() {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/api/v1/auctions");
+        SellerSuspendedException ex = new SellerSuspendedException(SuspensionReason.PENALTY_OWED);
+
+        ProblemDetail pd = handler.handleSellerSuspended(ex, req);
+
+        assertThat(pd.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(pd.getProperties()).containsEntry("code", "PENALTY_OWED");
+        assertThat(pd.getTitle()).isEqualTo("Listing creation suspended");
+        assertThat(pd.getType().toString())
+                .isEqualTo("https://slpa.example/problems/seller-suspended");
+        assertThat(pd.getDetail())
+                .contains("outstanding penalty balance")
+                .contains("SLPA terminal");
+    }
+
+    @Test
+    void handlesTimedSuspension_returns403WithCodeTimed() {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/api/v1/auctions");
+        SellerSuspendedException ex = new SellerSuspendedException(SuspensionReason.TIMED_SUSPENSION);
+
+        ProblemDetail pd = handler.handleSellerSuspended(ex, req);
+
+        assertThat(pd.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(pd.getProperties()).containsEntry("code", "TIMED_SUSPENSION");
+        assertThat(pd.getDetail()).contains("temporarily suspended");
+    }
+
+    @Test
+    void handlesPermanentBan_returns403WithCodeBan() {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/api/v1/auctions");
+        SellerSuspendedException ex = new SellerSuspendedException(SuspensionReason.PERMANENT_BAN);
+
+        ProblemDetail pd = handler.handleSellerSuspended(ex, req);
+
+        assertThat(pd.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(pd.getProperties()).containsEntry("code", "PERMANENT_BAN");
+        assertThat(pd.getDetail()).contains("permanently suspended");
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/monitoring/OwnershipCheckTaskTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/monitoring/OwnershipCheckTaskTest.java
@@ -2,6 +2,7 @@ package com.slparcelauctions.backend.auction.monitoring;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -26,6 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.slparcelauctions.backend.auction.Auction;
 import com.slparcelauctions.backend.auction.AuctionRepository;
 import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.CancellationLogRepository;
 import com.slparcelauctions.backend.auction.VerificationMethod;
 import com.slparcelauctions.backend.parcel.Parcel;
 import com.slparcelauctions.backend.sl.SlWorldApiClient;
@@ -53,6 +55,7 @@ class OwnershipCheckTaskTest {
     @Mock AuctionRepository auctionRepo;
     @Mock SlWorldApiClient worldApi;
     @Mock SuspensionService suspensionService;
+    @Mock CancellationLogRepository cancellationLogRepo;
 
     OwnershipCheckTask task;
     Clock fixed;
@@ -60,7 +63,8 @@ class OwnershipCheckTaskTest {
     @BeforeEach
     void setUp() {
         fixed = Clock.fixed(Instant.parse("2026-04-16T12:00:00Z"), ZoneOffset.UTC);
-        task = new OwnershipCheckTask(auctionRepo, worldApi, suspensionService, fixed);
+        task = new OwnershipCheckTask(auctionRepo, worldApi, suspensionService,
+                cancellationLogRepo, fixed);
         lenient().when(auctionRepo.save(any(Auction.class)))
                 .thenAnswer(inv -> inv.getArgument(0));
     }
@@ -152,6 +156,98 @@ class OwnershipCheckTaskTest {
         verifyNoInteractions(worldApi);
         verifyNoInteractions(suspensionService);
         verify(auctionRepo, never()).save(any(Auction.class));
+    }
+
+    // -------------------------------------------------------------------------
+    // Post-cancel watcher path — Epic 08 sub-spec 2 §6
+    // -------------------------------------------------------------------------
+
+    @Test
+    void cancelledWatchOpen_mismatch_raisesCancelAndSellFlag_clearsWatchUntil() {
+        Auction a = buildActive();
+        a.setStatus(AuctionStatus.CANCELLED);
+        OffsetDateTime watchUntil = OffsetDateTime.now(fixed).plusHours(24);
+        a.setPostCancelWatchUntil(watchUntil);
+        OffsetDateTime cancelledAt = OffsetDateTime.now(fixed).minusHours(4);
+        when(auctionRepo.findByIdForUpdate(AUCTION_ID)).thenReturn(Optional.of(a));
+        when(worldApi.fetchParcel(PARCEL_UUID))
+                .thenReturn(Mono.just(meta(OTHER_AVATAR, "agent")));
+        com.slparcelauctions.backend.auction.CancellationLog log =
+                com.slparcelauctions.backend.auction.CancellationLog.builder()
+                        .id(7L).auction(a).seller(a.getSeller())
+                        .cancelledFromStatus("ACTIVE").hadBids(true)
+                        .cancelledAt(cancelledAt)
+                        .build();
+        when(cancellationLogRepo.findLatestByAuctionId(eq(AUCTION_ID), any()))
+                .thenReturn(java.util.List.of(log));
+
+        task.checkOne(AUCTION_ID);
+
+        verify(suspensionService).raiseCancelAndSellFlag(a, OTHER_AVATAR, cancelledAt);
+        // Watch window cleared so subsequent ticks don't re-flag.
+        assertThat(a.getPostCancelWatchUntil()).isNull();
+        // Status stays CANCELLED — the ACTIVE-only suspension flow does not run.
+        assertThat(a.getStatus()).isEqualTo(AuctionStatus.CANCELLED);
+        // Last check timestamp stamped so cadence gate is satisfied for any
+        // remaining (pointless, post-clear) ticks.
+        assertThat(a.getLastOwnershipCheckAt()).isEqualTo(OffsetDateTime.now(fixed));
+        verify(auctionRepo).save(a);
+        // Should NOT route through the ACTIVE-suspension path.
+        verify(suspensionService, never()).suspendForOwnershipChange(any(Auction.class), any());
+    }
+
+    @Test
+    void cancelledWatchOpen_ownerMatches_doesNotRaiseFlag() {
+        // Seller re-buys their own parcel within 48h — alt-account round-trip
+        // edge case from spec §6.4. Owner still resolves to seller's avatar
+        // UUID, so no flag raised.
+        Auction a = buildActive();
+        a.setStatus(AuctionStatus.CANCELLED);
+        a.setPostCancelWatchUntil(OffsetDateTime.now(fixed).plusHours(24));
+        when(auctionRepo.findByIdForUpdate(AUCTION_ID)).thenReturn(Optional.of(a));
+        when(worldApi.fetchParcel(PARCEL_UUID))
+                .thenReturn(Mono.just(meta(SELLER_AVATAR, "agent")));
+
+        task.checkOne(AUCTION_ID);
+
+        verify(suspensionService, never()).raiseCancelAndSellFlag(any(), any(), any());
+        // Watch window stays open — no flag, no clear.
+        assertThat(a.getPostCancelWatchUntil()).isNotNull();
+        // But the cadence timestamp advanced.
+        assertThat(a.getLastOwnershipCheckAt()).isEqualTo(OffsetDateTime.now(fixed));
+        verify(auctionRepo).save(a);
+    }
+
+    @Test
+    void cancelledWatchExpired_shortCircuits_noWorldApiCall() {
+        // Belt-and-braces guard: even if the scheduler dispatched an id
+        // whose watch window has since closed (race between query and
+        // async execution), the task itself short-circuits.
+        Auction a = buildActive();
+        a.setStatus(AuctionStatus.CANCELLED);
+        a.setPostCancelWatchUntil(OffsetDateTime.now(fixed).minusMinutes(1));
+        when(auctionRepo.findByIdForUpdate(AUCTION_ID)).thenReturn(Optional.of(a));
+
+        task.checkOne(AUCTION_ID);
+
+        verifyNoInteractions(worldApi);
+        verifyNoInteractions(suspensionService);
+    }
+
+    @Test
+    void cancelledNoWatchUntil_shortCircuits_noWorldApiCall() {
+        // CANCELLED auctions without an open watch window don't get probed
+        // (e.g. pre-active or active-without-bids cancellations whose
+        // postCancelWatchUntil was never set).
+        Auction a = buildActive();
+        a.setStatus(AuctionStatus.CANCELLED);
+        a.setPostCancelWatchUntil(null);
+        when(auctionRepo.findByIdForUpdate(AUCTION_ID)).thenReturn(Optional.of(a));
+
+        task.checkOne(AUCTION_ID);
+
+        verifyNoInteractions(worldApi);
+        verifyNoInteractions(suspensionService);
     }
 
     @Test

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/monitoring/OwnershipMonitorSchedulerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/monitoring/OwnershipMonitorSchedulerTest.java
@@ -52,19 +52,22 @@ class OwnershipMonitorSchedulerTest {
     }
 
     @Test
-    void dispatchDueChecks_queriesWithCutoff_andDispatchesEachId() {
-        when(auctionRepo.findDueForOwnershipCheck(any()))
+    void dispatchDueChecks_queriesWithCutoffAndNow_andDispatchesEachId() {
+        when(auctionRepo.findDueForOwnershipCheck(any(), any()))
                 .thenReturn(List.of(1L, 2L, 3L));
 
         scheduler.dispatchDueChecks();
 
         ArgumentCaptor<OffsetDateTime> cutoffCap = ArgumentCaptor.forClass(OffsetDateTime.class);
-        verify(auctionRepo).findDueForOwnershipCheck(cutoffCap.capture());
+        ArgumentCaptor<OffsetDateTime> nowCap = ArgumentCaptor.forClass(OffsetDateTime.class);
+        verify(auctionRepo).findDueForOwnershipCheck(cutoffCap.capture(), nowCap.capture());
         OffsetDateTime cutoff = cutoffCap.getValue();
+        OffsetDateTime now = nowCap.getValue();
         // With a fixed clock at 2026-04-17T12:00:00Z and checkIntervalMinutes=30,
-        // the cutoff must be exactly 30 minutes earlier.
-        assertThat(Duration.between(cutoff, OffsetDateTime.now(fixed)).toMinutes())
-                .isEqualTo(30L);
+        // the cutoff must be exactly 30 minutes earlier than now, and now must
+        // equal the clock instant.
+        assertThat(now).isEqualTo(OffsetDateTime.now(fixed));
+        assertThat(Duration.between(cutoff, now).toMinutes()).isEqualTo(30L);
 
         InOrder inOrder = inOrder(checkTask);
         inOrder.verify(checkTask).checkOne(1L);
@@ -74,7 +77,7 @@ class OwnershipMonitorSchedulerTest {
 
     @Test
     void dispatchDueChecks_emptyList_doesNotDispatch() {
-        when(auctionRepo.findDueForOwnershipCheck(any())).thenReturn(List.of());
+        when(auctionRepo.findDueForOwnershipCheck(any(), any())).thenReturn(List.of());
 
         scheduler.dispatchDueChecks();
 

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/monitoring/SuspensionServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/monitoring/SuspensionServiceTest.java
@@ -98,6 +98,55 @@ class SuspensionServiceTest {
     }
 
     @Test
+    void raiseCancelAndSellFlag_writesEvidenceWithExpectedShape() {
+        // Spec §6.3 evidence: cancelledAt, expectedSellerKey, observedOwnerKey,
+        // hoursSinceCancellation, parcelRegion, parcelLocalId, auctionTitle.
+        Auction a = buildActive();
+        a.setStatus(AuctionStatus.CANCELLED);
+        OffsetDateTime cancelledAt = OffsetDateTime.now(fixed).minusHours(4).minusMinutes(15);
+
+        service.raiseCancelAndSellFlag(a, ATTACKER_AVATAR, cancelledAt);
+
+        // No status change — auction was already CANCELLED. No save on the
+        // auction either; the caller (OwnershipCheckTask) writes the row.
+        assertThat(a.getStatus()).isEqualTo(AuctionStatus.CANCELLED);
+
+        ArgumentCaptor<FraudFlag> captor = ArgumentCaptor.forClass(FraudFlag.class);
+        verify(fraudFlagRepo).save(captor.capture());
+        FraudFlag flag = captor.getValue();
+        assertThat(flag.getReason()).isEqualTo(FraudFlagReason.CANCEL_AND_SELL);
+        assertThat(flag.getDetectedAt()).isEqualTo(OffsetDateTime.now(fixed));
+        assertThat(flag.isResolved()).isFalse();
+        assertThat(flag.getEvidenceJson())
+                .containsEntry("cancelledAt", cancelledAt.toString())
+                .containsEntry("expectedSellerKey", SELLER_AVATAR.toString())
+                .containsEntry("observedOwnerKey", ATTACKER_AVATAR.toString())
+                .containsEntry("parcelRegion", "Coniston")
+                .containsEntry("parcelLocalId", PARCEL_ID)
+                .containsEntry("auctionTitle", "Test listing");
+        // hoursSinceCancellation: ~4.25 hours (4h 15m)
+        Object hours = flag.getEvidenceJson().get("hoursSinceCancellation");
+        assertThat(hours).isInstanceOf(Double.class);
+        assertThat(((Double) hours)).isEqualTo(4.25);
+    }
+
+    @Test
+    void raiseCancelAndSellFlag_handlesNullCancelledAt() {
+        // Defensive: if the cancellation log is missing for some reason,
+        // the flag still writes — hoursSinceCancellation is null.
+        Auction a = buildActive();
+        a.setStatus(AuctionStatus.CANCELLED);
+
+        service.raiseCancelAndSellFlag(a, ATTACKER_AVATAR, null);
+
+        ArgumentCaptor<FraudFlag> captor = ArgumentCaptor.forClass(FraudFlag.class);
+        verify(fraudFlagRepo).save(captor.capture());
+        FraudFlag flag = captor.getValue();
+        assertThat(flag.getEvidenceJson()).containsEntry("hoursSinceCancellation", null);
+        assertThat(flag.getEvidenceJson()).containsEntry("cancelledAt", null);
+    }
+
+    @Test
     void suspendForDeletedParcel_flipsStatus_stampsTimestamp_writesFlagWithParcelOnly() {
         Auction a = buildActive();
 

--- a/backend/src/test/java/com/slparcelauctions/backend/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auth/AuthControllerTest.java
@@ -154,6 +154,8 @@ class AuthControllerTest {
     private UserResponse stubUser() {
         return new UserResponse(
             1L, "new@example.com", "Newbie", null, null, null, null, null, null, null, null,
-            null, null, null, null, null, OffsetDateTime.now(), OffsetDateTime.now());
+            null, null, null, null, null,
+            0L, null, false,
+            OffsetDateTime.now(), OffsetDateTime.now());
     }
 }

--- a/backend/src/test/java/com/slparcelauctions/backend/parceltag/ParcelTagControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/parceltag/ParcelTagControllerIntegrationTest.java
@@ -36,9 +36,14 @@ class ParcelTagControllerIntegrationTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    void list_unauthenticated_returns401() throws Exception {
+    void list_unauthenticated_returnsPublicTagCatalogue() throws Exception {
+        // GET /api/v1/parcel-tags is intentionally public so anonymous
+        // /browse callers can render tag filters without first
+        // authenticating. SecurityConfig matcher at line 123 flips this
+        // ahead of the /api/v1/** authenticated catch-all.
         mockMvc.perform(get("/api/v1/parcel-tags"))
-                .andExpect(status().isUnauthorized());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
     }
 
     @Test

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/PenaltyTerminalControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/PenaltyTerminalControllerSliceTest.java
@@ -1,0 +1,292 @@
+package com.slparcelauctions.backend.sl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.slparcelauctions.backend.auth.JwtAuthenticationEntryPoint;
+import com.slparcelauctions.backend.auth.JwtAuthenticationFilter;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.auth.config.JwtConfig;
+import com.slparcelauctions.backend.bot.BotSharedSecretAuthorizer;
+import com.slparcelauctions.backend.config.SecurityConfig;
+import com.slparcelauctions.backend.sl.dto.PenaltyLookupResponse;
+import com.slparcelauctions.backend.sl.dto.PenaltyPaymentRequest;
+import com.slparcelauctions.backend.sl.dto.PenaltyPaymentResponse;
+import com.slparcelauctions.backend.sl.exception.InvalidSlHeadersException;
+import com.slparcelauctions.backend.sl.exception.PenaltyOverpaymentException;
+import com.slparcelauctions.backend.user.UserNotFoundException;
+
+/**
+ * Slice tests for {@link PenaltyTerminalController}. Stubs
+ * {@link PenaltyTerminalService} + {@link SlHeaderValidator} and
+ * exercises the real Spring Security filter chain plus
+ * {@link SlExceptionHandler} so the 200/400/403/404/422 paths render
+ * the advertised ProblemDetail / DTO shapes. Covers the scenarios in
+ * plan Step 3.
+ */
+@WebMvcTest(PenaltyTerminalController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class,
+        JwtAuthenticationEntryPoint.class, SlExceptionHandler.class})
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "jwt.secret=dGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdA==",
+        "jwt.access-token-lifetime=PT15M",
+        "jwt.refresh-token-lifetime=P7D"
+})
+class PenaltyTerminalControllerSliceTest {
+
+    private static final String SHARD = "Production";
+    private static final String OWNER_KEY = "00000000-0000-0000-0000-000000000001";
+    private static final String AVATAR_UUID = "11111111-1111-1111-1111-111111111111";
+    private static final String TERMINAL_ID = "terminal-7";
+    private static final String SL_TXN = "sl-txn-pen-abc123";
+
+    @Autowired MockMvc mockMvc;
+    @MockitoBean PenaltyTerminalService service;
+    @MockitoBean SlHeaderValidator headerValidator;
+    @MockitoBean JwtService jwtService;
+    @MockitoBean JwtConfig jwtConfig;
+    // SecurityConfig depends on BotSharedSecretAuthorizer (Epic 06 Task 3).
+    @MockitoBean BotSharedSecretAuthorizer botSharedSecretAuthorizer;
+
+    private static String lookupBody(String avatar, String terminal) {
+        return String.format("""
+                { "slAvatarUuid":"%s", "terminalId":"%s" }
+                """, avatar, terminal);
+    }
+
+    private static String paymentBody(String avatar, String slTxn, long amount, String terminal) {
+        return String.format("""
+                {
+                  "slAvatarUuid":"%s",
+                  "slTransactionId":"%s",
+                  "amount":%d,
+                  "terminalId":"%s"
+                }
+                """, avatar, slTxn, amount, terminal);
+    }
+
+    // -----------------------------------------------------------------
+    // Lookup
+    // -----------------------------------------------------------------
+
+    @Test
+    void lookup_returnsBalance_whenUserOwes() throws Exception {
+        doNothing().when(headerValidator).validate(SHARD, OWNER_KEY);
+        when(service.lookup(any(UUID.class)))
+                .thenReturn(new PenaltyLookupResponse(42L, "Alice", 1000L));
+
+        mockMvc.perform(post("/api/v1/sl/penalty-lookup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-SecondLife-Shard", SHARD)
+                        .header("X-SecondLife-Owner-Key", OWNER_KEY)
+                        .content(lookupBody(AVATAR_UUID, TERMINAL_ID)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(42))
+                .andExpect(jsonPath("$.displayName").value("Alice"))
+                .andExpect(jsonPath("$.penaltyBalanceOwed").value(1000));
+    }
+
+    @Test
+    void lookup_returns404_whenAvatarUnknown() throws Exception {
+        doNothing().when(headerValidator).validate(SHARD, OWNER_KEY);
+        when(service.lookup(any(UUID.class)))
+                .thenThrow(new UserNotFoundException(
+                        "No SLPA user found for avatar " + AVATAR_UUID));
+
+        mockMvc.perform(post("/api/v1/sl/penalty-lookup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-SecondLife-Shard", SHARD)
+                        .header("X-SecondLife-Owner-Key", OWNER_KEY)
+                        .content(lookupBody(AVATAR_UUID, TERMINAL_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+    }
+
+    @Test
+    void lookup_returns404_whenBalanceIsZero() throws Exception {
+        doNothing().when(headerValidator).validate(SHARD, OWNER_KEY);
+        when(service.lookup(any(UUID.class)))
+                .thenThrow(new UserNotFoundException(
+                        "No outstanding penalty balance for avatar " + AVATAR_UUID));
+
+        mockMvc.perform(post("/api/v1/sl/penalty-lookup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-SecondLife-Shard", SHARD)
+                        .header("X-SecondLife-Owner-Key", OWNER_KEY)
+                        .content(lookupBody(AVATAR_UUID, TERMINAL_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+    }
+
+    @Test
+    void lookup_returns403_withoutSlOwnerKeyHeader() throws Exception {
+        doThrow(new InvalidSlHeadersException("Owner key missing or malformed"))
+                .when(headerValidator).validate(any(), any());
+
+        mockMvc.perform(post("/api/v1/sl/penalty-lookup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(lookupBody(AVATAR_UUID, TERMINAL_ID)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("SL_INVALID_HEADERS"));
+
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    void lookup_returns400_whenAvatarUuidMalformed() throws Exception {
+        doNothing().when(headerValidator).validate(anyString(), anyString());
+
+        mockMvc.perform(post("/api/v1/sl/penalty-lookup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-SecondLife-Shard", SHARD)
+                        .header("X-SecondLife-Owner-Key", OWNER_KEY)
+                        .content("""
+                                { "slAvatarUuid":"not-a-uuid", "terminalId":"t" }
+                                """))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(service);
+    }
+
+    // -----------------------------------------------------------------
+    // Payment
+    // -----------------------------------------------------------------
+
+    @Test
+    void payment_partialClear_returns200WithRemainingBalance() throws Exception {
+        doNothing().when(headerValidator).validate(SHARD, OWNER_KEY);
+        when(service.pay(any(PenaltyPaymentRequest.class)))
+                .thenReturn(new PenaltyPaymentResponse(400L));
+
+        mockMvc.perform(post("/api/v1/sl/penalty-payment")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-SecondLife-Shard", SHARD)
+                        .header("X-SecondLife-Owner-Key", OWNER_KEY)
+                        .content(paymentBody(AVATAR_UUID, SL_TXN, 600L, TERMINAL_ID)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.remainingBalance").value(400));
+    }
+
+    @Test
+    void payment_fullClear_returnsZeroBalance() throws Exception {
+        doNothing().when(headerValidator).validate(SHARD, OWNER_KEY);
+        when(service.pay(any(PenaltyPaymentRequest.class)))
+                .thenReturn(new PenaltyPaymentResponse(0L));
+
+        mockMvc.perform(post("/api/v1/sl/penalty-payment")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-SecondLife-Shard", SHARD)
+                        .header("X-SecondLife-Owner-Key", OWNER_KEY)
+                        .content(paymentBody(AVATAR_UUID, SL_TXN, 1000L, TERMINAL_ID)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.remainingBalance").value(0));
+    }
+
+    @Test
+    void payment_overpayment_returns422() throws Exception {
+        doNothing().when(headerValidator).validate(SHARD, OWNER_KEY);
+        when(service.pay(any(PenaltyPaymentRequest.class)))
+                .thenThrow(new PenaltyOverpaymentException(1000L, 500L));
+
+        mockMvc.perform(post("/api/v1/sl/penalty-payment")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-SecondLife-Shard", SHARD)
+                        .header("X-SecondLife-Owner-Key", OWNER_KEY)
+                        .content(paymentBody(AVATAR_UUID, SL_TXN, 1000L, TERMINAL_ID)))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("SL_PENALTY_OVERPAYMENT"))
+                .andExpect(jsonPath("$.requested").value(1000))
+                .andExpect(jsonPath("$.available").value(500));
+    }
+
+    @Test
+    void payment_unknownAvatar_returns404() throws Exception {
+        doNothing().when(headerValidator).validate(SHARD, OWNER_KEY);
+        when(service.pay(any(PenaltyPaymentRequest.class)))
+                .thenThrow(new UserNotFoundException(
+                        "No SLPA user found for avatar " + AVATAR_UUID));
+
+        mockMvc.perform(post("/api/v1/sl/penalty-payment")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-SecondLife-Shard", SHARD)
+                        .header("X-SecondLife-Owner-Key", OWNER_KEY)
+                        .content(paymentBody(AVATAR_UUID, SL_TXN, 100L, TERMINAL_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+    }
+
+    @Test
+    void payment_amountZero_returns400() throws Exception {
+        doNothing().when(headerValidator).validate(anyString(), anyString());
+
+        mockMvc.perform(post("/api/v1/sl/penalty-payment")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-SecondLife-Shard", SHARD)
+                        .header("X-SecondLife-Owner-Key", OWNER_KEY)
+                        .content(paymentBody(AVATAR_UUID, SL_TXN, 0L, TERMINAL_ID)))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    void payment_negativeAmount_returns400() throws Exception {
+        doNothing().when(headerValidator).validate(anyString(), anyString());
+
+        mockMvc.perform(post("/api/v1/sl/penalty-payment")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-SecondLife-Shard", SHARD)
+                        .header("X-SecondLife-Owner-Key", OWNER_KEY)
+                        .content(paymentBody(AVATAR_UUID, SL_TXN, -100L, TERMINAL_ID)))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    void payment_blankSlTransactionId_returns400() throws Exception {
+        doNothing().when(headerValidator).validate(anyString(), anyString());
+
+        mockMvc.perform(post("/api/v1/sl/penalty-payment")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-SecondLife-Shard", SHARD)
+                        .header("X-SecondLife-Owner-Key", OWNER_KEY)
+                        .content(paymentBody(AVATAR_UUID, "", 100L, TERMINAL_ID)))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    void payment_returns403_withoutSlOwnerKeyHeader() throws Exception {
+        doThrow(new InvalidSlHeadersException("Owner key missing or malformed"))
+                .when(headerValidator).validate(any(), any());
+
+        mockMvc.perform(post("/api/v1/sl/penalty-payment")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(paymentBody(AVATAR_UUID, SL_TXN, 100L, TERMINAL_ID)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("SL_INVALID_HEADERS"));
+
+        verifyNoInteractions(service);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/PenaltyTerminalServiceConcurrencyIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/PenaltyTerminalServiceConcurrencyIntegrationTest.java
@@ -1,0 +1,229 @@
+package com.slparcelauctions.backend.sl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import com.slparcelauctions.backend.escrow.EscrowTransactionRepository;
+import com.slparcelauctions.backend.escrow.EscrowTransactionType;
+import com.slparcelauctions.backend.sl.dto.PenaltyPaymentRequest;
+import com.slparcelauctions.backend.sl.exception.PenaltyOverpaymentException;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Epic 08 sub-spec 2 Task 3 regression: two concurrent penalty payments
+ * targeting the SAME seller from two different terminals must serialise
+ * on the User-row pessimistic lock acquired inside
+ * {@link PenaltyTerminalService#pay}. Without the lock, both transactions
+ * could read the same outstanding balance and both apply, double-debiting
+ * the seller below zero.
+ *
+ * <p>Mirrors the harness style of {@code CancelLadderRaceTest}: NOT
+ * {@code @Transactional}, so each thread runs its own transaction and
+ * the row lock actually contends.
+ *
+ * <p>Setup: seller owes L$1000. Two threads each attempt to pay L$600
+ * with distinct {@code slTransactionId}s. Accepted outcome:
+ * <ol>
+ *   <li>One thread commits, leaving balance = 400 and one
+ *       LISTING_PENALTY_PAYMENT ledger row.</li>
+ *   <li>The second thread sees balance = 400, tries 600, hits
+ *       {@link PenaltyOverpaymentException}; no second ledger row,
+ *       balance unchanged at 400.</li>
+ * </ol>
+ * Total ledger rows for this seller = 1; balance never goes negative.
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.auction-end.enabled=false",
+        "slpa.ownership-monitor.enabled=false",
+        "slpa.escrow.ownership-monitor-job.enabled=false"
+})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class PenaltyTerminalServiceConcurrencyIntegrationTest {
+
+    @Autowired PenaltyTerminalService service;
+    @Autowired UserRepository userRepository;
+    @Autowired EscrowTransactionRepository ledgerRepository;
+    @Autowired DataSource dataSource;
+
+    private Long sellerId;
+    private UUID avatarUuid;
+
+    @AfterEach
+    void cleanup() throws Exception {
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var stmt = conn.createStatement()) {
+                if (sellerId != null) {
+                    stmt.execute(
+                            "DELETE FROM escrow_transactions WHERE payer_id = " + sellerId);
+                    stmt.execute("DELETE FROM users WHERE id = " + sellerId);
+                }
+            }
+        }
+        sellerId = null;
+        avatarUuid = null;
+    }
+
+    @Test
+    void pay_simultaneousAtTwoTerminals_serializesViaUserRowLock() throws Exception {
+        setup(1000L);
+
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch go = new CountDownLatch(1);
+        AtomicReference<Throwable> err1 = new AtomicReference<>();
+        AtomicReference<Throwable> err2 = new AtomicReference<>();
+
+        Runnable pay1 = () -> {
+            ready.countDown();
+            try {
+                go.await();
+                service.pay(new PenaltyPaymentRequest(
+                        avatarUuid, "sl-txn-race-1", 600L, "terminal-A"));
+            } catch (Throwable t) {
+                err1.set(t);
+            }
+        };
+        Runnable pay2 = () -> {
+            ready.countDown();
+            try {
+                go.await();
+                service.pay(new PenaltyPaymentRequest(
+                        avatarUuid, "sl-txn-race-2", 600L, "terminal-B"));
+            } catch (Throwable t) {
+                err2.set(t);
+            }
+        };
+
+        Thread t1 = new Thread(pay1, "race-pay-1");
+        Thread t2 = new Thread(pay2, "race-pay-2");
+        t1.setDaemon(true);
+        t2.setDaemon(true);
+        t1.start();
+        t2.start();
+
+        assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+        go.countDown();
+
+        t1.join(TimeUnit.SECONDS.toMillis(20));
+        t2.join(TimeUnit.SECONDS.toMillis(20));
+
+        // Exactly one thread succeeds; the other must throw
+        // PenaltyOverpaymentException because 1000 - 600 = 400 < 600.
+        Throwable e1 = err1.get();
+        Throwable e2 = err2.get();
+        boolean firstSucceeded = e1 == null;
+        boolean secondSucceeded = e2 == null;
+        assertThat(firstSucceeded ^ secondSucceeded)
+                .as("exactly one of the two payments must succeed; the other must overpay")
+                .isTrue();
+        Throwable failure = firstSucceeded ? e2 : e1;
+        assertThat(failure)
+                .as("the losing thread must hit overpayment, not a generic error")
+                .isInstanceOf(PenaltyOverpaymentException.class);
+
+        // Final balance is 1000 - 600 = 400; never negative.
+        User reloaded = userRepository.findById(sellerId).orElseThrow();
+        assertThat(reloaded.getPenaltyBalanceOwed())
+                .as("balance must not go negative; one payment of 600 lands")
+                .isEqualTo(400L);
+
+        // Exactly one ledger row for the seller.
+        long ledgerRows = ledgerRepository.findAll().stream()
+                .filter(t -> t.getPayer() != null
+                        && sellerId.equals(t.getPayer().getId()))
+                .filter(t -> t.getType() == EscrowTransactionType.LISTING_PENALTY_PAYMENT)
+                .count();
+        assertThat(ledgerRows)
+                .as("exactly one LISTING_PENALTY_PAYMENT ledger row must land")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void pay_sequentialPartials_bothLand() throws Exception {
+        setup(1000L);
+
+        // First partial: 600 → 400 remaining.
+        var resp1 = service.pay(new PenaltyPaymentRequest(
+                avatarUuid, "sl-txn-seq-1", 600L, "terminal-A"));
+        assertThat(resp1.remainingBalance()).isEqualTo(400L);
+
+        // Second partial: 400 → 0 remaining.
+        var resp2 = service.pay(new PenaltyPaymentRequest(
+                avatarUuid, "sl-txn-seq-2", 400L, "terminal-B"));
+        assertThat(resp2.remainingBalance()).isEqualTo(0L);
+
+        User reloaded = userRepository.findById(sellerId).orElseThrow();
+        assertThat(reloaded.getPenaltyBalanceOwed()).isEqualTo(0L);
+
+        long ledgerRows = ledgerRepository.findAll().stream()
+                .filter(t -> t.getPayer() != null
+                        && sellerId.equals(t.getPayer().getId()))
+                .filter(t -> t.getType() == EscrowTransactionType.LISTING_PENALTY_PAYMENT)
+                .count();
+        assertThat(ledgerRows)
+                .as("both partial payments must produce exactly one ledger row each")
+                .isEqualTo(2);
+    }
+
+    @Test
+    void pay_idempotentReplay_doesNotDoubleDebit() throws Exception {
+        setup(1000L);
+
+        var first = service.pay(new PenaltyPaymentRequest(
+                avatarUuid, "sl-txn-idem", 600L, "terminal-A"));
+        assertThat(first.remainingBalance()).isEqualTo(400L);
+
+        // Replay of the same slTransactionId — must short-circuit.
+        var replay = service.pay(new PenaltyPaymentRequest(
+                avatarUuid, "sl-txn-idem", 600L, "terminal-A"));
+        assertThat(replay.remainingBalance())
+                .as("replay must return the current balance, not re-decrement")
+                .isEqualTo(400L);
+
+        User reloaded = userRepository.findById(sellerId).orElseThrow();
+        assertThat(reloaded.getPenaltyBalanceOwed())
+                .as("balance must reflect exactly one payment")
+                .isEqualTo(400L);
+
+        long ledgerRows = ledgerRepository.findAll().stream()
+                .filter(t -> t.getPayer() != null
+                        && sellerId.equals(t.getPayer().getId()))
+                .filter(t -> t.getType() == EscrowTransactionType.LISTING_PENALTY_PAYMENT)
+                .count();
+        assertThat(ledgerRows)
+                .as("idempotent replay must not write a second ledger row")
+                .isEqualTo(1);
+    }
+
+    private void setup(long initialBalance) {
+        avatarUuid = UUID.randomUUID();
+        User seller = userRepository.save(User.builder()
+                .email("penalty-payer-" + UUID.randomUUID() + "@example.com")
+                .passwordHash("$2a$10$dummy.hash.value.for.test.only.aaaaaaaaaaaaaaaaaaaa")
+                .displayName("Penalty Payer")
+                .slAvatarUuid(avatarUuid)
+                .verified(true)
+                .penaltyBalanceOwed(initialBalance)
+                .bannedFromListing(false)
+                .build());
+        this.sellerId = seller.getId();
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/PenaltyTerminalServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/PenaltyTerminalServiceTest.java
@@ -1,0 +1,241 @@
+package com.slparcelauctions.backend.sl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.slparcelauctions.backend.escrow.EscrowTransaction;
+import com.slparcelauctions.backend.escrow.EscrowTransactionRepository;
+import com.slparcelauctions.backend.escrow.EscrowTransactionStatus;
+import com.slparcelauctions.backend.escrow.EscrowTransactionType;
+import com.slparcelauctions.backend.sl.dto.PenaltyLookupResponse;
+import com.slparcelauctions.backend.sl.dto.PenaltyPaymentRequest;
+import com.slparcelauctions.backend.sl.dto.PenaltyPaymentResponse;
+import com.slparcelauctions.backend.sl.exception.PenaltyOverpaymentException;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserNotFoundException;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Pure service-layer pins for {@link PenaltyTerminalService}. Mocks
+ * {@link UserRepository} + {@link EscrowTransactionRepository} so the
+ * idempotency / overpayment / pessimistic-lock logic is exercised
+ * without spinning up Spring. Concurrent serialisation under a real
+ * row-lock is covered by the integration test
+ * {@code PenaltyTerminalServiceConcurrencyIntegrationTest}.
+ */
+class PenaltyTerminalServiceTest {
+
+    private static final OffsetDateTime NOW = OffsetDateTime.of(
+            2026, 4, 25, 18, 0, 0, 0, ZoneOffset.UTC);
+    private static final Clock FIXED = Clock.fixed(NOW.toInstant(), ZoneOffset.UTC);
+    private static final UUID AVATAR = UUID.fromString("a1b2c3d4-a1b2-c3d4-e5f6-000000000123");
+    private static final String SL_TXN = "sl-txn-pen-1";
+    private static final String TERMINAL = "terminal-7";
+
+    private UserRepository userRepo;
+    private EscrowTransactionRepository ledgerRepo;
+    private PenaltyTerminalService service;
+
+    @BeforeEach
+    void setup() {
+        userRepo = mock(UserRepository.class);
+        ledgerRepo = mock(EscrowTransactionRepository.class);
+        service = new PenaltyTerminalService(userRepo, ledgerRepo, FIXED);
+    }
+
+    private static User userWithBalance(Long id, String displayName, Long balance) {
+        return User.builder()
+                .id(id)
+                .email("seller-" + id + "@example.test")
+                .passwordHash("x")
+                .displayName(displayName)
+                .slAvatarUuid(AVATAR)
+                .penaltyBalanceOwed(balance)
+                .build();
+    }
+
+    // -----------------------------------------------------------------
+    // Lookup
+    // -----------------------------------------------------------------
+
+    @Test
+    void lookup_returnsBalance_whenUserOwes() {
+        User u = userWithBalance(7L, "Alice", 1000L);
+        when(userRepo.findBySlAvatarUuid(AVATAR)).thenReturn(Optional.of(u));
+
+        PenaltyLookupResponse resp = service.lookup(AVATAR);
+
+        assertThat(resp.userId()).isEqualTo(7L);
+        assertThat(resp.displayName()).isEqualTo("Alice");
+        assertThat(resp.penaltyBalanceOwed()).isEqualTo(1000L);
+    }
+
+    @Test
+    void lookup_throwsUserNotFound_whenAvatarUnknown() {
+        when(userRepo.findBySlAvatarUuid(AVATAR)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.lookup(AVATAR))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
+    void lookup_throwsUserNotFound_whenBalanceIsZero() {
+        User u = userWithBalance(7L, "Alice", 0L);
+        when(userRepo.findBySlAvatarUuid(AVATAR)).thenReturn(Optional.of(u));
+
+        assertThatThrownBy(() -> service.lookup(AVATAR))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
+    void lookup_treatsNullBalanceAsZero() {
+        User u = userWithBalance(7L, "Alice", null);
+        when(userRepo.findBySlAvatarUuid(AVATAR)).thenReturn(Optional.of(u));
+
+        assertThatThrownBy(() -> service.lookup(AVATAR))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    // -----------------------------------------------------------------
+    // Payment — happy paths
+    // -----------------------------------------------------------------
+
+    @Test
+    void pay_partialClear_decrementsBalanceAndWritesLedgerRow() {
+        User u = userWithBalance(7L, "Alice", 1000L);
+        when(userRepo.findIdBySlAvatarUuid(AVATAR)).thenReturn(Optional.of(7L));
+        when(ledgerRepo.findFirstBySlTransactionIdAndType(
+                SL_TXN, EscrowTransactionType.LISTING_PENALTY_PAYMENT))
+                .thenReturn(Optional.empty());
+        when(userRepo.findByIdForUpdate(7L)).thenReturn(Optional.of(u));
+        when(userRepo.save(any(User.class))).thenAnswer(i -> i.getArgument(0));
+
+        PenaltyPaymentResponse resp = service.pay(
+                new PenaltyPaymentRequest(AVATAR, SL_TXN, 600L, TERMINAL));
+
+        assertThat(resp.remainingBalance()).isEqualTo(400L);
+        assertThat(u.getPenaltyBalanceOwed()).isEqualTo(400L);
+
+        ArgumentCaptor<EscrowTransaction> tx = ArgumentCaptor.forClass(EscrowTransaction.class);
+        verify(ledgerRepo).save(tx.capture());
+        EscrowTransaction saved = tx.getValue();
+        assertThat(saved.getType()).isEqualTo(EscrowTransactionType.LISTING_PENALTY_PAYMENT);
+        assertThat(saved.getStatus()).isEqualTo(EscrowTransactionStatus.COMPLETED);
+        assertThat(saved.getAmount()).isEqualTo(600L);
+        assertThat(saved.getPayer()).isSameAs(u);
+        assertThat(saved.getPayee()).isNull();
+        assertThat(saved.getSlTransactionId()).isEqualTo(SL_TXN);
+        assertThat(saved.getTerminalId()).isEqualTo(TERMINAL);
+        assertThat(saved.getCompletedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    void pay_fullClear_zeroesBalance() {
+        User u = userWithBalance(7L, "Alice", 1000L);
+        when(userRepo.findIdBySlAvatarUuid(AVATAR)).thenReturn(Optional.of(7L));
+        when(ledgerRepo.findFirstBySlTransactionIdAndType(
+                SL_TXN, EscrowTransactionType.LISTING_PENALTY_PAYMENT))
+                .thenReturn(Optional.empty());
+        when(userRepo.findByIdForUpdate(7L)).thenReturn(Optional.of(u));
+        when(userRepo.save(any(User.class))).thenAnswer(i -> i.getArgument(0));
+
+        PenaltyPaymentResponse resp = service.pay(
+                new PenaltyPaymentRequest(AVATAR, SL_TXN, 1000L, TERMINAL));
+
+        assertThat(resp.remainingBalance()).isEqualTo(0L);
+        assertThat(u.getPenaltyBalanceOwed()).isEqualTo(0L);
+        verify(ledgerRepo).save(any(EscrowTransaction.class));
+    }
+
+    // -----------------------------------------------------------------
+    // Payment — idempotency
+    // -----------------------------------------------------------------
+
+    @Test
+    void pay_idempotentReplay_returnsCurrentBalanceWithoutSecondLedgerRow() {
+        // Simulate a prior partial payment of 600 already on the ledger.
+        // The user's balance is currently 400 (post-prior-payment) and a
+        // retry of the same slTransactionId comes in.
+        User u = userWithBalance(7L, "Alice", 400L);
+        when(userRepo.findIdBySlAvatarUuid(AVATAR)).thenReturn(Optional.of(7L));
+        when(userRepo.findById(7L)).thenReturn(Optional.of(u));
+        EscrowTransaction prior = EscrowTransaction.builder()
+                .type(EscrowTransactionType.LISTING_PENALTY_PAYMENT)
+                .status(EscrowTransactionStatus.COMPLETED)
+                .amount(600L)
+                .payer(u)
+                .slTransactionId(SL_TXN)
+                .terminalId(TERMINAL)
+                .completedAt(NOW)
+                .build();
+        when(ledgerRepo.findFirstBySlTransactionIdAndType(
+                SL_TXN, EscrowTransactionType.LISTING_PENALTY_PAYMENT))
+                .thenReturn(Optional.of(prior));
+
+        PenaltyPaymentResponse resp = service.pay(
+                new PenaltyPaymentRequest(AVATAR, SL_TXN, 600L, TERMINAL));
+
+        // Replay returns the user's current (already-decremented) balance.
+        assertThat(resp.remainingBalance()).isEqualTo(400L);
+
+        // No second decrement, no second ledger row, no lock acquired.
+        assertThat(u.getPenaltyBalanceOwed()).isEqualTo(400L);
+        verify(userRepo, never()).findByIdForUpdate(any());
+        verify(userRepo, never()).save(any(User.class));
+        verify(ledgerRepo, never()).save(any(EscrowTransaction.class));
+    }
+
+    // -----------------------------------------------------------------
+    // Payment — overpayment
+    // -----------------------------------------------------------------
+
+    @Test
+    void pay_overpayment_throwsAndLeavesStateUnchanged() {
+        User u = userWithBalance(7L, "Alice", 500L);
+        when(userRepo.findIdBySlAvatarUuid(AVATAR)).thenReturn(Optional.of(7L));
+        when(ledgerRepo.findFirstBySlTransactionIdAndType(
+                SL_TXN, EscrowTransactionType.LISTING_PENALTY_PAYMENT))
+                .thenReturn(Optional.empty());
+        when(userRepo.findByIdForUpdate(7L)).thenReturn(Optional.of(u));
+
+        assertThatThrownBy(() -> service.pay(
+                new PenaltyPaymentRequest(AVATAR, SL_TXN, 1000L, TERMINAL)))
+                .isInstanceOf(PenaltyOverpaymentException.class)
+                .satisfies(e -> {
+                    PenaltyOverpaymentException ex = (PenaltyOverpaymentException) e;
+                    assertThat(ex.getRequested()).isEqualTo(1000L);
+                    assertThat(ex.getAvailable()).isEqualTo(500L);
+                });
+
+        // Balance untouched, no ledger row, no save.
+        assertThat(u.getPenaltyBalanceOwed()).isEqualTo(500L);
+        verify(userRepo, never()).save(any(User.class));
+        verify(ledgerRepo, never()).save(any(EscrowTransaction.class));
+    }
+
+    @Test
+    void pay_unknownAvatar_throwsUserNotFound() {
+        when(userRepo.findIdBySlAvatarUuid(AVATAR)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.pay(
+                new PenaltyPaymentRequest(AVATAR, SL_TXN, 100L, TERMINAL)))
+                .isInstanceOf(UserNotFoundException.class);
+
+        verify(ledgerRepo, never()).save(any(EscrowTransaction.class));
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/user/UserControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/user/UserControllerTest.java
@@ -53,7 +53,9 @@ class UserControllerTest {
     void createUser_returns201() throws Exception {
         UserResponse response = new UserResponse(
                 1L, "alice@example.com", "Alice", null, null, null, null, null, null, null, null,
-                false, null, false, Map.of(), Map.of(), OffsetDateTime.now(), OffsetDateTime.now());
+                false, null, false, Map.of(), Map.of(),
+                0L, null, false,
+                OffsetDateTime.now(), OffsetDateTime.now());
         when(userService.createUser(any(CreateUserRequest.class))).thenReturn(response);
 
         CreateUserRequest request = new CreateUserRequest("alice@example.com", "password123", "Alice");
@@ -157,7 +159,9 @@ class UserControllerTest {
     void getMe_returnsUserDto_whenAuthenticated() throws Exception {
         UserResponse expected = new UserResponse(
                 1L, "test@example.com", "Test User", null, null, null, null, null, null, null, null,
-                false, null, false, Map.of(), Map.of(), OffsetDateTime.now(), OffsetDateTime.now());
+                false, null, false, Map.of(), Map.of(),
+                0L, null, false,
+                OffsetDateTime.now(), OffsetDateTime.now());
         when(userService.getUserById(1L)).thenReturn(expected);
 
         mockMvc.perform(get("/api/v1/users/me"))

--- a/docs/implementation/DEFERRED_WORK.md
+++ b/docs/implementation/DEFERRED_WORK.md
@@ -356,6 +356,24 @@ When finishing a sub-spec that completes a deferred item, remove the entry.
 - **When:** Pre-launch ops checklist; remove after first prod deployment lands cleanly.
 - **Notes:** `AuctionTitleDevTouchUp` is the dev-side workaround. `MaturityRatingDevTouchUp` is the same pattern for the maturity_rating canonicalization.
 
+### libwebp native-load failures on arm64 macOS in image-processing tests
+- **From:** Pre-existing baseline noise; rediscovered by every backend test run since at least Epic 05. Surfaced in Epic 08 sub-spec 1 + sub-spec 2 implementer reports.
+- **Why:** `ListingPhotoProcessorTest`, `ImageUploadValidatorTest`, and `AvatarImageProcessorTest` fail to load `libwebp-imageio.dylib` on arm64 Apple Silicon (the bundled native is x86_64 only). 3 errors per `./mvnw test` run, always the same three tests, never affected by application code changes. CI on Linux x86_64 is unaffected.
+- **When:** Indefinite — needs an arm64 build of `webp-imageio` OR a different webp library (e.g., `imageio-webp` from `com.github.gotson` which ships native arm64), OR `@DisabledOnOs` gating these tests on macOS arm64 with a clear comment.
+- **Notes:** Implementer agents have been independently re-explaining these failures in every task report on this branch. Worth either fixing or explicitly silencing so they stop polluting test reports. The files: `backend/src/test/java/com/slparcelauctions/backend/auction/photos/ListingPhotoProcessorTest.java`, `backend/src/test/java/com/slparcelauctions/backend/storage/ImageUploadValidatorTest.java`, `backend/src/test/java/com/slparcelauctions/backend/user/AvatarImageProcessorTest.java`.
+
+### `ParcelTagControllerIntegrationTest.list_unauthenticated_returns401` baseline failure
+- **From:** Pre-existing baseline noise; rediscovered by every backend test run since at least Epic 07. Surfaced in Epic 08 sub-spec 1 + sub-spec 2 implementer reports.
+- **Why:** Test asserts `GET /api/v1/parcel-tags` returns 401 when unauthenticated, but the SecurityConfig matcher for that path was flipped to `permitAll()` in an earlier task without updating the test. Test now sees 200 instead of 401. Single failure per `./mvnw test` run.
+- **When:** Indefinite — either revert the matcher to `authenticated()` OR update the test to assert 200 with the public list shape, depending on whether the public-tag-list decision was intentional. The matcher change history needs to be audited to confirm intent.
+- **Notes:** File: `backend/src/test/java/com/slparcelauctions/backend/parceltag/ParcelTagControllerIntegrationTest.java`. Quick fix is one line either way; the question is which direction is correct. Worth a 5-minute investigation rather than letting it sit.
+
+### Real-time `PENALTY_CLEARED` push for SuspensionBanner
+- **From:** Epic 08 sub-spec 2 (§5.6 + §12)
+- **Why:** When a seller pays off their `penaltyBalanceOwed` at a SLPA terminal, the dashboard `<SuspensionBanner>` should dismiss in real time. Sub-spec 2 ships a window-focus refetch + 30s `staleTime` on `/me` as the freshness mechanism — adequate for the walk-in flow (seller tabs back from SL, banner dismisses within seconds) but not instantaneous. A `/user/{userId}/queue/account` envelope `PENALTY_CLEARED` would push the update the moment the terminal payment commits.
+- **When:** Behind the existing "User-targeted WebSocket queues" deferred entry (above) — once the principal-gated `/user/**` STOMP destination lands, `PenaltyTerminalService.pay` registers an `afterCommit` callback that publishes `PENALTY_CLEARED` to the user's queue when balance hits 0.
+- **Notes:** `PenaltyTerminalService.pay` already has the right hook point (the `if (newBalance == 0)` branch); just no publisher yet. Frontend `SuspensionBanner` would subscribe to `/user/queue/account` (currently doesn't exist) and on `PENALTY_CLEARED` invalidate `["currentUser"]`. No backend data shape change needed beyond the new envelope record.
+
 ---
 
 ## Removal Criteria

--- a/docs/implementation/DEFERRED_WORK.md
+++ b/docs/implementation/DEFERRED_WORK.md
@@ -362,12 +362,6 @@ When finishing a sub-spec that completes a deferred item, remove the entry.
 - **When:** Indefinite — needs an arm64 build of `webp-imageio` OR a different webp library (e.g., `imageio-webp` from `com.github.gotson` which ships native arm64), OR `@DisabledOnOs` gating these tests on macOS arm64 with a clear comment.
 - **Notes:** Implementer agents have been independently re-explaining these failures in every task report on this branch. Worth either fixing or explicitly silencing so they stop polluting test reports. The files: `backend/src/test/java/com/slparcelauctions/backend/auction/photos/ListingPhotoProcessorTest.java`, `backend/src/test/java/com/slparcelauctions/backend/storage/ImageUploadValidatorTest.java`, `backend/src/test/java/com/slparcelauctions/backend/user/AvatarImageProcessorTest.java`.
 
-### `ParcelTagControllerIntegrationTest.list_unauthenticated_returns401` baseline failure
-- **From:** Pre-existing baseline noise; rediscovered by every backend test run since at least Epic 07. Surfaced in Epic 08 sub-spec 1 + sub-spec 2 implementer reports.
-- **Why:** Test asserts `GET /api/v1/parcel-tags` returns 401 when unauthenticated, but the SecurityConfig matcher for that path was flipped to `permitAll()` in an earlier task without updating the test. Test now sees 200 instead of 401. Single failure per `./mvnw test` run.
-- **When:** Indefinite — either revert the matcher to `authenticated()` OR update the test to assert 200 with the public list shape, depending on whether the public-tag-list decision was intentional. The matcher change history needs to be audited to confirm intent.
-- **Notes:** File: `backend/src/test/java/com/slparcelauctions/backend/parceltag/ParcelTagControllerIntegrationTest.java`. Quick fix is one line either way; the question is which direction is correct. Worth a 5-minute investigation rather than letting it sit.
-
 ### Real-time `PENALTY_CLEARED` push for SuspensionBanner
 - **From:** Epic 08 sub-spec 2 (§5.6 + §12)
 - **Why:** When a seller pays off their `penaltyBalanceOwed` at a SLPA terminal, the dashboard `<SuspensionBanner>` should dismiss in real time. Sub-spec 2 ships a window-focus refetch + 30s `staleTime` on `/me` as the freshness mechanism — adequate for the walk-in flow (seller tabs back from SL, banner dismisses within seconds) but not instantaneous. A `/user/{userId}/queue/account` envelope `PENALTY_CLEARED` would push the update the moment the terminal payment commits.

--- a/docs/implementation/DEFERRED_WORK.md
+++ b/docs/implementation/DEFERRED_WORK.md
@@ -152,12 +152,6 @@ When finishing a sub-spec that completes a deferred item, remove the entry.
 - **When:** Epic 09 (Notifications) — when email + SL IM + in-app push unify on a single publisher, add the user-queue destination at the same time for consistency.
 - **Notes:** The `JwtChannelInterceptor` already understands principal-gated destinations — adding `/user/**` to the gate is a small change. The frontend's `useStompSubscription` hook would grow a `/user/queue/*` variant.
 
-### Cancellation WS broadcast on active-auction cancel
-- **From:** Epic 04 sub-spec 1 (spec §15)
-- **Why:** When a seller cancels an ACTIVE auction with bids (rare — requires explicit confirmation through the sub-spec 2 cancel modal), no `/topic/auction/{id}` envelope is currently published. Bidders watching the auction detail page in real-time see no update until they reload. This is a consistency gap with the bid/end broadcasts that both publish on `afterCommit`.
-- **When:** Re-evaluate during Epic 04 sub-spec 2 when the frontend auction detail page lands and the UX for "auction cancelled while you were bidding" is in hand. May turn out that a banner on the next REST read is sufficient UX; may turn out a WS envelope is needed to interrupt mid-bid.
-- **Notes:** Currently visible via `GET /api/v1/auctions/{id}` returning `status=CANCELLED` and via the seller's My Listings on next page load. The data surface exists — only the broadcast is missing. `CancellationService.cancel` would register a `TransactionSynchronization.afterCommit` that publishes an `AuctionCancelledEnvelope` (new DTO).
-
 ### Region autocomplete for DistanceSearchBlock
 - **From:** Epic 07 sub-spec 2 (Task 2b)
 - **Why:** Phase 1 ships a free-form region text input with server-side validation on submit (REGION_NOT_FOUND surfaces inline under the input). Client-side autocomplete needs a new lightweight `/sl/regions/search?q=` endpoint, debounced input, keyboard nav, and a popover primitive — scope for its own design pass.

--- a/docs/superpowers/plans/2026-04-25-epic-08-sub-2-cancellation-penalties.md
+++ b/docs/superpowers/plans/2026-04-25-epic-08-sub-2-cancellation-penalties.md
@@ -1,0 +1,1693 @@
+# Epic 08 Sub-Spec 2 — Cancellation Penalties & Anti-Circumvention Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Layer escalating penalties + suspension enforcement + 48h post-cancel ownership watcher onto the existing cancellation flow. Pay-at-terminal "suspended-until-paid" model. Single PR to `dev`.
+
+**Architecture:** Sub-spec 2 adds NO new backend packages. Extends `auction/CancellationService`, `auction/AuctionService`, `auction/monitoring/OwnershipCheckTask`, and creates a small `sl/PenaltyTerminalController`. Adds 2 columns on User, 1 on Auction, 2 on CancellationLog. New `CancellationOffenseKind` enum + new value on `FraudFlagReason` and `EscrowTransactionType`. Frontend adds `components/cancellation/`, two new dashboard components, and modifies the existing `CancelListingModal`. Closes the deferred-ledger "Cancellation WS broadcast" entry by folding `AUCTION_CANCELLED` into this sub-spec.
+
+**Tech Stack:** Spring Boot 4 / Java 26 / JPA `ddl-auto: update` (no Flyway migrations). Next.js 16 / React 19 / TanStack Query v5 / Vitest 4 / MSW 2 / Headless UI.
+
+**Spec:** `docs/superpowers/specs/2026-04-24-epic-08-sub-2-cancellation-penalties.md`
+
+---
+
+## Task 1 — Backend ladder + cancel-flow extensions
+
+**Goal:** Land the penalty data model (User + Auction + CancellationLog columns), the `CancellationOffenseKind` enum, the new fraud + ledger enum values, the configuration properties class, and the `CancellationService.cancel` extension that walks the ladder and broadcasts `AUCTION_CANCELLED` on commit. No endpoints in this task — those are Task 2 / Task 3.
+
+**Files:**
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/user/User.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/Auction.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLog.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/auction/CancellationOffenseKind.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/auction/dto/AuctionCancelledEnvelope.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/fraud/FraudFlagReason.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowTransactionType.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/auction/CancellationPenaltyProperties.java`
+- Modify: `backend/src/main/resources/application.yml`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/CancellationService.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLogRepository.java`
+- Modify: existing broadcast publisher (find under `auction/` or `escrow/broadcast/`) to add `publishCancelled` method
+- Tests at: `backend/src/test/java/com/slparcelauctions/backend/auction/CancellationServiceLadderTest.java` (new), `CancellationServiceTest.java` (existing — extend)
+
+### Steps
+
+- [ ] **Step 1: Add the User columns**
+
+```java
+// User.java — alongside listingSuspensionUntil, around line 124
+@Builder.Default
+@Column(name = "penalty_balance_owed", nullable = false,
+        columnDefinition = "bigint not null default 0")
+private Long penaltyBalanceOwed = 0L;
+
+@Builder.Default
+@Column(name = "banned_from_listing", nullable = false,
+        columnDefinition = "boolean not null default false")
+private Boolean bannedFromListing = false;
+```
+
+`columnDefinition` includes the SQL-side default so `ddl-auto: update` can add NOT NULL columns to existing rows on dev databases without failing — same pattern used for `tokenVersion` and `escrowExpiredUnfulfilled`.
+
+- [ ] **Step 2: Add the Auction column**
+
+```java
+// Auction.java — find a logical position near other monitoring fields
+@Column(name = "post_cancel_watch_until")
+private OffsetDateTime postCancelWatchUntil;  // nullable
+```
+
+- [ ] **Step 3: Create `CancellationOffenseKind` enum**
+
+```java
+// auction/CancellationOffenseKind.java
+package com.slparcelauctions.backend.auction;
+
+/**
+ * Discriminator for the consequence applied at a single cancellation event.
+ * Stored on {@link CancellationLog} as a snapshot — historical fact, not a
+ * derivation of what would be computed today. The decision uses live query
+ * of prior log rows; the record is immutable. See spec §4.3.
+ */
+public enum CancellationOffenseKind {
+    NONE,
+    WARNING,
+    PENALTY,
+    PENALTY_AND_30D,
+    PERMANENT_BAN
+}
+```
+
+- [ ] **Step 4: Add columns to CancellationLog**
+
+```java
+// CancellationLog.java
+@Enumerated(EnumType.STRING)
+@Column(name = "penalty_kind", length = 30)
+private CancellationOffenseKind penaltyKind;  // nullable for pre-sub-spec-2 rows
+
+@Column(name = "penalty_amount_l")
+private Long penaltyAmountL;  // nullable
+```
+
+- [ ] **Step 5: Add `CANCEL_AND_SELL` to `FraudFlagReason`**
+
+```java
+// FraudFlagReason.java — append
+/**
+ * Raised by the post-cancel ownership watcher (Epic 08 sub-spec 2 §6) when
+ * a CANCELLED auction's parcel ownership flips to a non-seller avatar
+ * within 48h of cancellation. Strong signal of off-platform deal.
+ */
+CANCEL_AND_SELL
+```
+
+The existing `FraudFlagReasonCheckConstraintInitializer` refreshes the SQL constraint at startup — no migration needed.
+
+- [ ] **Step 6: Add `LISTING_PENALTY_PAYMENT` to `EscrowTransactionType`**
+
+```java
+// EscrowTransactionType.java — append
+/**
+ * Penalty payment from a seller at a SLPA terminal, paying down their
+ * {@code User.penaltyBalanceOwed} debt. Sub-spec 2 §4.6.
+ */
+LISTING_PENALTY_PAYMENT
+```
+
+If `EscrowTransactionType` has a SQL constraint sync, it auto-handles. Otherwise check that the column is `EnumType.STRING` and accepts arbitrary values.
+
+- [ ] **Step 7: Create `CancellationPenaltyProperties`**
+
+```java
+// auction/CancellationPenaltyProperties.java
+package com.slparcelauctions.backend.auction;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+@ConfigurationProperties(prefix = "slpa.cancellation")
+@Validated
+public record CancellationPenaltyProperties(
+        @NotNull Penalty penalty,
+        @Min(1) int postCancelWatchHours
+) {
+    public record Penalty(
+            @Min(1) long secondOffenseL,
+            @Min(1) long thirdOffenseL,
+            @Min(1) int thirdOffenseSuspensionDays
+    ) {}
+}
+```
+
+Register via `@EnableConfigurationProperties(CancellationPenaltyProperties.class)` on the configuration class for the `auction` package, OR `@ConfigurationPropertiesScan` if it's already enabled at app level.
+
+- [ ] **Step 8: Add config to `application.yml`**
+
+```yaml
+slpa:
+  cancellation:
+    penalty:
+      second-offense-l: 1000
+      third-offense-l: 2500
+      third-offense-suspension-days: 30
+    post-cancel-watch-hours: 48
+```
+
+- [ ] **Step 9: Write failing test — `CancellationServiceLadderTest` ladder boundaries**
+
+Create the file with these tests (use Mockito for dependencies — pure unit test):
+
+```java
+@Test
+void cancel_activeWithBids_zeroPriorOffenses_writesWarningKind() {
+    // Set up: seller with 0 prior cancelled-with-bids log rows.
+    // Auction status = ACTIVE, bidCount = 1.
+    // Action: cancellationService.cancel(auctionId, "reason")
+    // Assert: log row penaltyKind = WARNING, penaltyAmountL = null.
+    // Assert: seller.penaltyBalanceOwed unchanged (0).
+    // Assert: seller.listingSuspensionUntil unchanged.
+    // Assert: seller.bannedFromListing = false.
+    // Assert: auction.postCancelWatchUntil = now + 48h.
+}
+
+@Test
+void cancel_activeWithBids_onePriorOffense_writesPenaltyKindAndDebits1000() {
+    // Set up: seller with 1 prior CancellationLog where hadBids=true.
+    // Action: cancel
+    // Assert: log row penaltyKind = PENALTY, penaltyAmountL = 1000.
+    // Assert: seller.penaltyBalanceOwed = 1000 (was 0).
+    // Assert: seller.listingSuspensionUntil unchanged.
+}
+
+@Test
+void cancel_activeWithBids_twoPriorOffenses_writesPenaltyAnd30dAndDebits2500AndSuspends() {
+    // Set up: seller with 2 prior cancelled-with-bids log rows.
+    // Action: cancel
+    // Assert: log row penaltyKind = PENALTY_AND_30D, penaltyAmountL = 2500.
+    // Assert: seller.penaltyBalanceOwed += 2500.
+    // Assert: seller.listingSuspensionUntil = now + 30 days (within 1s tolerance).
+}
+
+@Test
+void cancel_activeWithBids_threePriorOffenses_writesPermanentBan() {
+    // Set up: seller with 3 prior cancelled-with-bids log rows.
+    // Action: cancel
+    // Assert: log row penaltyKind = PERMANENT_BAN, penaltyAmountL = null.
+    // Assert: seller.bannedFromListing = true.
+    // Assert: penaltyBalanceOwed and listingSuspensionUntil unchanged from prior state.
+}
+
+@Test
+void cancel_activeWithBids_fivePriorOffenses_stillWritesPermanentBan() {
+    // Set up: seller with 5 prior offenses (already banned previously).
+    // Assert: log row penaltyKind = PERMANENT_BAN.
+    // Assert: bannedFromListing remains true (idempotent).
+}
+
+@Test
+void cancel_activeWithoutBids_writesNoneKind() {
+    // Set up: ACTIVE auction with bidCount = 0.
+    // Assert: log row penaltyKind = NONE, penaltyAmountL = null.
+    // Assert: seller fields unchanged.
+    // Assert: auction.postCancelWatchUntil = null.
+}
+
+@Test
+void cancel_preActiveStatus_writesNoneKindAndQueuesRefund() {
+    // Set up: DRAFT_PAID auction, listingFeePaid = true.
+    // Assert: log row penaltyKind = NONE.
+    // Assert: ListingFeeRefund row queued (existing behavior).
+    // Assert: postCancelWatchUntil = null.
+}
+
+@Test
+void cancel_activeWithBids_existingPenaltyBalance_addsToIt() {
+    // Set up: seller already owes 1000 (from prior offense).
+    //         Now they hit offense #3.
+    // Assert: penaltyBalanceOwed = 3500 (1000 + 2500 from offense #3).
+}
+```
+
+Run: `cd backend && ./mvnw test -Dtest=CancellationServiceLadderTest` — expect all to FAIL (logic not yet implemented).
+
+- [ ] **Step 10: Add the COUNT query to `CancellationLogRepository`**
+
+```java
+// CancellationLogRepository.java
+@Query("SELECT count(c) FROM CancellationLog c " +
+       "WHERE c.seller.id = :sellerId AND c.hadBids = true")
+long countPriorOffensesWithBids(@Param("sellerId") Long sellerId);
+```
+
+- [ ] **Step 11: Implement the ladder in `CancellationService.cancel`**
+
+Replace the existing method body. Key changes: COUNT before INSERT, ladder evaluation, snapshot to log row, apply consequence, set postCancelWatchUntil, register afterCommit broadcast. Inject `CancellationPenaltyProperties` and the broadcast publisher.
+
+```java
+@Transactional
+public Auction cancel(Long auctionId, String reason) {
+    Auction a = auctionRepo.findByIdForUpdate(auctionId)
+            .orElseThrow(() -> new AuctionNotFoundException(auctionId));
+    if (!CANCELLABLE.contains(a.getStatus())) {
+        throw new InvalidAuctionStateException(a.getId(), a.getStatus(), "CANCEL");
+    }
+    if (a.getStatus() == AuctionStatus.ACTIVE
+            && a.getEndsAt() != null
+            && OffsetDateTime.now(clock).isAfter(a.getEndsAt())) {
+        throw new InvalidAuctionStateException(a.getId(), a.getStatus(), "CANCEL_AFTER_END");
+    }
+
+    AuctionStatus from = a.getStatus();
+    boolean hadBids = a.getBidCount() != null && a.getBidCount() > 0;
+    boolean activeWithBids = from == AuctionStatus.ACTIVE && hadBids;
+
+    User seller = userRepo.findByIdForUpdate(a.getSeller().getId())
+            .orElseThrow();  // pessimistic lock — must exist (FK)
+
+    // 1) Pre-INSERT count → ladder index → consequence snapshot
+    CancellationOffenseKind kind;
+    Long amountL;
+    if (activeWithBids) {
+        long prior = logRepo.countPriorOffensesWithBids(seller.getId());
+        long index = Math.min(prior, 3);
+        switch ((int) index) {
+            case 0 -> { kind = CancellationOffenseKind.WARNING; amountL = null; }
+            case 1 -> { kind = CancellationOffenseKind.PENALTY;
+                        amountL = props.penalty().secondOffenseL(); }
+            case 2 -> { kind = CancellationOffenseKind.PENALTY_AND_30D;
+                        amountL = props.penalty().thirdOffenseL(); }
+            default -> { kind = CancellationOffenseKind.PERMANENT_BAN; amountL = null; }
+        }
+    } else {
+        kind = CancellationOffenseKind.NONE;
+        amountL = null;
+    }
+
+    // 2) INSERT log row with snapshot
+    logRepo.save(CancellationLog.builder()
+            .auction(a)
+            .seller(seller)
+            .cancelledFromStatus(from.name())
+            .hadBids(hadBids)
+            .reason(reason)
+            .penaltyKind(kind)
+            .penaltyAmountL(amountL)
+            .build());
+
+    // 3) Apply consequence + watcher window
+    if (activeWithBids) {
+        seller.setCancelledWithBids(seller.getCancelledWithBids() + 1);
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        switch (kind) {
+            case PENALTY -> seller.setPenaltyBalanceOwed(
+                    seller.getPenaltyBalanceOwed() + amountL);
+            case PENALTY_AND_30D -> {
+                seller.setPenaltyBalanceOwed(
+                        seller.getPenaltyBalanceOwed() + amountL);
+                seller.setListingSuspensionUntil(
+                        now.plusDays(props.penalty().thirdOffenseSuspensionDays()));
+            }
+            case PERMANENT_BAN -> seller.setBannedFromListing(true);
+            default -> { /* WARNING — no-op */ }
+        }
+        userRepo.save(seller);
+        a.setPostCancelWatchUntil(now.plusHours(props.postCancelWatchHours()));
+    }
+
+    // 4) Existing listing-fee refund logic (unchanged)
+    if (Boolean.TRUE.equals(a.getListingFeePaid())
+            && from != AuctionStatus.ACTIVE) {
+        refundRepo.save(ListingFeeRefund.builder()
+                .auction(a)
+                .amount(a.getListingFeeAmt() == null ? 0L : a.getListingFeeAmt())
+                .status(RefundStatus.PENDING)
+                .build());
+        log.info("Listing fee refund (PENDING) created for auction {}", a.getId());
+    }
+
+    // 5) Status flip + monitor lifecycle
+    a.setStatus(AuctionStatus.CANCELLED);
+    Auction saved = auctionRepo.save(a);
+    monitorLifecycle.onAuctionClosed(saved);
+    log.info("Auction {} cancelled from {} (hadBids={}, kind={})",
+            a.getId(), from, hadBids, kind);
+
+    // 6) afterCommit WS broadcast — never inside the tx
+    final AuctionCancelledEnvelope env = AuctionCancelledEnvelope.of(
+            saved, hadBids, OffsetDateTime.now(clock));
+    TransactionSynchronizationManager.registerSynchronization(
+            new TransactionSynchronization() {
+                @Override public void afterCommit() {
+                    broadcastPublisher.publishCancelled(env);
+                }
+            });
+
+    return saved;
+}
+```
+
+Update the constructor injection list (`@RequiredArgsConstructor` adds these automatically): `CancellationPenaltyProperties props`, `AuctionBroadcastPublisher broadcastPublisher` (or whatever the existing publisher is named).
+
+- [ ] **Step 12: Add `findByIdForUpdate` to UserRepository if missing**
+
+Check if exists; if not add:
+```java
+@Query("select u from User u where u.id = :id")
+@Lock(LockModeType.PESSIMISTIC_WRITE)
+Optional<User> findByIdForUpdate(@Param("id") Long id);
+```
+
+- [ ] **Step 13: Create `AuctionCancelledEnvelope`**
+
+```java
+// auction/dto/AuctionCancelledEnvelope.java
+package com.slparcelauctions.backend.auction.dto;
+
+import com.slparcelauctions.backend.auction.Auction;
+import java.time.OffsetDateTime;
+
+public record AuctionCancelledEnvelope(
+        String type,
+        Long auctionId,
+        OffsetDateTime cancelledAt,
+        Boolean hadBids
+) {
+    public static AuctionCancelledEnvelope of(Auction a, boolean hadBids, OffsetDateTime now) {
+        return new AuctionCancelledEnvelope(
+                "AUCTION_CANCELLED",
+                a.getId(),
+                now,
+                hadBids
+        );
+    }
+}
+```
+
+- [ ] **Step 14: Add `publishCancelled` to broadcast publisher**
+
+Find the existing publisher under `auction/` (look for one that publishes bid envelopes or auction-end envelopes — sub-spec 1 added `publishReviewRevealed` to a similar file). Add:
+
+```java
+public void publishCancelled(AuctionCancelledEnvelope envelope) {
+    messaging.convertAndSend(
+            "/topic/auction/" + envelope.auctionId(),
+            envelope);
+    log.debug("Broadcast AUCTION_CANCELLED: auctionId={}", envelope.auctionId());
+}
+```
+
+- [ ] **Step 15: Run ladder tests — pass**
+
+`cd backend && ./mvnw test -Dtest=CancellationServiceLadderTest` — all 8 should pass.
+
+- [ ] **Step 16: Add the WS broadcast test**
+
+```java
+// CancellationServiceLadderTest
+@Test
+void cancel_registersAfterCommitBroadcast() {
+    // Use TransactionTemplate or @SpringBootTest minimal slice to verify
+    // that registerSynchronization was called with afterCommit logic.
+    // Alternatively, mock TransactionSynchronizationManager.
+    // Assert publishCancelled called with correct envelope shape.
+}
+```
+
+If tx synchronization is awkward to test in pure unit, leave as a slice/integration test in Step 17.
+
+- [ ] **Step 17: Concurrent cancel race test**
+
+Add to integration tests (use Testcontainers if available in the project, or `@DataJpaTest` with explicit transactions):
+
+```java
+@Test
+void cancel_concurrent_serializesViaUserRowLock() {
+    // Two threads cancelling two different auctions for the SAME seller
+    // simultaneously, both with hadBids=true.
+    // Both should serialize through the User row's PESSIMISTIC_WRITE lock.
+    // Assert: priorOffenses readings are consistent (one sees 0, the other sees 1)
+    //         and the cumulative penaltyBalanceOwed matches expectation.
+}
+```
+
+If a concurrency test isn't already part of the test setup (sub-spec 1 didn't have one), this can be folded into the existing `BidCancelRaceTest` style. Read that file for the established pattern.
+
+- [ ] **Step 18: Run the full backend test suite**
+
+`cd backend && ./mvnw test`
+
+All review tests + cancellation ladder tests should pass. Pre-existing flakes (libwebp native-load on arm64 Mac × 3 + parcel-tags 401 mismatch) remain unchanged from Sub-spec 1's baseline.
+
+- [ ] **Step 19: Commit Task 1**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/user/User.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/Auction.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLog.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/CancellationOffenseKind.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/CancellationPenaltyProperties.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLogRepository.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/CancellationService.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/dto/AuctionCancelledEnvelope.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/fraud/FraudFlagReason.java \
+        backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowTransactionType.java \
+        backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java \
+        backend/src/main/resources/application.yml \
+        backend/src/test/java/com/slparcelauctions/backend/auction/CancellationServiceLadderTest.java
+git commit -m "feat(cancellation): penalty ladder + offense snapshot on log + AUCTION_CANCELLED broadcast"
+```
+
+(Adjust file list to whatever broadcast-publisher file you actually edited in Step 14.)
+
+---
+
+## Task 2 — Backend gate + endpoints + watcher
+
+**Goal:** Land the suspension gate at listing creation, the two GET endpoints (cancellation-status preview + paginated history), the extended `/me` response, and the post-cancel watcher integration in the existing ownership scheduler.
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/auction/exception/SellerSuspendedException.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/auction/exception/SuspensionReason.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/auction/exception/CancellationExceptionHandler.java` (or extend an existing auction-package handler)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/auction/CancellationStatusController.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/auction/CancellationStatusService.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/auction/dto/CancellationStatusResponse.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/auction/dto/CancellationHistoryDto.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/auction/dto/NextConsequenceDto.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/AuctionService.java` — gate in `create`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/user/dto/CurrentUserResponse.java` (or wherever `/me` shape lives) — add 3 fields
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/AuctionRepository.java` — extend `findDueForOwnershipCheck`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/OwnershipMonitorScheduler.java` — pass `now` param
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/OwnershipCheckTask.java` — branch on auction status, route fraud reason
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java` — auth rules for new GET endpoints
+- Tests for each new path
+
+### Steps
+
+- [ ] **Step 1: Create `SuspensionReason` enum**
+
+```java
+// auction/exception/SuspensionReason.java
+package com.slparcelauctions.backend.auction.exception;
+
+public enum SuspensionReason {
+    PENALTY_OWED,
+    TIMED_SUSPENSION,
+    PERMANENT_BAN
+}
+```
+
+- [ ] **Step 2: Create `SellerSuspendedException`**
+
+```java
+// auction/exception/SellerSuspendedException.java
+package com.slparcelauctions.backend.auction.exception;
+
+import lombok.Getter;
+
+@Getter
+public class SellerSuspendedException extends RuntimeException {
+    private final SuspensionReason reason;
+
+    public SellerSuspendedException(SuspensionReason reason) {
+        super("Seller is suspended from listing: " + reason);
+        this.reason = reason;
+    }
+}
+```
+
+- [ ] **Step 3: Write failing test — gate trips with right reason for each suspension state**
+
+```java
+// AuctionServiceTest (existing — extend) or new AuctionServiceSuspensionGateTest
+
+@Test
+void create_throwsPenaltyOwed_whenPenaltyBalancePositive() {
+    User seller = sellerWith(penaltyBalanceOwed = 500L);
+    AuctionCreateRequest req = validRequest();
+
+    SellerSuspendedException ex = assertThrows(
+            SellerSuspendedException.class,
+            () -> auctionService.create(seller.getId(), req));
+
+    assertThat(ex.getReason()).isEqualTo(SuspensionReason.PENALTY_OWED);
+}
+
+@Test
+void create_throwsTimedSuspension_whenSuspensionUntilFuture() {
+    User seller = sellerWith(listingSuspensionUntil = now.plusDays(5));
+    // assert reason = TIMED_SUSPENSION
+}
+
+@Test
+void create_throwsPermanentBan_whenBannedFromListingTrue() {
+    User seller = sellerWith(bannedFromListing = true);
+    // assert reason = PERMANENT_BAN
+}
+
+@Test
+void create_succeeds_whenAllGatesClear() {
+    User seller = sellerWith(/* default — clean */);
+    Auction created = auctionService.create(seller.getId(), validRequest());
+    assertThat(created).isNotNull();
+}
+
+@Test
+void create_throwsBan_evenWhenAlsoSuspendedAndOwesPenalty() {
+    // Order: ban → timed → penalty. Most restrictive first.
+    User seller = sellerWith(
+            bannedFromListing = true,
+            listingSuspensionUntil = now.plusDays(5),
+            penaltyBalanceOwed = 500L);
+    // assert reason = PERMANENT_BAN (not TIMED or PENALTY)
+}
+```
+
+Run: fails (gate not yet implemented).
+
+- [ ] **Step 4: Implement the gate in `AuctionService.create`**
+
+Add at the top of the `create` method, before the existing validation:
+
+```java
+@Transactional
+public Auction create(Long sellerId, AuctionCreateRequest req) {
+    User seller = userRepo.findById(sellerId)
+            .orElseThrow(() -> new IllegalStateException("Authenticated user not found: " + sellerId));
+
+    SuspensionReason reason = checkCanCreateListing(seller);
+    if (reason != null) throw new SellerSuspendedException(reason);
+
+    // ...existing validation + entity build, unchanged
+}
+
+private SuspensionReason checkCanCreateListing(User u) {
+    if (Boolean.TRUE.equals(u.getBannedFromListing())) {
+        return SuspensionReason.PERMANENT_BAN;
+    }
+    if (u.getListingSuspensionUntil() != null
+            && OffsetDateTime.now(clock).isBefore(u.getListingSuspensionUntil())) {
+        return SuspensionReason.TIMED_SUSPENSION;
+    }
+    if (u.getPenaltyBalanceOwed() != null && u.getPenaltyBalanceOwed() > 0L) {
+        return SuspensionReason.PENALTY_OWED;
+    }
+    return null;
+}
+```
+
+Inject `Clock` if not already (`@RequiredArgsConstructor` handles it). The existing `AuctionService` already loads the seller — keep that single load and pass to the gate check.
+
+Run: gate tests pass.
+
+- [ ] **Step 5: Create `CancellationExceptionHandler` mapping**
+
+Look for an existing `auction/exception` handler. Either extend it or create a new `@RestControllerAdvice(basePackageClasses = AuctionController.class)`:
+
+```java
+@ExceptionHandler(SellerSuspendedException.class)
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public ProblemDetail sellerSuspended(SellerSuspendedException ex) {
+    ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.FORBIDDEN);
+    pd.setType(URI.create("https://slpa.example/problems/seller-suspended"));
+    pd.setTitle("Listing creation suspended");
+    pd.setProperty("code", ex.getReason().name());
+    pd.setDetail(switch (ex.getReason()) {
+        case PENALTY_OWED -> "You have an outstanding penalty balance. Pay at any SLPA terminal to resume listing.";
+        case TIMED_SUSPENSION -> "Your listing privileges are temporarily suspended.";
+        case PERMANENT_BAN -> "Your listing privileges have been permanently suspended.";
+    });
+    return pd;
+}
+```
+
+Test the handler in a `@WebMvcTest` slice — assert 403 status, `code` field carries the right enum value.
+
+- [ ] **Step 6: Write failing test — `/users/me/cancellation-status` shape**
+
+```java
+// CancellationStatusControllerTest — @WebMvcTest
+
+@Test
+void status_zeroPriorOffenses_returnsWarningAsNextConsequence() {
+    // mock service: priorOffensesWithBids = 0
+    // assert: nextConsequenceIfBidsPresent.kind = "WARNING"
+    // assert: amountL = null, suspends30Days = false, permanentBan = false
+}
+
+@Test
+void status_onePriorOffense_returnsPenaltyAsNext() { /* kind=PENALTY, amountL=1000 */ }
+
+@Test
+void status_twoPriorOffenses_returnsPenaltyAnd30dAsNext() { /* kind=PENALTY_AND_30D, amountL=2500, suspends30Days=true */ }
+
+@Test
+void status_threePlusOffenses_returnsPermanentBanAsNext() { /* kind=PERMANENT_BAN, permanentBan=true, amountL=null */ }
+
+@Test
+void status_currentSuspensionEchoesUserState() {
+    // user has penaltyBalanceOwed=500, listingSuspensionUntil=t+5d, bannedFromListing=false
+    // assert response.currentSuspension matches
+}
+```
+
+- [ ] **Step 7: Create the DTOs**
+
+```java
+// auction/dto/CancellationStatusResponse.java
+public record CancellationStatusResponse(
+        long priorOffensesWithBids,
+        CurrentSuspension currentSuspension,
+        NextConsequenceDto nextConsequenceIfBidsPresent
+) {
+    public record CurrentSuspension(
+            Long penaltyBalanceOwed,
+            OffsetDateTime listingSuspensionUntil,
+            Boolean bannedFromListing
+    ) {}
+}
+
+// auction/dto/NextConsequenceDto.java
+public record NextConsequenceDto(
+        CancellationOffenseKind kind,
+        Long amountL,           // nullable
+        Boolean suspends30Days,
+        Boolean permanentBan
+) {
+    public static NextConsequenceDto from(CancellationOffenseKind kind, Long amount) {
+        return new NextConsequenceDto(
+                kind,
+                amount,
+                kind == CancellationOffenseKind.PENALTY_AND_30D,
+                kind == CancellationOffenseKind.PERMANENT_BAN
+        );
+    }
+}
+
+// auction/dto/CancellationHistoryDto.java
+public record CancellationHistoryDto(
+        Long auctionId,
+        String auctionTitle,
+        String primaryPhotoUrl,
+        String cancelledFromStatus,
+        Boolean hadBids,
+        String reason,
+        OffsetDateTime cancelledAt,
+        PenaltyApplied penaltyApplied  // nullable
+) {
+    public record PenaltyApplied(
+            CancellationOffenseKind kind,
+            Long amountL
+    ) {}
+
+    public static CancellationHistoryDto from(CancellationLog log, String primaryPhotoUrl) {
+        PenaltyApplied applied = (log.getPenaltyKind() == null
+                || log.getPenaltyKind() == CancellationOffenseKind.NONE)
+                ? null
+                : new PenaltyApplied(log.getPenaltyKind(), log.getPenaltyAmountL());
+        return new CancellationHistoryDto(
+                log.getAuction().getId(),
+                log.getAuction().getTitle(),
+                primaryPhotoUrl,
+                log.getCancelledFromStatus(),
+                log.getHadBids(),
+                log.getReason(),
+                log.getCancelledAt(),
+                applied);
+    }
+}
+```
+
+- [ ] **Step 8: Create `CancellationStatusService`**
+
+```java
+@Service
+@RequiredArgsConstructor
+public class CancellationStatusService {
+    private final CancellationLogRepository logRepo;
+    private final UserRepository userRepo;
+    private final CancellationPenaltyProperties props;
+
+    @Transactional(readOnly = true)
+    public CancellationStatusResponse statusFor(Long userId) {
+        User u = userRepo.findById(userId).orElseThrow(...);
+        long prior = logRepo.countPriorOffensesWithBids(userId);
+        long index = Math.min(prior, 3);
+        CancellationOffenseKind nextKind;
+        Long nextAmount;
+        switch ((int) index) {
+            case 0 -> { nextKind = CancellationOffenseKind.WARNING; nextAmount = null; }
+            case 1 -> { nextKind = CancellationOffenseKind.PENALTY;
+                        nextAmount = props.penalty().secondOffenseL(); }
+            case 2 -> { nextKind = CancellationOffenseKind.PENALTY_AND_30D;
+                        nextAmount = props.penalty().thirdOffenseL(); }
+            default -> { nextKind = CancellationOffenseKind.PERMANENT_BAN; nextAmount = null; }
+        }
+
+        return new CancellationStatusResponse(
+                prior,
+                new CancellationStatusResponse.CurrentSuspension(
+                        u.getPenaltyBalanceOwed(),
+                        u.getListingSuspensionUntil(),
+                        u.getBannedFromListing()),
+                NextConsequenceDto.from(nextKind, nextAmount));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CancellationHistoryDto> historyFor(Long userId, Pageable page) {
+        Pageable sorted = PageRequest.of(page.getPageNumber(),
+                Math.min(page.getPageSize(), 50),
+                Sort.by(Sort.Direction.DESC, "cancelledAt"));
+        Page<CancellationLog> logs = logRepo.findBySellerId(userId, sorted);
+        return logs.map(log -> CancellationHistoryDto.from(log,
+                resolvePrimaryPhotoUrl(log.getAuction())));
+    }
+
+    private String resolvePrimaryPhotoUrl(Auction auction) {
+        return auction.getPhotos().stream()
+                .sorted(Comparator.comparing(AuctionPhoto::getSortOrder))
+                .findFirst()
+                .map(AuctionPhoto::getUrl)
+                .orElseGet(() -> auction.getParcel().getSnapshotUrl());
+    }
+}
+```
+
+Add to `CancellationLogRepository`:
+```java
+Page<CancellationLog> findBySellerId(Long sellerId, Pageable page);
+```
+
+- [ ] **Step 9: Create `CancellationStatusController`**
+
+```java
+@RestController
+@RequestMapping("/api/v1/users/me")
+@RequiredArgsConstructor
+public class CancellationStatusController {
+    private final CancellationStatusService service;
+
+    @GetMapping("/cancellation-status")
+    public CancellationStatusResponse status(
+            @AuthenticationPrincipal AuthPrincipal principal) {
+        return service.statusFor(principal.userId());
+    }
+
+    @GetMapping("/cancellation-history")
+    public PagedResponse<CancellationHistoryDto> history(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return PagedResponse.from(
+                service.historyFor(principal.userId(), PageRequest.of(page, size)));
+    }
+}
+```
+
+- [ ] **Step 10: Update SecurityConfig**
+
+```java
+.requestMatchers(HttpMethod.GET, "/api/v1/users/me/cancellation-status").authenticated()
+.requestMatchers(HttpMethod.GET, "/api/v1/users/me/cancellation-history").authenticated()
+```
+
+Place these BEFORE any catch-all `/api/v1/**` rule.
+
+- [ ] **Step 11: Run controller tests — pass**
+
+`./mvnw test -Dtest=CancellationStatusControllerTest` — pass.
+
+- [ ] **Step 12: Extend `/me` response with new fields**
+
+Find the existing `/me` endpoint controller / DTO. The DTO is likely `CurrentUserResponse` or similar in `user/dto/`. Add 3 fields:
+
+```java
+public record CurrentUserResponse(
+    // ... existing fields
+    Long penaltyBalanceOwed,
+    OffsetDateTime listingSuspensionUntil,
+    Boolean bannedFromListing
+) {
+    public static CurrentUserResponse from(User u) {
+        return new CurrentUserResponse(
+            // ... existing field mappings
+            u.getPenaltyBalanceOwed(),
+            u.getListingSuspensionUntil(),
+            u.getBannedFromListing()
+        );
+    }
+}
+```
+
+Run any existing `/me` tests — they may fail on positional constructor changes. Update them to include the new fields.
+
+- [ ] **Step 13: Extend `findDueForOwnershipCheck` for post-cancel watch**
+
+```java
+// AuctionRepository.java
+@Query("""
+    SELECT a.id FROM Auction a
+    WHERE (a.status = com.slparcelauctions.backend.auction.AuctionStatus.ACTIVE
+            AND (a.lastOwnershipCheckAt IS NULL OR a.lastOwnershipCheckAt < :cutoff))
+       OR (a.postCancelWatchUntil IS NOT NULL
+            AND a.postCancelWatchUntil > :now
+            AND (a.lastOwnershipCheckAt IS NULL OR a.lastOwnershipCheckAt < :cutoff))
+    """)
+List<Long> findDueForOwnershipCheck(
+        @Param("cutoff") OffsetDateTime cutoff,
+        @Param("now") OffsetDateTime now);
+```
+
+- [ ] **Step 14: Update `OwnershipMonitorScheduler` to pass `now`**
+
+```java
+@Scheduled(fixedDelayString = "${slpa.ownership-monitor.scheduler-frequency:PT30S}")
+public void dispatchDueChecks() {
+    OffsetDateTime now = OffsetDateTime.now(clock);
+    OffsetDateTime cutoff = now.minusMinutes(props.getCheckIntervalMinutes());
+    List<Long> dueIds = auctionRepo.findDueForOwnershipCheck(cutoff, now);
+    // ... existing dispatch logic
+}
+```
+
+- [ ] **Step 15: Branch `OwnershipCheckTask` on auction status**
+
+The current `OwnershipCheckTask.checkOne(id)` raises `OWNERSHIP_CHANGED_TO_UNKNOWN` on mismatch. Branch on `auction.status`:
+
+```java
+@Async
+@Transactional
+public void checkOne(Long auctionId) {
+    Auction a = auctionRepo.findById(auctionId).orElseThrow(...);
+    // ... existing World API call to get observed owner ...
+
+    a.setLastOwnershipCheckAt(OffsetDateTime.now(clock));
+
+    if (mismatchDetected) {
+        FraudFlagReason reason = (a.getStatus() == AuctionStatus.CANCELLED)
+                ? FraudFlagReason.CANCEL_AND_SELL
+                : FraudFlagReason.OWNERSHIP_CHANGED_TO_UNKNOWN;
+
+        Map<String, Object> evidence = (a.getStatus() == AuctionStatus.CANCELLED)
+                ? buildCancelAndSellEvidence(a, observedOwnerKey)
+                : buildExistingMismatchEvidence(a, observedOwnerKey);
+
+        raiseFlag(a, reason, evidence);
+
+        if (a.getStatus() == AuctionStatus.CANCELLED) {
+            // Prevent re-flagging on subsequent ticks
+            a.setPostCancelWatchUntil(null);
+        }
+        // ACTIVE auctions go through the existing SuspensionService.suspendDueToOwnershipChange
+        // which already pulls them out of the watcher query (status changes from ACTIVE).
+    }
+
+    auctionRepo.save(a);
+}
+
+private Map<String, Object> buildCancelAndSellEvidence(Auction a, String observedKey) {
+    OffsetDateTime cancelledAt = /* derive from CancellationLog or auction status-change time */;
+    OffsetDateTime now = OffsetDateTime.now(clock);
+    double hoursSince = (now.toEpochSecond() - cancelledAt.toEpochSecond()) / 3600.0;
+    return Map.of(
+        "cancelledAt", cancelledAt.toString(),
+        "expectedSellerKey", a.getSeller().getSlAvatarUuid().toString(),
+        "observedOwnerKey", observedKey,
+        "hoursSinceCancellation", hoursSince,
+        "parcelRegion", a.getParcel().getRegionName(),
+        "parcelLocalId", a.getParcel().getLocalId(),
+        "auctionTitle", a.getTitle()
+    );
+}
+```
+
+For `cancelledAt`: easiest is to query the CancellationLog by auction id; alternatively, add a `cancelledAt` column to Auction (mirrors `postCancelWatchUntil`). The query approach is one read per flag — acceptable. Decide based on existing patterns; the spec doesn't constrain this.
+
+- [ ] **Step 16: Test the watcher integration**
+
+```java
+@Test
+void checkOne_cancelledStatus_mismatch_raisesCancelAndSellFlag() {
+    // Set up: cancelled auction, postCancelWatchUntil = now + 47h
+    //         World API returns owner != seller
+    // Action: checkOne(auctionId)
+    // Assert: FraudFlag created with reason = CANCEL_AND_SELL
+    // Assert: evidence map contains expected fields including hoursSinceCancellation
+    // Assert: auction.postCancelWatchUntil == null (cleared)
+}
+
+@Test
+void checkOne_cancelledStatus_noMismatch_doesNotRaiseFlag() {
+    // Owner matches seller — no flag, watcher window unchanged
+}
+
+@Test
+void checkOne_cancelledStatus_postWatchExpired_doesNotRunWorldApi() {
+    // postCancelWatchUntil < now → query shouldn't pick it up at all
+    // (verify by repository test, since OwnershipCheckTask already gets
+    //  filtered ids from the scheduler).
+}
+
+@Test
+void findDueForOwnershipCheck_includesActiveAndPostCancelWatched() {
+    // Repo test:
+    // 3 auctions: ACTIVE, CANCELLED-watched, CANCELLED-watch-expired
+    // assert: returns ids of first two only
+}
+```
+
+- [ ] **Step 17: Run full backend suite**
+
+`./mvnw test` — all pass.
+
+- [ ] **Step 18: Commit Task 2**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/auction/exception/ \
+        backend/src/main/java/com/slparcelauctions/backend/auction/CancellationStatusController.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/CancellationStatusService.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/dto/CancellationStatusResponse.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/dto/CancellationHistoryDto.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/dto/NextConsequenceDto.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/AuctionService.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/AuctionRepository.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLogRepository.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/ \
+        backend/src/main/java/com/slparcelauctions/backend/user/dto/CurrentUserResponse.java \
+        backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java \
+        backend/src/test/java/com/slparcelauctions/backend/auction/
+git commit -m "feat(cancellation): suspension gate + status/history endpoints + post-cancel watcher"
+```
+
+---
+
+## Task 3 — Backend terminal payment endpoints
+
+**Goal:** Land the two SL-terminal-only endpoints (lookup + payment), terminal auth integration, partial payment + idempotent replay, ledger row insertion, pessimistic User-row lock.
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/sl/PenaltyTerminalController.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/sl/PenaltyTerminalService.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/sl/dto/PenaltyLookupRequest.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/sl/dto/PenaltyLookupResponse.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/sl/dto/PenaltyPaymentRequest.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/sl/dto/PenaltyPaymentResponse.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/sl/exception/PenaltyOverpaymentException.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java` — terminal-auth on `/sl/penalty-*`
+- Tests for each path
+
+### Steps
+
+- [ ] **Step 1: Create the request/response DTOs**
+
+```java
+// PenaltyLookupRequest.java
+public record PenaltyLookupRequest(
+    @NotNull UUID slAvatarUuid,
+    @NotBlank String terminalId
+) {}
+
+// PenaltyLookupResponse.java
+public record PenaltyLookupResponse(
+    Long userId,
+    String displayName,
+    Long penaltyBalanceOwed
+) {}
+
+// PenaltyPaymentRequest.java
+public record PenaltyPaymentRequest(
+    @NotNull UUID slAvatarUuid,
+    @NotBlank String slTransactionId,
+    @Min(1) Long amount,
+    @NotBlank String terminalId
+) {}
+
+// PenaltyPaymentResponse.java
+public record PenaltyPaymentResponse(Long remainingBalance) {}
+```
+
+- [ ] **Step 2: Create `PenaltyOverpaymentException`**
+
+```java
+@Getter
+@RequiredArgsConstructor
+public class PenaltyOverpaymentException extends RuntimeException {
+    private final long requested;
+    private final long available;
+}
+```
+
+Map to 422 in the existing SL exception handler (look for one in the `sl` package or extend `GlobalExceptionHandler` with a slice-scoped advice).
+
+- [ ] **Step 3: Write failing slice tests for both endpoints**
+
+```java
+// PenaltyTerminalControllerTest — @WebMvcTest(PenaltyTerminalController.class)
+
+@Test
+void lookup_returnsBalance_whenUserOwes() {
+    // mock: user with penaltyBalanceOwed = 1000
+    // POST /sl/penalty-lookup with valid X-SecondLife-Owner-Key header
+    // assert 200 with response { userId, displayName, penaltyBalanceOwed: 1000 }
+}
+
+@Test
+void lookup_returns404_whenNoUserForAvatar() { /* unknown UUID */ }
+
+@Test
+void lookup_returns404_whenBalanceIsZero() {
+    // user exists, owes nothing — terminal can show "no debt"
+}
+
+@Test
+void lookup_returns401_withoutSlOwnerKeyHeader() { /* terminal auth */ }
+
+@Test
+void payment_partialClear_returns200WithRemainingBalance() {
+    // user owes 1000, pay 600 → remainingBalance = 400
+}
+
+@Test
+void payment_fullClear_returnsZeroBalance() { /* pay 1000 → remainingBalance = 0 */ }
+
+@Test
+void payment_idempotentReplay_returnsCurrentBalance() {
+    // pay txn-1 of 600 (balance: 1000 → 400)
+    // replay txn-1 → returns { remainingBalance: 400 }, NO double-decrement
+}
+
+@Test
+void payment_overpayment_returns422() {
+    // user owes 500, attempt to pay 1000 → 422 PenaltyOverpaymentException
+}
+
+@Test
+void payment_unknownAvatar_returns404() { /* avatar UUID doesn't map to a user */ }
+
+@Test
+void payment_amountZero_returns400() { /* validation @Min(1) */ }
+
+@Test
+void payment_returns401_withoutSlOwnerKeyHeader() { /* terminal auth */ }
+```
+
+- [ ] **Step 4: Create `PenaltyTerminalService`**
+
+```java
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PenaltyTerminalService {
+    private final UserRepository userRepo;
+    private final EscrowTransactionRepository ledgerRepo;
+    private final Clock clock;
+
+    @Transactional(readOnly = true)
+    public PenaltyLookupResponse lookup(UUID slAvatarUuid) {
+        User u = userRepo.findBySlAvatarUuid(slAvatarUuid)
+                .orElseThrow(() -> new UserNotFoundException("Avatar: " + slAvatarUuid));
+        long balance = u.getPenaltyBalanceOwed() == null ? 0L : u.getPenaltyBalanceOwed();
+        if (balance == 0) {
+            // 404 — no debt
+            throw new UserNotFoundException("No penalty balance for avatar: " + slAvatarUuid);
+        }
+        return new PenaltyLookupResponse(u.getId(), u.getDisplayName(), balance);
+    }
+
+    @Transactional
+    public PenaltyPaymentResponse pay(PenaltyPaymentRequest req) {
+        User u = userRepo.findBySlAvatarUuid(req.slAvatarUuid())
+                .orElseThrow(() -> new UserNotFoundException("Avatar: " + req.slAvatarUuid()));
+
+        // Idempotency check — has this slTransactionId already been recorded?
+        Optional<EscrowTransaction> existing =
+                ledgerRepo.findBySlTransactionId(req.slTransactionId());
+        if (existing.isPresent()) {
+            // Benign replay — return current balance, no double-debit
+            log.info("Idempotent replay of penalty payment {} for user {}",
+                    req.slTransactionId(), u.getId());
+            return new PenaltyPaymentResponse(
+                    u.getPenaltyBalanceOwed() == null ? 0L : u.getPenaltyBalanceOwed());
+        }
+
+        // Pessimistic lock for the apply
+        User locked = userRepo.findByIdForUpdate(u.getId()).orElseThrow();
+        long balance = locked.getPenaltyBalanceOwed() == null ? 0L : locked.getPenaltyBalanceOwed();
+        if (req.amount() > balance) {
+            throw new PenaltyOverpaymentException(req.amount(), balance);
+        }
+
+        long newBalance = balance - req.amount();
+        locked.setPenaltyBalanceOwed(newBalance);
+        userRepo.save(locked);
+
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        ledgerRepo.save(EscrowTransaction.builder()
+                .type(EscrowTransactionType.LISTING_PENALTY_PAYMENT)
+                .status(EscrowTransactionStatus.COMPLETED)
+                .amount(req.amount())
+                .payer(locked)
+                .payee(null)
+                .slTransactionId(req.slTransactionId())
+                .terminalId(req.terminalId())
+                .completedAt(now)
+                .build());
+
+        log.info("Penalty payment recorded: user={}, amount={}, remaining={}, terminal={}",
+                locked.getId(), req.amount(), newBalance, req.terminalId());
+
+        return new PenaltyPaymentResponse(newBalance);
+    }
+}
+```
+
+Add to `UserRepository` if missing:
+```java
+Optional<User> findBySlAvatarUuid(UUID slAvatarUuid);
+```
+
+Add to `EscrowTransactionRepository` if missing:
+```java
+Optional<EscrowTransaction> findBySlTransactionId(String slTransactionId);
+```
+
+- [ ] **Step 5: Create `PenaltyTerminalController`**
+
+```java
+@RestController
+@RequestMapping("/api/v1/sl")
+@RequiredArgsConstructor
+public class PenaltyTerminalController {
+    private final PenaltyTerminalService service;
+
+    @PostMapping("/penalty-lookup")
+    public PenaltyLookupResponse lookup(@Valid @RequestBody PenaltyLookupRequest req) {
+        return service.lookup(req.slAvatarUuid());
+    }
+
+    @PostMapping("/penalty-payment")
+    public PenaltyPaymentResponse pay(@Valid @RequestBody PenaltyPaymentRequest req) {
+        return service.pay(req);
+    }
+}
+```
+
+The terminal auth (X-SecondLife-Owner-Key) is enforced by the existing security filter chain configured for `/sl/**` paths in SecurityConfig — find the existing pattern (Epic 02 / Epic 03 set this up).
+
+- [ ] **Step 6: Update SecurityConfig for the new paths**
+
+```java
+.requestMatchers(HttpMethod.POST, "/api/v1/sl/penalty-lookup").hasRole("SL_TERMINAL")
+.requestMatchers(HttpMethod.POST, "/api/v1/sl/penalty-payment").hasRole("SL_TERMINAL")
+```
+
+(Adjust the role/auth mechanism to match the existing terminal pattern from Epic 02 / 03 / 05 — copy the exact pattern used by the escrow terminal endpoints, which already validate `X-SecondLife-Owner-Key`.)
+
+- [ ] **Step 7: Map `PenaltyOverpaymentException` to 422**
+
+In an existing or new `@RestControllerAdvice`:
+```java
+@ExceptionHandler(PenaltyOverpaymentException.class)
+@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+public ProblemDetail overpayment(PenaltyOverpaymentException ex) {
+    ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.UNPROCESSABLE_ENTITY);
+    pd.setTitle("Penalty payment exceeds outstanding balance");
+    pd.setProperty("requested", ex.getRequested());
+    pd.setProperty("available", ex.getAvailable());
+    return pd;
+}
+```
+
+- [ ] **Step 8: Concurrency test — simultaneous payments at two terminals**
+
+```java
+// PenaltyTerminalServiceConcurrencyTest — integration test
+@Test
+void pay_simultaneousAtTwoTerminals_serializesViaUserRowLock() {
+    // Set up: user owes 1000.
+    // Two threads call pay() simultaneously, each with amount=600.
+    // First commits → balance: 400. Second sees 400, attempts 600 → overpayment 422.
+    // Or both commit if amounts fit: e.g., 400 + 600 → first leaves 600, second leaves 0.
+    // Assert: ledger has exactly two LISTING_PENALTY_PAYMENT rows totaling correct amount,
+    //         no double-debit, no negative balance.
+}
+```
+
+- [ ] **Step 9: Run all backend tests**
+
+`./mvnw test` — pass.
+
+- [ ] **Step 10: Commit Task 3**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/sl/ \
+        backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java \
+        backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowTransactionRepository.java \
+        backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java \
+        backend/src/test/java/com/slparcelauctions/backend/sl/
+git commit -m "feat(cancellation): /sl/penalty-lookup + /sl/penalty-payment with idempotent replay"
+```
+
+---
+
+## Task 4 — Frontend
+
+**Goal:** Land all UI surfaces — modal copy, suspension banner, history section, listing-wizard gate handling, AUCTION_CANCELLED WS handler. All built on top of the primitives that already exist in the design system.
+
+**Files:**
+- Create: `frontend/src/types/cancellation.ts`
+- Create: `frontend/src/lib/api/cancellations.ts`
+- Create: `frontend/src/hooks/useCancellationStatus.ts`
+- Create: `frontend/src/hooks/useCancellationHistory.ts`
+- Create: `frontend/src/components/cancellation/CancellationConsequenceBadge.tsx`
+- Create: `frontend/src/components/dashboard/SuspensionBanner.tsx`
+- Create: `frontend/src/components/dashboard/CancellationHistorySection.tsx`
+- Modify: `frontend/src/components/listing/CancelListingModal.tsx`
+- Modify: `frontend/src/types/auction.ts` (extend AuctionTopicEnvelope union)
+- Modify: `frontend/src/app/auction/[id]/AuctionDetailClient.tsx`
+- Modify: `frontend/src/app/dashboard/(verified)/overview/page.tsx`
+- Modify: `frontend/src/lib/user.ts` (or wherever `/me` types live) — add 3 fields
+- Modify: listing wizard error handler to catch 403 SellerSuspendedException
+- Tests for each component + hook
+
+### Steps
+
+- [ ] **Step 1: `types/cancellation.ts`**
+
+```typescript
+export type CancellationOffenseKind =
+  | "NONE"
+  | "WARNING"
+  | "PENALTY"
+  | "PENALTY_AND_30D"
+  | "PERMANENT_BAN";
+
+export type SuspensionReasonCode =
+  | "PENALTY_OWED"
+  | "TIMED_SUSPENSION"
+  | "PERMANENT_BAN";
+
+export interface CancellationStatusResponse {
+  priorOffensesWithBids: number;
+  currentSuspension: {
+    penaltyBalanceOwed: number;
+    listingSuspensionUntil: string | null;
+    bannedFromListing: boolean;
+  };
+  nextConsequenceIfBidsPresent: {
+    kind: CancellationOffenseKind;
+    amountL: number | null;
+    suspends30Days: boolean;
+    permanentBan: boolean;
+  };
+}
+
+export interface CancellationHistoryDto {
+  auctionId: number;
+  auctionTitle: string;
+  primaryPhotoUrl: string | null;
+  cancelledFromStatus: string;
+  hadBids: boolean;
+  reason: string;
+  cancelledAt: string;
+  penaltyApplied: {
+    kind: CancellationOffenseKind;
+    amountL: number | null;
+  } | null;
+}
+```
+
+- [ ] **Step 2: `lib/api/cancellations.ts`**
+
+Use the project's existing `api.get` helper (Sub-spec 1's plan referenced a non-existent `apiFetch` — the actual primitive is `api.get`/`api.post` from `@/lib/api`).
+
+```typescript
+import { api } from "@/lib/api";
+import type { PagedResponse } from "@/types/page";
+import type { CancellationStatusResponse, CancellationHistoryDto } from "@/types/cancellation";
+
+export const getCancellationStatus = () =>
+  api.get<CancellationStatusResponse>("/api/v1/users/me/cancellation-status");
+
+export const getCancellationHistory = (page = 0, size = 10) =>
+  api.get<PagedResponse<CancellationHistoryDto>>(
+    `/api/v1/users/me/cancellation-history?page=${page}&size=${size}`,
+  );
+```
+
+- [ ] **Step 3: `hooks/useCancellationStatus.ts` + `useCancellationHistory.ts`**
+
+```typescript
+// useCancellationStatus.ts
+import { useQuery } from "@tanstack/react-query";
+import { getCancellationStatus } from "@/lib/api/cancellations";
+
+export const cancellationKeys = {
+  status: ["me", "cancellation-status"] as const,
+  historyAll: ["me", "cancellation-history"] as const,
+  history: (page: number, size: number) =>
+    [...cancellationKeys.historyAll, page, size] as const,
+};
+
+export const useCancellationStatus = () =>
+  useQuery({
+    queryKey: cancellationKeys.status,
+    queryFn: getCancellationStatus,
+    staleTime: 30_000,
+  });
+
+// useCancellationHistory.ts
+import { useQuery } from "@tanstack/react-query";
+import { getCancellationHistory } from "@/lib/api/cancellations";
+import { cancellationKeys } from "./useCancellationStatus";
+
+export const useCancellationHistory = (page: number, size = 10) =>
+  useQuery({
+    queryKey: cancellationKeys.history(page, size),
+    queryFn: () => getCancellationHistory(page, size),
+  });
+```
+
+Tests for each — assert query keys are stable, MSW handlers respond, refetch behavior on staleness. Pattern from Sub-spec 1's `useReviews.test.tsx`.
+
+- [ ] **Step 4: `CancellationConsequenceBadge`**
+
+```tsx
+import { Badge } from "@/components/ui/Badge";
+import type { CancellationOffenseKind } from "@/types/cancellation";
+
+interface Props {
+  kind: CancellationOffenseKind | null;
+  amountL: number | null;
+}
+
+export function CancellationConsequenceBadge({ kind, amountL }: Props) {
+  if (!kind || kind === "NONE") {
+    return <Badge variant="muted">No penalty</Badge>;
+  }
+  switch (kind) {
+    case "WARNING":
+      return <Badge variant="warning">Warning</Badge>;
+    case "PENALTY":
+      return <Badge variant="danger">L${amountL?.toLocaleString()} penalty</Badge>;
+    case "PENALTY_AND_30D":
+      return (
+        <Badge variant="danger">
+          L${amountL?.toLocaleString()} + 30-day suspension
+        </Badge>
+      );
+    case "PERMANENT_BAN":
+      return <Badge variant="danger">Permanent ban</Badge>;
+    default:
+      return null;
+  }
+}
+```
+
+Use the existing `Badge` primitive variants. If `muted`/`warning`/`danger` don't exist as badge variants, look at the project's design tokens and pick equivalents (the existing primitives may use `tone="default" | "warning" | "danger"` per CONVENTIONS.md §164).
+
+Test: render each kind, assert correct copy + tone class.
+
+- [ ] **Step 5: `SuspensionBanner`**
+
+```tsx
+"use client";
+import { useCurrentUser } from "@/lib/user";
+import { Banner } from "@/components/ui/Banner";  // or existing equivalent
+
+export function SuspensionBanner() {
+  const { data: user } = useCurrentUser();
+  if (!user) return null;
+
+  const banned = user.bannedFromListing;
+  const suspendedUntil = user.listingSuspensionUntil
+    ? new Date(user.listingSuspensionUntil)
+    : null;
+  const isTimedSuspended = suspendedUntil && suspendedUntil > new Date();
+  const owesPenalty = (user.penaltyBalanceOwed ?? 0) > 0;
+
+  if (banned) {
+    return (
+      <Banner tone="danger">
+        Your listing privileges have been permanently suspended.{" "}
+        Contact support to request a review.
+      </Banner>
+    );
+  }
+  if (isTimedSuspended && owesPenalty) {
+    return (
+      <Banner tone="warning">
+        Listing suspended until {formatDate(suspendedUntil)}. You also owe{" "}
+        <strong>L${user.penaltyBalanceOwed?.toLocaleString()}</strong>. Visit any
+        SLPA terminal to pay.
+      </Banner>
+    );
+  }
+  if (isTimedSuspended) {
+    return (
+      <Banner tone="warning">
+        Listing suspended until {formatDate(suspendedUntil)}.
+      </Banner>
+    );
+  }
+  if (owesPenalty) {
+    return (
+      <Banner tone="warning">
+        You owe <strong>L${user.penaltyBalanceOwed?.toLocaleString()}</strong> in
+        cancellation penalties. Visit any SLPA terminal to pay and resume listing.
+      </Banner>
+    );
+  }
+  return null;
+}
+```
+
+(Adjust `<Banner>` to whatever the project's actual primitive is. If none exists, use a `Card` + design tokens.)
+
+Tests cover all 4 states + null state + dark/light token output.
+
+- [ ] **Step 6: `CancellationHistorySection`**
+
+Renders a paginated list using `useCancellationHistory`. Each row uses `<ListingCard variant="compact">` (or equivalent) on the left + `<CancellationConsequenceBadge>` on the right + click-to-expand for the reason. Empty state: "No cancellations yet."
+
+Tests cover empty state, pagination clicks, badge rendering for each kind, reason expand/collapse.
+
+- [ ] **Step 7: Modify `CancelListingModal.tsx` for consequence-aware copy**
+
+Add the status fetch + dynamic copy table (top-down precedence):
+
+```tsx
+const { data: status } = useCancellationStatus();
+const { data: user } = useCurrentUser();
+const auction = props.auction;
+
+// Compute copy variant — top-down precedence
+const copyVariant = (() => {
+  if (user?.bannedFromListing) return "BANNED";
+  const hasBids = (auction.bidCount ?? 0) > 0;
+  if (!hasBids) return "NO_BIDS";
+  const prior = status?.priorOffensesWithBids ?? 0;
+  if (prior === 0) return "FIRST_OFFENSE";
+  if (prior === 1) return "SECOND_OFFENSE";
+  if (prior === 2) return "THIRD_OFFENSE";
+  return "FOURTH_PLUS_OFFENSE";  // unbanned but on offense #4 — about to ban
+})();
+
+const copy = COPY_MAP[copyVariant];  // map to the spec §8.1 table
+```
+
+The `COPY_MAP` constant inlines the strings from spec §8.1. Confirmation button stays `variant="destructive"`; reason textarea stays free-text required.
+
+Tests cover all 6 variants — set up the test environment with the right user state + auction state and assert the rendered copy matches.
+
+- [ ] **Step 8: Extend `types/auction.ts` with `AuctionCancelledEnvelope`**
+
+```typescript
+export type AuctionCancelledEnvelope = {
+  type: "AUCTION_CANCELLED";
+  auctionId: number;
+  cancelledAt: string;
+  hadBids: boolean;
+};
+
+export type AuctionTopicEnvelope =
+  | AuctionEnvelope
+  | EscrowEnvelope
+  | ReviewRevealedEnvelope
+  | AuctionCancelledEnvelope;
+```
+
+- [ ] **Step 9: Handle `AUCTION_CANCELLED` in `AuctionDetailClient`**
+
+Find the existing WS envelope switch in `AuctionDetailClient.tsx`. The Sub-spec 1 fix already added a `REVIEW_REVEALED` branch and narrowed the union for type safety. Add:
+
+```tsx
+} else if (env.type === "AUCTION_CANCELLED") {
+  // Invalidate the auction query so the page transitions to "cancelled" state
+  queryClient.invalidateQueries({ queryKey: ["auction", auctionId] });
+}
+```
+
+The existing render path checks `auction.status === "CANCELLED"` (or should) and renders a cancellation banner instead of the bid form. If that branch doesn't exist yet in `AuctionDetailClient`, add it as a small UI tweak — see how cancelled auctions are shown in the My Listings flow (Epic 03 sub-spec 2) for the existing pattern.
+
+Test: simulate the WS envelope, assert query invalidation fires.
+
+- [ ] **Step 10: Extend `/me` types**
+
+Find `lib/user.ts` (or wherever the `CurrentUserResponse` mirror is). Add 3 fields:
+
+```typescript
+export interface CurrentUser {
+  // ... existing
+  penaltyBalanceOwed: number;
+  listingSuspensionUntil: string | null;
+  bannedFromListing: boolean;
+}
+```
+
+Update `useCurrentUser` to expect these. Existing tests + MSW handlers may need to provide defaults — inject `{ penaltyBalanceOwed: 0, listingSuspensionUntil: null, bannedFromListing: false }` into existing fixtures.
+
+- [ ] **Step 11: Mount banner + history on dashboard**
+
+Edit `app/dashboard/(verified)/overview/page.tsx`:
+
+```tsx
+<>
+  <SuspensionBanner />
+  <PendingReviewsSection />
+  {/* existing My Listings / My Bids sections */}
+  <CancellationHistorySection />
+</>
+```
+
+Place `SuspensionBanner` at the top (highest priority), `PendingReviewsSection` (from Sub-spec 1) next, then existing sections, then `CancellationHistorySection` near the bottom (informational, lowest priority).
+
+- [ ] **Step 12: Listing wizard — handle 403 with structured `code`**
+
+Find the wizard's submit handler (likely `app/listings/new/`-something or `components/listing/ListingWizardForm.tsx`'s onSubmit). Catch 403 errors:
+
+```tsx
+try {
+  await submitListing(data);
+} catch (e) {
+  if (isApiError(e) && e.status === 403 && e.problem?.code) {
+    const code = e.problem.code as SuspensionReasonCode;
+    // Show focused modal/error with the right copy per code
+    // Link to dashboard banner
+    setSuspensionError(code);
+    return;
+  }
+  throw e;
+}
+```
+
+The error display can be a small `<SuspensionErrorModal>` or inline error block with copy keyed on `code`:
+- `PENALTY_OWED`: "You have an outstanding penalty balance. Pay at any SLPA terminal to resume listing. ([Go to dashboard])"
+- `TIMED_SUSPENSION`: "Your listing privileges are temporarily suspended. ([Go to dashboard])"
+- `PERMANENT_BAN`: "Your listing privileges have been permanently suspended. Contact support to request a review."
+
+Test: mock the API to return 403 with each `code`, assert the right copy renders.
+
+- [ ] **Step 13: Run all frontend tests**
+
+```bash
+cd frontend && npm test -- --run
+```
+
+All pass. ~40 new tests across components + hooks expected.
+
+- [ ] **Step 14: Run lint + build**
+
+```bash
+cd frontend && npm run lint
+cd frontend && npm run build
+```
+
+Both pass. The Sub-spec 1 build was green at PR merge; Sub-spec 2 should not regress.
+
+- [ ] **Step 15: Commit Task 4**
+
+```bash
+git add frontend/src/types/cancellation.ts \
+        frontend/src/types/auction.ts \
+        frontend/src/lib/api/cancellations.ts \
+        frontend/src/hooks/useCancellationStatus.ts \
+        frontend/src/hooks/useCancellationHistory.ts \
+        frontend/src/components/cancellation/ \
+        frontend/src/components/dashboard/SuspensionBanner.tsx \
+        frontend/src/components/dashboard/SuspensionBanner.test.tsx \
+        frontend/src/components/dashboard/CancellationHistorySection.tsx \
+        frontend/src/components/dashboard/CancellationHistorySection.test.tsx \
+        frontend/src/components/listing/CancelListingModal.tsx \
+        frontend/src/components/listing/CancelListingModal.test.tsx \
+        frontend/src/app/auction/[id]/AuctionDetailClient.tsx \
+        frontend/src/app/dashboard/\(verified\)/overview/page.tsx \
+        frontend/src/lib/user.ts
+git commit -m "feat(cancellation): suspension banner + history section + consequence-aware modal + AUCTION_CANCELLED handler"
+```
+
+---
+
+## Final steps — DEFERRED_WORK + PR
+
+- [ ] **Resolve deferred ledger entry**
+
+Edit `docs/implementation/DEFERRED_WORK.md`. Find and DELETE the entry titled "Cancellation WS broadcast on active-auction cancel" (around line 155 per spec §12). Sub-spec 2 ships this.
+
+```bash
+git add docs/implementation/DEFERRED_WORK.md
+git commit -m "docs(deferred): remove WS-broadcast-on-cancel — shipped in sub-spec 2"
+```
+
+- [ ] **Cross-branch final review**
+
+Dispatch a final `code-reviewer` subagent at this branch with full context. Inputs:
+- Spec: `docs/superpowers/specs/2026-04-24-epic-08-sub-2-cancellation-penalties.md`
+- Plan: this file
+- Branch: full diff against `dev`
+
+Verify cross-task coherence (DTO shapes match between backend and frontend, enum values consistent, copy strings match spec §8.1, security rules cover new endpoints, no leaked admin endpoints).
+
+- [ ] **Open PR to `dev`**
+
+```bash
+gh pr create --base dev --title "Epic 08 sub-spec 2 — Cancellation Penalties" --body "..."
+```
+
+Body should follow Sub-spec 1's PR shape — summary of what shipped per task, DEFERRED_WORK changes, test plan checkbox.
+
+---
+
+## Self-review (plan)
+
+1. **Spec coverage:**
+   - §2 ladder → Task 1 Steps 9-11
+   - §4 data model → Task 1 Steps 1-6
+   - §5 cancel flow → Task 1 Step 11
+   - §6 watcher → Task 2 Steps 13-16
+   - §7 API surface → Task 2 (gate + GET endpoints) + Task 3 (terminal endpoints)
+   - §8 frontend → Task 4
+   - §12 deferred-work changes → Final steps
+
+2. **Placeholder scan:** No TBD/TODO. Code snippets are concrete; one minor "(adjust to match)" note for the SecurityConfig terminal-auth role pattern, which is acceptable since the existing pattern is the source of truth.
+
+3. **Type consistency:**
+   - `CancellationOffenseKind` values match across Java enum and TS union (NONE, WARNING, PENALTY, PENALTY_AND_30D, PERMANENT_BAN)
+   - `SuspensionReason` Java enum matches `SuspensionReasonCode` TS union (PENALTY_OWED, TIMED_SUSPENSION, PERMANENT_BAN)
+   - `AuctionCancelledEnvelope` field names match between Java record and TS type
+   - DTO shapes match: `CancellationStatusResponse`, `CancellationHistoryDto`, `PenaltyLookupResponse`, `PenaltyPaymentResponse`
+
+4. **Idempotency pins:**
+   - `ReviewService.reveal` from sub-spec 1 — already idempotent
+   - `CancellationService.cancel` — pessimistic lock prevents double-application; permanent ban write is idempotent (true → true)
+   - `PenaltyTerminalService.pay` — `slTransactionId` lookup before debit catches replay
+   - `OwnershipCheckTask` for cancelled auctions — clears `postCancelWatchUntil` after raising flag, preventing re-flag
+
+5. **Race pins:**
+   - Concurrent cancellations same seller → User row pessimistic lock (Step 17)
+   - Concurrent payments at two terminals → User row pessimistic lock + idempotent slTransactionId (Step 8)
+   - Reveal scheduler vs cancellation race → not applicable (different resources)

--- a/docs/superpowers/specs/2026-04-24-epic-08-sub-2-cancellation-penalties.md
+++ b/docs/superpowers/specs/2026-04-24-epic-08-sub-2-cancellation-penalties.md
@@ -1,0 +1,713 @@
+# Epic 08 Sub-Spec 2 — Cancellation Penalties & Anti-Circumvention
+
+**Date:** 2026-04-24
+**Epic:** 08 — Ratings & Reputation
+**Sub-spec scope:** Task 03 from `docs/implementation/epic-08/`. Layers escalating penalties + suspension enforcement + 48h post-cancel ownership watcher onto the existing cancellation flow.
+**Branch:** `task/08-sub-2-cancellation-penalties` → `dev`
+**Predecessor:** Sub-spec 1 (reviews + reputation) merged in PR #27.
+
+---
+
+## 1. Goal
+
+Make seller cancellations with active bids carry real consequences: an escalating penalty ladder enforced via a "pay at terminal to unsuspend" model, a 48-hour parcel-ownership watch on cancelled-with-bids auctions, and a frontend that warns sellers up-front about what their next cancellation will cost. Closes Task 03 of Epic 08 in one PR.
+
+Out of scope: admin endpoints (Epic 10), notifications (Epic 09), user-targeted WebSocket queues for live banner push (deferred — using window-focus refetch).
+
+---
+
+## 2. The penalty ladder
+
+Counted by `count(CancellationLog WHERE seller=? AND hadBids=true)` — the live query of prior offenses, BEFORE the current cancellation's log row is inserted. Cancellations with no bids and pre-ACTIVE cancellations don't count.
+
+| Prior offenses | Action this cancel | Result on User row |
+|---|---|---|
+| 0 | Warning recorded | (no change beyond existing `cancelledWithBids++`) |
+| 1 | L$1000 penalty added | `penaltyBalanceOwed += 1000` |
+| 2 | L$2500 penalty + 30-day timed suspension | `penaltyBalanceOwed += 2500`; `listingSuspensionUntil = now + 30d` |
+| 3+ | Permanent ban | `bannedFromListing = true` |
+
+Penalty amounts come from `application.yml` (`slpa.cancellation.penalty.second-offense-l: 1000`, `third-offense-l: 2500`). Spec text and storage capture the live-config value at the time of the offense — see §4.
+
+### Why this ladder
+
+The user's preferred model — over the spec's "deduct from next payout" — is **suspended-until-paid**. A seller who incurs a penalty cannot create new listings until they walk to a terminal and pay the L$ off. This makes the consequence binary, immediate, and impossible to dodge by going dormant. Settled in Q1 of the brainstorm.
+
+### Concurrent gates on offense #3
+
+The 30-day suspension and the L$2500 debt are independent dimensions, both gating listing creation. Paying the L$2500 clears one gate; the 30-day clock continues to run. Waiting 30 days clears the other gate; the debt remains. Both must clear to list again. (Q1 of brainstorm.)
+
+### Permanent ban irreversibility
+
+Set `bannedFromListing = true` on offense #4. Only an admin can clear it (Epic 10). The 30-day suspension and any owed balance stay on the record but are dominated by the ban — the admin lift action explicitly clears all three.
+
+---
+
+## 3. Architecture
+
+### 3.1 Backend — minimal new code
+
+Sub-spec 2 adds NO new backend packages. All work extends existing ones:
+
+```
+auction/
+├── CancellationService.java          (extend with ladder + watcher set + WS broadcast)
+├── CancellationLog.java              (add penaltyKind, penaltyAmountL columns)
+├── CancellationOffenseKind.java      NEW — small enum
+├── CancellationStatusController.java NEW — /me/cancellation-status + /me/cancellation-history
+├── CancellationStatusService.java    NEW — preview + history queries
+├── dto/
+│   ├── CancellationStatusResponse.java          NEW
+│   ├── CancellationHistoryDto.java              NEW
+│   └── NextConsequenceDto.java                  NEW
+├── exception/
+│   ├── SellerSuspendedException.java           NEW (→ 403)
+│   └── SuspensionReason.java                   NEW (PENALTY_OWED / TIMED_SUSPENSION / PERMANENT_BAN)
+├── AuctionCancelledEnvelope.java     NEW (joins AuctionTopicEnvelope)
+├── AuctionService.java               (gate in create())
+├── Auction.java                      (add postCancelWatchUntil column)
+└── monitoring/
+    ├── OwnershipMonitorScheduler.java (extend query — pass `now`)
+    ├── OwnershipCheckTask.java        (branch on auction status, route fraud reason)
+    └── ... existing files
+
+auction/fraud/
+└── FraudFlagReason.java              (add CANCEL_AND_SELL value)
+
+user/
+└── User.java                         (add penaltyBalanceOwed, bannedFromListing)
+
+escrow/
+└── EscrowTransactionType.java        (add LISTING_PENALTY_PAYMENT)
+
+sl/
+└── PenaltyTerminalController.java    NEW — /sl/penalty-lookup + /sl/penalty-payment
+
+config/
+└── SecurityConfig.java               (permit terminal-auth on /sl/penalty-* paths)
+```
+
+### 3.2 Frontend — one new component package
+
+```
+components/cancellation/             NEW
+└── CancellationConsequenceBadge.tsx
+components/dashboard/                EXISTS (Epic 02)
+├── SuspensionBanner.tsx             NEW
+└── CancellationHistorySection.tsx   NEW
+components/listing/
+└── CancelListingModal.tsx           MODIFY — consequence-aware copy
+hooks/
+├── useCancellationStatus.ts         NEW
+└── useCancellationHistory.ts        NEW
+lib/api/
+└── cancellations.ts                 NEW — 2 fetcher functions
+types/
+├── cancellation.ts                  NEW — DTO mirrors
+└── auction.ts                       MODIFY — AuctionCancelledEnvelope joins union
+app/auction/[id]/
+└── AuctionDetailClient.tsx          MODIFY — handle AUCTION_CANCELLED
+app/dashboard/(verified)/overview/
+└── page.tsx                         MODIFY — mount banner + history
+lib/user.ts                          MODIFY — extend /me types
+```
+
+### 3.3 Configuration
+
+```yaml
+slpa:
+  cancellation:
+    penalty:
+      second-offense-l: 1000
+      third-offense-l: 2500
+      third-offense-suspension-days: 30
+    post-cancel-watch-hours: 48
+```
+
+`@ConfigurationProperties` class `CancellationPenaltyProperties` reads these. Penalty amounts and durations are live-config — historical `CancellationLog` rows snapshot the amount applied so retroactive config changes don't rewrite history (§4).
+
+---
+
+## 4. Data model
+
+### 4.1 New / modified columns on `User`
+
+```java
+@Builder.Default
+@Column(name = "penalty_balance_owed", nullable = false,
+        columnDefinition = "bigint not null default 0")
+private Long penaltyBalanceOwed = 0L;
+
+@Builder.Default
+@Column(name = "banned_from_listing", nullable = false,
+        columnDefinition = "boolean not null default false")
+private Boolean bannedFromListing = false;
+```
+
+`listingSuspensionUntil OffsetDateTime` already exists on `User` (Epic 02). Sub-spec 2 starts writing it.
+
+### 4.2 New column on `Auction`
+
+```java
+@Column(name = "post_cancel_watch_until")
+private OffsetDateTime postCancelWatchUntil;  // nullable
+```
+
+Set to `now + 48h` on ACTIVE-with-bids cancellation. Cleared in `OwnershipCheckTask` after a `CANCEL_AND_SELL` flag is raised, so subsequent scheduler ticks don't re-flag the same observation. Naturally falls out of the watcher query once `now > postCancelWatchUntil`.
+
+### 4.3 New columns on `CancellationLog`
+
+```java
+@Enumerated(EnumType.STRING)
+@Column(name = "penalty_kind", length = 30)
+private CancellationOffenseKind penaltyKind;  // nullable for pre-sub-spec-2 rows
+
+@Column(name = "penalty_amount_l")
+private Long penaltyAmountL;  // nullable
+```
+
+Both written at cancellation time inside the same transaction. The KIND captures the discriminator (used by the history view's badge map). The AMOUNT captures the L$ snapshotted from config — if the config changes later, historical rows stay correct.
+
+**Why store on the log row instead of deriving:** an admin retroactively forgiving a past cancellation (setting that row's `had_bids = false`) correctly changes the live offense COUNT — so future decisions self-heal — but the penalty actually applied at that moment is historical fact and cannot be recomputed safely. Decision uses live query; record uses snapshot. (Section 2 correction.)
+
+### 4.4 New enum `CancellationOffenseKind`
+
+```java
+public enum CancellationOffenseKind {
+    NONE,             // no bids OR pre-ACTIVE cancel
+    WARNING,          // 1st offense with bids
+    PENALTY,          // 2nd offense with bids: L$1000
+    PENALTY_AND_30D,  // 3rd offense with bids: L$2500 + 30-day suspension
+    PERMANENT_BAN     // 4th+ offense with bids
+}
+```
+
+### 4.5 New enum value `FraudFlagReason.CANCEL_AND_SELL`
+
+Appended to existing enum at `auction/fraud/FraudFlagReason.java`. Existing `FraudFlagReasonCheckConstraintInitializer` refreshes the `fraud_flags_reason_check` constraint at startup automatically — no migration needed.
+
+### 4.6 New enum value `EscrowTransactionType.LISTING_PENALTY_PAYMENT`
+
+Tag for ledger rows from `/sl/penalty-payment`. Mirrors the existing `LISTING_FEE_REFUND`-class shape: `payer = seller`, `payee = null` (platform side), `amount = paid amount`, `slTransactionId`, `terminalId`, `completedAt`.
+
+### 4.7 No new entities
+
+No `PenaltyPayment` entity, no `Suspension` entity, no `OffenseRecord` entity. All state is captured by:
+- `CancellationLog` (existing) for history
+- `User.penaltyBalanceOwed` for live debt
+- `User.listingSuspensionUntil` for time-based suspension
+- `User.bannedFromListing` for permanent ban
+- `EscrowTransaction` (existing) for payment audit
+
+---
+
+## 5. The cancellation flow (single transaction)
+
+```
+CancellationService.cancel(auctionId, reason)
+  ├── findByIdForUpdate(auctionId) [lock auction]
+  ├── validate cancellable status + not-after-end (existing)
+  ├── seller = auction.seller
+  ├── userRepo.findByIdForUpdate(seller.id) [lock user — same tx]
+  │
+  ├── from = auction.status; hadBids = auction.bidCount > 0
+  │
+  ├── // Pre-INSERT count → ladder index
+  ├── if (from == ACTIVE && hadBids) {
+  │     priorOffenses = count(CancellationLog WHERE seller=? AND hadBids=true)
+  │     consequence = ladder[min(priorOffenses, 3)]
+  │       0 → CancellationOffenseKind.WARNING,   amountL=null
+  │       1 → PENALTY,                            amountL=1000
+  │       2 → PENALTY_AND_30D,                    amountL=2500
+  │       3 → PERMANENT_BAN,                      amountL=null
+  │   } else {
+  │     consequence = NONE, amountL=null
+  │   }
+  │
+  ├── INSERT CancellationLog (auction, seller, from, hadBids, reason,
+  │                           penaltyKind=consequence.kind,
+  │                           penaltyAmountL=consequence.amountL)
+  │
+  ├── if (from == ACTIVE && hadBids) {
+  │     seller.cancelledWithBids++   // existing denormalised counter
+  │     switch (consequence.kind) {
+  │       case PENALTY:
+  │         seller.penaltyBalanceOwed += consequence.amountL
+  │       case PENALTY_AND_30D:
+  │         seller.penaltyBalanceOwed += consequence.amountL
+  │         seller.listingSuspensionUntil = now + 30d
+  │       case PERMANENT_BAN:
+  │         seller.bannedFromListing = true
+  │     }
+  │     auction.postCancelWatchUntil = now + 48h
+  │     userRepo.save(seller)
+  │   }
+  │
+  ├── if (listingFeePaid && from != ACTIVE) {
+  │     INSERT ListingFeeRefund (existing)
+  │   }
+  │
+  ├── auction.status = CANCELLED
+  ├── auctionRepo.save(auction)
+  ├── monitorLifecycle.onAuctionClosed(auction) (existing)
+  │
+  └── registerSync.afterCommit:
+        broadcastPublisher.publishCancelled(AuctionCancelledEnvelope)
+```
+
+### Invariants
+
+- **All-or-nothing transaction**: counter, debt, suspension, ban, watcher timestamp, log row, refund record — atomic. Crash mid-flow rolls everything back.
+- **Pessimistic lock on User row** prevents two concurrent cancellations (same seller, different auctions) from both reading priorOffenses=N and both applying as the (N+1)th.
+- **Offense count is fresh COUNT before INSERT**, indexed by `priorOffenses` directly. No off-by-one arithmetic. (Section 3 correction.)
+- **Permanent ban irreversible** within sub-spec 2. Pre-existing 30-day suspension and owed penalty stay on the user row alongside the ban — admin lift action (Epic 10) clears all three explicitly.
+
+---
+
+## 6. The 48-hour ownership watcher
+
+### 6.1 Query extension
+
+`AuctionRepository.findDueForOwnershipCheck` extended:
+
+```java
+@Query("""
+    SELECT a.id FROM Auction a
+    WHERE (a.status = AuctionStatus.ACTIVE
+            AND (a.lastOwnershipCheckAt IS NULL OR a.lastOwnershipCheckAt < :cutoff))
+       OR (a.postCancelWatchUntil IS NOT NULL
+            AND a.postCancelWatchUntil > :now
+            AND (a.lastOwnershipCheckAt IS NULL OR a.lastOwnershipCheckAt < :cutoff))
+    """)
+List<Long> findDueForOwnershipCheck(
+        @Param("cutoff") OffsetDateTime cutoff,
+        @Param("now") OffsetDateTime now);
+```
+
+The `lastOwnershipCheckAt` column gates polling cadence for both ACTIVE and post-cancel-watched auctions.
+
+### 6.2 Task branching
+
+```java
+@Async
+@Transactional
+public void checkOne(Long auctionId) {
+    Auction a = auctionRepo.findById(auctionId).orElseThrow(...);
+    OwnerLookupResult result = worldApi.lookupOwner(a.getParcel());
+    a.setLastOwnershipCheckAt(OffsetDateTime.now(clock));
+
+    if (result.isMismatch()) {
+        FraudFlagReason reason = (a.getStatus() == AuctionStatus.CANCELLED)
+                ? FraudFlagReason.CANCEL_AND_SELL
+                : FraudFlagReason.OWNERSHIP_CHANGED_TO_UNKNOWN;
+        raiseFlag(a, reason, buildEvidence(a, result));
+
+        if (a.getStatus() == AuctionStatus.CANCELLED) {
+            a.setPostCancelWatchUntil(null);  // prevent re-flag on next tick
+        }
+        // ACTIVE path's existing flow suspends the auction via SuspensionService,
+        // which removes it from the query naturally. No equivalent change there.
+    }
+    auctionRepo.save(a);
+}
+```
+
+The shared `raiseFlag` helper extracts the fraud-flag write logic; the CANCELLED branch skips suspension (auction is already cancelled).
+
+### 6.3 Evidence payload for `CANCEL_AND_SELL`
+
+```json
+{
+  "cancelledAt": "2026-04-22T14:30:00Z",
+  "expectedSellerKey": "abc-123-...",
+  "observedOwnerKey": "xyz-789-...",
+  "hoursSinceCancellation": 17.4,
+  "parcelRegion": "Aurora",
+  "parcelLocalId": 42,
+  "auctionTitle": "Lakefront Lot at Aurora"
+}
+```
+
+`hoursSinceCancellation` is computed at flag-creation time so admin reviewers can score temporal proximity ("4 hours after = strong signal" vs "30 hours = weaker").
+
+### 6.4 Edge cases
+
+- **Seller re-buys their own parcel within 48h** (alt-account round-trip): no flag — owner still resolves to seller's avatar UUID.
+- **World API failure during watch window**: existing threshold logic (`WORLD_API_FAILURE_THRESHOLD`) applies. Doesn't escalate to `CANCEL_AND_SELL` based on absence of data.
+- **Cancellation timing relative to ticks**: `OwnershipMonitorScheduler` runs at `PT30S` cadence; first observation lands ~30s after cancellation. Acceptable.
+- **Post-flag ownership reverts**: if owner flips to non-seller (flag raised, watcher cleared), then back to seller before 48h expires — flag stays. Off-platform deal-then-undo doesn't erase the signal. Admin reviews.
+- **Multiple cancellations within 48h**: each cancellation gets its own `postCancelWatchUntil` window scoped to that auction. Each auction can raise at most one `CANCEL_AND_SELL` flag.
+
+---
+
+## 7. API surface
+
+All endpoints under `/api/v1`. `J` = JWT, `T` = SL terminal-only (`X-SecondLife-Owner-Key` validated).
+
+### 7.1 New endpoints
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| `GET` | `/users/me/cancellation-status` | J | Cancel modal preview + current suspension state |
+| `GET` | `/users/me/cancellation-history` | J | Paginated seller-only cancellation log |
+| `POST` | `/sl/penalty-lookup` | T | Terminal queries debt by SL avatar UUID |
+| `POST` | `/sl/penalty-payment` | T | Terminal posts payment confirmation after pulling L$ |
+
+### 7.2 Modified endpoints
+
+- `GET /users/me` — extend response with `penaltyBalanceOwed`, `listingSuspensionUntil`, `bannedFromListing` so the dashboard banner has session-level state without an extra fetch.
+- `POST /auctions` — gate now throws `SellerSuspendedException` (→ **403**, not 422) when suspended/banned. Existing happy path unchanged.
+- `POST /auctions/{id}/cancel` — service-layer extends with penalty ladder + `AUCTION_CANCELLED` WS broadcast on `afterCommit`.
+
+### 7.3 `GET /users/me/cancellation-status`
+
+```json
+{
+  "priorOffensesWithBids": 1,
+  "currentSuspension": {
+    "penaltyBalanceOwed": 1000,
+    "listingSuspensionUntil": "2026-05-24T10:15:00Z",
+    "bannedFromListing": false
+  },
+  "nextConsequenceIfBidsPresent": {
+    "kind": "PENALTY",
+    "amountL": 1000,
+    "suspends30Days": false,
+    "permanentBan": false
+  }
+}
+```
+
+`nextConsequenceIfBidsPresent.kind` is one of `WARNING`, `PENALTY`, `PENALTY_AND_30D`, `PERMANENT_BAN` (never `NONE`, since the query asks "what would happen IF this cancel had bids").
+
+### 7.4 `GET /users/me/cancellation-history?page=0&size=10`
+
+`PagedResponse<CancellationHistoryDto>` per CONVENTIONS.md §PagedResponse, sorted `cancelledAt DESC`. Each row:
+
+```json
+{
+  "auctionId": 1234,
+  "auctionTitle": "Aurora Parcel",
+  "primaryPhotoUrl": "https://...",
+  "cancelledFromStatus": "ACTIVE",
+  "hadBids": true,
+  "reason": "Personal reasons.",
+  "cancelledAt": "2026-04-20T10:15:00Z",
+  "penaltyApplied": {
+    "kind": "PENALTY",
+    "amountL": 1000
+  }
+}
+```
+
+`penaltyApplied` is null when `penaltyKind == NONE` on the log row. Read directly from the snapshotted columns — no live recomputation.
+
+### 7.5 `POST /sl/penalty-lookup`
+
+Terminal request:
+```json
+{ "slAvatarUuid": "abc-123-...", "terminalId": "terminal-7" }
+```
+
+Response (200) when debt exists:
+```json
+{
+  "userId": 42,
+  "displayName": "Alice",
+  "penaltyBalanceOwed": 1000
+}
+```
+
+Response (404) when avatar unknown OR balance is 0. Validates `X-SecondLife-Owner-Key` per existing terminal auth pattern.
+
+### 7.6 `POST /sl/penalty-payment`
+
+Terminal-side request after pulling L$:
+```json
+{
+  "slAvatarUuid": "abc-123-...",
+  "slTransactionId": "tx-uuid",
+  "amount": 600,
+  "terminalId": "terminal-7"
+}
+```
+
+Server-side single transaction (pessimistic lock on User row):
+
+1. Validate `X-SecondLife-Owner-Key` (existing terminal auth)
+2. Resolve user from `slAvatarUuid`; 404 if unknown
+3. Idempotency: if `slTransactionId` already recorded as `LISTING_PENALTY_PAYMENT`, return `200 { remainingBalance: <current> }` (benign replay)
+4. `findByIdForUpdate(user)` — pessimistic lock
+5. Validate `0 < amount <= user.penaltyBalanceOwed` — return 422 if overpayment attempted
+6. `user.penaltyBalanceOwed -= amount`
+7. `INSERT EscrowTransaction { type=LISTING_PENALTY_PAYMENT, payer=user, payee=null, amount, slTransactionId, terminalId, completedAt=now }`
+8. Return `{ remainingBalance: <new value> }`
+
+Partial payments allowed and additive — a seller without L$1000 in their account can pay L$600 now and L$400 later. Each partial is its own ledger row. Suspension stays active until `penaltyBalanceOwed == 0`.
+
+### 7.7 `POST /auctions` (suspension gate)
+
+```java
+public Auction create(Long sellerId, AuctionCreateRequest req) {
+    User seller = userRepo.findById(sellerId).orElseThrow(...);
+
+    SuspensionReason reason = checkCanCreateListing(seller, clock);
+    if (reason != null) throw new SellerSuspendedException(reason);
+
+    // existing validation + entity build
+}
+
+private SuspensionReason checkCanCreateListing(User u, Clock c) {
+    if (u.getBannedFromListing()) return SuspensionReason.PERMANENT_BAN;
+    if (u.getListingSuspensionUntil() != null
+            && OffsetDateTime.now(c).isBefore(u.getListingSuspensionUntil()))
+        return SuspensionReason.TIMED_SUSPENSION;
+    if (u.getPenaltyBalanceOwed() > 0)
+        return SuspensionReason.PENALTY_OWED;
+    return null;
+}
+```
+
+`SellerSuspendedException` → 403 ProblemDetail with `code` field carrying the enum:
+
+```json
+{
+  "type": "https://slpa.example/problems/seller-suspended",
+  "title": "Listing creation suspended",
+  "status": 403,
+  "code": "PENALTY_OWED",
+  "detail": "You owe L$1000 in cancellation penalties. Pay at any SLPA terminal."
+}
+```
+
+Frontend branches on `code`, not status.
+
+---
+
+## 8. Frontend surfaces
+
+### 8.1 Cancel modal — consequence-aware copy
+
+`CancelListingModal.tsx` extends with one new fetch on open:
+
+```tsx
+const { data: status } = useQuery({
+  queryKey: ["me", "cancellation-status"],
+  queryFn: () => apiGet("/api/v1/users/me/cancellation-status"),
+  staleTime: 30_000,
+});
+```
+
+Copy table — checked **top-down, first match wins**:
+
+| Condition | Copy |
+|---|---|
+| `user.bannedFromListing === true` | "You are permanently banned from creating new listings. This cancellation will be recorded." |
+| no bids, any prior count | "No penalty will apply. Listing fee is non-refundable for already-paid auctions." |
+| has bids, 0 prior offenses | "This is a cancellation with active bids. Your first such cancellation is recorded as a warning — no L$ penalty." |
+| has bids, 1 prior | "**This will be your 2nd cancellation with active bids. You will be suspended from new listings until you pay a L$1000 penalty at any SLPA terminal.**" |
+| has bids, 2 prior | "**This will be your 3rd cancellation with active bids. You will be suspended from new listings for 30 days AND must pay a L$2500 penalty before listing again. One more cancellation will result in a permanent ban.**" |
+| has bids, 3+ prior (unbanned) | "**This will be your 4th cancellation with active bids. This will result in a permanent ban from new listings.**" |
+
+Reason field: free text, required, ≤500 chars. Confirm button: `Button variant="destructive"`.
+
+### 8.2 SuspensionBanner
+
+Component renders when `!user.canCreateListing`. State sourced from extended `/me` response. Variants:
+
+| Condition | Banner |
+|---|---|
+| `bannedFromListing` | "Your listing privileges have been permanently suspended. Contact support to request a review." |
+| timed AND debt | "Listing suspended until {date}. You also owe **L${amount}**. Visit any SLPA terminal to pay." |
+| timed only | "Listing suspended until {date}." |
+| debt only | "You owe **L${amount}** in cancellation penalties. Visit any SLPA terminal to pay and resume listing." |
+
+No "Pay now" button on web — pure walk-in model. State refreshes via React Query window-focus refetch on `/me` (no WS push for `PENALTY_CLEARED` in sub-spec 2; deferred to user-targeted-queue infrastructure work).
+
+### 8.3 CancellationHistorySection
+
+Lives on the seller's dashboard. `useCancellationHistory()` returns paginated `PagedResponse<CancellationHistoryDto>`. Empty state: "No cancellations yet."
+
+Each row: compact auction card (existing `<ListingCard variant="compact">`-shape) + `<CancellationConsequenceBadge>` on the right + click-to-expand reason text.
+
+`<CancellationConsequenceBadge>` map:
+- `null` / `NONE` → grey "No penalty"
+- `WARNING` → yellow "Warning"
+- `PENALTY` → orange "L${amount} penalty"
+- `PENALTY_AND_30D` → red "L${amount} + 30-day suspension"
+- `PERMANENT_BAN` → red "Permanent ban"
+
+### 8.4 Listing wizard suspension gate
+
+**Frontend pre-check:** Dashboard "Create new listing" CTA renders as a disabled button with tooltip when `!user.canCreateListing`. The disabled state carries the same suspension-reason copy.
+
+**Backend gate authoritative:** Any request that bypasses the pre-check (deep link, API client) gets a 403 with structured `code`. The wizard's submit handler catches the 403, reads `code`, and routes to a focused modal carrying the right banner copy + a link back to the dashboard.
+
+### 8.5 WebSocket integration
+
+**`AUCTION_CANCELLED` envelope** added to `AuctionTopicEnvelope` union:
+
+```typescript
+export type AuctionCancelledEnvelope = {
+  type: "AUCTION_CANCELLED";
+  auctionId: number;
+  cancelledAt: string;
+  hadBids: boolean;
+};
+
+export type AuctionTopicEnvelope =
+  | AuctionEnvelope
+  | EscrowEnvelope
+  | ReviewRevealedEnvelope
+  | AuctionCancelledEnvelope;
+```
+
+`AuctionDetailClient` handles it by invalidating the auction query — page transitions to "auction cancelled" state in real time. Bidders mid-bid see their bid form replaced with a cancellation banner. `EscrowPageClient` ignores it (escrow doesn't exist for cancelled auctions).
+
+Closes the deferred ledger entry "Cancellation WS broadcast on active-auction cancel."
+
+### 8.6 No `PENALTY_CLEARED` push in sub-spec 2
+
+Banner state freshness depends on:
+- React Query `staleTime` on `/me` (default 30s)
+- Window-focus refetch when seller tabs back from SL after paying
+- Manual refresh
+
+A few seconds of staleness between L$ payment and banner dismissal is acceptable for the walk-in flow. Real-time push deferred until user-targeted WS queues land (existing deferred ledger item "User-targeted WebSocket queues").
+
+---
+
+## 9. Security & authorization
+
+- `/users/me/cancellation-status` and `/users/me/cancellation-history`: JWT required, scoped to caller (no cross-user reads).
+- `/sl/penalty-lookup` and `/sl/penalty-payment`: terminal auth via `X-SecondLife-Owner-Key` header. Existing pattern from escrow terminals (Epic 05). No JWT on these — terminals don't carry user JWTs.
+- `POST /auctions`: existing JWT requirement; gate is service-layer, not filter (visible in tests).
+- Idempotency on `/sl/penalty-payment`: `slTransactionId` is unique-indexed on `EscrowTransaction.slTransactionId` (existing unique constraint). Replay returns 200-with-current-balance instead of 409 for benign terminal retries.
+
+Penalty amounts and suspension dates are private data — only the user's own `/me/cancellation-status` exposes them. No cross-user visibility into another seller's debt or ban status; only the public profile signals (review count, completion rate from sub-spec 1) are externally visible.
+
+---
+
+## 10. Testing strategy
+
+### 10.1 Backend
+
+| Layer | Coverage |
+|---|---|
+| Unit (service) | `CancellationService.cancel` ladder branches at every offense level (0/1/2/3+); concurrent cancel race serialised at User row lock; `CancellationStatusService.preview` returns correct kind+amount per prior count; `OwnershipCheckTask` routes `CANCEL_AND_SELL` for cancelled-status auctions and clears `postCancelWatchUntil` after flag |
+| Slice (`@WebMvcTest`) | All 4 new endpoints: happy path, auth failures (401/403), 422 on overpayment, 404 on unknown avatar / zero balance, idempotent replay returns 200 with current balance |
+| Integration (`@SpringBootTest` + Testcontainers) | End-to-end: seller hits offense ladder 1→2→3→4 across 4 cancellations; ban applied; gate trips on `POST /auctions`; pay penalty at terminal partial then full; banner clears; ownership-watcher fires on a cancelled auction with parcel ownership change → `CANCEL_AND_SELL` flag created with evidence payload populated |
+
+Key test — **suspended-while-cancelling-existing-listing**: user is banned (offense #4 already happened), they cancel a 5th ACTIVE-with-bids auction → ladder records `PERMANENT_BAN` on log row, `bannedFromListing` stays true (no-op write), no new debt, watcher window still set on auction row.
+
+Key test — **partial payment idempotency**: pay L$600 with `txn-1`, balance L$400; replay `txn-1` → returns 200 with `remainingBalance: 400`, no double-debit; pay L$400 with `txn-2` → balance 0; replay `txn-2` → returns 200 with `remainingBalance: 0`; replay `txn-1` → still 200 with `remainingBalance: 0`.
+
+Key test — **ladder uses pre-INSERT count**: insert 3 prior cancelled-with-bids log rows manually, call `cancel()` on a 4th ACTIVE-with-bids auction, assert `penaltyKind == PERMANENT_BAN` on the new log row. (Verifies no off-by-one in count timing.)
+
+### 10.2 Frontend
+
+| File | Coverage |
+|---|---|
+| `CancelListingModal.test.tsx` | All 6 copy variants render correctly; ban-precedence branch wins over ladder-row branches |
+| `SuspensionBanner.test.tsx` | All 4 banner variants; renders nothing when `canCreateListing` |
+| `CancellationHistorySection.test.tsx` | Pagination, empty state, badge mapping per kind; reason text expand/collapse |
+| `useCancellationStatus.test.tsx` | Query key stability, cache invalidation on mutations |
+| `AuctionDetailClient.test.tsx` | `AUCTION_CANCELLED` envelope invalidates auction query; bid form replaced |
+| `app/listings/new/page.test.tsx` (or wizard) | 403 SellerSuspendedException with each `code` value routes to correct modal copy |
+
+MSW 2 with `onUnhandledRequest: "error"` for all hook + component tests.
+
+---
+
+## 11. Task breakdown
+
+Four tasks, sequenced via `superpowers:subagent-driven-development`.
+
+### Task 1 — Backend ladder + cancel-flow extensions
+- `User.penaltyBalanceOwed` + `User.bannedFromListing` columns
+- `Auction.postCancelWatchUntil` column
+- `CancellationLog.penaltyKind` + `CancellationLog.penaltyAmountL` columns + `CancellationOffenseKind` enum
+- New `FraudFlagReason.CANCEL_AND_SELL` value
+- New `EscrowTransactionType.LISTING_PENALTY_PAYMENT` value
+- `CancellationService.cancel` extension: pre-INSERT COUNT, ladder, postCancelWatchUntil set, `afterCommit` `AuctionCancelledEnvelope` broadcast
+- `AuctionCancelledEnvelope` record + broadcaster method on existing publisher
+- `CancellationPenaltyProperties` `@ConfigurationProperties` class + `application.yml` keys
+- Tests covering every ladder rung + concurrent-cancel race + WS broadcast firing
+
+### Task 2 — Backend gate + endpoints + watcher
+- `SellerSuspendedException` (→ 403) + `SuspensionReason` enum + ProblemDetail mapping
+- `AuctionService.create` gate (ban → timed → penalty order)
+- `GET /users/me/cancellation-status` controller + service
+- `GET /users/me/cancellation-history` controller + service (paginated)
+- Extend `/users/me` response shape
+- `AuctionRepository.findDueForOwnershipCheck` query extension (passes `now`)
+- `OwnershipCheckTask` status branch + `CANCEL_AND_SELL` evidence builder
+- Tests: gate by reason, status preview at every level, history pagination, watcher fires correctly + clears postCancelWatchUntil
+
+### Task 3 — Backend terminal payment endpoints
+- `PenaltyTerminalController` with `/sl/penalty-lookup` + `/sl/penalty-payment`
+- Idempotency on `slTransactionId` (existing unique-constraint reuse)
+- Pessimistic User-row lock during payment apply
+- `LISTING_PENALTY_PAYMENT` ledger row insertion
+- `SecurityConfig` updates for new `/sl/penalty-*` paths (terminal auth)
+- Tests: lookup happy + 404 paths, partial payment, full clear, idempotent replay, overpayment 422, simultaneous payments at two terminals serialise
+
+### Task 4 — Frontend
+- `types/cancellation.ts` + extend `types/auction.ts` with `AuctionCancelledEnvelope`
+- `lib/api/cancellations.ts` (2 fetchers)
+- `hooks/useCancellationStatus.ts` + `hooks/useCancellationHistory.ts`
+- `components/cancellation/CancellationConsequenceBadge.tsx`
+- `components/dashboard/SuspensionBanner.tsx` (4 variants)
+- `components/dashboard/CancellationHistorySection.tsx`
+- Modify `components/listing/CancelListingModal.tsx` — consequence-aware copy with ban-precedence branch
+- Modify `app/dashboard/(verified)/overview/page.tsx` — mount banner + history section
+- Modify `app/auction/[id]/AuctionDetailClient.tsx` — handle `AUCTION_CANCELLED`
+- Modify `lib/user.ts` (or wherever) — extend `/me` shape
+- Modify listing wizard — catch 403 `SellerSuspendedException` with structured `code`, route to right copy
+- Tests for all variants + 403 routing + WS handling
+
+---
+
+## 12. DEFERRED_WORK ledger changes
+
+**Resolve (delete):**
+- "Cancellation WS broadcast on active-auction cancel" — Section 8.5
+
+**Out of scope (carried forward):**
+- Admin endpoint for cancellation history — Epic 10
+- Admin lift action for permanent ban / penalty balance / timed suspension — Epic 10
+- Admin fraud-flag triage UI — Epic 10 (existing deferred entry, unchanged)
+- Email/IM notification of suspension events — Epic 09 (existing deferred entry, unchanged)
+- User-targeted WS queue infrastructure (`/user/{id}/queue/*`) — kept deferred (existing entry, unchanged)
+- Real-time `PENALTY_CLEARED` push — deferred behind the queue infrastructure
+- Cancellation reason categorisation / enum — kept free-text per Q3 of brainstorm
+- Automatic write-off / decay of penalty balance over time — admin-only, no design need today
+- LSL terminal-side script implementation — Phase 11
+- Notifications when listing is auto-cancelled by admin (separate flow) — Epic 10
+
+---
+
+## 13. Out of scope (explicit)
+
+- Spec's original "deduct from next payout" model — replaced by the user's pay-at-terminal model in Q1 of brainstorm
+- Spec's L$500 amount — replaced with L$1000 / L$2500 per user direction
+- Storing the "next consequence" on the user record — derived live from log row count
+- Visual cancellation-progression timeline on the dashboard — current row-per-cancellation history is sufficient
+- Auto-decay of cancelled_with_bids counter or penalty balance — no time-based forgiveness
+- Per-region or per-listing-class penalty schedules — flat ladder for all auctions
+
+---
+
+## 14. Open questions
+
+None. All design questions resolved in brainstorm Q1–Q5.
+
+---
+
+## 15. Cross-references
+
+- Sub-spec 1 (reviews & reputation, merged): `docs/superpowers/specs/2026-04-24-epic-08-sub-1-reviews-reputation.md`
+- Original epic doc: `docs/implementation/epic-08/08-ratings-and-reputation.md` + `task-03-cancellation-penalties.md`
+- DESIGN.md section 8 (Anti-Circumvention)
+- Epic 03 ownership-monitoring infrastructure: `backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/`
+- Epic 05 escrow terminal patterns: `backend/src/main/java/com/slparcelauctions/backend/escrow/command/TerminalCommandService.java`

--- a/frontend/src/app/auction/[id]/AuctionDetailClient.test.tsx
+++ b/frontend/src/app/auction/[id]/AuctionDetailClient.test.tsx
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act } from "react";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, waitFor } from "@/test/render";
+import { server } from "@/test/msw/server";
+import { fakePublicAuction } from "@/test/fixtures/auction";
+import type { Page } from "@/types/page";
+import type { BidHistoryEntry } from "@/types/auction";
+import { AuctionDetailClient } from "./AuctionDetailClient";
+
+// -------------------------------------------------------------
+// WebSocket module mock. Mirrors the EscrowPageClient test pattern —
+// we capture the envelope callback and drive AUCTION_CANCELLED into
+// it directly instead of running real STOMP / SockJS plumbing.
+// -------------------------------------------------------------
+const { subscribeMock, subscribeToConnectionStateMock, getConnectionStateMock } =
+  vi.hoisted(() => {
+    type WsStatus =
+      | "disconnected"
+      | "connecting"
+      | "connected"
+      | "reconnecting"
+      | "error";
+    return {
+      subscribeMock: vi.fn(),
+      subscribeToConnectionStateMock: vi.fn(),
+      getConnectionStateMock: vi.fn(() => ({
+        status: "connected" as WsStatus,
+      })),
+    };
+  });
+
+vi.mock("@/lib/ws/client", () => ({
+  subscribe: (...args: unknown[]) => subscribeMock(...args),
+  subscribeToConnectionState: (
+    listener: (state: { status: string }) => void,
+  ) => subscribeToConnectionStateMock(listener),
+  getConnectionState: getConnectionStateMock,
+}));
+
+const emptyBidPage: Page<BidHistoryEntry> = {
+  content: [],
+  totalElements: 0,
+  totalPages: 0,
+  number: 0,
+  size: 20,
+};
+
+describe("AuctionDetailClient — AUCTION_CANCELLED envelope", () => {
+  beforeEach(() => {
+    subscribeMock.mockReset();
+    subscribeMock.mockImplementation(() => () => {});
+    subscribeToConnectionStateMock.mockReset();
+    subscribeToConnectionStateMock.mockImplementation((listener) => {
+      listener({ status: "connected" });
+      return () => {};
+    });
+    getConnectionStateMock.mockReset();
+    getConnectionStateMock.mockReturnValue({ status: "connected" });
+  });
+
+  it("invalidates the auction + bid history queries when AUCTION_CANCELLED arrives", async () => {
+    const initialAuction = fakePublicAuction({
+      id: 7,
+      status: "ACTIVE",
+      seller: {
+        id: 42,
+        displayName: "Seller",
+        avatarUrl: null,
+        averageRating: null,
+        reviewCount: null,
+        completedSales: 0,
+        completionRate: null,
+        memberSince: null,
+      },
+    });
+
+    let auctionFetchCount = 0;
+    let bidHistoryFetchCount = 0;
+    server.use(
+      http.get("*/api/v1/auctions/7", () => {
+        auctionFetchCount += 1;
+        // Keep the auction ACTIVE on the refetch so the page does not
+        // mount AuctionEndedPanel — the public DTO collapses CANCELLED
+        // to ENDED but the panel requires a populated endOutcome to
+        // render. The test's contract is "the invalidation fires", not
+        // "the page transitions" — both are observed by the fetch
+        // counter incrementing.
+        return HttpResponse.json(initialAuction);
+      }),
+      http.get("*/api/v1/auctions/7/bids", () => {
+        bidHistoryFetchCount += 1;
+        return HttpResponse.json(emptyBidPage);
+      }),
+    );
+
+    renderWithProviders(
+      <AuctionDetailClient
+        initialAuction={initialAuction}
+        initialBidPage={emptyBidPage}
+      />,
+      { auth: "anonymous" },
+    );
+
+    // Drive the envelope through the captured handler.
+    const handler = subscribeMock.mock.calls[0]?.[1] as (
+      env: unknown,
+    ) => void;
+    expect(handler).toBeDefined();
+
+    const initialAuctionFetches = auctionFetchCount;
+    const initialBidFetches = bidHistoryFetchCount;
+
+    act(() => {
+      handler({
+        type: "AUCTION_CANCELLED",
+        auctionId: 7,
+        cancelledAt: "2026-04-25T12:00:00Z",
+        hadBids: true,
+      });
+    });
+
+    // The handler invalidates ["auction", id] + ["bids", id, 0] +
+    // myProxy. The first two refetch via MSW; assert their counts
+    // increased.
+    await waitFor(() => {
+      expect(auctionFetchCount).toBeGreaterThan(initialAuctionFetches);
+    });
+    await waitFor(() => {
+      expect(bidHistoryFetchCount).toBeGreaterThan(initialBidFetches);
+    });
+  });
+});

--- a/frontend/src/app/auction/[id]/AuctionDetailClient.tsx
+++ b/frontend/src/app/auction/[id]/AuctionDetailClient.tsx
@@ -170,6 +170,21 @@ export function AuctionDetailClient({ initialAuction, initialBidPage }: Props) {
         return;
       }
 
+      // AUCTION_CANCELLED envelopes (Epic 08 sub-spec 2 §8.5) flip the
+      // auction into the CANCELLED status. Like REVIEW_REVEALED, they do
+      // not carry {@code serverTime} — handle them before the offset
+      // refresh below. The invalidation refetches the public auction DTO
+      // so the next render observes {@code status === "CANCELLED"} and
+      // the bid form is replaced by the cancellation banner. {@code
+      // myProxyKey} is also invalidated so any active proxy bid surfaces
+      // its cancelled state.
+      if (env.type === "AUCTION_CANCELLED") {
+        queryClient.invalidateQueries({ queryKey: auctionKey(id) });
+        queryClient.invalidateQueries({ queryKey: bidHistoryKey(id, 0) });
+        queryClient.invalidateQueries({ queryKey: myProxyKey(id) });
+        return;
+      }
+
       // Refine the server-time offset on every envelope so the countdown
       // stays accurate even if the user's clock drifts mid-session.
       serverTimeOffsetRef.current =
@@ -228,9 +243,10 @@ export function AuctionDetailClient({ initialAuction, initialBidPage }: Props) {
               bidderCount: env.bidCount,
             };
           }
-          // Any other envelope type (ESCROW_*, REVIEW_REVEALED) is already
-          // handled by the early-returns above and never reaches this
-          // callback — leave the cache untouched as a defensive fallback.
+          // Any other envelope type (ESCROW_*, REVIEW_REVEALED,
+          // AUCTION_CANCELLED) is already handled by the early-returns
+          // above and never reaches this callback — leave the cache
+          // untouched as a defensive fallback.
           return prev;
         },
       );

--- a/frontend/src/app/dashboard/(verified)/overview/page.tsx
+++ b/frontend/src/app/dashboard/(verified)/overview/page.tsx
@@ -1,21 +1,37 @@
 "use client";
 
+import { CancellationHistorySection } from "@/components/dashboard/CancellationHistorySection";
+import { SuspensionBanner } from "@/components/dashboard/SuspensionBanner";
 import { PendingReviewsSection } from "@/components/reviews/PendingReviewsSection";
 import { VerifiedOverview } from "@/components/user/VerifiedOverview";
 
 /**
- * Verified-dashboard landing page. Renders the time-bound
- * {@link PendingReviewsSection} at the top — reviewing a completed sale is
- * a higher-priority CTA than identity / profile maintenance because the
- * review window closes. The section collapses to {@code null} when the
- * viewer has no pending reviews, so established users see their normal
- * identity / profile layout unchanged.
+ * Verified-dashboard landing page. Section ordering reflects priority:
+ *
+ * <ol>
+ *   <li>{@link SuspensionBanner} (Epic 08 sub-spec 2 §8.2) — surfaces a
+ *       penalty / suspension / ban so the seller sees it before anything
+ *       else. Returns {@code null} on a clean account.</li>
+ *   <li>{@link PendingReviewsSection} (Epic 08 sub-spec 1 §8.4) — the
+ *       review window closes, so the CTA is more urgent than identity
+ *       maintenance.</li>
+ *   <li>{@link VerifiedOverview} — long-form identity + profile chrome.</li>
+ *   <li>{@link CancellationHistorySection} (Epic 08 sub-spec 2 §8.3) —
+ *       informational, lowest priority. Renders an empty-state card
+ *       when the seller has no cancellations on record.</li>
+ * </ol>
+ *
+ * <p>Each section short-circuits independently when there is nothing to
+ * show, so an established user with a clean record sees the same layout
+ * they had before sub-spec 2 landed.
  */
 export default function OverviewPage() {
   return (
     <div className="flex flex-col gap-8">
+      <SuspensionBanner />
       <PendingReviewsSection />
       <VerifiedOverview />
+      <CancellationHistorySection />
     </div>
   );
 }

--- a/frontend/src/components/cancellation/CancellationConsequenceBadge.test.tsx
+++ b/frontend/src/components/cancellation/CancellationConsequenceBadge.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { renderWithProviders, screen } from "@/test/render";
+import { CancellationConsequenceBadge } from "./CancellationConsequenceBadge";
+
+describe("CancellationConsequenceBadge", () => {
+  it("renders 'No penalty' when kind is null", () => {
+    renderWithProviders(
+      <CancellationConsequenceBadge kind={null} amountL={null} />,
+    );
+    const badge = screen.getByTestId("cancellation-consequence-badge");
+    expect(badge).toHaveTextContent("No penalty");
+    // default tone uses on-surface-variant text
+    expect(badge.className).toMatch(/text-on-surface-variant/);
+  });
+
+  it("renders 'No penalty' when kind is NONE", () => {
+    renderWithProviders(
+      <CancellationConsequenceBadge kind="NONE" amountL={null} />,
+    );
+    expect(screen.getByTestId("cancellation-consequence-badge")).toHaveTextContent(
+      "No penalty",
+    );
+  });
+
+  it("renders 'Warning' on WARNING with warning tone", () => {
+    renderWithProviders(
+      <CancellationConsequenceBadge kind="WARNING" amountL={null} />,
+    );
+    const badge = screen.getByTestId("cancellation-consequence-badge");
+    expect(badge).toHaveTextContent("Warning");
+    expect(badge.className).toMatch(/secondary-container/);
+  });
+
+  it("formats the L$ amount with locale grouping on PENALTY", () => {
+    renderWithProviders(
+      <CancellationConsequenceBadge kind="PENALTY" amountL={1000} />,
+    );
+    const badge = screen.getByTestId("cancellation-consequence-badge");
+    expect(badge).toHaveTextContent("L$1,000 penalty");
+    expect(badge.className).toMatch(/error-container/);
+  });
+
+  it("renders the combined copy on PENALTY_AND_30D", () => {
+    renderWithProviders(
+      <CancellationConsequenceBadge kind="PENALTY_AND_30D" amountL={2500} />,
+    );
+    const badge = screen.getByTestId("cancellation-consequence-badge");
+    expect(badge).toHaveTextContent("L$2,500 + 30-day suspension");
+    expect(badge.className).toMatch(/error-container/);
+  });
+
+  it("renders 'Permanent ban' on PERMANENT_BAN", () => {
+    renderWithProviders(
+      <CancellationConsequenceBadge kind="PERMANENT_BAN" amountL={null} />,
+    );
+    const badge = screen.getByTestId("cancellation-consequence-badge");
+    expect(badge).toHaveTextContent("Permanent ban");
+    expect(badge.className).toMatch(/error-container/);
+  });
+
+  it("falls back to '0' when amountL is null on a PENALTY", () => {
+    // Defensive — backend should always populate amountL on the L$
+    // rungs, but the UI mustn't crash if a stray null arrives.
+    renderWithProviders(
+      <CancellationConsequenceBadge kind="PENALTY" amountL={null} />,
+    );
+    expect(screen.getByTestId("cancellation-consequence-badge")).toHaveTextContent(
+      "L$0 penalty",
+    );
+  });
+});

--- a/frontend/src/components/cancellation/CancellationConsequenceBadge.tsx
+++ b/frontend/src/components/cancellation/CancellationConsequenceBadge.tsx
@@ -1,0 +1,88 @@
+import { StatusBadge } from "@/components/ui/StatusBadge";
+import type { CancellationOffenseKind } from "@/types/cancellation";
+
+export interface CancellationConsequenceBadgeProps {
+  /**
+   * The snapshotted offense kind from the cancellation log row.
+   * {@code null} indicates the row had no penalty payload (the log's
+   * {@code penaltyKind} was {@code NONE}, e.g. a pre-active or
+   * active-without-bids cancellation), which the UI renders as the same
+   * "No penalty" badge as an explicit {@code NONE}.
+   */
+  kind: CancellationOffenseKind | null;
+  /**
+   * L$ amount snapshotted on the log row at the time of cancellation.
+   * Only read for {@code PENALTY} / {@code PENALTY_AND_30D} where the
+   * label includes the figure; ignored otherwise.
+   */
+  amountL: number | null;
+}
+
+/**
+ * Maps a {@link CancellationOffenseKind} to a {@link StatusBadge} on the
+ * existing tone palette. Sub-spec 2 §8.3 requires:
+ *
+ * <ul>
+ *   <li>{@code null} / {@code NONE} → "No penalty" (default tone)</li>
+ *   <li>{@code WARNING} → "Warning" (warning tone)</li>
+ *   <li>{@code PENALTY} → "L${amount} penalty" (danger tone)</li>
+ *   <li>{@code PENALTY_AND_30D} → "L${amount} + 30-day suspension"
+ *       (danger tone)</li>
+ *   <li>{@code PERMANENT_BAN} → "Permanent ban" (danger tone)</li>
+ * </ul>
+ *
+ * <p>The amount is rendered with the standard browser locale formatter
+ * so a value of {@code 2500} reads as {@code 2,500} in en-US.
+ */
+export function CancellationConsequenceBadge({
+  kind,
+  amountL,
+}: CancellationConsequenceBadgeProps) {
+  if (!kind || kind === "NONE") {
+    return (
+      <StatusBadge tone="default" data-testid="cancellation-consequence-badge">
+        No penalty
+      </StatusBadge>
+    );
+  }
+  switch (kind) {
+    case "WARNING":
+      return (
+        <StatusBadge
+          tone="warning"
+          data-testid="cancellation-consequence-badge"
+        >
+          Warning
+        </StatusBadge>
+      );
+    case "PENALTY":
+      return (
+        <StatusBadge
+          tone="danger"
+          data-testid="cancellation-consequence-badge"
+        >
+          L${(amountL ?? 0).toLocaleString()} penalty
+        </StatusBadge>
+      );
+    case "PENALTY_AND_30D":
+      return (
+        <StatusBadge
+          tone="danger"
+          data-testid="cancellation-consequence-badge"
+        >
+          L${(amountL ?? 0).toLocaleString()} + 30-day suspension
+        </StatusBadge>
+      );
+    case "PERMANENT_BAN":
+      return (
+        <StatusBadge
+          tone="danger"
+          data-testid="cancellation-consequence-badge"
+        >
+          Permanent ban
+        </StatusBadge>
+      );
+    default:
+      return null;
+  }
+}

--- a/frontend/src/components/dashboard/CancellationHistorySection.test.tsx
+++ b/frontend/src/components/dashboard/CancellationHistorySection.test.tsx
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/test/render";
+import { server } from "@/test/msw/server";
+import type { CancellationHistoryDto } from "@/types/cancellation";
+import type { Page } from "@/types/page";
+import { CancellationHistorySection } from "./CancellationHistorySection";
+
+function makeRow(
+  overrides: Partial<CancellationHistoryDto> = {},
+): CancellationHistoryDto {
+  return {
+    auctionId: 1,
+    auctionTitle: "Aurora Parcel",
+    primaryPhotoUrl: null,
+    cancelledFromStatus: "ACTIVE",
+    hadBids: true,
+    reason: "Buyer changed mind.",
+    cancelledAt: "2026-04-20T10:00:00Z",
+    penaltyApplied: { kind: "PENALTY", amountL: 1000 },
+    ...overrides,
+  };
+}
+
+function makePage(
+  content: CancellationHistoryDto[] = [],
+  overrides: Partial<Page<CancellationHistoryDto>> = {},
+): Page<CancellationHistoryDto> {
+  return {
+    content,
+    totalElements: content.length,
+    totalPages: Math.max(1, Math.ceil(content.length / 10)),
+    number: 0,
+    size: 10,
+    ...overrides,
+  };
+}
+
+describe("CancellationHistorySection", () => {
+  it("renders nothing while loading", () => {
+    server.use(
+      http.get("*/api/v1/users/me/cancellation-history", async () => {
+        await new Promise((r) => setTimeout(r, 200));
+        return HttpResponse.json(makePage());
+      }),
+    );
+    renderWithProviders(<CancellationHistorySection />, {
+      auth: "authenticated",
+    });
+    expect(
+      screen.queryByTestId("cancellation-history-section"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the empty-state card when there are no cancellations", async () => {
+    server.use(
+      http.get("*/api/v1/users/me/cancellation-history", () =>
+        HttpResponse.json(makePage()),
+      ),
+    );
+    renderWithProviders(<CancellationHistorySection />, {
+      auth: "authenticated",
+    });
+    const section = await screen.findByTestId("cancellation-history-section");
+    expect(section.dataset.variant).toBe("empty");
+    expect(section).toHaveTextContent(/no cancellations yet/i);
+  });
+
+  it("renders a row per cancellation with badge mapped from the kind", async () => {
+    const rows = [
+      makeRow({
+        auctionId: 1,
+        auctionTitle: "Aurora Parcel",
+        penaltyApplied: { kind: "WARNING", amountL: null },
+      }),
+      makeRow({
+        auctionId: 2,
+        auctionTitle: "Lakeview Shore",
+        penaltyApplied: { kind: "PENALTY_AND_30D", amountL: 2500 },
+      }),
+      makeRow({
+        auctionId: 3,
+        auctionTitle: "Skyhigh Plot",
+        penaltyApplied: null,
+      }),
+    ];
+    server.use(
+      http.get("*/api/v1/users/me/cancellation-history", () =>
+        HttpResponse.json(makePage(rows)),
+      ),
+    );
+    renderWithProviders(<CancellationHistorySection />, {
+      auth: "authenticated",
+    });
+
+    expect(
+      await screen.findByText("Aurora Parcel"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Lakeview Shore")).toBeInTheDocument();
+    expect(screen.getByText("Skyhigh Plot")).toBeInTheDocument();
+
+    const badges = screen.getAllByTestId("cancellation-consequence-badge");
+    expect(badges).toHaveLength(3);
+    expect(badges[0]).toHaveTextContent("Warning");
+    expect(badges[1]).toHaveTextContent("L$2,500 + 30-day suspension");
+    expect(badges[2]).toHaveTextContent("No penalty");
+  });
+
+  it("expands and collapses the reason via the toggle button", async () => {
+    server.use(
+      http.get("*/api/v1/users/me/cancellation-history", () =>
+        HttpResponse.json(makePage([makeRow({ reason: "Buyer changed mind." })])),
+      ),
+    );
+    renderWithProviders(<CancellationHistorySection />, {
+      auth: "authenticated",
+    });
+
+    const toggle = await screen.findByTestId("cancellation-reason-toggle");
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(
+      screen.queryByTestId("cancellation-reason-text"),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("cancellation-reason-text")).toHaveTextContent(
+      "Buyer changed mind.",
+    );
+
+    await userEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(
+      screen.queryByTestId("cancellation-reason-text"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render the reason toggle when the row has no reason", async () => {
+    server.use(
+      http.get("*/api/v1/users/me/cancellation-history", () =>
+        HttpResponse.json(makePage([makeRow({ reason: "" })])),
+      ),
+    );
+    renderWithProviders(<CancellationHistorySection />, {
+      auth: "authenticated",
+    });
+    await screen.findByText("Aurora Parcel");
+    expect(
+      screen.queryByTestId("cancellation-reason-toggle"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("paginates and refetches when the user clicks a different page", async () => {
+    const pageZero = makePage(
+      [makeRow({ auctionId: 1, auctionTitle: "Page 0 row" })],
+      { totalElements: 12, totalPages: 2, number: 0, size: 10 },
+    );
+    const pageOne = makePage(
+      [makeRow({ auctionId: 99, auctionTitle: "Page 1 row" })],
+      { totalElements: 12, totalPages: 2, number: 1, size: 10 },
+    );
+    server.use(
+      http.get("*/api/v1/users/me/cancellation-history", ({ request }) => {
+        const url = new URL(request.url);
+        return HttpResponse.json(
+          url.searchParams.get("page") === "1" ? pageOne : pageZero,
+        );
+      }),
+    );
+
+    renderWithProviders(<CancellationHistorySection />, {
+      auth: "authenticated",
+    });
+    expect(await screen.findByText("Page 0 row")).toBeInTheDocument();
+
+    const pageTwoButton = screen.getByRole("button", { name: /page 2/i });
+    await userEvent.click(pageTwoButton);
+
+    await waitFor(() =>
+      expect(screen.getByText("Page 1 row")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Page 0 row")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/CancellationHistorySection.tsx
+++ b/frontend/src/components/dashboard/CancellationHistorySection.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState } from "react";
+import { Card } from "@/components/ui/Card";
+import { ChevronDown, ChevronUp } from "@/components/ui/icons";
+import { Pagination } from "@/components/ui/Pagination";
+import { cn } from "@/lib/cn";
+import { useCancellationHistory } from "@/hooks/useCancellationHistory";
+import type { CancellationHistoryDto } from "@/types/cancellation";
+import { CancellationConsequenceBadge } from "@/components/cancellation/CancellationConsequenceBadge";
+
+/**
+ * Renders {@code cancelledAt} as a stable date label. Hour-precision is
+ * dropped on purpose — the row already conveys "this happened at some
+ * point" and a precise timestamp adds noise without value.
+ */
+function formatCancelledAt(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function CancellationHistoryRow({ row }: { row: CancellationHistoryDto }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasReason = row.reason != null && row.reason.trim().length > 0;
+  const reasonId = `cancellation-reason-${row.auctionId}`;
+
+  return (
+    <li
+      className="flex flex-col gap-3 rounded-default bg-surface-container-low p-4 ring-1 ring-outline-variant"
+      data-testid="cancellation-history-row"
+      data-auction-id={row.auctionId}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="relative h-20 w-full shrink-0 overflow-hidden rounded-default bg-surface-container sm:w-28">
+          {row.primaryPhotoUrl && (
+            // eslint-disable-next-line @next/next/no-img-element -- Deferred: swap to next/image when backend returns image dimensions + a stable remotePatterns list for SL CDN hosts is agreed upon. Matches the PendingReviewsSection deferral.
+            <img
+              src={row.primaryPhotoUrl}
+              alt=""
+              className="h-full w-full object-cover"
+              loading="lazy"
+            />
+          )}
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <span className="truncate text-title-md font-bold text-on-surface">
+            {row.auctionTitle}
+          </span>
+          <p className="text-label-sm text-on-surface-variant">
+            Cancelled {formatCancelledAt(row.cancelledAt)} ·{" "}
+            {row.cancelledFromStatus}
+            {row.hadBids ? " · had bids" : ""}
+          </p>
+        </div>
+        <div className="shrink-0">
+          <CancellationConsequenceBadge
+            kind={row.penaltyApplied?.kind ?? null}
+            amountL={row.penaltyApplied?.amountL ?? null}
+          />
+        </div>
+      </div>
+      {hasReason && (
+        <div className="flex flex-col gap-1">
+          <button
+            type="button"
+            onClick={() => setExpanded((prev) => !prev)}
+            aria-expanded={expanded}
+            aria-controls={reasonId}
+            data-testid="cancellation-reason-toggle"
+            className="inline-flex items-center gap-1 self-start rounded-default text-label-sm text-on-surface-variant hover:text-on-surface focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+          >
+            {expanded ? (
+              <ChevronUp className="size-4" aria-hidden="true" />
+            ) : (
+              <ChevronDown className="size-4" aria-hidden="true" />
+            )}
+            {expanded ? "Hide reason" : "Show reason"}
+          </button>
+          {expanded && (
+            <p
+              id={reasonId}
+              className={cn(
+                "rounded-default bg-surface-container px-3 py-2 text-body-sm text-on-surface",
+              )}
+              data-testid="cancellation-reason-text"
+            >
+              {row.reason}
+            </p>
+          )}
+        </div>
+      )}
+    </li>
+  );
+}
+
+/**
+ * Dashboard "Cancellation history" card (Epic 08 sub-spec 2 §8.3). Renders
+ * a paginated, newest-first list of the seller's prior cancellations,
+ * each annotated with a {@link CancellationConsequenceBadge} mapped from
+ * the snapshotted log row's penalty payload. The section short-circuits
+ * to {@code null} when the page is loading or errored — matches the
+ * established {@code PendingReviewsSection} pattern from Sub-spec 1, so a
+ * failed fetch never poisons the dashboard.
+ *
+ * <p>An explicit empty-state card renders "No cancellations yet." when the
+ * seller has a clean record and the response is just an empty page. The
+ * empty card still renders so the section is discoverable from the
+ * dashboard — sellers can see "this is where my cancellations would
+ * appear" before they hit the ladder, which is informational, not
+ * accusatory.
+ */
+export function CancellationHistorySection({
+  className,
+}: { className?: string } = {}) {
+  const [page, setPage] = useState(0);
+  const { data, isPending, isError } = useCancellationHistory(page);
+
+  if (isPending || isError) return null;
+
+  if (data.totalElements === 0) {
+    return (
+      <Card
+        className={className}
+        data-testid="cancellation-history-section"
+        data-variant="empty"
+      >
+        <Card.Header>
+          <h2 className="text-title-md font-bold">Cancellation history</h2>
+        </Card.Header>
+        <Card.Body>
+          <p className="text-body-md text-on-surface-variant">
+            No cancellations yet.
+          </p>
+        </Card.Body>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={className} data-testid="cancellation-history-section">
+      <Card.Header>
+        <h2 className="text-title-md font-bold">Cancellation history</h2>
+      </Card.Header>
+      <Card.Body>
+        <ul className="flex flex-col gap-3">
+          {data.content.map((row) => (
+            <CancellationHistoryRow key={row.auctionId} row={row} />
+          ))}
+        </ul>
+      </Card.Body>
+      {data.totalPages > 1 && (
+        <Card.Footer>
+          <Pagination
+            page={page}
+            totalPages={data.totalPages}
+            onPageChange={setPage}
+          />
+        </Card.Footer>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/components/dashboard/SuspensionBanner.test.tsx
+++ b/frontend/src/components/dashboard/SuspensionBanner.test.tsx
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, screen, waitFor } from "@/test/render";
+import { server } from "@/test/msw/server";
+import { mockVerifiedCurrentUser } from "@/test/msw/fixtures";
+import type { CurrentUser } from "@/lib/user/api";
+import { SuspensionBanner } from "./SuspensionBanner";
+
+function makeMe(overrides: Partial<CurrentUser> = {}): CurrentUser {
+  return {
+    ...mockVerifiedCurrentUser,
+    ...overrides,
+  };
+}
+
+function farFutureIso(): string {
+  return new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+}
+
+describe("SuspensionBanner", () => {
+  it("returns null while the /me query is still loading", () => {
+    server.use(
+      http.get("*/api/v1/users/me", async () => {
+        // Delay so the query never resolves before the assertion runs.
+        await new Promise((r) => setTimeout(r, 200));
+        return HttpResponse.json(makeMe());
+      }),
+    );
+    renderWithProviders(<SuspensionBanner />, { auth: "authenticated" });
+    expect(screen.queryByTestId("suspension-banner")).not.toBeInTheDocument();
+  });
+
+  it("returns null when the user has a clean account", async () => {
+    server.use(
+      http.get("*/api/v1/users/me", () => HttpResponse.json(makeMe())),
+    );
+    renderWithProviders(<SuspensionBanner />, { auth: "authenticated" });
+    // Wait for a turn so the query has a chance to resolve, then assert null.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(screen.queryByTestId("suspension-banner")).not.toBeInTheDocument();
+  });
+
+  it("renders the permanent-ban variant when bannedFromListing is true", async () => {
+    server.use(
+      http.get("*/api/v1/users/me", () =>
+        HttpResponse.json(
+          makeMe({
+            bannedFromListing: true,
+            // Banned takes precedence even when other suspensions are set.
+            penaltyBalanceOwed: 1000,
+            listingSuspensionUntil: farFutureIso(),
+          }),
+        ),
+      ),
+    );
+    renderWithProviders(<SuspensionBanner />, { auth: "authenticated" });
+    const banner = await screen.findByTestId("suspension-banner");
+    expect(banner.dataset.variant).toBe("banned");
+    expect(banner.className).toMatch(/error-container/);
+    expect(banner).toHaveTextContent(
+      /listing privileges have been permanently suspended/i,
+    );
+    expect(banner).toHaveTextContent(/contact support/i);
+  });
+
+  it("renders the timed-and-debt variant when both suspensions are active", async () => {
+    server.use(
+      http.get("*/api/v1/users/me", () =>
+        HttpResponse.json(
+          makeMe({
+            bannedFromListing: false,
+            penaltyBalanceOwed: 2500,
+            listingSuspensionUntil: farFutureIso(),
+          }),
+        ),
+      ),
+    );
+    renderWithProviders(<SuspensionBanner />, { auth: "authenticated" });
+    const banner = await screen.findByTestId("suspension-banner");
+    expect(banner.dataset.variant).toBe("timed-and-debt");
+    expect(banner.className).toMatch(/secondary-container/);
+    expect(banner).toHaveTextContent(/listing suspended until/i);
+    expect(banner).toHaveTextContent(/L\$2,500/);
+    expect(banner).toHaveTextContent(/visit any slpa terminal/i);
+  });
+
+  it("renders the timed-only variant when only the suspension is active", async () => {
+    server.use(
+      http.get("*/api/v1/users/me", () =>
+        HttpResponse.json(
+          makeMe({
+            bannedFromListing: false,
+            penaltyBalanceOwed: 0,
+            listingSuspensionUntil: farFutureIso(),
+          }),
+        ),
+      ),
+    );
+    renderWithProviders(<SuspensionBanner />, { auth: "authenticated" });
+    const banner = await screen.findByTestId("suspension-banner");
+    expect(banner.dataset.variant).toBe("timed-only");
+    expect(banner).toHaveTextContent(/listing suspended until/i);
+    expect(banner).not.toHaveTextContent(/L\$/);
+  });
+
+  it("renders the debt-only variant when only the penalty is outstanding", async () => {
+    server.use(
+      http.get("*/api/v1/users/me", () =>
+        HttpResponse.json(
+          makeMe({
+            bannedFromListing: false,
+            penaltyBalanceOwed: 1000,
+            listingSuspensionUntil: null,
+          }),
+        ),
+      ),
+    );
+    renderWithProviders(<SuspensionBanner />, { auth: "authenticated" });
+    const banner = await screen.findByTestId("suspension-banner");
+    expect(banner.dataset.variant).toBe("debt-only");
+    expect(banner).toHaveTextContent(/L\$1,000 in cancellation penalties/i);
+    expect(banner).toHaveTextContent(/visit any slpa terminal/i);
+  });
+
+  it("treats an expired listingSuspensionUntil as no timed suspension", async () => {
+    server.use(
+      http.get("*/api/v1/users/me", () =>
+        HttpResponse.json(
+          makeMe({
+            bannedFromListing: false,
+            penaltyBalanceOwed: 0,
+            listingSuspensionUntil: "2020-01-01T00:00:00Z",
+          }),
+        ),
+      ),
+    );
+    renderWithProviders(<SuspensionBanner />, { auth: "authenticated" });
+    await waitFor(() => {
+      expect(screen.queryByTestId("suspension-banner")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/dashboard/SuspensionBanner.tsx
+++ b/frontend/src/components/dashboard/SuspensionBanner.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { Card } from "@/components/ui/Card";
+import { useCurrentUser } from "@/lib/user";
+
+/**
+ * Date formatter for the timed-suspension copy. Uses the user's locale via
+ * the browser default and a sensible "Apr 25, 2026" format. Hour-precision
+ * isn't shown — the suspension reads naturally on a calendar day boundary.
+ */
+function formatSuspensionDate(date: Date): string {
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/**
+ * L$ amount formatter shared between the timed+debt and debt-only variants.
+ * Uses the standard locale grouping so {@code 2500} reads as {@code 2,500}.
+ */
+function formatPenalty(amountL: number): string {
+  return `L$${amountL.toLocaleString()}`;
+}
+
+/**
+ * Dashboard banner that surfaces the seller's listing-suspension state
+ * (Epic 08 sub-spec 2 §8.2). Renders one of four variants based on the
+ * current {@code /me} payload, in priority order:
+ *
+ * <ol>
+ *   <li>{@code bannedFromListing} — permanent ban; takes precedence over
+ *       any other state.</li>
+ *   <li>Timed suspension AND outstanding penalty — combined copy directing
+ *       the seller to a terminal.</li>
+ *   <li>Timed suspension only.</li>
+ *   <li>Outstanding penalty only.</li>
+ * </ol>
+ *
+ * <p>Returns {@code null} when the seller can create listings (no ban,
+ * no active timed suspension, no outstanding L$ debt). The banner does
+ * NOT include a "Pay now" button — sub-spec 2 ships the walk-in payment
+ * model only; payment happens at any SLPA terminal in-world.
+ *
+ * <p>Banner state freshness depends on the existing window-focus refetch
+ * on {@code useCurrentUser} plus a 60s {@code staleTime} on the {@code /me}
+ * query. No WS push for {@code PENALTY_CLEARED} ships in sub-spec 2.
+ */
+export function SuspensionBanner() {
+  const { data: user } = useCurrentUser();
+  if (!user) return null;
+
+  const banned = user.bannedFromListing;
+  const suspendedUntilRaw = user.listingSuspensionUntil;
+  const suspendedUntil = suspendedUntilRaw ? new Date(suspendedUntilRaw) : null;
+  const isTimedSuspended = suspendedUntil != null && suspendedUntil > new Date();
+  const owesPenalty = (user.penaltyBalanceOwed ?? 0) > 0;
+
+  if (banned) {
+    return (
+      <Card
+        className="bg-error-container text-on-error-container"
+        data-testid="suspension-banner"
+        data-variant="banned"
+        role="alert"
+      >
+        <Card.Body>
+          <p className="text-body-md">
+            Your listing privileges have been permanently suspended. Contact
+            support to request a review.
+          </p>
+        </Card.Body>
+      </Card>
+    );
+  }
+
+  if (isTimedSuspended && owesPenalty && suspendedUntil) {
+    return (
+      <Card
+        className="bg-secondary-container text-on-secondary-container"
+        data-testid="suspension-banner"
+        data-variant="timed-and-debt"
+        role="alert"
+      >
+        <Card.Body>
+          <p className="text-body-md">
+            Listing suspended until {formatSuspensionDate(suspendedUntil)}. You
+            also owe{" "}
+            <strong className="font-bold">
+              {formatPenalty(user.penaltyBalanceOwed)}
+            </strong>
+            . Visit any SLPA terminal to pay.
+          </p>
+        </Card.Body>
+      </Card>
+    );
+  }
+
+  if (isTimedSuspended && suspendedUntil) {
+    return (
+      <Card
+        className="bg-secondary-container text-on-secondary-container"
+        data-testid="suspension-banner"
+        data-variant="timed-only"
+        role="alert"
+      >
+        <Card.Body>
+          <p className="text-body-md">
+            Listing suspended until {formatSuspensionDate(suspendedUntil)}.
+          </p>
+        </Card.Body>
+      </Card>
+    );
+  }
+
+  if (owesPenalty) {
+    return (
+      <Card
+        className="bg-secondary-container text-on-secondary-container"
+        data-testid="suspension-banner"
+        data-variant="debt-only"
+        role="alert"
+      >
+        <Card.Body>
+          <p className="text-body-md">
+            You owe{" "}
+            <strong className="font-bold">
+              {formatPenalty(user.penaltyBalanceOwed)}
+            </strong>{" "}
+            in cancellation penalties. Visit any SLPA terminal to pay and
+            resume listing.
+          </p>
+        </Card.Body>
+      </Card>
+    );
+  }
+
+  return null;
+}

--- a/frontend/src/components/listing/CancelListingModal.test.tsx
+++ b/frontend/src/components/listing/CancelListingModal.test.tsx
@@ -7,8 +7,17 @@ import {
   waitFor,
 } from "@/test/render";
 import { server } from "@/test/msw/server";
+import { mockVerifiedCurrentUser } from "@/test/msw/fixtures";
 import type { SellerAuctionResponse } from "@/types/auction";
-import { CancelListingModal } from "./CancelListingModal";
+import type {
+  CancellationOffenseKind,
+  CancellationStatusResponse,
+} from "@/types/cancellation";
+import type { CurrentUser } from "@/lib/user/api";
+import {
+  CancelListingModal,
+  resolveCopyVariant,
+} from "./CancelListingModal";
 
 const push = vi.fn();
 vi.mock("next/navigation", () => ({
@@ -87,8 +96,232 @@ function baseAuction(
   };
 }
 
+function makeMe(overrides: Partial<CurrentUser> = {}): CurrentUser {
+  return { ...mockVerifiedCurrentUser, ...overrides };
+}
+
+function makeStatus(
+  priorOffensesWithBids: number,
+  nextKind: CancellationOffenseKind = "WARNING",
+  amountL: number | null = null,
+): CancellationStatusResponse {
+  return {
+    priorOffensesWithBids,
+    currentSuspension: {
+      penaltyBalanceOwed: 0,
+      listingSuspensionUntil: null,
+      bannedFromListing: false,
+    },
+    nextConsequenceIfBidsPresent: {
+      kind: nextKind,
+      amountL,
+      suspends30Days: nextKind === "PENALTY_AND_30D",
+      permanentBan: nextKind === "PERMANENT_BAN",
+    },
+  };
+}
+
+/**
+ * Common MSW seeding for the consequence-aware copy renders. Wires both
+ * {@code /me} and {@code /me/cancellation-status} so the modal has the
+ * data it needs to compute the variant on the first paint.
+ */
+function seedHandlers(user: CurrentUser, status: CancellationStatusResponse) {
+  server.use(
+    http.get("*/api/v1/users/me", () => HttpResponse.json(user)),
+    http.get("*/api/v1/users/me/cancellation-status", () =>
+      HttpResponse.json(status),
+    ),
+  );
+}
+
+describe("resolveCopyVariant", () => {
+  it("returns BANNED first regardless of priors or bid count", () => {
+    expect(
+      resolveCopyVariant({
+        bannedFromListing: true,
+        bidCount: 5,
+        priorOffensesWithBids: 0,
+      }),
+    ).toBe("BANNED");
+    expect(
+      resolveCopyVariant({
+        bannedFromListing: true,
+        bidCount: 0,
+        priorOffensesWithBids: 99,
+      }),
+    ).toBe("BANNED");
+  });
+
+  it("returns NO_BIDS when bidCount is 0 (and not banned)", () => {
+    expect(
+      resolveCopyVariant({
+        bannedFromListing: false,
+        bidCount: 0,
+        priorOffensesWithBids: 3,
+      }),
+    ).toBe("NO_BIDS");
+  });
+
+  it("returns FIRST_OFFENSE when 0 priors and bids present", () => {
+    expect(
+      resolveCopyVariant({
+        bannedFromListing: false,
+        bidCount: 1,
+        priorOffensesWithBids: 0,
+      }),
+    ).toBe("FIRST_OFFENSE");
+  });
+
+  it("returns FIRST_OFFENSE while priors are still loading (undefined)", () => {
+    expect(
+      resolveCopyVariant({
+        bannedFromListing: false,
+        bidCount: 1,
+        priorOffensesWithBids: undefined,
+      }),
+    ).toBe("FIRST_OFFENSE");
+  });
+
+  it("ladders to SECOND/THIRD/FOURTH+ as priors increase", () => {
+    expect(
+      resolveCopyVariant({
+        bannedFromListing: false,
+        bidCount: 1,
+        priorOffensesWithBids: 1,
+      }),
+    ).toBe("SECOND_OFFENSE");
+    expect(
+      resolveCopyVariant({
+        bannedFromListing: false,
+        bidCount: 1,
+        priorOffensesWithBids: 2,
+      }),
+    ).toBe("THIRD_OFFENSE");
+    expect(
+      resolveCopyVariant({
+        bannedFromListing: false,
+        bidCount: 1,
+        priorOffensesWithBids: 3,
+      }),
+    ).toBe("FOURTH_PLUS_OFFENSE");
+    expect(
+      resolveCopyVariant({
+        bannedFromListing: false,
+        bidCount: 1,
+        priorOffensesWithBids: 7,
+      }),
+    ).toBe("FOURTH_PLUS_OFFENSE");
+  });
+});
+
+describe("CancelListingModal — consequence-aware copy", () => {
+  it("renders the BANNED variant when the user is permanently banned", async () => {
+    seedHandlers(makeMe({ bannedFromListing: true }), makeStatus(2));
+    renderWithProviders(
+      <CancelListingModal
+        open
+        onClose={vi.fn()}
+        auction={baseAuction({ status: "ACTIVE", bidCount: 3 })}
+      />,
+      { auth: "authenticated" },
+    );
+    const copy = await screen.findByTestId("cancel-modal-consequence-copy");
+    // /me may resolve a tick after first paint, so wait for the
+    // variant to settle on BANNED rather than reading the snapshot at
+    // findBy time.
+    await waitFor(() => expect(copy.dataset.variant).toBe("BANNED"));
+    expect(copy).toHaveTextContent(
+      /permanently banned from creating new listings/i,
+    );
+  });
+
+  it("renders NO_BIDS when there are no bids on the auction", async () => {
+    seedHandlers(makeMe(), makeStatus(2));
+    renderWithProviders(
+      <CancelListingModal
+        open
+        onClose={vi.fn()}
+        auction={baseAuction({ status: "ACTIVE", bidCount: 0 })}
+      />,
+      { auth: "authenticated" },
+    );
+    const copy = await screen.findByTestId("cancel-modal-consequence-copy");
+    await waitFor(() => expect(copy.dataset.variant).toBe("NO_BIDS"));
+    expect(copy).toHaveTextContent(/no penalty will apply/i);
+  });
+
+  it("renders FIRST_OFFENSE when bids present and 0 priors", async () => {
+    seedHandlers(makeMe(), makeStatus(0, "WARNING"));
+    renderWithProviders(
+      <CancelListingModal
+        open
+        onClose={vi.fn()}
+        auction={baseAuction({ status: "ACTIVE", bidCount: 2 })}
+      />,
+      { auth: "authenticated" },
+    );
+    const copy = await screen.findByTestId("cancel-modal-consequence-copy");
+    await waitFor(() => expect(copy.dataset.variant).toBe("FIRST_OFFENSE"));
+    expect(copy).toHaveTextContent(/recorded as a warning/i);
+  });
+
+  it("renders SECOND_OFFENSE on 1 prior with bids present", async () => {
+    seedHandlers(makeMe(), makeStatus(1, "PENALTY", 1000));
+    renderWithProviders(
+      <CancelListingModal
+        open
+        onClose={vi.fn()}
+        auction={baseAuction({ status: "ACTIVE", bidCount: 2 })}
+      />,
+      { auth: "authenticated" },
+    );
+    const copy = await screen.findByTestId("cancel-modal-consequence-copy");
+    await waitFor(() => expect(copy.dataset.variant).toBe("SECOND_OFFENSE"));
+    expect(copy).toHaveTextContent(/2nd cancellation/i);
+    expect(copy).toHaveTextContent(/L\$1000 penalty/i);
+  });
+
+  it("renders THIRD_OFFENSE on 2 priors with bids present", async () => {
+    seedHandlers(makeMe(), makeStatus(2, "PENALTY_AND_30D", 2500));
+    renderWithProviders(
+      <CancelListingModal
+        open
+        onClose={vi.fn()}
+        auction={baseAuction({ status: "ACTIVE", bidCount: 2 })}
+      />,
+      { auth: "authenticated" },
+    );
+    const copy = await screen.findByTestId("cancel-modal-consequence-copy");
+    await waitFor(() => expect(copy.dataset.variant).toBe("THIRD_OFFENSE"));
+    expect(copy).toHaveTextContent(/3rd cancellation/i);
+    expect(copy).toHaveTextContent(/30 days/i);
+    expect(copy).toHaveTextContent(/L\$2500/i);
+    expect(copy).toHaveTextContent(/permanent ban/i);
+  });
+
+  it("renders FOURTH_PLUS_OFFENSE on 3 priors when not yet banned", async () => {
+    seedHandlers(makeMe(), makeStatus(3, "PERMANENT_BAN"));
+    renderWithProviders(
+      <CancelListingModal
+        open
+        onClose={vi.fn()}
+        auction={baseAuction({ status: "ACTIVE", bidCount: 2 })}
+      />,
+      { auth: "authenticated" },
+    );
+    const copy = await screen.findByTestId("cancel-modal-consequence-copy");
+    await waitFor(() =>
+      expect(copy.dataset.variant).toBe("FOURTH_PLUS_OFFENSE"),
+    );
+    expect(copy).toHaveTextContent(/4th cancellation/i);
+    expect(copy).toHaveTextContent(/permanent ban/i);
+  });
+});
+
 describe("CancelListingModal", () => {
   it("renders the refund copy derived from the auction status", () => {
+    seedHandlers(makeMe(), makeStatus(0));
     renderWithProviders(
       <CancelListingModal
         open
@@ -103,6 +336,7 @@ describe("CancelListingModal", () => {
   });
 
   it("shows the ACTIVE-forfeit copy when cancelling an active listing", () => {
+    seedHandlers(makeMe(), makeStatus(0));
     renderWithProviders(
       <CancelListingModal
         open
@@ -120,6 +354,7 @@ describe("CancelListingModal", () => {
 
   it("posts the cancel and redirects on success", async () => {
     push.mockClear();
+    seedHandlers(makeMe(), makeStatus(0));
     let received: { reason?: string } | null = null;
     server.use(
       http.put("*/api/v1/auctions/42/cancel", async ({ request }) => {

--- a/frontend/src/components/listing/CancelListingModal.tsx
+++ b/frontend/src/components/listing/CancelListingModal.tsx
@@ -8,8 +8,10 @@ import { Button } from "@/components/ui/Button";
 import { FormError } from "@/components/ui/FormError";
 import { useToast } from "@/components/ui/Toast";
 import { ApiError, isApiError } from "@/lib/api";
+import { useCurrentUser } from "@/lib/user";
 import { cancelAuction } from "@/lib/api/auctions";
 import { computeRefund } from "@/lib/listing/refundCalculation";
+import { useCancellationStatus } from "@/hooks/useCancellationStatus";
 import type { SellerAuctionResponse } from "@/types/auction";
 import { ListingStatusBadge } from "./ListingStatusBadge";
 
@@ -25,6 +27,76 @@ export interface CancelListingModalProps {
 }
 
 /**
+ * Discriminator for the consequence-aware copy table (Epic 08 sub-spec 2
+ * §8.1). The order matches the spec's top-down precedence: ban first
+ * (overrides every ladder rung), then no-bids (no penalty regardless of
+ * priors), then ladder rungs by prior count.
+ */
+type CopyVariant =
+  | "BANNED"
+  | "NO_BIDS"
+  | "FIRST_OFFENSE"
+  | "SECOND_OFFENSE"
+  | "THIRD_OFFENSE"
+  | "FOURTH_PLUS_OFFENSE";
+
+/**
+ * Sub-spec 2 §8.1 copy table, keyed by variant. The strings are inlined
+ * here (rather than imported from a constants module) because they are
+ * the test contract — every spec change should be a textual diff in this
+ * map, not a remote-edited import.
+ */
+const COPY_MAP: Record<CopyVariant, string> = {
+  BANNED:
+    "You are permanently banned from creating new listings. This cancellation will be recorded.",
+  NO_BIDS:
+    "No penalty will apply. Listing fee is non-refundable for already-paid auctions.",
+  FIRST_OFFENSE:
+    "This is a cancellation with active bids. Your first such cancellation is recorded as a warning — no L$ penalty.",
+  SECOND_OFFENSE:
+    "This will be your 2nd cancellation with active bids. You will be suspended from new listings until you pay a L$1000 penalty at any SLPA terminal.",
+  THIRD_OFFENSE:
+    "This will be your 3rd cancellation with active bids. You will be suspended from new listings for 30 days AND must pay a L$2500 penalty before listing again. One more cancellation will result in a permanent ban.",
+  FOURTH_PLUS_OFFENSE:
+    "This will be your 4th cancellation with active bids. This will result in a permanent ban from new listings.",
+};
+
+/**
+ * Resolves the copy variant from the user's ban state and the
+ * cancellation-status fetch. Pure function — exported on the side so the
+ * unit tests can drive every branch without rendering the modal.
+ *
+ * Precedence (top-down, first match wins):
+ * <ol>
+ *   <li>Banned seller → {@code BANNED} (overrides ladder).</li>
+ *   <li>Auction has no bids → {@code NO_BIDS} (regardless of prior count).</li>
+ *   <li>0 prior offenses → {@code FIRST_OFFENSE} (warning).</li>
+ *   <li>1 prior offense → {@code SECOND_OFFENSE} (L$1000 penalty).</li>
+ *   <li>2 prior offenses → {@code THIRD_OFFENSE} (L$2500 + 30d suspension).</li>
+ *   <li>3+ prior offenses (unbanned) → {@code FOURTH_PLUS_OFFENSE}
+ *       (permanent ban).</li>
+ * </ol>
+ *
+ * <p>While the cancellation-status fetch is in flight (status is undefined)
+ * and bids are present, the modal falls through to FIRST_OFFENSE — the
+ * least-alarming default — so the copy never flashes the wrong rung
+ * mid-load. Once the fetch resolves, the right copy snaps into place.
+ */
+export function resolveCopyVariant(args: {
+  bannedFromListing: boolean;
+  bidCount: number;
+  priorOffensesWithBids: number | undefined;
+}): CopyVariant {
+  if (args.bannedFromListing) return "BANNED";
+  if (args.bidCount <= 0) return "NO_BIDS";
+  const prior = args.priorOffensesWithBids ?? 0;
+  if (prior <= 0) return "FIRST_OFFENSE";
+  if (prior === 1) return "SECOND_OFFENSE";
+  if (prior === 2) return "THIRD_OFFENSE";
+  return "FOURTH_PLUS_OFFENSE";
+}
+
+/**
  * "Cancel this listing?" confirmation modal.
  *
  * Refund copy is derived locally via {@link computeRefund} (spec §5.6):
@@ -33,6 +105,11 @@ export interface CancelListingModalProps {
  * amount before clicking "Cancel listing". DRAFT → no refund,
  * DRAFT_PAID / VERIFICATION_PENDING / VERIFICATION_FAILED → full
  * refund, ACTIVE → forfeit.
+ *
+ * Sub-spec 2 §8.1 layers consequence-aware copy on top of the refund row:
+ * the cancel-modal preview reads {@code /me/cancellation-status} on open
+ * and renders one of six variants per the {@link COPY_MAP}, with the
+ * permanent-ban variant taking precedence over every ladder rung.
  *
  * The reason textarea is optional. An empty/whitespace reason is sent
  * as {@code {}} (no reason key) rather than an empty string so the
@@ -49,8 +126,17 @@ export function CancelListingModal({
   const qc = useQueryClient();
   const router = useRouter();
   const toast = useToast();
+  const { data: currentUser } = useCurrentUser();
+  const { data: status } = useCancellationStatus();
 
   const refund = computeRefund(auction.status, auction.listingFeeAmt);
+
+  const copyVariant = resolveCopyVariant({
+    bannedFromListing: currentUser?.bannedFromListing ?? false,
+    bidCount: auction.bidCount ?? 0,
+    priorOffensesWithBids: status?.priorOffensesWithBids,
+  });
+  const consequenceCopy = COPY_MAP[copyVariant];
 
   const mutation = useMutation<SellerAuctionResponse, unknown, void>({
     mutationFn: () =>
@@ -61,6 +147,13 @@ export function CancelListingModal({
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["my-listings"] });
       qc.invalidateQueries({ queryKey: ["auction", String(auction.id)] });
+      // The status preview depends on the seller's offense history; a
+      // successful cancel-with-bids changes priorOffensesWithBids and
+      // possibly the suspension state, so invalidate both the status
+      // and history queries to force a refetch on next open.
+      qc.invalidateQueries({ queryKey: ["me", "cancellation-status"] });
+      qc.invalidateQueries({ queryKey: ["me", "cancellation-history"] });
+      qc.invalidateQueries({ queryKey: ["currentUser"] });
       toast.success("Listing cancelled.");
       onClose();
       router.push(redirectTo);
@@ -100,6 +193,13 @@ export function CancelListingModal({
             <div>
               <ListingStatusBadge status={auction.status} />
             </div>
+            <p
+              className="text-body-sm text-on-surface-variant"
+              data-testid="cancel-modal-consequence-copy"
+              data-variant={copyVariant}
+            >
+              {consequenceCopy}
+            </p>
             <p className="text-body-sm text-on-surface-variant">
               {refund.copy}
             </p>

--- a/frontend/src/components/listing/ListingWizardForm.test.tsx
+++ b/frontend/src/components/listing/ListingWizardForm.test.tsx
@@ -365,3 +365,144 @@ describe("ListingWizardForm (edit flow)", () => {
     );
   });
 });
+
+/**
+ * Sub-spec 2 §8.4 — backend 403 carries a structured {@code code} field
+ * on the ProblemDetail. The wizard's submit handler reads the code and
+ * routes to {@link SuspensionErrorModal} per code value rather than the
+ * inline {@link FormError}.
+ */
+describe("ListingWizardForm (suspension gate)", () => {
+  async function setupAndAttemptSave() {
+    renderWithProviders(<ListingWizardForm mode="create" />);
+
+    await userEvent.type(
+      screen.getByLabelText(/listing title/i),
+      "Premium Waterfront",
+    );
+    await userEvent.type(
+      screen.getByLabelText(/Parcel UUID/i),
+      VALID_UUID,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /Look up/i }),
+    );
+    await screen.findByText("Beachfront retreat");
+    await userEvent.click(
+      screen.getByRole("button", { name: /Save as Draft/i }),
+    );
+  }
+
+  it("routes a 403 with PENALTY_OWED code to the SuspensionErrorModal", async () => {
+    server.use(
+      http.post("*/api/v1/parcels/lookup", () =>
+        HttpResponse.json(sampleParcel),
+      ),
+      http.get("*/api/v1/parcel-tags", () => HttpResponse.json([])),
+      http.post("*/api/v1/auctions", () =>
+        HttpResponse.json(
+          {
+            status: 403,
+            title: "Listing suspended",
+            detail: "You have an outstanding penalty.",
+            code: "PENALTY_OWED",
+          },
+          { status: 403 },
+        ),
+      ),
+    );
+
+    await setupAndAttemptSave();
+
+    const modal = await screen.findByTestId("suspension-error-modal");
+    expect(modal.dataset.code).toBe("PENALTY_OWED");
+    expect(modal).toHaveTextContent(/penalty owed/i);
+    // Inline error should be suppressed when the focused modal owns
+    // the surface area.
+    expect(
+      screen.queryByText(/You have an outstanding penalty\./i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("routes a 403 with TIMED_SUSPENSION code", async () => {
+    server.use(
+      http.post("*/api/v1/parcels/lookup", () =>
+        HttpResponse.json(sampleParcel),
+      ),
+      http.get("*/api/v1/parcel-tags", () => HttpResponse.json([])),
+      http.post("*/api/v1/auctions", () =>
+        HttpResponse.json(
+          {
+            status: 403,
+            title: "Listing suspended",
+            detail: "Suspended.",
+            code: "TIMED_SUSPENSION",
+          },
+          { status: 403 },
+        ),
+      ),
+    );
+
+    await setupAndAttemptSave();
+
+    const modal = await screen.findByTestId("suspension-error-modal");
+    expect(modal.dataset.code).toBe("TIMED_SUSPENSION");
+    expect(modal).toHaveTextContent(/temporarily suspended/i);
+  });
+
+  it("routes a 403 with PERMANENT_BAN code", async () => {
+    server.use(
+      http.post("*/api/v1/parcels/lookup", () =>
+        HttpResponse.json(sampleParcel),
+      ),
+      http.get("*/api/v1/parcel-tags", () => HttpResponse.json([])),
+      http.post("*/api/v1/auctions", () =>
+        HttpResponse.json(
+          {
+            status: 403,
+            title: "Listing suspended",
+            detail: "Banned.",
+            code: "PERMANENT_BAN",
+          },
+          { status: 403 },
+        ),
+      ),
+    );
+
+    await setupAndAttemptSave();
+
+    const modal = await screen.findByTestId("suspension-error-modal");
+    expect(modal.dataset.code).toBe("PERMANENT_BAN");
+    expect(modal).toHaveTextContent(/permanently suspended/i);
+    expect(modal).toHaveTextContent(/contact support/i);
+  });
+
+  it("falls through to the inline FormError on a 403 without a recognised code", async () => {
+    server.use(
+      http.post("*/api/v1/parcels/lookup", () =>
+        HttpResponse.json(sampleParcel),
+      ),
+      http.get("*/api/v1/parcel-tags", () => HttpResponse.json([])),
+      http.post("*/api/v1/auctions", () =>
+        HttpResponse.json(
+          {
+            status: 403,
+            title: "Forbidden",
+            detail: "Access denied.",
+            code: "OTHER_ROUTE",
+          },
+          { status: 403 },
+        ),
+      ),
+    );
+
+    await setupAndAttemptSave();
+
+    expect(
+      await screen.findByText(/Access denied\./i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("suspension-error-modal"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/listing/ListingWizardForm.tsx
+++ b/frontend/src/components/listing/ListingWizardForm.tsx
@@ -16,12 +16,34 @@ import type {
   AuctionPhotoDto,
   SellerAuctionResponse,
 } from "@/types/auction";
+import type { SuspensionReasonCode } from "@/types/cancellation";
 import { AuctionSettingsForm, type AuctionSettingsValue } from "./AuctionSettingsForm";
 import { ListingPreviewCard, type ListingPreviewAuction } from "./ListingPreviewCard";
 import { ListingWizardLayout } from "./ListingWizardLayout";
 import { ParcelLookupField } from "./ParcelLookupField";
 import { PARCEL_TAGS_KEY, TagSelector } from "./TagSelector";
 import { PhotoUploader } from "./PhotoUploader";
+import { SuspensionErrorModal } from "./SuspensionErrorModal";
+
+const SUSPENSION_CODES: ReadonlySet<SuspensionReasonCode> = new Set([
+  "PENALTY_OWED",
+  "TIMED_SUSPENSION",
+  "PERMANENT_BAN",
+]);
+
+/**
+ * Narrows a 403 ProblemDetail's {@code code} field to a known
+ * {@link SuspensionReasonCode}. The backend's
+ * {@code SellerSuspendedException} stamps one of three codes; any other
+ * 403 (e.g. a plain auth failure) returns {@code null} so the wizard
+ * falls back to its generic error path.
+ */
+function asSuspensionCode(value: unknown): SuspensionReasonCode | null {
+  if (typeof value !== "string") return null;
+  return SUSPENSION_CODES.has(value as SuspensionReasonCode)
+    ? (value as SuspensionReasonCode)
+    : null;
+}
 
 const WIZARD_STEPS = ["Configure", "Review & Submit"];
 const MAX_DESC = 5000;
@@ -72,6 +94,15 @@ export function ListingWizardForm({ mode, id }: ListingWizardFormProps) {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [titleError, setTitleError] = useState<string | null>(null);
+  /**
+   * Backend-driven suspension gate (Epic 08 sub-spec 2 §8.4). Set to a
+   * {@link SuspensionReasonCode} when the wizard's save call returns a
+   * 403 carrying the structured {@code code} field — drives the
+   * focused {@link SuspensionErrorModal} instead of the inline
+   * {@link FormError}. Cleared by the modal's dismiss handler.
+   */
+  const [suspensionCode, setSuspensionCode] =
+    useState<SuspensionReasonCode | null>(null);
 
   const isEdit = mode === "edit";
 
@@ -160,6 +191,21 @@ export function ListingWizardForm({ mode, id }: ListingWizardFormProps) {
       }
       return saved;
     } catch (e: unknown) {
+      // Listing-suspension gate (Epic 08 sub-spec 2 §8.4). Backend
+      // emits 403 with a structured {@code code} field on
+      // {@code SellerSuspendedException} — branch on the code rather
+      // than the status alone so other 403s (e.g. auth scoping) still
+      // surface the generic inline error. Suppress the inline copy
+      // when we route to the focused modal so the seller doesn't see
+      // both at once.
+      if (isApiError(e) && e.status === 403) {
+        const code = asSuspensionCode(e.problem.code);
+        if (code) {
+          setSuspensionCode(code);
+          setError(null);
+          return null;
+        }
+      }
       setError(
         isApiError(e)
           ? e.problem.detail ?? e.problem.title ?? "Save failed."
@@ -216,8 +262,20 @@ export function ListingWizardForm({ mode, id }: ListingWizardFormProps) {
       ? "Update your listing details before paying the listing fee or relisting."
       : "Set up your parcel auction. You can save a draft and return to it any time.";
 
+  // Mounted alongside both step branches so the focused suspension modal
+  // (sub-spec 2 §8.4) appears regardless of whether the seller hit the
+  // 403 from the Configure-step "Save" or the Review-step "Submit".
+  const suspensionModal = (
+    <SuspensionErrorModal
+      code={suspensionCode}
+      onClose={() => setSuspensionCode(null)}
+    />
+  );
+
   if (step === "configure") {
     return (
+      <>
+      {suspensionModal}
       <ListingWizardLayout
         steps={WIZARD_STEPS}
         currentIndex={0}
@@ -313,6 +371,7 @@ export function ListingWizardForm({ mode, id }: ListingWizardFormProps) {
           )}
         </div>
       </ListingWizardLayout>
+      </>
     );
   }
 
@@ -334,37 +393,40 @@ export function ListingWizardForm({ mode, id }: ListingWizardFormProps) {
     : null;
 
   return (
-    <ListingWizardLayout
-      steps={WIZARD_STEPS}
-      currentIndex={1}
-      title="Review & Submit"
-      description="Double-check your listing before continuing to activate."
-      footer={
-        <>
-          <Button
-            variant="secondary"
-            onClick={() => setStep("configure")}
-            disabled={submitting}
-          >
-            Back to edit
-          </Button>
-          <Button
-            onClick={handleSubmit}
-            loading={submitting}
-            disabled={submitting || !parcel}
-          >
-            Submit
-          </Button>
-        </>
-      }
-    >
-      <div className="flex flex-col gap-4">
-        <FormError message={error ?? undefined} />
-        {previewAuction && (
-          <ListingPreviewCard auction={previewAuction} isPreview />
-        )}
-      </div>
-    </ListingWizardLayout>
+    <>
+      {suspensionModal}
+      <ListingWizardLayout
+        steps={WIZARD_STEPS}
+        currentIndex={1}
+        title="Review & Submit"
+        description="Double-check your listing before continuing to activate."
+        footer={
+          <>
+            <Button
+              variant="secondary"
+              onClick={() => setStep("configure")}
+              disabled={submitting}
+            >
+              Back to edit
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              loading={submitting}
+              disabled={submitting || !parcel}
+            >
+              Submit
+            </Button>
+          </>
+        }
+      >
+        <div className="flex flex-col gap-4">
+          <FormError message={error ?? undefined} />
+          {previewAuction && (
+            <ListingPreviewCard auction={previewAuction} isPreview />
+          )}
+        </div>
+      </ListingWizardLayout>
+    </>
   );
 }
 

--- a/frontend/src/components/listing/MyListingsTab.test.tsx
+++ b/frontend/src/components/listing/MyListingsTab.test.tsx
@@ -7,6 +7,8 @@ import {
   waitFor,
 } from "@/test/render";
 import { server } from "@/test/msw/server";
+import { mockVerifiedCurrentUser } from "@/test/msw/fixtures";
+import type { CurrentUser } from "@/lib/user/api";
 import type { AuctionStatus, SellerAuctionResponse } from "@/types/auction";
 import { MyListingsTab } from "./MyListingsTab";
 
@@ -88,9 +90,19 @@ function row(
   };
 }
 
-function seed(rows: SellerAuctionResponse[]) {
+/**
+ * Seeds the listings endpoint plus a default {@code /me} response so the
+ * component's {@code useCurrentUser} call doesn't trip MSW's
+ * {@code onUnhandledRequest: "error"} guard. Tests that exercise the
+ * disabled-CTA suspension states pass a custom user via {@code me}.
+ */
+function seed(
+  rows: SellerAuctionResponse[],
+  me: CurrentUser = mockVerifiedCurrentUser,
+) {
   server.use(
     http.get("*/api/v1/users/me/auctions", () => HttpResponse.json(rows)),
+    http.get("*/api/v1/users/me", () => HttpResponse.json(me)),
   );
 }
 
@@ -163,5 +175,72 @@ describe("MyListingsTab", () => {
     expect(
       screen.queryByRole("tab", { name: /Suspended/ }),
     ).not.toBeInTheDocument();
+  });
+
+  // Spec §8.4 first paragraph: the dashboard CTA renders disabled with the
+  // suspension-reason copy as a tooltip when the seller cannot create a new
+  // listing. The four cases below cover the three suspension reasons plus
+  // the clean-user happy path.
+  describe("Create new listing CTA — suspension states", () => {
+    it("renders an enabled link for a clean user", async () => {
+      seed([row(1, "ACTIVE")]);
+      renderWithProviders(<MyListingsTab />, { auth: "authenticated" });
+      const link = await screen.findByRole("link", {
+        name: /Create new listing/,
+      });
+      expect(link).toHaveAttribute("href", "/listings/create");
+    });
+
+    it("renders a disabled button with permanent-ban tooltip when bannedFromListing", async () => {
+      seed([row(1, "ACTIVE")], {
+        ...mockVerifiedCurrentUser,
+        bannedFromListing: true,
+      });
+      renderWithProviders(<MyListingsTab />, { auth: "authenticated" });
+      const cta = await screen.findByRole("button", {
+        name: /Create new listing/,
+      });
+      await waitFor(() => expect(cta).toBeDisabled());
+      expect(cta).toHaveAttribute(
+        "title",
+        expect.stringMatching(/permanently banned/i),
+      );
+      expect(
+        screen.queryByRole("link", { name: /Create new listing/ }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders a disabled button with temporary-suspension tooltip when listingSuspensionUntil is in the future", async () => {
+      const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+      seed([row(1, "ACTIVE")], {
+        ...mockVerifiedCurrentUser,
+        listingSuspensionUntil: future,
+      });
+      renderWithProviders(<MyListingsTab />, { auth: "authenticated" });
+      const cta = await screen.findByRole("button", {
+        name: /Create new listing/,
+      });
+      await waitFor(() => expect(cta).toBeDisabled());
+      expect(cta).toHaveAttribute(
+        "title",
+        expect.stringMatching(/temporarily suspended/i),
+      );
+    });
+
+    it("renders a disabled button with outstanding-penalty tooltip when penaltyBalanceOwed > 0", async () => {
+      seed([row(1, "ACTIVE")], {
+        ...mockVerifiedCurrentUser,
+        penaltyBalanceOwed: 1000,
+      });
+      renderWithProviders(<MyListingsTab />, { auth: "authenticated" });
+      const cta = await screen.findByRole("button", {
+        name: /Create new listing/,
+      });
+      await waitFor(() => expect(cta).toBeDisabled());
+      expect(cta).toHaveAttribute(
+        "title",
+        expect.stringMatching(/outstanding penalty balance/i),
+      );
+    });
   });
 });

--- a/frontend/src/components/listing/MyListingsTab.tsx
+++ b/frontend/src/components/listing/MyListingsTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/Button";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -13,8 +13,73 @@ import {
   type MyListingsFilter,
 } from "@/hooks/useMyListings";
 import { ApiError, isApiError } from "@/lib/api";
+import { useCurrentUser } from "@/lib/user";
+import type { CurrentUser } from "@/lib/user/api";
 import { FilterChipsRow } from "./FilterChipsRow";
 import { ListingSummaryRow } from "./ListingSummaryRow";
+
+/**
+ * Spec §8.4 first paragraph: dashboard "Create new listing" CTA must render
+ * as a disabled button with a tooltip when the seller cannot create a new
+ * listing. The disabled-state copy mirrors the wizard's
+ * {@link SuspensionErrorModal} reason copy so the seller sees the same
+ * explanation whether they pre-clicked the dashboard CTA or hit the 403
+ * backstop in the wizard.
+ *
+ * <p>Returns {@code null} when the seller can create a listing — the call
+ * site renders the existing {@code <Link>} in that branch.
+ */
+function listingDisabledReason(user: CurrentUser | undefined): string | null {
+  if (!user) return null;
+  if (user.bannedFromListing) {
+    return "You are permanently banned from creating new listings.";
+  }
+  const owesPenalty = (user.penaltyBalanceOwed ?? 0) > 0;
+  if (owesPenalty) {
+    return "You have an outstanding penalty balance. Pay at any SLPA terminal to resume listing.";
+  }
+  const suspensionUntilRaw = user.listingSuspensionUntil;
+  const suspensionUntil = suspensionUntilRaw
+    ? new Date(suspensionUntilRaw)
+    : null;
+  const timedSuspended = suspensionUntil != null && suspensionUntil > new Date();
+  if (timedSuspended) {
+    return "Your listing privileges are temporarily suspended.";
+  }
+  return null;
+}
+
+/**
+ * Wraps the create-listing CTA so the disabled-state path lives in one
+ * place. When {@link listingDisabledReason} returns {@code null} the CTA
+ * renders as the existing {@code <Link>} → {@code <Button>} composite
+ * (clean user). Otherwise it renders a disabled {@code <Button>} carrying
+ * the suspension-reason copy as a {@code title} tooltip.
+ */
+function CreateListingCta({
+  disabledReason,
+  children,
+}: {
+  disabledReason: string | null;
+  children: ReactNode;
+}) {
+  if (disabledReason) {
+    return (
+      <Button
+        leftIcon={<Plus className="size-4" />}
+        disabled
+        title={disabledReason}
+      >
+        {children}
+      </Button>
+    );
+  }
+  return (
+    <Link href="/listings/create">
+      <Button leftIcon={<Plus className="size-4" />}>{children}</Button>
+    </Link>
+  );
+}
 
 /**
  * Top-level content for {@code /dashboard/listings}. Composes:
@@ -39,6 +104,8 @@ export function MyListingsTab() {
   const [filter, setFilter] = useState<MyListingsFilter>("All");
   const { listings, all, isLoading, isError, error } = useMyListings(filter);
   const suspendedCount = useMyListingsSuspendedCount();
+  const { data: currentUser } = useCurrentUser();
+  const disabledReason = listingDisabledReason(currentUser);
 
   if (isLoading) {
     return (
@@ -67,11 +134,9 @@ export function MyListingsTab() {
         headline="No listings yet"
         description="Put your first parcel up for auction to start selling."
       >
-        <Link href="/listings/create">
-          <Button leftIcon={<Plus className="size-4" />}>
-            Create your first listing
-          </Button>
-        </Link>
+        <CreateListingCta disabledReason={disabledReason}>
+          Create your first listing
+        </CreateListingCta>
       </EmptyState>
     );
   }
@@ -85,11 +150,9 @@ export function MyListingsTab() {
             ({all.length})
           </span>
         </h2>
-        <Link href="/listings/create">
-          <Button leftIcon={<Plus className="size-4" />}>
-            Create new listing
-          </Button>
-        </Link>
+        <CreateListingCta disabledReason={disabledReason}>
+          Create new listing
+        </CreateListingCta>
       </div>
       <FilterChipsRow
         value={filter}

--- a/frontend/src/components/listing/SuspensionErrorModal.test.tsx
+++ b/frontend/src/components/listing/SuspensionErrorModal.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen } from "@/test/render";
+import { SuspensionErrorModal } from "./SuspensionErrorModal";
+
+describe("SuspensionErrorModal", () => {
+  it("does not render anything when code is null", () => {
+    renderWithProviders(<SuspensionErrorModal code={null} onClose={vi.fn()} />);
+    expect(
+      screen.queryByTestId("suspension-error-modal"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the PENALTY_OWED variant", () => {
+    renderWithProviders(
+      <SuspensionErrorModal code="PENALTY_OWED" onClose={vi.fn()} />,
+    );
+    const modal = screen.getByTestId("suspension-error-modal");
+    expect(modal.dataset.code).toBe("PENALTY_OWED");
+    expect(modal).toHaveTextContent(/penalty owed/i);
+    expect(modal).toHaveTextContent(/outstanding penalty balance/i);
+    expect(modal).toHaveTextContent(/SLPA terminal/i);
+  });
+
+  it("renders the TIMED_SUSPENSION variant", () => {
+    renderWithProviders(
+      <SuspensionErrorModal code="TIMED_SUSPENSION" onClose={vi.fn()} />,
+    );
+    const modal = screen.getByTestId("suspension-error-modal");
+    expect(modal.dataset.code).toBe("TIMED_SUSPENSION");
+    expect(modal).toHaveTextContent(/temporarily suspended/i);
+  });
+
+  it("renders the PERMANENT_BAN variant", () => {
+    renderWithProviders(
+      <SuspensionErrorModal code="PERMANENT_BAN" onClose={vi.fn()} />,
+    );
+    const modal = screen.getByTestId("suspension-error-modal");
+    expect(modal.dataset.code).toBe("PERMANENT_BAN");
+    expect(modal).toHaveTextContent(/permanently suspended/i);
+    expect(modal).toHaveTextContent(/contact support/i);
+  });
+
+  it("includes a link back to the dashboard", () => {
+    renderWithProviders(
+      <SuspensionErrorModal code="PENALTY_OWED" onClose={vi.fn()} />,
+    );
+    expect(
+      screen.getByRole("link", { name: /go to dashboard/i }),
+    ).toHaveAttribute("href", "/dashboard");
+  });
+});

--- a/frontend/src/components/listing/SuspensionErrorModal.tsx
+++ b/frontend/src/components/listing/SuspensionErrorModal.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import Link from "next/link";
+import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
+import { Button } from "@/components/ui/Button";
+import type { SuspensionReasonCode } from "@/types/cancellation";
+
+export interface SuspensionErrorModalProps {
+  /**
+   * Structured {@code code} field on the ProblemDetail returned by the
+   * backend's {@code SellerSuspendedException} 403 handler. Drives the
+   * focused copy variant. {@code null} closes the modal — the wizard
+   * uses this for both initial state and dismissal.
+   */
+  code: SuspensionReasonCode | null;
+  onClose: () => void;
+}
+
+/**
+ * Title + body copy for each suspension reason. Mirrors the spec §8.4
+ * focused-error copy; the dashboard banner carries the same wording for
+ * the same reason. Source-of-truth for the {@code code} → copy mapping
+ * lives here so a future copy edit is a single-file diff.
+ */
+const COPY: Record<
+  SuspensionReasonCode,
+  { title: string; body: string; ctaLabel: string }
+> = {
+  PENALTY_OWED: {
+    title: "Penalty owed",
+    body: "You have an outstanding penalty balance. Pay at any SLPA terminal to resume listing.",
+    ctaLabel: "Go to dashboard",
+  },
+  TIMED_SUSPENSION: {
+    title: "Listing temporarily suspended",
+    body: "Your listing privileges are temporarily suspended. The dashboard banner shows when they will resume.",
+    ctaLabel: "Go to dashboard",
+  },
+  PERMANENT_BAN: {
+    title: "Listing privileges revoked",
+    body: "Your listing privileges have been permanently suspended. Contact support to request a review.",
+    ctaLabel: "Go to dashboard",
+  },
+};
+
+/**
+ * Surfaces the structured 403 from {@code SellerSuspendedException} as a
+ * focused error modal during the listing wizard's submit step (Epic 08
+ * sub-spec 2 §8.4). Routes on the {@code code} field of the
+ * ProblemDetail — the wizard's submit handler reads {@code e.problem.code}
+ * and forwards it here. The link goes back to the dashboard so the
+ * seller can read the full {@code SuspensionBanner} copy in context.
+ *
+ * <p>Returns {@code null} when {@code code} is {@code null} — the wizard
+ * keeps the modal mounted so the open/close transition is smooth, and
+ * dismissal is a {@code setSuspensionError(null)} on the parent.
+ */
+export function SuspensionErrorModal({
+  code,
+  onClose,
+}: SuspensionErrorModalProps) {
+  const open = code !== null;
+  // When closing, copy is no longer needed — fall back to PENALTY_OWED
+  // so the type narrowing stays clean. The Dialog's `open` prop drives
+  // visibility regardless.
+  const copy = COPY[code ?? "PENALTY_OWED"];
+
+  return (
+    <Dialog open={open} onClose={onClose} className="relative z-50">
+      <div
+        className="fixed inset-0 bg-inverse-surface/40 backdrop-blur-sm"
+        aria-hidden="true"
+      />
+      <div className="fixed inset-0 flex items-center justify-center p-4">
+        <DialogPanel
+          className="w-full max-w-md flex flex-col gap-4 rounded-default bg-surface-container-low p-6"
+          data-testid="suspension-error-modal"
+          data-code={code ?? undefined}
+        >
+          <DialogTitle className="text-title-lg text-on-surface">
+            {copy.title}
+          </DialogTitle>
+          <p className="text-body-md text-on-surface-variant">{copy.body}</p>
+          <div className="flex justify-end gap-2">
+            <Button variant="secondary" onClick={onClose}>
+              Dismiss
+            </Button>
+            <Link href="/dashboard">
+              <Button variant="primary">{copy.ctaLabel}</Button>
+            </Link>
+          </div>
+        </DialogPanel>
+      </div>
+    </Dialog>
+  );
+}

--- a/frontend/src/hooks/useCancellationHistory.test.tsx
+++ b/frontend/src/hooks/useCancellationHistory.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { renderHook, waitFor } from "@testing-library/react";
+import { makeWrapper } from "@/test/render";
+import { server } from "@/test/msw/server";
+import { useCancellationHistory } from "./useCancellationHistory";
+
+describe("useCancellationHistory", () => {
+  it("fetches a paged history response", async () => {
+    let receivedUrl: URL | null = null;
+    server.use(
+      http.get("*/api/v1/users/me/cancellation-history", ({ request }) => {
+        receivedUrl = new URL(request.url);
+        return HttpResponse.json({
+          content: [],
+          totalElements: 0,
+          totalPages: 0,
+          number: 0,
+          size: 10,
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useCancellationHistory(0), {
+      wrapper: makeWrapper({ auth: "authenticated" }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(receivedUrl!.searchParams.get("page")).toBe("0");
+    expect(receivedUrl!.searchParams.get("size")).toBe("10");
+  });
+
+  it("forwards the size override on the wire", async () => {
+    let receivedUrl: URL | null = null;
+    server.use(
+      http.get("*/api/v1/users/me/cancellation-history", ({ request }) => {
+        receivedUrl = new URL(request.url);
+        return HttpResponse.json({
+          content: [],
+          totalElements: 0,
+          totalPages: 0,
+          number: 0,
+          size: 5,
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useCancellationHistory(1, 5), {
+      wrapper: makeWrapper({ auth: "authenticated" }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(receivedUrl!.searchParams.get("page")).toBe("1");
+    expect(receivedUrl!.searchParams.get("size")).toBe("5");
+  });
+});

--- a/frontend/src/hooks/useCancellationHistory.ts
+++ b/frontend/src/hooks/useCancellationHistory.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import {
+  DEFAULT_CANCELLATION_HISTORY_SIZE,
+  getCancellationHistory,
+} from "@/lib/api/cancellations";
+import type { CancellationHistoryDto } from "@/types/cancellation";
+import type { Page } from "@/types/page";
+import { cancellationKeys } from "./useCancellationStatus";
+
+/**
+ * Paginated read hook for the seller's cancellation history. Default page
+ * size matches the API client default ({@link DEFAULT_CANCELLATION_HISTORY_SIZE}).
+ *
+ * <p>The query key is page+size scoped so flipping pages caches both
+ * pages independently — pager clicks feel instant on a return visit.
+ */
+export function useCancellationHistory(
+  page: number,
+  size: number = DEFAULT_CANCELLATION_HISTORY_SIZE,
+): UseQueryResult<Page<CancellationHistoryDto>> {
+  return useQuery<Page<CancellationHistoryDto>>({
+    queryKey: cancellationKeys.history(page, size),
+    queryFn: () => getCancellationHistory(page, size),
+  });
+}

--- a/frontend/src/hooks/useCancellationStatus.test.tsx
+++ b/frontend/src/hooks/useCancellationStatus.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { renderHook, waitFor } from "@testing-library/react";
+import { makeWrapper } from "@/test/render";
+import { server } from "@/test/msw/server";
+import { cancellationKeys, useCancellationStatus } from "./useCancellationStatus";
+
+describe("cancellationKeys", () => {
+  it("exposes a stable key for status", () => {
+    expect(cancellationKeys.status).toEqual(["me", "cancellation-status"]);
+  });
+
+  it("composes history keys with page + size", () => {
+    expect(cancellationKeys.historyAll).toEqual(["me", "cancellation-history"]);
+    expect(cancellationKeys.history(0, 10)).toEqual([
+      "me",
+      "cancellation-history",
+      0,
+      10,
+    ]);
+    expect(cancellationKeys.history(2, 5)).toEqual([
+      "me",
+      "cancellation-history",
+      2,
+      5,
+    ]);
+  });
+});
+
+describe("useCancellationStatus", () => {
+  it("fetches the status envelope and surfaces it via query.data", async () => {
+    server.use(
+      http.get("*/api/v1/users/me/cancellation-status", () =>
+        HttpResponse.json({
+          priorOffensesWithBids: 1,
+          currentSuspension: {
+            penaltyBalanceOwed: 1000,
+            listingSuspensionUntil: null,
+            bannedFromListing: false,
+          },
+          nextConsequenceIfBidsPresent: {
+            kind: "PENALTY_AND_30D",
+            amountL: 2500,
+            suspends30Days: true,
+            permanentBan: false,
+          },
+        }),
+      ),
+    );
+
+    const { result } = renderHook(() => useCancellationStatus(), {
+      wrapper: makeWrapper({ auth: "authenticated" }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.priorOffensesWithBids).toBe(1);
+    expect(result.current.data?.currentSuspension.penaltyBalanceOwed).toBe(
+      1000,
+    );
+    expect(result.current.data?.nextConsequenceIfBidsPresent.kind).toBe(
+      "PENALTY_AND_30D",
+    );
+  });
+});

--- a/frontend/src/hooks/useCancellationStatus.ts
+++ b/frontend/src/hooks/useCancellationStatus.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { getCancellationStatus } from "@/lib/api/cancellations";
+import type { CancellationStatusResponse } from "@/types/cancellation";
+
+/**
+ * React Query keys for the cancellation domain. Exported so the cancel
+ * modal, the dashboard banner, and any future WS handlers can invalidate
+ * without reaching into the hook internals.
+ *
+ * <p>Banner-state freshness in sub-spec 2 relies on
+ * <ul>
+ *   <li>{@code staleTime: 30_000} on {@code status} so a quick re-open of
+ *       the cancel modal doesn't refetch unnecessarily.</li>
+ *   <li>Window-focus refetch on {@code /me} (configured in
+ *       {@code useCurrentUser}) when the seller tabs back from SL after
+ *       paying.</li>
+ * </ul>
+ * No WS push for {@code PENALTY_CLEARED} ships in sub-spec 2 — that's
+ * gated on the user-targeted-queue infrastructure deferred elsewhere.
+ */
+export const cancellationKeys = {
+  status: ["me", "cancellation-status"] as const,
+  historyAll: ["me", "cancellation-history"] as const,
+  history: (page: number, size: number) =>
+    [...cancellationKeys.historyAll, page, size] as const,
+};
+
+/**
+ * Read hook for the cancel-modal preview envelope. Cached for 30s so
+ * back-to-back modal opens don't refetch — the spec calls out staleness
+ * tolerance because the answer rarely changes mid-session.
+ */
+export function useCancellationStatus(): UseQueryResult<CancellationStatusResponse> {
+  return useQuery<CancellationStatusResponse>({
+    queryKey: cancellationKeys.status,
+    queryFn: getCancellationStatus,
+    staleTime: 30_000,
+  });
+}

--- a/frontend/src/lib/api/cancellations.test.ts
+++ b/frontend/src/lib/api/cancellations.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/msw/server";
+import type {
+  CancellationHistoryDto,
+  CancellationStatusResponse,
+} from "@/types/cancellation";
+import type { Page } from "@/types/page";
+import {
+  getCancellationHistory,
+  getCancellationStatus,
+} from "./cancellations";
+
+function makeStatus(
+  overrides: Partial<CancellationStatusResponse> = {},
+): CancellationStatusResponse {
+  return {
+    priorOffensesWithBids: 0,
+    currentSuspension: {
+      penaltyBalanceOwed: 0,
+      listingSuspensionUntil: null,
+      bannedFromListing: false,
+    },
+    nextConsequenceIfBidsPresent: {
+      kind: "WARNING",
+      amountL: null,
+      suspends30Days: false,
+      permanentBan: false,
+    },
+    ...overrides,
+  };
+}
+
+function makeRow(
+  overrides: Partial<CancellationHistoryDto> = {},
+): CancellationHistoryDto {
+  return {
+    auctionId: 1,
+    auctionTitle: "Aurora Parcel",
+    primaryPhotoUrl: null,
+    cancelledFromStatus: "ACTIVE",
+    hadBids: true,
+    reason: "Buyer changed mind.",
+    cancelledAt: "2026-04-20T10:00:00Z",
+    penaltyApplied: { kind: "PENALTY", amountL: 1000 },
+    ...overrides,
+  };
+}
+
+function makePage(
+  content: CancellationHistoryDto[] = [],
+  overrides: Partial<Page<CancellationHistoryDto>> = {},
+): Page<CancellationHistoryDto> {
+  return {
+    content,
+    totalElements: content.length,
+    totalPages: Math.max(1, Math.ceil(content.length / 10)),
+    number: 0,
+    size: 10,
+    ...overrides,
+  };
+}
+
+describe("getCancellationStatus", () => {
+  it("hits /api/v1/users/me/cancellation-status and returns the envelope", async () => {
+    const expected = makeStatus({
+      priorOffensesWithBids: 2,
+      currentSuspension: {
+        penaltyBalanceOwed: 1500,
+        listingSuspensionUntil: "2026-05-20T00:00:00Z",
+        bannedFromListing: false,
+      },
+      nextConsequenceIfBidsPresent: {
+        kind: "PENALTY_AND_30D",
+        amountL: 2500,
+        suspends30Days: true,
+        permanentBan: false,
+      },
+    });
+    server.use(
+      http.get("*/api/v1/users/me/cancellation-status", () =>
+        HttpResponse.json(expected),
+      ),
+    );
+
+    const result = await getCancellationStatus();
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("getCancellationHistory", () => {
+  it("defaults to page=0 size=10 when called without args", async () => {
+    let receivedUrl: URL | null = null;
+    server.use(
+      http.get("*/api/v1/users/me/cancellation-history", ({ request }) => {
+        receivedUrl = new URL(request.url);
+        return HttpResponse.json(makePage());
+      }),
+    );
+
+    await getCancellationHistory();
+
+    expect(receivedUrl).not.toBeNull();
+    expect(receivedUrl!.searchParams.get("page")).toBe("0");
+    expect(receivedUrl!.searchParams.get("size")).toBe("10");
+  });
+
+  it("passes through page + size args as query params", async () => {
+    let receivedUrl: URL | null = null;
+    server.use(
+      http.get("*/api/v1/users/me/cancellation-history", ({ request }) => {
+        receivedUrl = new URL(request.url);
+        return HttpResponse.json(makePage());
+      }),
+    );
+
+    await getCancellationHistory(2, 5);
+
+    expect(receivedUrl!.searchParams.get("page")).toBe("2");
+    expect(receivedUrl!.searchParams.get("size")).toBe("5");
+  });
+
+  it("returns the deserialized Page envelope verbatim", async () => {
+    const rows = [
+      makeRow({ auctionId: 1 }),
+      makeRow({
+        auctionId: 2,
+        penaltyApplied: null,
+        cancelledFromStatus: "DRAFT_PAID",
+        hadBids: false,
+      }),
+    ];
+    const expected = makePage(rows, { totalElements: 12, totalPages: 2 });
+    server.use(
+      http.get("*/api/v1/users/me/cancellation-history", () =>
+        HttpResponse.json(expected),
+      ),
+    );
+
+    const result = await getCancellationHistory(0, 10);
+    expect(result).toEqual(expected);
+  });
+});

--- a/frontend/src/lib/api/cancellations.ts
+++ b/frontend/src/lib/api/cancellations.ts
@@ -1,0 +1,49 @@
+import { api } from "@/lib/api";
+import type { Page } from "@/types/page";
+import type {
+  CancellationHistoryDto,
+  CancellationStatusResponse,
+} from "@/types/cancellation";
+
+/**
+ * Read-only client for the seller-scoped cancellation endpoints (Epic 08
+ * sub-spec 2 §7.3 / §7.4). Both endpoints require JWT and resolve to the
+ * caller — there is no cross-user view, by design.
+ *
+ * GET /api/v1/users/me/cancellation-status returns the cancel-modal
+ * preview envelope ({@code priorOffensesWithBids}, {@code currentSuspension},
+ * {@code nextConsequenceIfBidsPresent}).
+ *
+ * GET /api/v1/users/me/cancellation-history returns a paginated, newest-
+ * first list of {@link CancellationHistoryDto} rows. The frontend defaults
+ * to {@code size=10} so the dashboard card renders a manageable list and
+ * the pager does the rest.
+ */
+
+export const DEFAULT_CANCELLATION_HISTORY_SIZE = 10;
+
+/**
+ * GET /api/v1/users/me/cancellation-status. Drives the consequence-aware
+ * copy in {@code CancelListingModal} and supplies the cancel-modal
+ * preview without requiring a second {@code /me} fetch.
+ */
+export function getCancellationStatus(): Promise<CancellationStatusResponse> {
+  return api.get<CancellationStatusResponse>(
+    "/api/v1/users/me/cancellation-status",
+  );
+}
+
+/**
+ * GET /api/v1/users/me/cancellation-history?page=&size=. Server returns a
+ * standard Spring Data {@link Page} envelope; pagination is exposed
+ * through the existing UI {@code <Pagination>} primitive.
+ */
+export function getCancellationHistory(
+  page = 0,
+  size = DEFAULT_CANCELLATION_HISTORY_SIZE,
+): Promise<Page<CancellationHistoryDto>> {
+  return api.get<Page<CancellationHistoryDto>>(
+    "/api/v1/users/me/cancellation-history",
+    { params: { page, size } },
+  );
+}

--- a/frontend/src/lib/api/parcelTags.ts
+++ b/frontend/src/lib/api/parcelTags.ts
@@ -3,9 +3,10 @@ import type { ParcelTagGroupDto } from "@/types/parcelTag";
 
 /**
  * GET /api/v1/parcel-tags — returns the full active tag catalogue grouped
- * by category. Public to any authenticated user; the TagSelector and the
- * Epic 07 browse filters both consume this list, so React Query callers
- * should use a long staleTime (the catalogue changes rarely).
+ * by category. Public endpoint (no auth required) — both the anonymous
+ * Epic 07 browse filters and the authenticated listing-wizard TagSelector
+ * consume this list, so React Query callers should use a long staleTime
+ * (the catalogue changes rarely).
  */
 export function listParcelTagGroups(): Promise<ParcelTagGroupDto[]> {
   return api.get<ParcelTagGroupDto[]>("/api/v1/parcel-tags");

--- a/frontend/src/lib/user/api.ts
+++ b/frontend/src/lib/user/api.ts
@@ -17,6 +17,28 @@ export type CurrentUser = {
   emailVerified: boolean;
   notifyEmail: Record<string, unknown>;
   notifySlIm: Record<string, unknown>;
+  /**
+   * Outstanding L$ penalty balance owed by this seller (Epic 08 sub-spec 2
+   * §7.2). Sourced from {@code User.penaltyBalanceOwed}; defaults to 0 for
+   * sellers with no offenses on the ladder. Cleared by walk-in payment at
+   * any SLPA terminal — there is no "Pay now" button on the web side.
+   */
+  penaltyBalanceOwed: number;
+  /**
+   * UTC timestamp at which the seller's listing privileges automatically
+   * resume, or {@code null} if no timed suspension is active. Independent
+   * of {@code penaltyBalanceOwed} — a seller can owe L$ without being
+   * timed-suspended (PENALTY rung) and vice-versa (PENALTY_AND_30D after
+   * payment clears).
+   */
+  listingSuspensionUntil: string | null;
+  /**
+   * {@code true} once the seller hits the fourth cancel-with-bids offense.
+   * Permanent (subject to admin reversal); a banned seller's listing
+   * wizard is gated server-side on this flag and the dashboard surfaces
+   * the {@code SuspensionBanner} permanent variant.
+   */
+  bannedFromListing: boolean;
   createdAt: string;
   updatedAt: string;
 };

--- a/frontend/src/test/msw/fixtures.ts
+++ b/frontend/src/test/msw/fixtures.ts
@@ -42,6 +42,13 @@ export const mockUnverifiedCurrentUser: CurrentUser = {
   emailVerified: true,
   notifyEmail: {},
   notifySlIm: {},
+  // Listing-suspension defaults — a clean account has no pending penalty,
+  // no timed suspension, and is not banned. Tests that exercise the
+  // SuspensionBanner / cancel-modal ban-precedence paths override these
+  // per-test (Epic 08 sub-spec 2 §7.2).
+  penaltyBalanceOwed: 0,
+  listingSuspensionUntil: null,
+  bannedFromListing: false,
   createdAt: "2026-04-01T10:00:00Z",
   updatedAt: "2026-04-01T10:00:00Z",
 };

--- a/frontend/src/types/auction.ts
+++ b/frontend/src/types/auction.ts
@@ -349,6 +349,22 @@ export interface ReviewRevealedEnvelope {
 }
 
 /**
+ * Broadcast on {@code /topic/auction/{auctionId}} when an auction transitions
+ * to {@code CANCELLED} (Epic 08 sub-spec 2 §8.5). Subscribers in the auction
+ * detail page invalidate their auction query so the page transitions to the
+ * "auction cancelled" UI on the next refetch — bidders mid-bid see their bid
+ * form replaced by the cancellation banner. Like {@link ReviewRevealedEnvelope}
+ * this envelope does not carry a {@code serverTime} field; subscribers that
+ * read it should short-circuit on the type discriminator first.
+ */
+export interface AuctionCancelledEnvelope {
+  type: "AUCTION_CANCELLED";
+  auctionId: number;
+  cancelledAt: string;
+  hadBids: boolean;
+}
+
+/**
  * Every envelope type that can arrive on `/topic/auction/{id}`.
  * {@code AuctionDetailClient} and {@code EscrowPageClient} both subscribe
  * with this union; handlers discriminate on {@code type}. Re-exports the
@@ -357,12 +373,15 @@ export interface ReviewRevealedEnvelope {
  * lives on the same topic (Epic 08 sub-spec 1 §7) — subscribers that don't
  * care about reviews should short-circuit on {@code type === "REVIEW_REVEALED"}
  * before reading any envelope-specific field, since review envelopes do not
- * carry {@code serverTime}.
+ * carry {@code serverTime}. The cancellation envelope (sub-spec 2 §8.5) is
+ * the same shape pattern — early-return on {@code type === "AUCTION_CANCELLED"}
+ * before reading {@code serverTime}.
  */
 export type AuctionTopicEnvelope =
   | AuctionEnvelope
   | EscrowEnvelope
-  | ReviewRevealedEnvelope;
+  | ReviewRevealedEnvelope
+  | AuctionCancelledEnvelope;
 
 /**
  * POST /api/v1/auctions/{id}/bids response body. Returns the just-committed

--- a/frontend/src/types/cancellation.ts
+++ b/frontend/src/types/cancellation.ts
@@ -1,0 +1,114 @@
+// Wire-shape mirrors of the cancellation-penalty DTOs (Epic 08 sub-spec 2 §7).
+// Source of truth on the Java side:
+//   - CancellationOffenseKind enum
+//     (com.slparcelauctions.backend.auction.CancellationOffenseKind)
+//   - SuspensionReason enum (used as the {@code code} field on the structured
+//     ProblemDetail emitted by SellerSuspendedException — frontend names it
+//     {@code SuspensionReasonCode} to make the routing intent explicit)
+//   - CancellationStatusResponse + nested CurrentSuspension + NextConsequenceDto
+//     (com.slparcelauctions.backend.auction.dto.*)
+//   - CancellationHistoryDto + nested PenaltyApplied
+//
+// Kept flat and un-opinionated so the lib/api layer can JSON.parse straight
+// into these types without custom mapping. If a backend record adds a field,
+// add it here too — there is no DTO codegen.
+
+/**
+ * Five-rung ladder applied at cancel-with-bids time. Mirrors the Java enum.
+ *
+ * <ul>
+ *   <li>{@code NONE} — pre-active or active-without-bids cancellation; no
+ *       penalty was logged. {@code CancellationLog.penaltyKind} is
+ *       {@code null} or {@code NONE} in this case.</li>
+ *   <li>{@code WARNING} — first cancel-with-bids; logged but no L$ debit and
+ *       no suspension.</li>
+ *   <li>{@code PENALTY} — second cancel-with-bids; L$ debit + listing
+ *       suspension until paid.</li>
+ *   <li>{@code PENALTY_AND_30D} — third cancel-with-bids; L$ debit + 30-day
+ *       suspension that runs concurrently with the debt.</li>
+ *   <li>{@code PERMANENT_BAN} — fourth cancel-with-bids; sets
+ *       {@code User.bannedFromListing = true}.</li>
+ * </ul>
+ */
+export type CancellationOffenseKind =
+  | "NONE"
+  | "WARNING"
+  | "PENALTY"
+  | "PENALTY_AND_30D"
+  | "PERMANENT_BAN";
+
+/**
+ * The {@code code} field on the structured ProblemDetail emitted by
+ * {@code SellerSuspendedException}. The listing wizard's submit handler
+ * branches on this value to render focused error copy.
+ */
+export type SuspensionReasonCode =
+  | "PENALTY_OWED"
+  | "TIMED_SUSPENSION"
+  | "PERMANENT_BAN";
+
+/**
+ * Echo of the three new {@code User} columns. The same fields are also
+ * surfaced on {@link CurrentUser} so the dashboard banner can render off a
+ * single {@code /me} fetch — this nested object lets the cancel modal read
+ * them out of the {@code /me/cancellation-status} response without a second
+ * round-trip when {@code /me} is stale.
+ */
+export interface CurrentSuspension {
+  penaltyBalanceOwed: number;
+  listingSuspensionUntil: string | null;
+  bannedFromListing: boolean;
+}
+
+/**
+ * Cancel-modal preview row — what the next cancel-with-bids would trigger
+ * given {@code priorOffensesWithBids}. {@code kind} is never {@code NONE} —
+ * the question is hypothetical so even a clean record yields
+ * {@code WARNING}. {@code suspends30Days} / {@code permanentBan} are
+ * derived from {@code kind} server-side so the frontend can map kind →
+ * badge in one place.
+ */
+export interface NextConsequence {
+  kind: CancellationOffenseKind;
+  amountL: number | null;
+  suspends30Days: boolean;
+  permanentBan: boolean;
+}
+
+/**
+ * Response body for {@code GET /api/v1/users/me/cancellation-status}.
+ * Used by the cancel modal to drive the consequence-aware copy table and
+ * by tests that exercise the four banner variants.
+ */
+export interface CancellationStatusResponse {
+  priorOffensesWithBids: number;
+  currentSuspension: CurrentSuspension;
+  nextConsequenceIfBidsPresent: NextConsequence;
+}
+
+/**
+ * Snapshotted penalty payload on a single history row. Null when the log's
+ * {@code penaltyKind} was {@code NONE} (pre-active / active-without-bids
+ * cancellation) — the dashboard renders a "No penalty" badge in that case.
+ */
+export interface CancellationHistoryPenalty {
+  kind: CancellationOffenseKind;
+  amountL: number | null;
+}
+
+/**
+ * Single row in {@code GET /api/v1/users/me/cancellation-history}. All
+ * fields are read straight off the snapshotted log row server-side — the
+ * ladder is not re-derived against today's offense count, so historical
+ * rows reflect what the seller saw at the time of cancellation.
+ */
+export interface CancellationHistoryDto {
+  auctionId: number;
+  auctionTitle: string;
+  primaryPhotoUrl: string | null;
+  cancelledFromStatus: string;
+  hadBids: boolean;
+  reason: string;
+  cancelledAt: string;
+  penaltyApplied: CancellationHistoryPenalty | null;
+}

--- a/frontend/src/types/cancellation.ts
+++ b/frontend/src/types/cancellation.ts
@@ -108,7 +108,7 @@ export interface CancellationHistoryDto {
   primaryPhotoUrl: string | null;
   cancelledFromStatus: string;
   hadBids: boolean;
-  reason: string;
+  reason: string | null;
   cancelledAt: string;
   penaltyApplied: CancellationHistoryPenalty | null;
 }


### PR DESCRIPTION
## Summary

Layers escalating penalties + suspension enforcement + 48h post-cancel ownership watcher onto the existing cancellation flow. Pay-at-terminal "suspended-until-paid" model. Closes Task 03 of Epic 08.

**Spec:** [`docs/superpowers/specs/2026-04-24-epic-08-sub-2-cancellation-penalties.md`](./docs/superpowers/specs/2026-04-24-epic-08-sub-2-cancellation-penalties.md)
**Plan:** [`docs/superpowers/plans/2026-04-25-epic-08-sub-2-cancellation-penalties.md`](./docs/superpowers/plans/2026-04-25-epic-08-sub-2-cancellation-penalties.md)

## What ships

### Backend
- **Penalty ladder** in `CancellationService.cancel`: COUNT-before-INSERT, snapshot `penaltyKind` + `penaltyAmountL` on `CancellationLog` row (historical fact, not derivation). 0 prior → WARNING, 1 → L$1000 PENALTY, 2 → L$2500 PENALTY_AND_30D, 3+ → PERMANENT_BAN. Concurrent gates on offense #3 (debt + 30-day clock independent).
- New `User` columns: `penaltyBalanceOwed Long`, `bannedFromListing Boolean` (with SQL-side defaults for ddl-auto safety).
- New `Auction.postCancelWatchUntil` column, set on ACTIVE-with-bids cancellations, naturally expires.
- `CancellationOffenseKind` enum + `FraudFlagReason.CANCEL_AND_SELL` + `EscrowTransactionType.LISTING_PENALTY_PAYMENT` (with check-constraint initializer following established pattern).
- **Suspension gate** in `AuctionService.create` — order BAN → TIMED → PENALTY, `SellerSuspendedException` → 403 ProblemDetail with structured `code` field.
- **`AUCTION_CANCELLED` WS envelope** broadcast on `afterCommit` from `CancellationService.cancel`.
- `GET /api/v1/users/me/cancellation-status` — modal preview + current suspension state.
- `GET /api/v1/users/me/cancellation-history` — `PagedResponse<CancellationHistoryDto>`, sorted newest-first, size clamped at 50, `auction.photos` batch-loaded via `@EntityGraph` (no N+1).
- `/me` extended with `penaltyBalanceOwed`, `listingSuspensionUntil`, `bannedFromListing`.
- **48h post-cancel ownership watcher**: `AuctionRepository.findDueForOwnershipCheck(cutoff, now)` covers ACTIVE OR (postCancelWatchUntil > now). `OwnershipCheckTask.checkOne` branches on auction status — CANCELLED routes to `SuspensionService.raiseCancelAndSellFlag` with rich evidence payload (cancelledAt, observedOwnerKey, hoursSinceCancellation, etc.), clears `postCancelWatchUntil` on flag-raise to prevent re-flagging.
- `POST /api/v1/sl/penalty-lookup` + `POST /api/v1/sl/penalty-payment` — terminal-auth via `X-SecondLife-Owner-Key`. Idempotency-before-pessimistic-lock; type-scoped `slTransactionId` lookup. Partial payments allowed and additive.
- `CancellationPenaltyProperties` `@ConfigurationProperties` for L$1000/L$2500/30d/48h values.

### Frontend
- New `components/cancellation/CancellationConsequenceBadge.tsx` — 5-kind tone map.
- New `components/dashboard/SuspensionBanner.tsx` — 4 variants (banned / timed+debt / timed only / debt only) + null when clean. Pure walk-in CTA, no "Pay now" button.
- New `components/dashboard/CancellationHistorySection.tsx` — paginated, sorted newest-first, click-to-expand reason, empty state.
- Modified `CancelListingModal.tsx` — consequence-aware copy via `resolveCopyVariant()` helper with **ban-precedence row** (banned sellers cancelling existing listings see factual "permanently banned" copy, NOT a misleading 4th-offense threat).
- Modified `MyListingsTab.tsx` — "Create new listing" CTA pre-disabled with role-specific tooltip when user can't list.
- Modified `AuctionDetailClient.tsx` — handles `AUCTION_CANCELLED` envelope (invalidates auction + bid history + my-proxy queries).
- Modified listing wizard — catches 403 SellerSuspendedException, branches on structured `code` field, routes to focused `SuspensionErrorModal` with role-specific copy.
- Six React Query hooks + API client + types/cancellation.ts mirroring backend DTOs.

### DEFERRED_WORK ledger changes

**Resolved (deleted):** "Cancellation WS broadcast on active-auction cancel" — shipped via `AUCTION_CANCELLED` envelope in this sub-spec.

**Carried forward (out of scope for sub-spec 2):**
- Admin endpoints for cancellation history + admin lift for ban/suspension/balance — Epic 10
- Email/IM notifications of suspension events — Epic 09
- User-targeted WS queue for live `PENALTY_CLEARED` push — using window-focus refetch for now
- LSL terminal-side script implementation — Phase 11

## Test plan

- [x] Backend: `cd backend && ./mvnw test` — 1068 tests pass, 4 pre-existing baseline failures unchanged (libwebp arm64 native-load × 3, parcel-tags 401 mismatch × 1)
- [x] Frontend: `cd frontend && npm test -- --run` — 1199+ tests pass
- [x] Frontend lint: `cd frontend && npm run lint` — clean
- [x] Frontend build: `cd frontend && npm run build` — passing (21 static pages, no Suspense regressions)
- [ ] Manual: cancel auction with bids 4 times → ladder lands warning, L$1000 debt, L$2500 + 30d, permanent ban
- [ ] Manual: pay at terminal partial then full → balance clears, banner dismisses on window-focus refetch
- [ ] Manual: cancel auction with bids → 48h watcher → simulate ownership change via dev endpoint → CANCEL_AND_SELL fraud flag created
- [ ] Manual: suspended seller's "Create new listing" CTA disabled with tooltip; deep-link to /listings/new gets 403 → focused modal with right copy

## Commits

8 commits — 2 docs + 6 implementation, organized per task with spec-review and code-quality-review fixup commits where issues surfaced.