### PR TITLE
chore: resolve deferred-work items before Epic 09

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionController.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,6 +26,7 @@ import com.slparcelauctions.backend.auction.dto.PendingVerification;
 import com.slparcelauctions.backend.auction.dto.PublicAuctionResponse;
 import com.slparcelauctions.backend.auction.dto.SellerAuctionResponse;
 import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
+import com.slparcelauctions.backend.auction.exception.NotVerifiedException;
 import com.slparcelauctions.backend.auth.AuthPrincipal;
 import com.slparcelauctions.backend.common.PagedResponse;
 import com.slparcelauctions.backend.escrow.Escrow;
@@ -224,7 +224,7 @@ public class AuctionController {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(userId));
         if (!Boolean.TRUE.equals(user.getVerified())) {
-            throw new AccessDeniedException(
+            throw new NotVerifiedException(
                     "SL avatar verification required to manage auctions.");
         }
     }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionRepository.java
@@ -165,4 +165,21 @@ public interface AuctionRepository extends JpaRepository<Auction, Long>, JpaSpec
     @EntityGraph(attributePaths = {"parcel", "tags"})
     @Query("SELECT a FROM Auction a WHERE a.id IN :ids ORDER BY a.endsAt ASC")
     List<Auction> findAllByIdInWithParcelAndTags(@Param("ids") Collection<Long> ids);
+
+    /**
+     * Bulk-loads auction aggregates with {@code parcel} + {@code seller} eagerly
+     * fetched. Used by {@link com.slparcelauctions.backend.auction.mybids.MyBidsService}
+     * to avoid the per-id loop + lazy-seller N+1 (~43 queries on a page of 20)
+     * that the previous {@code findById}-in-a-loop pattern produced. Tags
+     * batch-load via {@code @BatchSize} on {@code Auction.tags} so a separate
+     * fetch over them is unnecessary.
+     *
+     * <p>The DB does not guarantee ordering for {@code IN}-clause results;
+     * callers that need a specific page order must zip the returned list back
+     * against the original ID list themselves (the same pattern as
+     * {@link #findAllByIdInWithParcelAndTags}).
+     */
+    @EntityGraph(attributePaths = {"parcel", "seller"})
+    @Query("SELECT a FROM Auction a WHERE a.id IN :ids")
+    List<Auction> findAllByIdWithParcelAndSeller(@Param("ids") Collection<Long> ids);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/BidRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/BidRepository.java
@@ -49,11 +49,12 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
               AND a.status IN :statuses
             GROUP BY b.auction.id,
                      CASE WHEN a.status = com.slparcelauctions.backend.auction.AuctionStatus.ACTIVE THEN 0 ELSE 1 END,
+                     a.status,
                      a.endsAt,
                      a.endedAt
             ORDER BY CASE WHEN a.status = com.slparcelauctions.backend.auction.AuctionStatus.ACTIVE THEN 0 ELSE 1 END ASC,
-                     a.endsAt DESC,
-                     a.endedAt DESC,
+                     CASE WHEN a.status = com.slparcelauctions.backend.auction.AuctionStatus.ACTIVE THEN a.endsAt END DESC,
+                     CASE WHEN a.status <> com.slparcelauctions.backend.auction.AuctionStatus.ACTIVE THEN a.endedAt END DESC,
                      b.auction.id ASC
             """,
             countQuery = """
@@ -81,11 +82,12 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
             WHERE b.bidder.id = :userId
             GROUP BY b.auction.id,
                      CASE WHEN a.status = com.slparcelauctions.backend.auction.AuctionStatus.ACTIVE THEN 0 ELSE 1 END,
+                     a.status,
                      a.endsAt,
                      a.endedAt
             ORDER BY CASE WHEN a.status = com.slparcelauctions.backend.auction.AuctionStatus.ACTIVE THEN 0 ELSE 1 END ASC,
-                     a.endsAt DESC,
-                     a.endedAt DESC,
+                     CASE WHEN a.status = com.slparcelauctions.backend.auction.AuctionStatus.ACTIVE THEN a.endsAt END DESC,
+                     CASE WHEN a.status <> com.slparcelauctions.backend.auction.AuctionStatus.ACTIVE THEN a.endedAt END DESC,
                      b.auction.id ASC
             """,
             countQuery = """

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/mybids/MyBidsService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/mybids/MyBidsService.java
@@ -92,15 +92,14 @@ public class MyBidsService {
             return new PageImpl<>(List.of(), effective, auctionIdsPage.getTotalElements());
         }
 
-        // Hydrate auctions via findById to trip the @EntityGraph on parcel+tags.
-        // Note: auction.seller is FetchType.LAZY and is NOT in the EntityGraph,
-        // so each summary touches seller.getDisplayName() causing one extra
-        // SELECT per auction. At page size 20 this is bounded (~43 queries per
-        // page). See DEFERRED_WORK.md ("N+1 on My Bids auction loading") for
-        // the followup to join seller into the graph.
+        // Bulk-load auctions with parcel + seller eagerly fetched in one query
+        // — replaces the previous per-id findById loop that triggered ~43
+        // SELECTs on a page of 20 (one per id, plus one lazy seller fetch per
+        // row). The DB does not guarantee IN-clause ordering, so we walk the
+        // original ids list when assembling summaries to preserve page order.
         Map<Long, Auction> byId = new HashMap<>();
-        for (Long id : ids) {
-            auctionRepo.findById(id).ifPresent(a -> byId.put(id, a));
+        for (Auction a : auctionRepo.findAllByIdWithParcelAndSeller(ids)) {
+            byId.put(a.getId(), a);
         }
 
         // Caller's bid aggregates per auction.

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/search/AuctionSearchPredicateBuilder.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/search/AuctionSearchPredicateBuilder.java
@@ -1,5 +1,6 @@
 package com.slparcelauctions.backend.auction.search;
 
+import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +19,7 @@ import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Subquery;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Builds a JPA {@link Specification} from a validated
@@ -43,7 +45,10 @@ import jakarta.persistence.criteria.Subquery;
  * would not be index-usable.
  */
 @Component
+@RequiredArgsConstructor
 public class AuctionSearchPredicateBuilder {
+
+    private final Clock clock;
 
     public Specification<Auction> build(AuctionSearchQuery q) {
         return (root, query, cb) -> {
@@ -111,7 +116,7 @@ public class AuctionSearchPredicateBuilder {
             predicates.add(cb.equal(seller.get("id"), q.sellerId()));
         }
         if (q.endingWithinHours() != null) {
-            OffsetDateTime now = OffsetDateTime.now();
+            OffsetDateTime now = OffsetDateTime.now(clock);
             OffsetDateTime upper = now.plusHours(q.endingWithinHours());
             predicates.add(cb.greaterThan(root.get("endsAt"), now));
             predicates.add(cb.lessThanOrEqualTo(root.get("endsAt"), upper));

--- a/backend/src/main/java/com/slparcelauctions/backend/auth/RefreshTokenCleanupJob.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auth/RefreshTokenCleanupJob.java
@@ -6,6 +6,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import java.time.Clock;
 import java.time.OffsetDateTime;
 
 /**
@@ -25,11 +26,12 @@ public class RefreshTokenCleanupJob {
     private static final int RETENTION_DAYS = 30;
 
     private final RefreshTokenRepository refreshTokenRepository;
+    private final Clock clock;
 
     @Scheduled(cron = "0 30 3 * * *")  // 03:30 server local time, daily
     @Transactional
     public void cleanupExpiredTokens() {
-        OffsetDateTime cutoff = OffsetDateTime.now().minusDays(RETENTION_DAYS);
+        OffsetDateTime cutoff = OffsetDateTime.now(clock).minusDays(RETENTION_DAYS);
         int deleted = refreshTokenRepository.deleteOldRows(cutoff);
         log.info("Refresh token cleanup: deleted {} rows older than {}", deleted, cutoff);
     }

--- a/backend/src/main/java/com/slparcelauctions/backend/auth/RefreshTokenService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auth/RefreshTokenService.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.OffsetDateTime;
 
 /**
@@ -31,6 +32,7 @@ public class RefreshTokenService {
     private final RefreshTokenRepository repository;
     private final UserService userService;
     private final JwtConfig jwtConfig;
+    private final Clock clock;
 
     // -------------------------------------------------------------------------
     // Public record types
@@ -64,7 +66,7 @@ public class RefreshTokenService {
     public IssuedRefreshToken issueForUser(Long userId, String userAgent, String ipAddress) {
         String rawToken = TokenHasher.secureRandomBase64Url(32);
         String tokenHash = TokenHasher.sha256Hex(rawToken);
-        OffsetDateTime expiresAt = OffsetDateTime.now().plus(jwtConfig.getRefreshTokenLifetime());
+        OffsetDateTime expiresAt = OffsetDateTime.now(clock).plus(jwtConfig.getRefreshTokenLifetime());
 
         String truncatedAgent = userAgent != null && userAgent.length() > MAX_USER_AGENT_LENGTH
                 ? userAgent.substring(0, MAX_USER_AGENT_LENGTH)
@@ -113,17 +115,17 @@ public class RefreshTokenService {
             // REUSE DETECTED — cascade. FOOTGUNS §B.6.
             log.warn("Refresh token reuse detected: userId={} ip={} userAgent={}",
                     row.getUserId(), ipAddress, userAgent);
-            repository.revokeAllByUserId(row.getUserId(), OffsetDateTime.now());
+            repository.revokeAllByUserId(row.getUserId(), OffsetDateTime.now(clock));
             userService.bumpTokenVersion(row.getUserId());  // invalidate live access tokens
             throw new RefreshTokenReuseDetectedException(row.getUserId());
         }
 
-        if (row.getExpiresAt().isBefore(OffsetDateTime.now())) {
+        if (row.getExpiresAt().isBefore(OffsetDateTime.now(clock))) {
             throw new TokenExpiredException("Refresh token has expired.");
         }
 
         // Happy path: rotate
-        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime now = OffsetDateTime.now(clock);
         row.setLastUsedAt(now);
         row.setRevokedAt(now);
         // Dirty checking flushes on transaction commit
@@ -144,7 +146,7 @@ public class RefreshTokenService {
         if (rawToken == null || rawToken.isBlank()) return;  // null-safe
         repository.findByTokenHash(TokenHasher.sha256Hex(rawToken)).ifPresent(row -> {
             if (row.getRevokedAt() == null) {
-                row.setRevokedAt(OffsetDateTime.now());  // dirty checking saves
+                row.setRevokedAt(OffsetDateTime.now(clock));  // dirty checking saves
             }
         });
         // NEVER throws. NEVER logs details that could leak validity (FOOTGUNS §B.7).
@@ -159,6 +161,6 @@ public class RefreshTokenService {
      */
     @Transactional
     public int revokeAllForUser(Long userId) {
-        return repository.revokeAllByUserId(userId, OffsetDateTime.now());
+        return repository.revokeAllByUserId(userId, OffsetDateTime.now(clock));
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/common/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
+import com.slparcelauctions.backend.auction.exception.NotVerifiedException;
 import com.slparcelauctions.backend.sl.exception.ExternalApiTimeoutException;
 import com.slparcelauctions.backend.sl.exception.NotMainlandException;
 import com.slparcelauctions.backend.sl.exception.ParcelNotFoundInSlException;
@@ -79,6 +80,26 @@ public class GlobalExceptionHandler {
         pd.setTitle("Access denied");
         pd.setInstance(URI.create(req.getRequestURI()));
         pd.setProperty("code", "ACCESS_DENIED");
+        return pd;
+    }
+
+    /**
+     * Mirrors the auction-package handler so {@link NotVerifiedException}
+     * thrown from non-auction controllers (e.g. {@code ParcelController})
+     * surfaces the same {@code NOT_VERIFIED} code instead of falling through
+     * to the {@code Exception.class} 500 catch-all. The auction-package
+     * handler retains the local mapping for in-package controllers; this
+     * global mapping is the safety net for everything else.
+     */
+    @ExceptionHandler(NotVerifiedException.class)
+    public ProblemDetail handleNotVerified(NotVerifiedException e,
+                                           HttpServletRequest req) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(
+                HttpStatus.FORBIDDEN, e.getMessage());
+        pd.setType(URI.create("https://slpa.example/problems/not-verified"));
+        pd.setTitle("Not Verified");
+        pd.setInstance(URI.create(req.getRequestURI()));
+        pd.setProperty("code", "NOT_VERIFIED");
         return pd;
     }
 

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/command/TerminalCommandService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/command/TerminalCommandService.java
@@ -159,16 +159,8 @@ public class TerminalCommandService {
             Escrow escrow = cmd.getEscrowId() == null
                     ? null
                     : escrowRepo.findById(cmd.getEscrowId()).orElse(null);
-            ledgerRepo.save(EscrowTransaction.builder()
-                    .escrow(escrow)
-                    .auction(escrow == null ? null : escrow.getAuction())
-                    .type(ledgerTypeFor(cmd))
-                    .status(EscrowTransactionStatus.FAILED)
-                    .amount(cmd.getAmount())
-                    .terminalId(cmd.getTerminalId())
-                    .slTransactionId(req.slTransactionKey())
-                    .errorMessage(req.errorMessage())
-                    .build());
+            ledgerRepo.save(buildFailedLedgerRow(
+                    cmd, escrow, req.errorMessage(), req.slTransactionKey()));
 
             cmd.setLastError(req.errorMessage());
             if (cmd.getAttemptCount() < EscrowRetryPolicy.MAX_ATTEMPTS) {
@@ -307,7 +299,34 @@ public class TerminalCommandService {
         // admin flow; the auction room has no reason to observe them.
     }
 
-    private EscrowTransactionType ledgerTypeFor(TerminalCommand cmd) {
+    /**
+     * Builds a FAILED {@link EscrowTransaction} ledger row for the given
+     * command + (optional) escrow + error context. Public + static so the
+     * dispatcher's transport-failure stall path can reuse the same row shape
+     * without duplicating the {@code .builder()} chain. Callers persist the
+     * returned entity via their own {@code EscrowTransactionRepository}.
+     *
+     * <p>Both branches that emit a FAILED row — terminal-reported failures
+     * (in this service) and transport-failure stalls (in the dispatcher) —
+     * route through this helper so the dispute timeline surfaces them
+     * uniformly.
+     */
+    public static EscrowTransaction buildFailedLedgerRow(
+            TerminalCommand cmd, Escrow escrow, String errorMessage,
+            String slTransactionId) {
+        return EscrowTransaction.builder()
+                .escrow(escrow)
+                .auction(escrow == null ? null : escrow.getAuction())
+                .type(ledgerTypeFor(cmd))
+                .status(EscrowTransactionStatus.FAILED)
+                .amount(cmd.getAmount())
+                .terminalId(cmd.getTerminalId())
+                .slTransactionId(slTransactionId)
+                .errorMessage(errorMessage)
+                .build();
+    }
+
+    private static EscrowTransactionType ledgerTypeFor(TerminalCommand cmd) {
         if (cmd.getPurpose() == TerminalCommandPurpose.LISTING_FEE_REFUND) {
             return EscrowTransactionType.LISTING_FEE_REFUND;
         }

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/scheduler/TerminalCommandDispatcherTask.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/scheduler/TerminalCommandDispatcherTask.java
@@ -13,12 +13,14 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import com.slparcelauctions.backend.escrow.Escrow;
 import com.slparcelauctions.backend.escrow.EscrowRepository;
+import com.slparcelauctions.backend.escrow.EscrowTransactionRepository;
 import com.slparcelauctions.backend.escrow.broadcast.EscrowBroadcastPublisher;
 import com.slparcelauctions.backend.escrow.broadcast.EscrowPayoutStalledEnvelope;
 import com.slparcelauctions.backend.escrow.command.EscrowRetryPolicy;
 import com.slparcelauctions.backend.escrow.command.TerminalCommand;
 import com.slparcelauctions.backend.escrow.command.TerminalCommandBody;
 import com.slparcelauctions.backend.escrow.command.TerminalCommandRepository;
+import com.slparcelauctions.backend.escrow.command.TerminalCommandService;
 import com.slparcelauctions.backend.escrow.command.TerminalCommandStatus;
 import com.slparcelauctions.backend.escrow.command.TerminalHttpClient;
 import com.slparcelauctions.backend.escrow.terminal.EscrowConfigProperties;
@@ -51,6 +53,7 @@ public class TerminalCommandDispatcherTask {
     private final TerminalCommandRepository cmdRepo;
     private final TerminalRepository terminalRepo;
     private final EscrowRepository escrowRepo;
+    private final EscrowTransactionRepository ledgerRepo;
     private final TerminalHttpClient terminalHttp;
     private final EscrowBroadcastPublisher broadcastPublisher;
     private final EscrowConfigProperties props;
@@ -123,7 +126,19 @@ public class TerminalCommandDispatcherTask {
         if (cmd.getAttemptCount() >= EscrowRetryPolicy.MAX_ATTEMPTS) {
             cmd.setRequiresManualReview(true);
             cmd = cmdRepo.save(cmd);
-            publishStallIfEscrow(cmd, now);
+            // Mirror the terminal-reported-failure ledger pattern: every
+            // exhausted attempt — whether the terminal reported a failure
+            // (TerminalCommandService.applyCallback) or the transport stalled
+            // out (this branch) — gets a FAILED row so the dispute timeline
+            // surfaces both shapes uniformly. The row is keyed to the
+            // originating escrow / auction when one exists; listing-fee
+            // refunds (no escrow) still get a row with a null escrow ref.
+            Escrow escrow = cmd.getEscrowId() == null
+                    ? null
+                    : escrowRepo.findById(cmd.getEscrowId()).orElse(null);
+            ledgerRepo.save(TerminalCommandService.buildFailedLedgerRow(
+                    cmd, escrow, result.errorMessage(), null));
+            publishStall(cmd, escrow, now);
             log.error("Terminal command {} STALLED after {} attempts (transport): err={}",
                     cmd.getId(), cmd.getAttemptCount(), result.errorMessage());
         } else {
@@ -170,9 +185,10 @@ public class TerminalCommandDispatcherTask {
         return false;
     }
 
-    private void publishStallIfEscrow(TerminalCommand cmd, OffsetDateTime now) {
-        if (cmd.getEscrowId() == null) return;
-        Escrow escrow = escrowRepo.findById(cmd.getEscrowId()).orElse(null);
+    private void publishStall(TerminalCommand cmd, Escrow escrow, OffsetDateTime now) {
+        // No escrow row (e.g. listing-fee-refund command, or escrow vanished)
+        // — the FAILED ledger row above still captures the stall, but the
+        // PAYOUT_STALLED envelope is escrow-scoped so we skip it.
         if (escrow == null) return;
         final EscrowPayoutStalledEnvelope env =
                 EscrowPayoutStalledEnvelope.of(cmd, escrow, now);

--- a/backend/src/main/java/com/slparcelauctions/backend/parcel/ParcelController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/parcel/ParcelController.java
@@ -1,12 +1,12 @@
 package com.slparcelauctions.backend.parcel;
 
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.slparcelauctions.backend.auction.exception.NotVerifiedException;
 import com.slparcelauctions.backend.auth.AuthPrincipal;
 import com.slparcelauctions.backend.parcel.dto.ParcelLookupRequest;
 import com.slparcelauctions.backend.parcel.dto.ParcelResponse;
@@ -21,8 +21,8 @@ import lombok.RequiredArgsConstructor;
  * Parcel lookup endpoint. Gated on authenticated + SL-verified user:
  * Spring Security enforces authentication (401 on missing/bad JWT) via
  * {@code SecurityConfig}; the verified-flag check runs inline below and
- * throws {@link AccessDeniedException} (mapped to 403 by
- * {@code GlobalExceptionHandler}) for authenticated-but-unverified users.
+ * throws {@link NotVerifiedException} (mapped to 403 NOT_VERIFIED by the
+ * global exception handler) for authenticated-but-unverified users.
  *
  * <p>No dedicated {@code @PreAuthorize} infrastructure exists in this
  * codebase yet; introducing one would be premature. When a second
@@ -49,7 +49,7 @@ public class ParcelController {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(userId));
         if (!Boolean.TRUE.equals(user.getVerified())) {
-            throw new AccessDeniedException(
+            throw new NotVerifiedException(
                     "SL avatar verification required to look up parcels.");
         }
     }

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionControllerIntegrationTest.java
@@ -196,7 +196,7 @@ class AuctionControllerIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.code").value("ACCESS_DENIED"));
+                .andExpect(jsonPath("$.code").value("NOT_VERIFIED"));
     }
 
     @Test

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/mybids/MyBidsIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/mybids/MyBidsIntegrationTest.java
@@ -24,6 +24,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.slparcelauctions.backend.auction.Auction;
@@ -62,7 +67,10 @@ import reactor.core.publisher.Mono;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("dev")
-@TestPropertySource(properties = "auth.cleanup.enabled=false")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "spring.jpa.properties.hibernate.generate_statistics=true"
+})
 @Transactional
 class MyBidsIntegrationTest {
 
@@ -73,6 +81,7 @@ class MyBidsIntegrationTest {
     @Autowired AuctionRepository auctionRepository;
     @Autowired BidRepository bidRepository;
     @Autowired UserRepository userRepository;
+    @PersistenceContext EntityManager entityManager;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -294,6 +303,114 @@ class MyBidsIntegrationTest {
         a.setEndsAt(endsAt);
         a.setOriginalEndsAt(endsAt);
         return auctionRepository.save(a);
+    }
+
+    // -------------------------------------------------------------------------
+    // Non-ACTIVE rows sort by endedAt (not endsAt). Spec §10 conditional
+    // ORDER BY — earlier deviation surfaced as DEFERRED_WORK ledger entry.
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getMyBids_endedRowsSortByEndedAt_notEndsAt() throws Exception {
+        // Seed two ENDED auctions whose endsAt order differs from endedAt order.
+        // auctionEarlyEndsAt: endsAt=now-10h, endedAt=now-1h (extended/snipe-protected)
+        // auctionLateEndsAt:  endsAt=now-2h,  endedAt=now-5h (closed earlier, no extension)
+        // If sorted by endsAt DESC: late (-2h) before early (-10h) -> WRONG
+        // If sorted by endedAt DESC: early (-1h) before late (-5h) -> CORRECT
+        Parcel pEarly = seedParcel(200);
+        Parcel pLate = seedParcel(201);
+
+        OffsetDateTime now = OffsetDateTime.now();
+        Auction earlyEndsAtAuction = seedEndedAuctionWithTimes(
+                pEarly, now.minusHours(10), now.minusHours(1));
+        Auction lateEndsAtAuction = seedEndedAuctionWithTimes(
+                pLate, now.minusHours(2), now.minusHours(5));
+        saveBid(earlyEndsAtAuction, bidderId, 1500L);
+        saveBid(lateEndsAtAuction, bidderId, 1500L);
+
+        MvcResult result = mockMvc.perform(get("/api/v1/users/me/bids")
+                        .param("status", "all")
+                        .header("Authorization", "Bearer " + bidderAccessToken))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode content = objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("content");
+
+        // Walk content in returned order, capturing positions of our two seeded rows.
+        int earlyIdx = -1;
+        int lateIdx = -1;
+        for (int i = 0; i < content.size(); i++) {
+            long id = content.get(i).get("auction").get("id").asLong();
+            if (id == earlyEndsAtAuction.getId()) earlyIdx = i;
+            if (id == lateEndsAtAuction.getId()) lateIdx = i;
+        }
+        org.assertj.core.api.Assertions.assertThat(earlyIdx)
+                .as("auction with endedAt=now-1h must appear before auction with endedAt=now-5h")
+                .isGreaterThanOrEqualTo(0)
+                .isLessThan(lateIdx);
+    }
+
+    private Auction seedEndedAuctionWithTimes(
+            Parcel parcelForAuction, OffsetDateTime endsAt, OffsetDateTime endedAt) {
+        User seller = userRepository.findById(sellerId).orElseThrow();
+        OffsetDateTime startsAt = endsAt.minusDays(7);
+        Auction a = Auction.builder()
+                .title("Test listing")
+                .parcel(parcelForAuction)
+                .seller(seller)
+                .status(AuctionStatus.ENDED)
+                .endOutcome(AuctionEndOutcome.SOLD)
+                .verificationMethod(VerificationMethod.UUID_ENTRY)
+                .verificationTier(VerificationTier.SCRIPT)
+                .startingBid(1000L)
+                .durationHours(168)
+                .snipeProtect(false)
+                .listingFeePaid(true)
+                .currentBid(1500L)
+                .bidCount(1)
+                .consecutiveWorldApiFailures(0)
+                .commissionRate(new BigDecimal("0.05"))
+                .agentFeeRate(BigDecimal.ZERO)
+                .build();
+        a.setStartsAt(startsAt);
+        a.setEndsAt(endsAt);
+        a.setOriginalEndsAt(endsAt);
+        a.setEndedAt(endedAt);
+        return auctionRepository.save(a);
+    }
+
+    // -------------------------------------------------------------------------
+    // Hydration query-count guard: bulk-load auctions with parcel + seller in
+    // one query rather than per-id findById (which lazy-loaded seller per row).
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getMyBids_hydratesAuctionsWithoutNPlusOne() throws Exception {
+        SessionFactory sessionFactory = entityManager.getEntityManagerFactory()
+                .unwrap(SessionFactory.class);
+        Statistics stats = sessionFactory.getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+
+        mockMvc.perform(get("/api/v1/users/me/bids")
+                        .param("status", "all")
+                        .header("Authorization", "Bearer " + bidderAccessToken))
+                .andExpect(status().isOk());
+
+        // Seven auctions are seeded in @BeforeEach. The previous per-id
+        // findById loop with a lazy seller would entity-load Auction 7 times
+        // (one per id) and User 7 additional times (lazy seller fetch per
+        // row). The bulk-load path entity-loads Auction 7 times too (once
+        // per row in the result set), but seller is in the EntityGraph so
+        // User loads come from the same SELECT — they do not show up as
+        // additional load events. The strict guard here is on the entity
+        // *fetch* (= lazy initialization) count, which the old path drove
+        // up via lazy seller hydration and the new path leaves at zero.
+        long entityFetchCount = stats.getEntityFetchCount();
+        org.assertj.core.api.Assertions.assertThat(entityFetchCount)
+                .as("My Bids must not lazy-fetch seller per row (regression to N+1)")
+                .isLessThan(7L);
     }
 
     // -------------------------------------------------------------------------

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/mybids/MyBidsServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/mybids/MyBidsServiceTest.java
@@ -223,9 +223,10 @@ class MyBidsServiceTest {
         org.mockito.Mockito.lenient().when(
                 bidRepo.findMyBidAuctionIdsUnfiltered(eq(USER_ID), any(Pageable.class)))
                 .thenReturn(idsPage);
-        for (Auction a : auctions) {
-            when(auctionRepo.findById(a.getId())).thenReturn(java.util.Optional.of(a));
-        }
+        // Bulk-load via parcel+seller graph replaces the previous per-id
+        // findById loop. Service zips back against original ids list to
+        // preserve page order, so the order returned here is irrelevant.
+        when(auctionRepo.findAllByIdWithParcelAndSeller(any())).thenReturn(auctions);
         when(bidRepo.findMyBidAggregatesForAuctions(eq(USER_ID), any()))
                 .thenReturn(aggregates);
     }

--- a/backend/src/test/java/com/slparcelauctions/backend/auth/RefreshTokenServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auth/RefreshTokenServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Optional;
@@ -38,7 +39,11 @@ class RefreshTokenServiceTest {
     void setUp() {
         JwtConfig config = new JwtConfig();
         config.setRefreshTokenLifetime(Duration.ofDays(7));
-        service = new RefreshTokenService(repository, userService, config);
+        // Real-time clock so the existing assertions ("expires in ~7d", "now is
+        // before expiry") still hold without rewriting them. Tests that need
+        // deterministic timestamps can construct the service with
+        // Clock.fixed(...) directly.
+        service = new RefreshTokenService(repository, userService, config, Clock.systemUTC());
     }
 
     // -------------------------------------------------------------------------

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/command/TerminalCommandDispatcherTaskTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/command/TerminalCommandDispatcherTaskTest.java
@@ -34,6 +34,10 @@ import com.slparcelauctions.backend.auction.VerificationMethod;
 import com.slparcelauctions.backend.escrow.Escrow;
 import com.slparcelauctions.backend.escrow.EscrowRepository;
 import com.slparcelauctions.backend.escrow.EscrowState;
+import com.slparcelauctions.backend.escrow.EscrowTransaction;
+import com.slparcelauctions.backend.escrow.EscrowTransactionRepository;
+import com.slparcelauctions.backend.escrow.EscrowTransactionStatus;
+import com.slparcelauctions.backend.escrow.EscrowTransactionType;
 import com.slparcelauctions.backend.escrow.broadcast.EscrowBroadcastPublisher;
 import com.slparcelauctions.backend.escrow.scheduler.TerminalCommandDispatcherTask;
 import com.slparcelauctions.backend.escrow.terminal.EscrowConfigProperties;
@@ -62,6 +66,7 @@ class TerminalCommandDispatcherTaskTest {
     @Mock TerminalCommandRepository cmdRepo;
     @Mock TerminalRepository terminalRepo;
     @Mock EscrowRepository escrowRepo;
+    @Mock EscrowTransactionRepository ledgerRepo;
     @Mock TerminalHttpClient terminalHttp;
     @Mock EscrowBroadcastPublisher broadcastPublisher;
     @Mock EscrowConfigProperties props;
@@ -73,7 +78,7 @@ class TerminalCommandDispatcherTaskTest {
     void setUp() {
         fixed = Clock.fixed(Instant.parse("2026-04-21T14:00:00Z"), ZoneOffset.UTC);
         task = new TerminalCommandDispatcherTask(
-                cmdRepo, terminalRepo, escrowRepo, terminalHttp,
+                cmdRepo, terminalRepo, escrowRepo, ledgerRepo, terminalHttp,
                 broadcastPublisher, props, fixed);
         lenient().when(props.terminalLiveWindow()).thenReturn(LIVE_WINDOW);
         lenient().when(props.commandInFlightTimeout()).thenReturn(IN_FLIGHT_TIMEOUT);
@@ -173,6 +178,59 @@ class TerminalCommandDispatcherTaskTest {
         // called only if the transaction commits. We can at least assert the
         // escrow lookup happened (so the envelope factory has its inputs).
         verify(escrowRepo).findById(ESCROW_ID);
+    }
+
+    @Test
+    void httpFailureAtCap_writesFailedLedgerRow() {
+        // Spec follow-up: transport-failure stalls now write a FAILED
+        // EscrowTransaction row mirroring the terminal-reported-failure path
+        // in TerminalCommandService.applyCallback. The dispute timeline can
+        // surface both shapes uniformly.
+        TerminalCommand cmd = buildQueued();
+        cmd.setStatus(TerminalCommandStatus.FAILED);
+        cmd.setAttemptCount(3);
+        cmd.setRequiresManualReview(false);
+
+        Terminal terminal = buildTerminal();
+        Escrow escrow = buildEscrow();
+        when(cmdRepo.findByIdForUpdate(CMD_ID)).thenReturn(Optional.of(cmd));
+        when(terminalRepo.findAnyLive(any())).thenReturn(Optional.of(terminal));
+        when(cmdRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(terminalHttp.post(anyString(), any()))
+                .thenReturn(TerminalHttpClient.TerminalHttpResult.fail("connection refused"));
+        when(escrowRepo.findById(ESCROW_ID)).thenReturn(Optional.of(escrow));
+
+        task.dispatchOne(CMD_ID);
+
+        ArgumentCaptor<EscrowTransaction> ledgerCaptor =
+                ArgumentCaptor.forClass(EscrowTransaction.class);
+        verify(ledgerRepo).save(ledgerCaptor.capture());
+        EscrowTransaction row = ledgerCaptor.getValue();
+        assertThat(row.getStatus()).isEqualTo(EscrowTransactionStatus.FAILED);
+        assertThat(row.getType()).isEqualTo(EscrowTransactionType.AUCTION_ESCROW_PAYOUT);
+        assertThat(row.getAmount()).isEqualTo(cmd.getAmount());
+        assertThat(row.getEscrow()).isEqualTo(escrow);
+        assertThat(row.getAuction()).isEqualTo(escrow.getAuction());
+        assertThat(row.getErrorMessage()).isEqualTo("connection refused");
+        assertThat(row.getTerminalId()).isEqualTo(TERMINAL_ID);
+    }
+
+    @Test
+    void httpFailureBelowCap_doesNotWriteFailedLedgerRow() {
+        // Below-cap retries leave the row in FAILED with backoff but do NOT
+        // write a per-attempt ledger row — that would balloon the ledger for
+        // every transient hiccup. Only the cap-exhaust transition writes one.
+        TerminalCommand cmd = buildQueued();
+        Terminal terminal = buildTerminal();
+        when(cmdRepo.findByIdForUpdate(CMD_ID)).thenReturn(Optional.of(cmd));
+        when(terminalRepo.findAnyLive(any())).thenReturn(Optional.of(terminal));
+        when(cmdRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(terminalHttp.post(anyString(), any()))
+                .thenReturn(TerminalHttpClient.TerminalHttpResult.fail("connect timeout"));
+
+        task.dispatchOne(CMD_ID);
+
+        verifyNoInteractions(ledgerRepo);
     }
 
     @Test

--- a/backend/src/test/java/com/slparcelauctions/backend/parcel/ParcelControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/parcel/ParcelControllerIntegrationTest.java
@@ -44,7 +44,7 @@ import reactor.core.publisher.Mono;
  * <p>User states covered:
  * <ul>
  *   <li>Unauthenticated -> 401 from {@code JwtAuthenticationEntryPoint}.</li>
- *   <li>Authenticated, unverified -> 403 via {@code AccessDeniedException}.</li>
+ *   <li>Authenticated, unverified -> 403 via {@code NotVerifiedException}.</li>
  *   <li>Authenticated, verified -> success paths and domain error paths.</li>
  * </ul>
  */
@@ -192,7 +192,7 @@ class ParcelControllerIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(new ParcelLookupRequest(parcelUuid))))
                 .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.code").value("ACCESS_DENIED"));
+                .andExpect(jsonPath("$.code").value("NOT_VERIFIED"));
     }
 
     // -------------------------------------------------------------------------

--- a/docs/implementation/DEFERRED_WORK.md
+++ b/docs/implementation/DEFERRED_WORK.md
@@ -116,30 +116,6 @@ When finishing a sub-spec that completes a deferred item, remove the entry.
 - **When:** Indefinite — upgrade when a second destructive use case arrives and the current shape pinches.
 - **Notes:** The current token mapping (`bg-error` / `text-on-error`) is the load-bearing part. Any polish should NOT switch to raw Tailwind palette classes (`bg-red-500`) — keep it on the M3 token system.
 
-### N+1 on My Bids auction loading
-- **From:** Epic 04 sub-spec 1 (Task 8)
-- **Why:** `MyBidsService.findAuctionPage` loads auctions one-by-one via `AuctionRepository.findById` to trip the `@EntityGraph` on parcel + tags. `Auction.seller` is not in the EntityGraph and lazy-loads per-row, producing ~2 extra queries per auction on a page of 20 (up to ~43 queries total per page). At Phase 1 volumes this is acceptable (bounded by page size = 20) but is worth fixing before scale.
-- **When:** Near-term cleanup after sub-spec 2 frontend lands — likely the frontend will reveal whether seller display name is needed for every card.
-- **Notes:** Fix options: (a) add `seller` to the existing `@EntityGraph` on `findById` (affects all callers); (b) add a dedicated `findAllByIdWithParcelAndSeller(Collection<Long>)` query that `MyBidsService` uses instead of the per-id loop.
-
-### My Bids non-ACTIVE sort key deviation
-- **From:** Epic 04 sub-spec 1 (Task 8)
-- **Why:** Spec §10 specifies conditional `ORDER BY` using `CASE WHEN a.status = 'ACTIVE' THEN a.ends_at END DESC, CASE WHEN a.status != 'ACTIVE' THEN a.ended_at END DESC`. The actual query uses unconditional `a.endsAt DESC, a.endedAt DESC`, which means non-ACTIVE auctions are ordered by `endsAt` first. At Phase 1 volumes the drift is small (snipe-extended auctions diverge by at most 2-60 minutes) but is a documented spec deviation.
-- **When:** Fix when sub-spec 2 frontend surfaces sort-order concerns, or during an Epic 04 cleanup pass.
-- **Notes:** Replace `a.endsAt DESC, a.endedAt DESC` with `CASE WHEN a.status = 'ACTIVE' THEN a.endsAt END DESC, CASE WHEN a.status != 'ACTIVE' THEN a.endedAt END DESC` (Postgres tolerates NULLs in CASE-based ORDER BY).
-
-### Migrate Epic 02/03 write paths onto NotVerifiedException
-- **From:** Epic 04 sub-spec 1 (Task 2 — bid placement)
-- **Why:** `NotVerifiedException` was introduced to give the bid path a clean `NOT_VERIFIED` (403) error code. Pre-existing verification checks in `AuctionController.requireVerified`, parcel controllers, and other write paths still throw raw `AccessDeniedException` with inline message strings, producing `ACCESS_DENIED` instead of `NOT_VERIFIED`. Frontend UX distinguishing the two codes will only see `NOT_VERIFIED` from the bid path until the migration lands.
-- **When:** Near-term — trivially, a one-line swap at each existing call site. Deferred from Task 2 to keep the scope tight; pick up as a standalone cleanup task or roll into the Epic 04 sub-spec 2 frontend work when the UX for verification prompts is wired.
-- **Notes:** Search for `AccessDeniedException` call sites that include the string "verification required" (or equivalent) — those are the migration targets. `NotVerifiedException` already exists at `backend/src/main/java/com/slparcelauctions/backend/auction/exception/NotVerifiedException.java` and has an existing handler in `AuctionExceptionHandler.java`.
-
-### DESIGN.md §554 stale wording cleanup
-- **From:** Epic 04 sub-spec 1 (spec §15 follow-up)
-- **Why:** DESIGN.md §554 says "Bid history (anonymized or public - configurable)" — leftover wording from an earlier iteration of the spec. §1589-1591 explicitly resolves bidder identity visibility as public (display name + avatar, no anonymization toggle) and Epic 04 sub-spec 1 ships the public-identity behavior. Anyone grepping DESIGN.md for "anonymized" will hit a contradiction.
-- **When:** Next doc sweep / any epic that reopens DESIGN.md for structural edits.
-- **Notes:** One-sentence replacement — "Bid history (public — displayName + avatar only, no IP or full name)" lines up with the implemented behavior.
-
 ### Outbid / won / reserve-not-met / auction-ended notifications
 - **From:** Epic 04 sub-spec 1 (spec §15)
 - **Why:** Epic 04 sub-spec 1 publishes the data sources — `Bid` rows carry `OUTBID` / `WON` / `LOST` derivable state, `Auction.endOutcome` carries `SOLD` / `RESERVE_NOT_MET` / `NO_BIDS` / `BOUGHT_NOW`, and the WS settlement + auction-ended envelopes broadcast the transitions. No email / SL IM fan-out exists yet. Bidders learn they've been outbid only by reloading the auction page or watching the live WS update; sellers learn the auction ended only by reloading My Listings.
@@ -194,12 +170,6 @@ When finishing a sub-spec that completes a deferred item, remove the entry.
 - **When:** Epic 10 (Admin & Moderation) — wire alongside the admin secret-rotation endpoint already deferred.
 - **Notes:** Column is nullable today; no data loss. Touchpoint: `TerminalCommandService.queue(...)` + a future rotation endpoint that stamps the new version on in-flight commands.
 
-### FAILED ledger row on transport-failure stall
-- **From:** Epic 05 sub-spec 1 (Task 7 code review, M6)
-- **Why:** Terminal-reported failures write a FAILED `EscrowTransaction` row per attempt (audit trail). Transport-level failures (HTTP 5xx, connection refused, timeout) only set `last_error` on the command + bump `attemptCount`; the dispute timeline lacks visibility into transport failures that exhaust the retry budget. On the stall path (attempt 4), consider writing a FAILED ledger row so the dispute timeline records the stall uniformly.
-- **When:** Opportunistic — pull in during the next Epic 05 maintenance task, or alongside Epic 10 admin tooling when the dispute-timeline UI surfaces this asymmetry.
-- **Notes:** Touchpoint: `TerminalCommandDispatcherTask.dispatchOne` + `TerminalCommandService.applyCallback` (need to factor the FAILED ledger row build into a shared helper).
-
 ### HMAC-SHA256 terminal auth
 - **From:** Epic 05 sub-spec 1
 - **Why:** Sub-spec 1 ships static shared secret + rotation via config + redeploy. HMAC-SHA256 adds per-request replay protection but requires SHA256 implementation in LSL (~50-100 line library). Premature to ship until a working LSL terminal exists to dogfood against.
@@ -228,11 +198,6 @@ When finishing a sub-spec that completes a deferred item, remove the entry.
 - **Why:** DESIGN.md §5.2 suggests "sum of pending escrow amounts should match the expected SL account balance." Sub-spec 1 writes every L$ movement to the `EscrowTransaction` ledger, so the data is there — just no job reconciles it against SL grid queries.
 - **When:** Epic 10 (Admin & Moderation).
 - **Notes:** Daily job that sums `EscrowTransaction` rows by type, queries SLPAEscrow account balance via World API, alerts on mismatch.
-
-### Retrofit existing Epic 03/04 code to Clock injection
-- **From:** Epic 05 sub-spec 1
-- **Why:** Sub-spec 1 code injects `Clock` and calls `OffsetDateTime.now(clock)` throughout. Existing Epic 03/04 services that use raw `OffsetDateTime.now()` are unaffected but can't be cleanly tested with a frozen clock. Out of scope for this sub-spec; retrofit when touched.
-- **When:** Opportunistic — pull in during the next maintenance pass that touches the affected services.
 
 ### Dispute evidence attachments
 - **From:** Epic 05 sub-spec 2

--- a/docs/initial-design/DESIGN.md
+++ b/docs/initial-design/DESIGN.md
@@ -551,7 +551,7 @@ Each listing receives a verification tier badge visible to buyers. Tier is deter
 - All parcel metadata + seller description
 - Live current bid + bid count
 - Countdown timer
-- Bid history (anonymized or public - configurable)
+- Bid history (public — display name and avatar only, no IP or full name)
 - **Parcel layout map** - generated grid image showing parcel boundaries within the region (see Section 5.5)
 - **"Visit in Second Life" button** - links to SLURL (opens SL viewer and teleports user to parcel)
     - Web link format: `https://maps.secondlife.com/secondlife/Region%20Name/x/y/z`


### PR DESCRIPTION
## Summary

Six small deferred-work items resolved in one PR ahead of Epic 09 (Notifications). All landed as separate commits — one per item, except items 1+2 which were batched (both touch My Bids).

## What ships

1. **My Bids sort key + N+1** (`3e5c1fd`) — `BidRepository` now uses conditional CASE-based ORDER BY so non-ACTIVE rows sort by \`endedAt\` (not \`endsAt\`). \`MyBidsService\` switched from per-ID \`findById\` loop to a single \`findAllByIdWithParcelAndSeller\` bulk fetch with \`@EntityGraph(parcel + seller)\`. Original ID ordering preserved via Map walk after fetch.

2. **NotVerifiedException migration** (\`9a191bd\`) — \`AuctionController.requireVerified\` and \`ParcelController.requireVerified\` now throw \`NotVerifiedException\` instead of \`AccessDeniedException\`. \`GlobalExceptionHandler\` extended to map \`NotVerifiedException\` so non-auction-package callers get the right ProblemDetail. \`DevAuctionController\` left alone — its throw is an authentication check ("Authentication required..."), not a verification check.

3. **DESIGN.md bid-history wording** (\`d24a889\`) — replaced stale "anonymized or public - configurable" with the implemented "public — display name and avatar only, no IP or full name".

4. **Clock injection retrofit** (\`6c65c94\`) — \`RefreshTokenService\`, \`RefreshTokenCleanupJob\`, \`AuctionSearchPredicateBuilder\` now use injected \`Clock\` instead of raw \`OffsetDateTime.now()\`. Tests updated to inject \`Clock.systemUTC()\` where assertions are real-time.

5. **FAILED ledger row on transport stall** (\`61b7f28\`) — \`TerminalCommandDispatcherTask\` now writes a FAILED \`EscrowTransaction\` row when a command exhausts retry budget on transport failures. Closes the asymmetry where terminal-reported failures wrote ledger rows but transport stalls didn't. Extracted \`TerminalCommandService.buildFailedLedgerRow\` as a shared helper.

6. **Deferred-ledger cleanup** (\`7363dce\`) — removed 6 resolved entries from DEFERRED_WORK.md.

## Test plan

- [x] Backend: \`./mvnw test\` — **1072 tests, 0 failures, 0 errors** (was 1068; +4 from new regression guards on items 1, 2, and 6)
- [x] Targeted: My Bids integration test asserts \`endedAt\`-based sorting + Hibernate Statistics-based N+1 guard
- [x] Targeted: NotVerifiedException MockMvc assertions on auction + parcel controllers
- [x] Targeted: TerminalCommandDispatcherTask FAILED-row write test (above-cap and below-cap branches)
- [ ] CI on Linux x86_64

## One concern flagged by implementer

The original brief mentioned \`DevAuctionController\` line 71 as a verification check to migrate. On closer reading, that throw is an **authentication** check (message: "Authentication required to simulate listing-fee payment"), not a verification check. Implementer left it untouched by analogy with the explicitly excluded \`ReviewService\` throws. If the intent was actually to migrate that line too, easy follow-up.