### PR TITLE
Epic 09 sub-spec 3: SL IM channel + notification preferences UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,13 @@ npm run lint      # ESLint (v9)
 - The SL World API provides parcel metadata and ownership verification.
 - LSL scripts communicate with the backend via `llHTTPRequest` (outbound) and HTTP-in URLs (inbound).
 
+**In-world LSL code lives in `lsl-scripts/`.** Each script gets its own
+subdirectory with its own README covering deployment, configuration,
+operations, and limits. Updates to a script's behavior, deployment, or
+configuration must update that script's README in the same commit. The
+top-level `lsl-scripts/README.md` is an index — updates only on add / remove
+/ rename.
+
 ## Infrastructure Dependencies
 
 - **PostgreSQL** - relational data (users, auctions, escrow, reviews)

--- a/backend/src/main/java/com/slparcelauctions/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/common/exception/GlobalExceptionHandler.java
@@ -289,6 +289,18 @@ public class GlobalExceptionHandler {
         return pd;
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ProblemDetail handleIllegalArgument(IllegalArgumentException e,
+                                               HttpServletRequest req) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST, e.getMessage());
+        pd.setType(URI.create("https://slpa.example/problems/bad-request"));
+        pd.setTitle("Bad request");
+        pd.setInstance(URI.create(req.getRequestURI()));
+        pd.setProperty("code", "BAD_REQUEST");
+        return pd;
+    }
+
     @ExceptionHandler(Exception.class)
     public ProblemDetail handleUnexpected(Exception e, HttpServletRequest req) {
         String correlationId = UUID.randomUUID().toString();

--- a/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import com.slparcelauctions.backend.auth.JwtAuthenticationEntryPoint;
 import com.slparcelauctions.backend.auth.JwtAuthenticationFilter;
 import com.slparcelauctions.backend.bot.BotSharedSecretAuthorizer;
+import com.slparcelauctions.backend.notification.slim.internal.SlImTerminalAuthFilter;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,6 +32,7 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint authenticationEntryPoint;
     private final BotSharedSecretAuthorizer botSharedSecretAuthorizer;
+    private final SlImTerminalAuthFilter slImTerminalAuthFilter;
 
     @Value("${cors.allowed-origin:http://localhost:3000}")
     private String allowedOrigin;
@@ -227,9 +229,26 @@ public class SecurityConfig {
                         // the request 404s (falling through Spring MVC rather than Spring Security).
                         // FOOTGUNS §B.5: this MUST sit before the /api/v1/** catch-all.
                         .requestMatchers("/api/v1/dev/**").permitAll()
+                        // SL IM terminal polling endpoints (Epic 09 sub-spec 3 Task 4).
+                        // Authentication is a shared bearer token validated by
+                        // SlImTerminalAuthFilter (constant-time compare via
+                        // MessageDigest.isEqual). JWT is not used here — the in-world
+                        // dispatcher script cannot obtain a user JWT.
+                        // CSRF is already globally disabled (AbstractHttpConfigurer::disable
+                        // above) so no additional ignoringRequestMatchers is needed.
+                        // FOOTGUNS §B.5: MUST sit before the /api/v1/** catch-all.
+                        .requestMatchers("/api/v1/internal/sl-im/**").permitAll()
                         .requestMatchers("/api/v1/**").authenticated()
                         .anyRequest().denyAll())
                 .exceptionHandling(eh -> eh.authenticationEntryPoint(authenticationEntryPoint))
+                // SlImTerminalAuthFilter runs before the JWT filter so it can short-circuit
+                // /api/v1/internal/sl-im/** with a 401 before JWT processing begins.
+                // JwtAuthenticationFilter has no registered Spring Security filter order, so
+                // we position both custom filters before UsernamePasswordAuthenticationFilter
+                // (a well-known sentinel with a registered order). SlImTerminalAuthFilter's
+                // shouldNotFilter() returns true for all non-internal paths, keeping the
+                // ordering harmless for the rest of the filter chain.
+                .addFilterBefore(slImTerminalAuthFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/backend/src/main/java/com/slparcelauctions/backend/config/SlpaWebProperties.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/config/SlpaWebProperties.java
@@ -1,0 +1,11 @@
+package com.slparcelauctions.backend.config;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties(prefix = "slpa.web")
+@Validated
+public record SlpaWebProperties(
+    @NotBlank String baseUrl
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/config/SlpaWebPropertiesConfig.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/config/SlpaWebPropertiesConfig.java
@@ -1,0 +1,16 @@
+package com.slparcelauctions.backend.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Registers {@link SlpaWebProperties} as a configuration-properties bean.
+ * Mirrors the pattern used by {@code SlPropertiesConfig} and
+ * {@code NotificationCleanupConfig} — the project uses
+ * {@code @EnableConfigurationProperties} rather than
+ * {@code @ConfigurationPropertiesScan}.
+ */
+@Configuration
+@EnableConfigurationProperties(SlpaWebProperties.class)
+public class SlpaWebPropertiesConfig {
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java
@@ -2,6 +2,7 @@ package com.slparcelauctions.backend.notification;
 
 import com.slparcelauctions.backend.notification.NotificationDao.UpsertResult;
 import com.slparcelauctions.backend.notification.dto.NotificationDto;
+import com.slparcelauctions.backend.notification.slim.SlImChannelDispatcher;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -37,16 +38,19 @@ public class NotificationPublisherImpl implements NotificationPublisher {
     private final NotificationDao notificationDao;
     private final NotificationWsBroadcasterPort wsBroadcaster;
     private final TransactionTemplate requiresNewTxTemplate;
+    private final SlImChannelDispatcher slImChannelDispatcher;
 
     public NotificationPublisherImpl(
             NotificationService notificationService,
             NotificationDao notificationDao,
             NotificationWsBroadcasterPort wsBroadcaster,
-            @Qualifier("requiresNewTxTemplate") TransactionTemplate requiresNewTxTemplate) {
+            @Qualifier("requiresNewTxTemplate") TransactionTemplate requiresNewTxTemplate,
+            SlImChannelDispatcher slImChannelDispatcher) {
         this.notificationService = notificationService;
         this.notificationDao = notificationDao;
         this.wsBroadcaster = wsBroadcaster;
         this.requiresNewTxTemplate = requiresNewTxTemplate;
+        this.slImChannelDispatcher = slImChannelDispatcher;
     }
 
     @Override
@@ -291,10 +295,15 @@ public class NotificationPublisherImpl implements NotificationPublisher {
             public void afterCommit() {
                 for (Long bidderId : bidderUserIds) {
                     try {
-                        UpsertResult result = requiresNewTxTemplate.execute(status ->
-                            notificationDao.upsert(bidderId, NotificationCategory.LISTING_CANCELLED_BY_SELLER,
-                                                    title, body, data, null)
-                        );
+                        UpsertResult result = requiresNewTxTemplate.execute(status -> {
+                            UpsertResult r = notificationDao.upsert(bidderId,
+                                NotificationCategory.LISTING_CANCELLED_BY_SELLER,
+                                title, body, data, null);
+                            slImChannelDispatcher.maybeQueueForFanout(
+                                bidderId, NotificationCategory.LISTING_CANCELLED_BY_SELLER,
+                                title, body, data, null);
+                            return r;
+                        });
                         wsBroadcaster.broadcastUpsert(bidderId, result, dtoFor(bidderId, result, data, title, body));
                     } catch (Exception ex) {
                         log.warn("Fan-out notification failed for userId={} auctionId={} category=LISTING_CANCELLED_BY_SELLER: {}",

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationService.java
@@ -2,6 +2,7 @@ package com.slparcelauctions.backend.notification;
 
 import com.slparcelauctions.backend.notification.NotificationDao.UpsertResult;
 import com.slparcelauctions.backend.notification.dto.NotificationDto;
+import com.slparcelauctions.backend.notification.slim.SlImChannelDispatcher;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -24,6 +25,7 @@ public class NotificationService {
     private final NotificationDao dao;
     private final NotificationRepository repo;
     private final NotificationWsBroadcasterPort wsBroadcaster;
+    private final SlImChannelDispatcher slImChannelDispatcher;
 
     /**
      * Publishes a notification within the caller's transaction.
@@ -43,6 +45,12 @@ public class NotificationService {
             @Override
             public void afterCommit() {
                 wsBroadcaster.broadcastUpsert(userId, result, dtoFromUpsert(event, result));
+            }
+        });
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                slImChannelDispatcher.maybeQueue(event);
             }
         });
         return result;

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/preferences/NotificationPreferencesController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/preferences/NotificationPreferencesController.java
@@ -1,0 +1,83 @@
+package com.slparcelauctions.backend.notification.preferences;
+
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users/me/notification-preferences")
+@RequiredArgsConstructor
+@PreAuthorize("isAuthenticated()")
+public class NotificationPreferencesController {
+
+    private final UserRepository userRepo;
+
+    /**
+     * The closed set of group keys the UI can edit. SYSTEM is delivered
+     * regardless; REALTY_GROUP and MARKETING have no shipping categories yet.
+     * Server is the source of truth for what's user-mutable.
+     */
+    private static final Set<String> ALLOWED_GROUP_KEYS = Set.of(
+        "bidding", "auction_result", "escrow", "listing_status", "reviews");
+
+    @GetMapping
+    public PreferencesDto get(@AuthenticationPrincipal AuthPrincipal caller) {
+        User user = userRepo.findById(caller.userId()).orElseThrow();
+        Map<String, Object> filtered = ALLOWED_GROUP_KEYS.stream()
+            .collect(Collectors.toMap(
+                k -> k,
+                k -> {
+                    if (user.getNotifySlIm() == null) return (Object) false;
+                    Object val = user.getNotifySlIm().getOrDefault(k, false);
+                    return Boolean.TRUE.equals(val);
+                }
+            ));
+        return new PreferencesDto(Boolean.TRUE.equals(user.getNotifySlImMuted()), filtered);
+    }
+
+    @PutMapping
+    @Transactional
+    public PreferencesDto put(
+        @AuthenticationPrincipal AuthPrincipal caller,
+        @RequestBody PreferencesDto body
+    ) {
+        if (body.slIm() == null || !body.slIm().keySet().equals(ALLOWED_GROUP_KEYS)) {
+            throw new IllegalArgumentException(
+                "slIm must contain exactly these keys: " + ALLOWED_GROUP_KEYS);
+        }
+        // Reject non-boolean values; Jackson deserializes JSON objects into Object,
+        // so string "true" becomes a String, not a Boolean.
+        boolean allBooleans = body.slIm().values().stream().allMatch(v -> v instanceof Boolean);
+        if (!allBooleans) {
+            throw new IllegalArgumentException(
+                "slIm values must all be JSON booleans (true/false), not strings or other types.");
+        }
+
+        User user = userRepo.findById(caller.userId()).orElseThrow();
+        user.setNotifySlImMuted(body.slImMuted());
+
+        // Merge into existing map: preserve keys we don't expose (system,
+        // realty_group, marketing) at their existing/default values.
+        Map<String, Object> merged = user.getNotifySlIm() == null
+            ? new HashMap<>()
+            : new HashMap<>(user.getNotifySlIm());
+        merged.putAll(body.slIm());
+        user.setNotifySlIm(merged);
+        userRepo.save(user);
+
+        return get(caller);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/preferences/PreferencesDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/preferences/PreferencesDto.java
@@ -1,0 +1,8 @@
+package com.slparcelauctions.backend.notification.preferences;
+
+import java.util.Map;
+
+public record PreferencesDto(
+    boolean slImMuted,
+    Map<String, Object> slIm
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImChannelDispatcher.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImChannelDispatcher.java
@@ -1,0 +1,103 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationEvent;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Two entry points for queueing an SL IM:
+ * <ul>
+ *   <li>{@link #maybeQueue(NotificationEvent)} — single-recipient. Caller has
+ *       registered this as an afterCommit hook on the parent transaction; we
+ *       open our own REQUIRES_NEW so failures don't propagate.</li>
+ *   <li>{@link #maybeQueueForFanout(long, NotificationCategory, String, String, Map, String)}
+ *       — fan-out. Caller is already inside a REQUIRES_NEW per-recipient lambda;
+ *       this writes as a sibling, atomic with the in-app row for that recipient.
+ *       Failures here propagate (caller's per-recipient try-catch isolates).</li>
+ * </ul>
+ *
+ * <p>Both paths read User fresh inside their respective transactions so a
+ * preferences PUT before the dispatch has read-your-writes semantics.
+ */
+@Component
+@Slf4j
+public class SlImChannelDispatcher {
+
+    private final UserRepository userRepo;
+    private final SlImChannelGate gate;
+    private final SlImMessageBuilder messageBuilder;
+    private final SlImLinkResolver linkResolver;
+    private final SlImMessageDao dao;
+    private final TransactionTemplate requiresNewTx;
+
+    // Explicit constructor — @RequiredArgsConstructor doesn't propagate @Qualifier
+    // (see sub-spec 1 Task 3 deviation note).
+    public SlImChannelDispatcher(
+        UserRepository userRepo,
+        SlImChannelGate gate,
+        SlImMessageBuilder messageBuilder,
+        SlImLinkResolver linkResolver,
+        SlImMessageDao dao,
+        @Qualifier("requiresNewTxTemplate") TransactionTemplate requiresNewTx
+    ) {
+        this.userRepo = userRepo;
+        this.gate = gate;
+        this.messageBuilder = messageBuilder;
+        this.linkResolver = linkResolver;
+        this.dao = dao;
+        this.requiresNewTx = requiresNewTx;
+    }
+
+    public void maybeQueue(NotificationEvent event) {
+        try {
+            requiresNewTx.execute(status -> {
+                doQueue(event.userId(), event.category(),
+                    event.title(), event.body(), event.data(), event.coalesceKey());
+                return null;
+            });
+        } catch (Exception ex) {
+            log.warn("SL IM dispatch failed for userId={} category={}: {}",
+                event.userId(), event.category(), ex.toString());
+        }
+    }
+
+    /**
+     * Fan-out variant. Caller (inside a per-recipient REQUIRES_NEW) gets atomic
+     * commit semantics: in-app row + IM queue row commit together or neither
+     * does. Caller's try-catch isolates this recipient's failure from siblings.
+     */
+    public void maybeQueueForFanout(
+        long userId, NotificationCategory category,
+        String title, String body, Map<String, Object> data, String coalesceKey
+    ) {
+        doQueue(userId, category, title, body, data, coalesceKey);
+    }
+
+    private void doQueue(
+        long userId, NotificationCategory category,
+        String title, String body, Map<String, Object> data, String coalesceKey
+    ) {
+        User user = userRepo.findById(userId)
+            .orElseThrow(() -> new IllegalStateException("user not found: " + userId));
+
+        SlImChannelGate.Decision decision = gate.decide(user, category);
+        log.debug("SL IM gate decision userId={} category={}: {}", userId, category, decision);
+
+        switch (decision) {
+            case QUEUE, QUEUE_BYPASS_PREFS -> {
+                String deeplink = linkResolver.resolve(category, data);
+                String messageText = messageBuilder.assemble(title, body, deeplink);
+                dao.upsert(userId, user.getSlAvatarUuid().toString(), messageText, coalesceKey);
+            }
+            case SKIP_NO_AVATAR, SKIP_MUTED, SKIP_GROUP_DISABLED -> {
+                // intentional no-op; decision logged at DEBUG above
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImChannelGate.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImChannelGate.java
@@ -1,0 +1,60 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationGroup;
+import com.slparcelauctions.backend.user.User;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/**
+ * Pure decision function for "should we queue an SL IM for this user/category?"
+ *
+ * <p>Stateless. Returns a discriminated {@link Decision} so callers can log the
+ * reason at DEBUG, which makes "I didn't get an IM" support tickets resolvable
+ * from logs alone without DB archaeology.
+ *
+ * <p>Order of checks (no-avatar is the universal floor — applies even to SYSTEM):
+ * <ol>
+ *   <li>{@link User#getSlAvatarUuid()} == null  → {@link Decision#SKIP_NO_AVATAR}</li>
+ *   <li>category.group == SYSTEM                → {@link Decision#QUEUE_BYPASS_PREFS}</li>
+ *   <li>{@link User#isNotifySlImMuted()} true   → {@link Decision#SKIP_MUTED}</li>
+ *   <li>notifySlIm[group] false or absent       → {@link Decision#SKIP_GROUP_DISABLED}</li>
+ *   <li>otherwise                               → {@link Decision#QUEUE}</li>
+ * </ol>
+ */
+@Component
+public class SlImChannelGate {
+
+    public enum Decision {
+        QUEUE,
+        QUEUE_BYPASS_PREFS,
+        SKIP_NO_AVATAR,
+        SKIP_MUTED,
+        SKIP_GROUP_DISABLED
+    }
+
+    public Decision decide(User user, NotificationCategory category) {
+        if (user.getSlAvatarUuid() == null) {
+            return Decision.SKIP_NO_AVATAR;
+        }
+
+        boolean isSystem = category.getGroup() == NotificationGroup.SYSTEM;
+        if (isSystem) {
+            return Decision.QUEUE_BYPASS_PREFS;
+        }
+
+        if (Boolean.TRUE.equals(user.getNotifySlImMuted())) {
+            return Decision.SKIP_MUTED;
+        }
+
+        Map<String, Object> prefs = user.getNotifySlIm();
+        String groupKey = category.getGroup().name().toLowerCase();
+        Object groupVal = prefs == null ? null : prefs.get(groupKey);
+        boolean groupOn = Boolean.TRUE.equals(groupVal);
+        if (!groupOn) {
+            return Decision.SKIP_GROUP_DISABLED;
+        }
+
+        return Decision.QUEUE;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImCleanupConfig.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImCleanupConfig.java
@@ -1,0 +1,17 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Registers {@link SlImCleanupProperties} as a configuration-properties bean.
+ *
+ * <p>The project uses {@code @EnableConfigurationProperties} rather than
+ * {@code @ConfigurationPropertiesScan} — mirrors the pattern from
+ * {@code SlImInternalConfig}, {@code NotificationCleanupConfig}, and
+ * {@code SlpaWebPropertiesConfig}.
+ */
+@Configuration
+@EnableConfigurationProperties(SlImCleanupProperties.class)
+public class SlImCleanupConfig {
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImCleanupJob.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImCleanupJob.java
@@ -1,0 +1,72 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "slpa.notifications.sl-im.cleanup",
+                       name = "enabled", havingValue = "true", matchIfMissing = false)
+@Slf4j
+public class SlImCleanupJob {
+
+    private final JdbcTemplate jdbc;
+    private final SlImCleanupProperties properties;
+    private final Clock clock;
+
+    @Scheduled(cron = "${slpa.notifications.sl-im.cleanup.cron}",
+               zone = "America/Los_Angeles")
+    public void run() {
+        OffsetDateTime expiryCutoff = OffsetDateTime.now(clock)
+            .minusHours(properties.expiryAfterHours());
+        OffsetDateTime retentionCutoff = OffsetDateTime.now(clock)
+            .minusDays(properties.retentionAfterDays());
+
+        // Capture top users BEFORE the UPDATE so the WHERE clause still matches
+        // the PENDING rows that are about to be transitioned to EXPIRED.
+        List<Map<String, Object>> topUsers = jdbc.queryForList("""
+            SELECT user_id, COUNT(*) AS n
+            FROM sl_im_message
+            WHERE status = 'PENDING' AND created_at < ?
+            GROUP BY user_id
+            ORDER BY n DESC
+            LIMIT ?
+            """, expiryCutoff, properties.topUsersInLog());
+
+        int expired = jdbc.update("""
+            UPDATE sl_im_message
+            SET status = 'EXPIRED', updated_at = now()
+            WHERE status = 'PENDING' AND created_at < ?
+            """, expiryCutoff);
+
+        int totalDeleted = 0;
+        int deletedThisChunk;
+        do {
+            deletedThisChunk = jdbc.update("""
+                DELETE FROM sl_im_message
+                WHERE id IN (
+                    SELECT id FROM sl_im_message
+                    WHERE status IN ('DELIVERED','EXPIRED','FAILED')
+                      AND updated_at < ?
+                    LIMIT ?
+                )
+                """, retentionCutoff, properties.batchSize());
+            totalDeleted += deletedThisChunk;
+        } while (deletedThisChunk == properties.batchSize());
+
+        String topUsersStr = topUsers.stream()
+            .map(r -> r.get("user_id") + ":" + r.get("n"))
+            .collect(Collectors.joining(", "));
+        log.info("SL IM cleanup sweep: expired={} deleted={} expiry_cutoff={} retention_cutoff={} top_users=[{}]",
+            expired, totalDeleted, expiryCutoff, retentionCutoff, topUsersStr);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImCleanupProperties.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImCleanupProperties.java
@@ -1,0 +1,19 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties(prefix = "slpa.notifications.sl-im.cleanup")
+@Validated
+public record SlImCleanupProperties(
+    boolean enabled,
+    @NotBlank String cron,
+    @Positive int expiryAfterHours,
+    @Positive int retentionAfterDays,
+    @Positive int batchSize,
+    @Min(0) @Max(20) int topUsersInLog
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImCoalesceIndexInitializer.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImCoalesceIndexInitializer.java
@@ -1,0 +1,35 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Emits the partial unique index that backs the ON CONFLICT clause in
+ * {@link SlImMessageDao}. Hibernate's ddl-auto cannot emit partial unique
+ * indexes, so we add it via an {@code ApplicationReadyEvent} listener that
+ * runs idempotent DDL.
+ *
+ * <p>Without this index the ON CONFLICT clause has nothing to match and every
+ * upsert call becomes a plain INSERT — coalescing silently breaks.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SlImCoalesceIndexInitializer {
+
+    private final JdbcTemplate jdbc;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void emit() {
+        jdbc.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_sl_im_pending_coalesce
+            ON sl_im_message (user_id, coalesce_key)
+            WHERE status = 'PENDING'
+            """);
+        log.info("SL IM partial unique index ensured: uq_sl_im_pending_coalesce");
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImLinkResolver.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImLinkResolver.java
@@ -1,0 +1,43 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import com.slparcelauctions.backend.config.SlpaWebProperties;
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Maps a notification category and its data blob to a deeplink URL for inclusion
+ * in the SL IM message. Mirrors the frontend {@code categoryMap.deeplink} logic
+ * — the duplication is intentional. Embedding the URL in the in-app row's data
+ * blob would couple in-app rows to a specific channel's URL semantics and make
+ * URL changes a data migration.
+ */
+@Component
+@RequiredArgsConstructor
+public class SlImLinkResolver {
+
+    private final SlpaWebProperties webProps;
+
+    public String resolve(NotificationCategory category, Map<String, Object> data) {
+        String base = webProps.baseUrl();
+        return switch (category) {
+            case OUTBID, PROXY_EXHAUSTED, AUCTION_LOST,
+                 AUCTION_ENDED_RESERVE_NOT_MET, AUCTION_ENDED_NO_BIDS,
+                 AUCTION_ENDED_BOUGHT_NOW, AUCTION_ENDED_SOLD,
+                 LISTING_VERIFIED, LISTING_CANCELLED_BY_SELLER,
+                 REVIEW_RECEIVED ->
+                base + "/auction/" + data.get("auctionId");
+            case AUCTION_WON ->
+                base + "/auction/" + data.get("auctionId") + "/escrow";
+            case ESCROW_FUNDED, ESCROW_TRANSFER_CONFIRMED, ESCROW_PAYOUT,
+                 ESCROW_EXPIRED, ESCROW_DISPUTED, ESCROW_FROZEN,
+                 ESCROW_PAYOUT_STALLED, ESCROW_TRANSFER_REMINDER ->
+                base + "/auction/" + data.get("auctionId") + "/escrow";
+            case LISTING_SUSPENDED, LISTING_REVIEW_REQUIRED ->
+                base + "/dashboard/listings";
+            case SYSTEM_ANNOUNCEMENT ->
+                base + "/notifications";
+        };
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessage.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessage.java
@@ -1,0 +1,53 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import jakarta.persistence.*;
+import java.time.OffsetDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(
+    name = "sl_im_message",
+    indexes = {
+        @Index(name = "ix_sl_im_status_created", columnList = "status, created_at"),
+        @Index(name = "ix_sl_im_user_status", columnList = "user_id, status")
+    }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+public class SlImMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "avatar_uuid", nullable = false, length = 36)
+    private String avatarUuid;
+
+    @Column(name = "coalesce_key", length = 128)
+    private String coalesceKey;
+
+    @Column(name = "message_text", nullable = false, length = 1024)
+    private String messageText;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private SlImMessageStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @Column(name = "delivered_at")
+    private OffsetDateTime deliveredAt;
+
+    @Column(nullable = false)
+    private int attempts;
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessageBuilder.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessageBuilder.java
@@ -1,0 +1,103 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import java.nio.charset.StandardCharsets;
+import org.springframework.stereotype.Component;
+
+/**
+ * Assembles the final SL IM text from (title, body, deeplink) components,
+ * enforcing the SL {@code llInstantMessage} 1024-BYTE limit.
+ *
+ * <p>The deeplink, the {@code [SLPA] } prefix, and the title are non-negotiable
+ * — they are reserved first and never trimmed. Only the body is ellipsizable.
+ *
+ * <p>SL truncates IMs that exceed 1024 bytes silently, from the end. If the
+ * deeplink lands at the end (it does), it gets cleanly cut off. UTF-8 multi-byte
+ * characters (CJK, emoji, accented Latin) push byte counts above char counts —
+ * a 1023-character message can occupy 1500+ bytes. Hence the byte-aware budget.
+ *
+ * <p>Trim algorithm: progressively shorten the body by Java {@code char} from
+ * the end until the assembled string fits. If a trim boundary lands on a high
+ * surrogate (would split a UTF-16 surrogate pair, producing an invalid
+ * sequence), back off one more char.
+ */
+@Component
+public class SlImMessageBuilder {
+
+    private static final int MAX_BYTES = 1024;
+    private static final String PREFIX = "[SLPA] ";
+    private static final String SEPARATOR = "\n\n";
+    private static final String ELLIPSIS = "…";  // 3 bytes UTF-8
+
+    public String assemble(String title, String body, String deeplink) {
+        String candidate = PREFIX + title + SEPARATOR + body + SEPARATOR + deeplink;
+        if (utf8Bytes(candidate) <= MAX_BYTES) {
+            return candidate;
+        }
+
+        int reservedBytes = utf8Bytes(PREFIX + title + SEPARATOR + SEPARATOR + deeplink + ELLIPSIS);
+        int availableForBody = MAX_BYTES - reservedBytes;
+
+        if (availableForBody <= 0) {
+            return assembleWithoutBody(title, deeplink);
+        }
+
+        int k = body.length();
+        String trimmedBody = null;
+        while (k > 0) {
+            int boundary = k;
+            if (Character.isHighSurrogate(body.charAt(boundary - 1))) {
+                boundary -= 1;
+            }
+            if (boundary <= 0) {
+                break;
+            }
+            String attempt = body.substring(0, boundary) + ELLIPSIS;
+            if (utf8Bytes(attempt) <= availableForBody) {
+                trimmedBody = attempt;
+                break;
+            }
+            k = boundary - 1;
+        }
+        if (trimmedBody == null) {
+            return assembleWithoutBody(title, deeplink);
+        }
+        return PREFIX + title + SEPARATOR + trimmedBody + SEPARATOR + deeplink;
+    }
+
+    private String assembleWithoutBody(String title, String deeplink) {
+        // Last-resort: no body, just title + deeplink. If even that exceeds the
+        // budget, trim the title. Deeplink stays whole.
+        String candidate = PREFIX + title + SEPARATOR + deeplink;
+        if (utf8Bytes(candidate) <= MAX_BYTES) {
+            return candidate;
+        }
+        int reserved = utf8Bytes(PREFIX + SEPARATOR + deeplink + ELLIPSIS);
+        int availableForTitle = MAX_BYTES - reserved;
+        int k = title.length();
+        while (k > 0) {
+            int boundary = k;
+            if (Character.isHighSurrogate(title.charAt(boundary - 1))) {
+                boundary -= 1;
+            }
+            if (boundary <= 0) {
+                break;
+            }
+            String attempt = title.substring(0, boundary) + ELLIPSIS;
+            if (utf8Bytes(attempt) <= availableForTitle) {
+                return PREFIX + attempt + SEPARATOR + deeplink;
+            }
+            k = boundary - 1;
+        }
+        // If even an empty-title fallback exceeds the budget, the deeplink itself
+        // is too long. Return the deeplink alone — truncated to MAX_BYTES.
+        byte[] bytes = deeplink.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length > MAX_BYTES) {
+            return new String(bytes, 0, MAX_BYTES, StandardCharsets.UTF_8);
+        }
+        return deeplink;
+    }
+
+    private static int utf8Bytes(String s) {
+        return s.getBytes(StandardCharsets.UTF_8).length;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessageDao.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessageDao.java
@@ -1,0 +1,70 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Native-SQL DAO for the SL IM message upsert path.
+ *
+ * <p>Uses {@code ON CONFLICT (user_id, coalesce_key) WHERE status = 'PENDING' DO UPDATE}
+ * to collapse repeated deliveries of the same logical event (e.g., repeated OUTBID
+ * notifications on the same auction) into a single PENDING row that the dispatcher
+ * delivers as one IM with the latest text.
+ *
+ * <p>The {@code xmax != 0} trick is a Postgres-native way to know whether INSERT
+ * (xmax = 0) or UPDATE (xmax holds updating tx ID) executed without a second roundtrip.
+ *
+ * <p>The partial unique index {@code uq_sl_im_pending_coalesce} is created at
+ * startup by {@link SlImCoalesceIndexInitializer} (Hibernate's ddl-auto cannot
+ * emit partial indexes). Without that index the ON CONFLICT clause has nothing
+ * to match and every call becomes a plain INSERT.
+ *
+ * <p>NULL coalesce_key never matches itself in Postgres unique constraints
+ * (NULL ≠ NULL semantics), so the same query handles coalescing and
+ * non-coalescing categories with no service-layer branching.
+ */
+@Component
+@RequiredArgsConstructor
+public class SlImMessageDao {
+
+    private final JdbcTemplate jdbc;
+
+    public record UpsertResult(
+        long id,
+        boolean wasUpdate,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
+    ) {}
+
+    public UpsertResult upsert(
+        long userId,
+        String avatarUuid,
+        String messageText,
+        String coalesceKey
+    ) {
+        String sql = """
+            INSERT INTO sl_im_message
+              (user_id, avatar_uuid, coalesce_key, message_text,
+               status, attempts, created_at, updated_at)
+            VALUES (?, ?, ?, ?, 'PENDING', 0, now(), now())
+            ON CONFLICT (user_id, coalesce_key) WHERE status = 'PENDING'
+            DO UPDATE SET
+              message_text = EXCLUDED.message_text,
+              avatar_uuid  = EXCLUDED.avatar_uuid,
+              updated_at   = now()
+            RETURNING id, (xmax != 0) AS was_update, created_at, updated_at
+            """;
+        Map<String, Object> row = jdbc.queryForMap(
+            sql, userId, avatarUuid, coalesceKey, messageText);
+        return new UpsertResult(
+            ((Number) row.get("id")).longValue(),
+            (Boolean) row.get("was_update"),
+            ((java.sql.Timestamp) row.get("created_at")).toInstant().atOffset(ZoneOffset.UTC),
+            ((java.sql.Timestamp) row.get("updated_at")).toInstant().atOffset(ZoneOffset.UTC)
+        );
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessageRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessageRepository.java
@@ -1,0 +1,21 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SlImMessageRepository extends JpaRepository<SlImMessage, Long> {
+
+    @Query(value = """
+        SELECT * FROM sl_im_message
+        WHERE status = 'PENDING'
+        ORDER BY created_at ASC
+        LIMIT :limit
+        FOR UPDATE SKIP LOCKED
+        """, nativeQuery = true)
+    List<SlImMessage> pollPending(@Param("limit") int limit);
+
+    @Query("SELECT m.status, count(m) FROM SlImMessage m GROUP BY m.status")
+    List<Object[]> countByStatus();
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessageStatus.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessageStatus.java
@@ -1,0 +1,8 @@
+package com.slparcelauctions.backend.notification.slim;
+
+public enum SlImMessageStatus {
+    PENDING,
+    DELIVERED,
+    EXPIRED,
+    FAILED
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/internal/SlImInternalConfig.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/internal/SlImInternalConfig.java
@@ -1,0 +1,27 @@
+package com.slparcelauctions.backend.notification.slim.internal;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Registers {@link SlImInternalProperties} as a configuration-properties bean
+ * and exposes {@link SlImTerminalAuthFilter} as a named {@code @Bean}.
+ *
+ * <p>{@link SlImTerminalAuthFilter} is NOT annotated with {@code @Component} —
+ * manual registration here prevents {@code @WebMvcTest} slice tests from
+ * auto-detecting it and failing on a missing {@code SlImInternalProperties} bean.
+ *
+ * <p>The project uses {@code @EnableConfigurationProperties} rather than
+ * {@code @ConfigurationPropertiesScan} — mirrors the pattern from
+ * {@code NotificationCleanupConfig} and {@code SlpaWebPropertiesConfig}.
+ */
+@Configuration
+@EnableConfigurationProperties(SlImInternalProperties.class)
+public class SlImInternalConfig {
+
+    @Bean
+    public SlImTerminalAuthFilter slImTerminalAuthFilter(SlImInternalProperties props) {
+        return new SlImTerminalAuthFilter(props);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/internal/SlImInternalController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/internal/SlImInternalController.java
@@ -1,0 +1,108 @@
+package com.slparcelauctions.backend.notification.slim.internal;
+
+import com.slparcelauctions.backend.notification.slim.SlImMessage;
+import com.slparcelauctions.backend.notification.slim.SlImMessageRepository;
+import com.slparcelauctions.backend.notification.slim.SlImMessageStatus;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/internal/sl-im")
+@RequiredArgsConstructor
+public class SlImInternalController {
+
+    private final SlImMessageRepository repo;
+    private final JdbcTemplate jdbc;
+    private final SlImInternalProperties props;
+
+    public record PendingItem(long id, String avatarUuid, String messageText) {}
+    public record PendingResponse(List<PendingItem> messages) {}
+
+    @GetMapping("/pending")
+    public PendingResponse pending(@RequestParam(defaultValue = "10") int limit) {
+        if (limit > props.maxBatchLimit() || limit < 1) {
+            throw new IllegalArgumentException(
+                "limit must be in [1, " + props.maxBatchLimit() + "]");
+        }
+        // FOR UPDATE SKIP LOCKED in pollPending() is advisory: this method isn't
+        // @Transactional, so the row lock releases when the query returns —
+        // before the LSL script delivers. Real multi-dispatcher dedup would need
+        // a PENDING → IN_PROGRESS → DELIVERED status transition.
+        List<SlImMessage> rows = repo.pollPending(limit);
+        List<PendingItem> items = rows.stream()
+            .map(m -> new PendingItem(m.getId(), m.getAvatarUuid(), m.getMessageText()))
+            .toList();
+        return new PendingResponse(items);
+    }
+
+    @PostMapping("/{id}/delivered")
+    public ResponseEntity<Void> delivered(@PathVariable long id) {
+        return transition(id, SlImMessageStatus.DELIVERED);
+    }
+
+    @PostMapping("/{id}/failed")
+    public ResponseEntity<Void> failed(@PathVariable long id) {
+        return transition(id, SlImMessageStatus.FAILED);
+    }
+
+    /**
+     * State machine for /delivered:
+     *   PENDING   → DELIVERED (204, set delivered_at + increment attempts)
+     *   DELIVERED → 204 no-op (idempotent; delivered_at NOT re-stamped)
+     *   FAILED    → 409
+     *   EXPIRED   → 409
+     *   missing   → 404
+     *
+     * State machine for /failed:
+     *   PENDING   → FAILED (204, increment attempts)
+     *   FAILED    → 204 no-op (idempotent)
+     *   DELIVERED → 409
+     *   EXPIRED   → 409
+     *   missing   → 404
+     *
+     * Implemented as a single conditional UPDATE returning affected rows count,
+     * with a follow-up read on the no-op path to determine the response.
+     */
+    private ResponseEntity<Void> transition(long id, SlImMessageStatus target) {
+        String sql = (target == SlImMessageStatus.DELIVERED)
+            ? """
+                UPDATE sl_im_message
+                SET status = 'DELIVERED',
+                    delivered_at = COALESCE(delivered_at, now()),
+                    updated_at = now(),
+                    attempts = attempts + 1
+                WHERE id = ? AND status = 'PENDING'
+                """
+            : """
+                UPDATE sl_im_message
+                SET status = 'FAILED',
+                    updated_at = now(),
+                    attempts = attempts + 1
+                WHERE id = ? AND status = 'PENDING'
+                """;
+        int updated = jdbc.update(sql, id);
+        if (updated == 1) {
+            return ResponseEntity.noContent().build();
+        }
+
+        Optional<SlImMessage> opt = repo.findById(id);
+        if (opt.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+        SlImMessageStatus current = opt.get().getStatus();
+        if (current == target) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/internal/SlImInternalProperties.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/internal/SlImInternalProperties.java
@@ -1,0 +1,14 @@
+package com.slparcelauctions.backend.notification.slim.internal;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties(prefix = "slpa.notifications.sl-im.dispatcher")
+@Validated
+public record SlImInternalProperties(
+    @NotBlank String sharedSecret,
+    @Positive @Max(50) int maxBatchLimit
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/internal/SlImTerminalAuthFilter.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/internal/SlImTerminalAuthFilter.java
@@ -1,0 +1,52 @@
+package com.slparcelauctions.backend.notification.slim.internal;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Shared-secret auth filter for {@code /api/v1/internal/sl-im/**}. Constant-time
+ * comparison via {@link MessageDigest#isEqual(byte[], byte[])} prevents secret
+ * inference via response timing.
+ *
+ * <p>NOT annotated with {@code @Component} — registered as a manual {@code @Bean}
+ * by {@link SlImInternalConfig} so that {@code @WebMvcTest} slice tests do not
+ * auto-detect it and fail on missing {@code SlImInternalProperties}.
+ */
+@RequiredArgsConstructor
+public class SlImTerminalAuthFilter extends OncePerRequestFilter {
+
+    private final SlImInternalProperties props;
+    private static final String PATH_PREFIX = "/api/v1/internal/sl-im/";
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest req) {
+        return !req.getRequestURI().startsWith(PATH_PREFIX);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+        throws IOException, ServletException {
+        String header = req.getHeader("Authorization");
+        String expected = "Bearer " + props.sharedSecret();
+        boolean ok = header != null && MessageDigest.isEqual(
+            header.getBytes(StandardCharsets.UTF_8),
+            expected.getBytes(StandardCharsets.UTF_8));
+        if (!ok) {
+            res.setStatus(HttpStatus.UNAUTHORIZED.value());
+            res.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
+            res.getWriter().write(
+                "{\"type\":\"about:blank\",\"title\":\"Unauthorized\",\"status\":401}");
+            return;
+        }
+        chain.doFilter(req, res);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -178,5 +178,12 @@ slpa:
       cron: "0 30 3 * * *"        # 3:30 AM UTC daily
       retention-days: 90
       batch-size: 1000
+    sl-im:
+      dispatcher:
+        # Shared secret for the SL IM terminal polling endpoints.
+        # No default — non-dev profiles MUST override via SL_IM_DISPATCHER_SECRET.
+        # Dev profile supplies a placeholder in application-dev.yml.
+        shared-secret: ${SL_IM_DISPATCHER_SECRET:dev-only-secret-do-not-use-in-prod}
+        max-batch-limit: 50
   web:
     base-url: ${SLPA_WEB_BASE_URL:http://localhost:3000}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -185,5 +185,12 @@ slpa:
         # Dev profile supplies a placeholder in application-dev.yml.
         shared-secret: ${SL_IM_DISPATCHER_SECRET:dev-only-secret-do-not-use-in-prod}
         max-batch-limit: 50
+      cleanup:
+        enabled: true
+        cron: "0 30 3 * * *"        # 03:30 daily, zone = America/Los_Angeles
+        expiry-after-hours: 48
+        retention-after-days: 30
+        batch-size: 1000
+        top-users-in-log: 10
   web:
     base-url: ${SLPA_WEB_BASE_URL:http://localhost:3000}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -178,3 +178,5 @@ slpa:
       cron: "0 30 3 * * *"        # 3:30 AM UTC daily
       retention-days: 90
       batch-size: 1000
+  web:
+    base-url: ${SLPA_WEB_BASE_URL:http://localhost:3000}

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionControllerIntegrationTest.java
@@ -57,7 +57,8 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class AuctionControllerIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionPhotoControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionPhotoControllerIntegrationTest.java
@@ -60,7 +60,8 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class AuctionPhotoControllerIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionRepositoryLockTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionRepositoryLockTest.java
@@ -37,7 +37,8 @@ import com.slparcelauctions.backend.user.UserRepository;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class AuctionRepositoryLockTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionRepositoryOwnershipCheckTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionRepositoryOwnershipCheckTest.java
@@ -35,7 +35,8 @@ import com.slparcelauctions.backend.user.UserRepository;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class AuctionRepositoryOwnershipCheckTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/BidBidRaceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/BidBidRaceTest.java
@@ -46,7 +46,8 @@ import com.slparcelauctions.backend.user.UserRepository;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class BidBidRaceTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/BidPersistenceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/BidPersistenceTest.java
@@ -31,7 +31,8 @@ import jakarta.persistence.PersistenceContext;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class BidPersistenceTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/BidPlacementIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/BidPlacementIntegrationTest.java
@@ -56,7 +56,8 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class BidPlacementIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/BidVsProxyCounterIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/BidVsProxyCounterIntegrationTest.java
@@ -57,7 +57,8 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class BidVsProxyCounterIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/DevAuctionControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/DevAuctionControllerTest.java
@@ -50,7 +50,8 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class DevAuctionControllerTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/ParcelLockingRaceIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/ParcelLockingRaceIntegrationTest.java
@@ -59,7 +59,8 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class ParcelLockingRaceIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/ProxyBidControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/ProxyBidControllerTest.java
@@ -55,7 +55,8 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class ProxyBidControllerTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/ProxyBidPartialUniqueIndexInitializerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/ProxyBidPartialUniqueIndexInitializerTest.java
@@ -24,7 +24,8 @@ import com.slparcelauctions.backend.auction.config.ProxyBidPartialUniqueIndexIni
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class ProxyBidPartialUniqueIndexInitializerTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/ProxyBidPersistenceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/ProxyBidPersistenceTest.java
@@ -42,7 +42,8 @@ import jakarta.persistence.PersistenceContext;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class ProxyBidPersistenceTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/ProxyBidResurrectionTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/ProxyBidResurrectionTest.java
@@ -59,7 +59,8 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class ProxyBidResurrectionTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/ProxyBidTieFlipTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/ProxyBidTieFlipTest.java
@@ -55,7 +55,8 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class ProxyBidTieFlipTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/SnipeAndBuyNowIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/SnipeAndBuyNowIntegrationTest.java
@@ -65,7 +65,8 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class SnipeAndBuyNowIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/auctionend/AuctionEndIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/auctionend/AuctionEndIntegrationTest.java
@@ -71,7 +71,8 @@ import com.slparcelauctions.backend.verification.VerificationCodeRepository;
         "slpa.auction-end.enabled=false",
         "slpa.ownership-monitor.enabled=false",
         "slpa.escrow.ownership-monitor-job.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Import(AuctionEndIntegrationTest.CapturingConfig.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/auctionend/BidSchedulerRaceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/auctionend/BidSchedulerRaceTest.java
@@ -71,7 +71,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.auction-end.enabled=false",
         "slpa.ownership-monitor.enabled=false",
         "slpa.escrow.ownership-monitor-job.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class BidSchedulerRaceTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/broadcast/BidWebSocketIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/broadcast/BidWebSocketIntegrationTest.java
@@ -75,7 +75,8 @@ import com.slparcelauctions.backend.user.UserRepository;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class BidWebSocketIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/concurrency/BidCancelRaceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/concurrency/BidCancelRaceTest.java
@@ -74,7 +74,8 @@ import javax.sql.DataSource;
         "slpa.auction-end.enabled=false",
         "slpa.ownership-monitor.enabled=false",
         "slpa.escrow.ownership-monitor-job.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class BidCancelRaceTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/concurrency/BidSuspendRaceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/concurrency/BidSuspendRaceTest.java
@@ -83,7 +83,8 @@ import reactor.core.publisher.Mono;
         "slpa.auction-end.enabled=false",
         "slpa.ownership-monitor.enabled=false",
         "slpa.escrow.ownership-monitor-job.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class BidSuspendRaceTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/concurrency/CancelLadderRaceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/concurrency/CancelLadderRaceTest.java
@@ -67,7 +67,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.auction-end.enabled=false",
         "slpa.ownership-monitor.enabled=false",
         "slpa.escrow.ownership-monitor-job.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class CancelLadderRaceTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/featured/FeaturedControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/featured/FeaturedControllerIntegrationTest.java
@@ -29,7 +29,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class FeaturedControllerIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/featured/FeaturedRepositoryIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/featured/FeaturedRepositoryIntegrationTest.java
@@ -41,7 +41,8 @@ import jakarta.persistence.PersistenceContext;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class FeaturedRepositoryIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/fraud/FraudFlagRepositoryTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/fraud/FraudFlagRepositoryTest.java
@@ -36,7 +36,8 @@ import jakarta.persistence.PersistenceContext;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class FraudFlagRepositoryTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/monitoring/OwnershipMonitorIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/monitoring/OwnershipMonitorIntegrationTest.java
@@ -80,7 +80,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.world-api.retry-attempts=2",
         "slpa.world-api.retry-backoff-ms=25",
         "slpa.world-api.timeout-ms=2000",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class OwnershipMonitorIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/mybids/MyBidsIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/mybids/MyBidsIntegrationTest.java
@@ -70,7 +70,8 @@ import reactor.core.publisher.Mono;
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
         "spring.jpa.properties.hibernate.generate_statistics=true",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class MyBidsIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/saved/SavedAuctionConcurrencyTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/saved/SavedAuctionConcurrencyTest.java
@@ -51,7 +51,8 @@ import com.slparcelauctions.backend.user.UserRepository;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class SavedAuctionConcurrencyTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/saved/SavedAuctionControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/saved/SavedAuctionControllerIntegrationTest.java
@@ -68,7 +68,8 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class SavedAuctionControllerIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/search/AuctionSearchControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/search/AuctionSearchControllerIntegrationTest.java
@@ -45,7 +45,8 @@ import com.slparcelauctions.backend.user.UserRepository;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class AuctionSearchControllerIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/search/AuctionSearchPredicateBuilderTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/search/AuctionSearchPredicateBuilderTest.java
@@ -40,7 +40,8 @@ import com.slparcelauctions.backend.user.UserRepository;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class AuctionSearchPredicateBuilderTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/search/PgIndexExistenceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/search/PgIndexExistenceTest.java
@@ -17,7 +17,8 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class PgIndexExistenceTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/search/SearchResponseCacheIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/search/SearchResponseCacheIntegrationTest.java
@@ -32,7 +32,8 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class SearchResponseCacheIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auth/AuthControllerTest.java
@@ -42,7 +42,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "jwt.secret=dGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdA==",
     "jwt.access-token-lifetime=PT15M",
     "jwt.refresh-token-lifetime=P7D",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class AuthControllerTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/auth/AuthFlowIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auth/AuthFlowIntegrationTest.java
@@ -27,7 +27,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class AuthFlowIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/bot/BotMonitorLifecycleServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/bot/BotMonitorLifecycleServiceTest.java
@@ -52,7 +52,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.escrow.listing-fee-refund-job.enabled=false",
         "slpa.bot-task.timeout-check-interval=PT10M",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class BotMonitorLifecycleServiceTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/bot/BotTaskClaimRaceIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/bot/BotTaskClaimRaceIntegrationTest.java
@@ -53,7 +53,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.escrow.listing-fee-refund-job.enabled=false",
         "slpa.bot-task.timeout-check-interval=PT10M",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class BotTaskClaimRaceIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/bot/BotTaskControllerAuthIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/bot/BotTaskControllerAuthIntegrationTest.java
@@ -37,7 +37,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class BotTaskControllerAuthIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/bot/BotTaskControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/bot/BotTaskControllerIntegrationTest.java
@@ -58,7 +58,8 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class BotTaskControllerIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/bot/BotTaskTimeoutJobInProgressTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/bot/BotTaskTimeoutJobInProgressTest.java
@@ -50,7 +50,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.escrow.listing-fee-refund-job.enabled=false",
         "slpa.bot-task.timeout-check-interval=PT10M",
         "slpa.bot-task.in-progress-timeout=PT1M",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class BotTaskTimeoutJobInProgressTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/bot/DevBotTaskControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/bot/DevBotTaskControllerTest.java
@@ -52,7 +52,8 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class DevBotTaskControllerTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/config/PrefixMigrationSmokeTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/config/PrefixMigrationSmokeTest.java
@@ -36,7 +36,8 @@ import org.springframework.transaction.annotation.Transactional;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class PrefixMigrationSmokeTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/config/PublicConfigControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/config/PublicConfigControllerTest.java
@@ -12,6 +12,7 @@ import com.slparcelauctions.backend.auth.JwtAuthenticationEntryPoint;
 import com.slparcelauctions.backend.auth.JwtAuthenticationFilter;
 import com.slparcelauctions.backend.auth.JwtService;
 import com.slparcelauctions.backend.bot.BotSharedSecretAuthorizer;
+import com.slparcelauctions.backend.notification.slim.internal.SlImInternalConfig;
 
 import static org.hamcrest.Matchers.isA;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -24,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * render the platform cost badge without a JWT.
  */
 @WebMvcTest(PublicConfigController.class)
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class, JwtAuthenticationEntryPoint.class})
+@Import({SlImInternalConfig.class, SecurityConfig.class, JwtAuthenticationFilter.class, JwtAuthenticationEntryPoint.class})
 @TestPropertySource(properties = {
         "slpa.listing-fee.amount-lindens=150",
         "slpa.notifications.cleanup.enabled=false"

--- a/backend/src/test/java/com/slparcelauctions/backend/config/PublicConfigControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/config/PublicConfigControllerTest.java
@@ -28,7 +28,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import({SlImInternalConfig.class, SecurityConfig.class, JwtAuthenticationFilter.class, JwtAuthenticationEntryPoint.class})
 @TestPropertySource(properties = {
         "slpa.listing-fee.amount-lindens=150",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class PublicConfigControllerTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/controller/HealthControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/controller/HealthControllerTest.java
@@ -11,6 +11,7 @@ import com.slparcelauctions.backend.auth.JwtAuthenticationEntryPoint;
 import com.slparcelauctions.backend.auth.JwtAuthenticationFilter;
 import com.slparcelauctions.backend.auth.JwtService;
 import com.slparcelauctions.backend.bot.BotSharedSecretAuthorizer;
+import com.slparcelauctions.backend.notification.slim.internal.SlImInternalConfig;
 import com.slparcelauctions.backend.config.SecurityConfig;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -18,7 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(HealthController.class)
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class, JwtAuthenticationEntryPoint.class})
+@Import({SlImInternalConfig.class, SecurityConfig.class, JwtAuthenticationFilter.class, JwtAuthenticationEntryPoint.class})
 class HealthControllerTest {
 
     @Autowired

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowControllerSliceTest.java
@@ -28,6 +28,7 @@ import com.slparcelauctions.backend.auth.JwtService;
 import com.slparcelauctions.backend.auth.config.JwtConfig;
 import com.slparcelauctions.backend.auth.test.WithMockAuthPrincipal;
 import com.slparcelauctions.backend.bot.BotSharedSecretAuthorizer;
+import com.slparcelauctions.backend.notification.slim.internal.SlImInternalConfig;
 import com.slparcelauctions.backend.config.SecurityConfig;
 import com.slparcelauctions.backend.escrow.dto.EscrowDisputeRequest;
 import com.slparcelauctions.backend.escrow.dto.EscrowStatusResponse;
@@ -45,7 +46,7 @@ import com.slparcelauctions.backend.escrow.exception.IllegalEscrowTransitionExce
  * the SecurityContext without minting real JWTs.
  */
 @WebMvcTest(EscrowController.class)
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class,
+@Import({SlImInternalConfig.class, SecurityConfig.class, JwtAuthenticationFilter.class,
         JwtAuthenticationEntryPoint.class, EscrowExceptionHandler.class})
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowControllerSliceTest.java
@@ -53,7 +53,8 @@ import com.slparcelauctions.backend.escrow.exception.IllegalEscrowTransitionExce
         "jwt.secret=dGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdA==",
         "jwt.access-token-lifetime=PT15M",
         "jwt.refresh-token-lifetime=P7D",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class EscrowControllerSliceTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowCreateOnAuctionEndIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowCreateOnAuctionEndIntegrationTest.java
@@ -72,7 +72,8 @@ import com.slparcelauctions.backend.verification.VerificationCodeType;
         "slpa.auction-end.enabled=false",
         "slpa.ownership-monitor.enabled=false",
         "slpa.escrow.ownership-monitor-job.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Import(EscrowCreateOnAuctionEndIntegrationTest.CapturingConfig.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowCreateOnBuyNowIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowCreateOnBuyNowIntegrationTest.java
@@ -70,7 +70,8 @@ import com.slparcelauctions.backend.verification.VerificationCodeType;
         "slpa.auction-end.enabled=false",
         "slpa.ownership-monitor.enabled=false",
         "slpa.escrow.ownership-monitor-job.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Import(EscrowCreateOnBuyNowIntegrationTest.CapturingConfig.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowDisputeIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowDisputeIntegrationTest.java
@@ -63,7 +63,8 @@ import com.slparcelauctions.backend.verification.VerificationCodeType;
         "slpa.auction-end.enabled=false",
         "slpa.ownership-monitor.enabled=false",
         "slpa.escrow.ownership-monitor-job.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Import(EscrowDisputeIntegrationTest.CapturingConfig.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowEndToEndIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowEndToEndIntegrationTest.java
@@ -83,7 +83,8 @@ import reactor.core.publisher.Mono;
         "slpa.escrow.ownership-monitor-job.fixed-delay=PT24H",
         "slpa.escrow.command-dispatcher-job.enabled=true",
         "slpa.escrow.command-dispatcher-job.fixed-delay=PT24H",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Import(EscrowEndToEndIntegrationTest.CapturingConfig.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowOwnershipMonitorIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowOwnershipMonitorIntegrationTest.java
@@ -97,7 +97,8 @@ import reactor.core.publisher.Mono;
         // Low threshold is irrelevant for these scenarios — none exercise
         // the World API failure counter branch.
         "slpa.escrow.ownership-api-failure-threshold=5",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Import(EscrowOwnershipMonitorIntegrationTest.CapturingConfig.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowPaymentIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowPaymentIntegrationTest.java
@@ -73,7 +73,8 @@ import com.slparcelauctions.backend.verification.VerificationCodeType;
         "slpa.auction-end.enabled=false",
         "slpa.ownership-monitor.enabled=false",
         "slpa.escrow.ownership-monitor-job.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Import(EscrowPaymentIntegrationTest.CapturingConfig.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowTimeoutIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowTimeoutIntegrationTest.java
@@ -89,7 +89,8 @@ import com.slparcelauctions.backend.verification.VerificationCodeType;
         // @Scheduled tick so only the explicit sweeps we drive execute.
         "slpa.escrow.timeout-job.enabled=true",
         "slpa.escrow.timeout-job.fixed-delay=PT24H",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Import({ClockOverrideConfig.class, EscrowTimeoutIntegrationTest.CapturingConfig.class})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/ListingFeeFlowIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/ListingFeeFlowIntegrationTest.java
@@ -87,7 +87,8 @@ import com.slparcelauctions.backend.verification.VerificationCodeType;
         // only the explicit drainPending() call we make executes.
         "slpa.escrow.listing-fee-refund-job.enabled=true",
         "slpa.escrow.listing-fee-refund-job.fixed-delay=PT24H",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class ListingFeeFlowIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/TerminalCommandRetryIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/TerminalCommandRetryIntegrationTest.java
@@ -76,7 +76,8 @@ import com.slparcelauctions.backend.verification.VerificationCodeType;
         // @Scheduled tick so only the explicit sweeps we drive execute.
         "slpa.escrow.command-dispatcher-job.enabled=true",
         "slpa.escrow.command-dispatcher-job.fixed-delay=PT24H",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Import(TerminalCommandRetryIntegrationTest.CapturingConfig.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/command/PayoutResultControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/command/PayoutResultControllerSliceTest.java
@@ -48,7 +48,8 @@ import com.slparcelauctions.backend.sl.exception.InvalidSlHeadersException;
         "jwt.secret=dGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdA==",
         "jwt.access-token-lifetime=PT15M",
         "jwt.refresh-token-lifetime=P7D",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class PayoutResultControllerSliceTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/command/PayoutResultControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/command/PayoutResultControllerSliceTest.java
@@ -23,6 +23,7 @@ import com.slparcelauctions.backend.auth.JwtAuthenticationFilter;
 import com.slparcelauctions.backend.auth.JwtService;
 import com.slparcelauctions.backend.auth.config.JwtConfig;
 import com.slparcelauctions.backend.bot.BotSharedSecretAuthorizer;
+import com.slparcelauctions.backend.notification.slim.internal.SlImInternalConfig;
 import com.slparcelauctions.backend.config.SecurityConfig;
 import com.slparcelauctions.backend.escrow.command.dto.PayoutResultRequest;
 import com.slparcelauctions.backend.escrow.command.exception.UnknownTerminalCommandException;
@@ -40,7 +41,7 @@ import com.slparcelauctions.backend.sl.exception.InvalidSlHeadersException;
  * responses for failure branches. Six scenarios per plan.
  */
 @WebMvcTest(PayoutResultController.class)
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class,
+@Import({SlImInternalConfig.class, SecurityConfig.class, JwtAuthenticationFilter.class,
         JwtAuthenticationEntryPoint.class, EscrowExceptionHandler.class})
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/payment/EscrowPaymentControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/payment/EscrowPaymentControllerSliceTest.java
@@ -50,7 +50,8 @@ import com.slparcelauctions.backend.sl.exception.InvalidSlHeadersException;
         "jwt.secret=dGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdA==",
         "jwt.access-token-lifetime=PT15M",
         "jwt.refresh-token-lifetime=P7D",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class EscrowPaymentControllerSliceTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/payment/EscrowPaymentControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/payment/EscrowPaymentControllerSliceTest.java
@@ -24,6 +24,7 @@ import com.slparcelauctions.backend.auth.JwtAuthenticationFilter;
 import com.slparcelauctions.backend.auth.JwtService;
 import com.slparcelauctions.backend.auth.config.JwtConfig;
 import com.slparcelauctions.backend.bot.BotSharedSecretAuthorizer;
+import com.slparcelauctions.backend.notification.slim.internal.SlImInternalConfig;
 import com.slparcelauctions.backend.config.SecurityConfig;
 import com.slparcelauctions.backend.escrow.EscrowService;
 import com.slparcelauctions.backend.escrow.exception.EscrowExceptionHandler;
@@ -42,7 +43,7 @@ import com.slparcelauctions.backend.sl.exception.InvalidSlHeadersException;
  * modes spanning domain REFUND/ERROR variants and the two 403 auth gates.
  */
 @WebMvcTest(EscrowPaymentController.class)
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class,
+@Import({SlImInternalConfig.class, SecurityConfig.class, JwtAuthenticationFilter.class,
         JwtAuthenticationEntryPoint.class, EscrowExceptionHandler.class})
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/payment/ListingFeePaymentControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/payment/ListingFeePaymentControllerSliceTest.java
@@ -50,7 +50,8 @@ import com.slparcelauctions.backend.sl.exception.InvalidSlHeadersException;
         "jwt.secret=dGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdA==",
         "jwt.access-token-lifetime=PT15M",
         "jwt.refresh-token-lifetime=P7D",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class ListingFeePaymentControllerSliceTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/payment/ListingFeePaymentControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/payment/ListingFeePaymentControllerSliceTest.java
@@ -24,6 +24,7 @@ import com.slparcelauctions.backend.auth.JwtAuthenticationFilter;
 import com.slparcelauctions.backend.auth.JwtService;
 import com.slparcelauctions.backend.auth.config.JwtConfig;
 import com.slparcelauctions.backend.bot.BotSharedSecretAuthorizer;
+import com.slparcelauctions.backend.notification.slim.internal.SlImInternalConfig;
 import com.slparcelauctions.backend.config.SecurityConfig;
 import com.slparcelauctions.backend.escrow.exception.EscrowExceptionHandler;
 import com.slparcelauctions.backend.escrow.exception.TerminalAuthException;
@@ -42,7 +43,7 @@ import com.slparcelauctions.backend.sl.exception.InvalidSlHeadersException;
  * amount, already paid, unknown auction, bad headers, bad secret.
  */
 @WebMvcTest(ListingFeePaymentController.class)
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class,
+@Import({SlImInternalConfig.class, SecurityConfig.class, JwtAuthenticationFilter.class,
         JwtAuthenticationEntryPoint.class, EscrowExceptionHandler.class})
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/terminal/TerminalRegistrationControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/terminal/TerminalRegistrationControllerSliceTest.java
@@ -26,6 +26,7 @@ import com.slparcelauctions.backend.auth.JwtAuthenticationFilter;
 import com.slparcelauctions.backend.auth.JwtService;
 import com.slparcelauctions.backend.auth.config.JwtConfig;
 import com.slparcelauctions.backend.bot.BotSharedSecretAuthorizer;
+import com.slparcelauctions.backend.notification.slim.internal.SlImInternalConfig;
 import com.slparcelauctions.backend.config.SecurityConfig;
 import com.slparcelauctions.backend.escrow.exception.EscrowExceptionHandler;
 import com.slparcelauctions.backend.escrow.exception.TerminalAuthException;
@@ -40,7 +41,7 @@ import com.slparcelauctions.backend.sl.exception.InvalidSlHeadersException;
  * ProblemDetail shapes.
  */
 @WebMvcTest(TerminalRegistrationController.class)
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class,
+@Import({SlImInternalConfig.class, SecurityConfig.class, JwtAuthenticationFilter.class,
         JwtAuthenticationEntryPoint.class, EscrowExceptionHandler.class})
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/terminal/TerminalRegistrationControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/terminal/TerminalRegistrationControllerSliceTest.java
@@ -48,7 +48,8 @@ import com.slparcelauctions.backend.sl.exception.InvalidSlHeadersException;
         "jwt.secret=dGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdA==",
         "jwt.access-token-lifetime=PT15M",
         "jwt.refresh-token-lifetime=P7D",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class TerminalRegistrationControllerSliceTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/integration/FullFlowSmokeTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/integration/FullFlowSmokeTest.java
@@ -60,7 +60,8 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class FullFlowSmokeTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/NotificationCleanupJobTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/NotificationCleanupJobTest.java
@@ -40,7 +40,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.escrow.ownership-monitor-job.enabled=false",
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
-        "slpa.review.scheduler.enabled=false"
+        "slpa.review.scheduler.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class NotificationCleanupJobTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/NotificationControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/NotificationControllerIntegrationTest.java
@@ -42,7 +42,8 @@ import org.springframework.transaction.support.TransactionTemplate;
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class NotificationControllerIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/NotificationDaoUpsertTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/NotificationDaoUpsertTest.java
@@ -43,7 +43,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class NotificationDaoUpsertTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/NotificationPublisherImplTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/NotificationPublisherImplTest.java
@@ -56,7 +56,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class NotificationPublisherImplTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/NotificationRepositoryTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/NotificationRepositoryTest.java
@@ -37,7 +37,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class NotificationRepositoryTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/NotificationServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/NotificationServiceTest.java
@@ -50,7 +50,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class NotificationServiceTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/integration/AuctionEndNotificationIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/integration/AuctionEndNotificationIntegrationTest.java
@@ -56,7 +56,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class AuctionEndNotificationIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/integration/BidNotificationIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/integration/BidNotificationIntegrationTest.java
@@ -50,7 +50,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class BidNotificationIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/integration/CancellationFanoutIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/integration/CancellationFanoutIntegrationTest.java
@@ -48,7 +48,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class CancellationFanoutIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/integration/EscrowNotificationIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/integration/EscrowNotificationIntegrationTest.java
@@ -60,7 +60,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class EscrowNotificationIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/integration/ParcelVerificationNotificationIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/integration/ParcelVerificationNotificationIntegrationTest.java
@@ -48,7 +48,8 @@ import com.slparcelauctions.backend.verification.VerificationCodeType;
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class ParcelVerificationNotificationIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/integration/PenaltyClearedBroadcastIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/integration/PenaltyClearedBroadcastIntegrationTest.java
@@ -43,7 +43,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class PenaltyClearedBroadcastIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/integration/ReviewNotificationIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/integration/ReviewNotificationIntegrationTest.java
@@ -52,7 +52,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class ReviewNotificationIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/integration/SuspensionNotificationIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/integration/SuspensionNotificationIntegrationTest.java
@@ -49,7 +49,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class SuspensionNotificationIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/integration/TerminalCommandStallNotificationIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/integration/TerminalCommandStallNotificationIntegrationTest.java
@@ -56,7 +56,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class TerminalCommandStallNotificationIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/preferences/NotificationPreferencesControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/preferences/NotificationPreferencesControllerTest.java
@@ -1,0 +1,269 @@
+package com.slparcelauctions.backend.notification.preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class NotificationPreferencesControllerTest {
+
+    @Autowired MockMvc mvc;
+    @Autowired UserRepository userRepo;
+    @Autowired JwtService jwt;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private User alice;
+    private User bob;
+    private String aliceJwt;
+    private String bobJwt;
+
+    @BeforeEach
+    void seed() {
+        alice = userRepo.save(User.builder()
+            .email("alice-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash").build());
+        bob = userRepo.save(User.builder()
+            .email("bob-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash").build());
+
+        aliceJwt = jwt.issueAccessToken(new AuthPrincipal(
+            alice.getId(), alice.getEmail(), alice.getTokenVersion()));
+        bobJwt = jwt.issueAccessToken(new AuthPrincipal(
+            bob.getId(), bob.getEmail(), bob.getTokenVersion()));
+    }
+
+    @Test
+    void get_returnsClosedShapeMap() throws Exception {
+        mvc.perform(get("/api/v1/users/me/notification-preferences")
+                .header("Authorization", "Bearer " + aliceJwt))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.slImMuted").value(false))
+            .andExpect(jsonPath("$.slIm.bidding").exists())
+            .andExpect(jsonPath("$.slIm.auction_result").exists())
+            .andExpect(jsonPath("$.slIm.escrow").exists())
+            .andExpect(jsonPath("$.slIm.listing_status").exists())
+            .andExpect(jsonPath("$.slIm.reviews").exists())
+            .andExpect(jsonPath("$.slIm.system").doesNotExist())
+            .andExpect(jsonPath("$.slIm.realty_group").doesNotExist())
+            .andExpect(jsonPath("$.slIm.marketing").doesNotExist());
+    }
+
+    @Test
+    void put_happyPath_persistsAndReturnsNewState() throws Exception {
+        Map<String, Object> body = Map.of(
+            "slImMuted", false,
+            "slIm", Map.of(
+                "bidding", true,
+                "auction_result", true,
+                "escrow", true,
+                "listing_status", false,
+                "reviews", true
+            )
+        );
+
+        mvc.perform(put("/api/v1/users/me/notification-preferences")
+                .header("Authorization", "Bearer " + aliceJwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.slIm.listing_status").value(false))
+            .andExpect(jsonPath("$.slIm.reviews").value(true));
+
+        // Persisted on User entity
+        User updated = userRepo.findById(alice.getId()).orElseThrow();
+        assertThat(updated.getNotifySlIm().get("listing_status")).isEqualTo(false);
+        assertThat(updated.getNotifySlIm().get("reviews")).isEqualTo(true);
+    }
+
+    @Test
+    void put_preservesUnexposedKeys() throws Exception {
+        // Pre-set system=true and realty_group=false on alice.
+        Map<String, Object> initial = new HashMap<>(alice.getNotifySlIm());
+        initial.put("system", true);
+        initial.put("realty_group", false);
+        alice.setNotifySlIm(initial);
+        userRepo.save(alice);
+
+        Map<String, Object> body = Map.of(
+            "slImMuted", false,
+            "slIm", Map.of(
+                "bidding", false,
+                "auction_result", true,
+                "escrow", true,
+                "listing_status", true,
+                "reviews", true
+            )
+        );
+
+        mvc.perform(put("/api/v1/users/me/notification-preferences")
+                .header("Authorization", "Bearer " + aliceJwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)))
+            .andExpect(status().isOk());
+
+        User updated = userRepo.findById(alice.getId()).orElseThrow();
+        // Visible keys updated:
+        assertThat(updated.getNotifySlIm().get("bidding")).isEqualTo(false);
+        // Unexposed keys preserved:
+        assertThat(updated.getNotifySlIm().get("system")).isEqualTo(true);
+        assertThat(updated.getNotifySlIm().get("realty_group")).isEqualTo(false);
+    }
+
+    @Test
+    void put_systemKey_returns400() throws Exception {
+        Map<String, Object> body = Map.of(
+            "slImMuted", false,
+            "slIm", Map.of(
+                "bidding", true,
+                "auction_result", true,
+                "escrow", true,
+                "listing_status", true,
+                "reviews", true,
+                "system", false  // rejected
+            )
+        );
+
+        mvc.perform(put("/api/v1/users/me/notification-preferences")
+                .header("Authorization", "Bearer " + aliceJwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void put_realtyGroupKey_returns400() throws Exception {
+        Map<String, Object> body = Map.of(
+            "slImMuted", false,
+            "slIm", Map.of(
+                "bidding", true,
+                "auction_result", true,
+                "escrow", true,
+                "listing_status", true,
+                "reviews", true,
+                "realty_group", true
+            )
+        );
+
+        mvc.perform(put("/api/v1/users/me/notification-preferences")
+                .header("Authorization", "Bearer " + aliceJwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void put_missingKey_returns400() throws Exception {
+        Map<String, Object> body = Map.of(
+            "slImMuted", false,
+            "slIm", Map.of(
+                "bidding", true,
+                "auction_result", true,
+                "escrow", true,
+                "listing_status", true
+                // missing "reviews"
+            )
+        );
+
+        mvc.perform(put("/api/v1/users/me/notification-preferences")
+                .header("Authorization", "Bearer " + aliceJwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void put_nonBooleanValue_returns400() throws Exception {
+        // Send raw JSON with a string where a boolean is expected.
+        String rawBody = """
+            {
+              "slImMuted": false,
+              "slIm": {
+                "bidding": "true",
+                "auction_result": true,
+                "escrow": true,
+                "listing_status": true,
+                "reviews": true
+              }
+            }""";
+
+        mvc.perform(put("/api/v1/users/me/notification-preferences")
+                .header("Authorization", "Bearer " + aliceJwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(rawBody))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void get_unauthenticated_returns401() throws Exception {
+        mvc.perform(get("/api/v1/users/me/notification-preferences"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void put_unauthenticated_returns401() throws Exception {
+        mvc.perform(put("/api/v1/users/me/notification-preferences")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void crossUser_aliceCannotAccessBobsPreferences() throws Exception {
+        // Bob's PUT updates Bob's prefs, not Alice's. Same endpoint path; the
+        // principal is the discriminator.
+        Map<String, Object> body = Map.of(
+            "slImMuted", true,
+            "slIm", Map.of(
+                "bidding", false, "auction_result", false,
+                "escrow", false, "listing_status", false, "reviews", false
+            )
+        );
+
+        mvc.perform(put("/api/v1/users/me/notification-preferences")
+                .header("Authorization", "Bearer " + bobJwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)))
+            .andExpect(status().isOk());
+
+        User aliceFresh = userRepo.findById(alice.getId()).orElseThrow();
+        User bobFresh = userRepo.findById(bob.getId()).orElseThrow();
+        assertThat(aliceFresh.getNotifySlImMuted()).isFalse();  // unchanged
+        assertThat(bobFresh.getNotifySlImMuted()).isTrue();      // updated
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImChannelDispatcherTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImChannelDispatcherTest.java
@@ -1,0 +1,199 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationEvent;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class SlImChannelDispatcherTest {
+
+    @Autowired SlImChannelDispatcher dispatcher;
+    @Autowired SlImMessageRepository repo;
+    @Autowired UserRepository userRepo;
+    @Autowired TransactionTemplate transactionTemplate;
+
+    @BeforeEach
+    void clean() {
+        repo.deleteAll();
+    }
+
+    private User userWithAvatarAndAllGroupsOn() {
+        User u = User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash")
+            .build();
+        u.setSlAvatarUuid(UUID.randomUUID());
+        u.setNotifySlImMuted(false);
+        Map<String, Object> prefs = new HashMap<>();
+        prefs.put("bidding", true);
+        prefs.put("auction_result", true);
+        prefs.put("escrow", true);
+        prefs.put("listing_status", true);
+        prefs.put("reviews", true);
+        prefs.put("system", true);
+        u.setNotifySlIm(prefs);
+        return userRepo.save(u);
+    }
+
+    @Test
+    void maybeQueue_happyPath_insertsRowWithBuiltMessage() {
+        User u = userWithAvatarAndAllGroupsOn();
+        Map<String, Object> data = Map.of("auctionId", 42, "parcelName", "Hampton",
+            "currentBidL", 2000L, "isProxyOutbid", false, "endsAt", "2026-04-26T18:00:00Z");
+        NotificationEvent event = new NotificationEvent(
+            u.getId(), NotificationCategory.OUTBID,
+            "You've been outbid on Hampton", "Current bid is L$2,000.",
+            data, "outbid:" + u.getId() + ":42");
+
+        // Run inside a transaction so the dispatcher's REQUIRES_NEW commits independently.
+        transactionTemplate.execute(status -> {
+            dispatcher.maybeQueue(event);
+            return null;
+        });
+
+        List<SlImMessage> rows = repo.findAll();
+        assertThat(rows).hasSize(1);
+        SlImMessage row = rows.get(0);
+        assertThat(row.getUserId()).isEqualTo(u.getId());
+        assertThat(row.getAvatarUuid()).isEqualTo(u.getSlAvatarUuid().toString());
+        assertThat(row.getStatus()).isEqualTo(SlImMessageStatus.PENDING);
+        assertThat(row.getMessageText()).startsWith("[SLPA] You've been outbid on Hampton");
+        assertThat(row.getMessageText()).contains("Current bid is L$2,000.");
+        assertThat(row.getMessageText()).endsWith("/auction/42");
+        assertThat(row.getCoalesceKey()).isEqualTo("outbid:" + u.getId() + ":42");
+    }
+
+    @Test
+    void maybeQueue_userMuted_doesNotQueue() {
+        User u = userWithAvatarAndAllGroupsOn();
+        u.setNotifySlImMuted(true);
+        userRepo.save(u);
+
+        NotificationEvent event = new NotificationEvent(
+            u.getId(), NotificationCategory.OUTBID, "title", "body",
+            Map.of("auctionId", 42), null);
+
+        transactionTemplate.execute(status -> { dispatcher.maybeQueue(event); return null; });
+
+        assertThat(repo.findAll()).isEmpty();
+    }
+
+    @Test
+    void maybeQueue_groupDisabled_doesNotQueue() {
+        User u = userWithAvatarAndAllGroupsOn();
+        Map<String, Object> prefs = new HashMap<>(u.getNotifySlIm());
+        prefs.put("bidding", false);
+        u.setNotifySlIm(prefs);
+        userRepo.save(u);
+
+        NotificationEvent event = new NotificationEvent(
+            u.getId(), NotificationCategory.OUTBID, "title", "body",
+            Map.of("auctionId", 42), null);
+
+        transactionTemplate.execute(status -> { dispatcher.maybeQueue(event); return null; });
+
+        assertThat(repo.findAll()).isEmpty();
+    }
+
+    @Test
+    void maybeQueue_noAvatar_doesNotQueue() {
+        User u = userWithAvatarAndAllGroupsOn();
+        u.setSlAvatarUuid(null);
+        userRepo.save(u);
+
+        NotificationEvent event = new NotificationEvent(
+            u.getId(), NotificationCategory.OUTBID, "title", "body",
+            Map.of("auctionId", 42), null);
+
+        transactionTemplate.execute(status -> { dispatcher.maybeQueue(event); return null; });
+
+        assertThat(repo.findAll()).isEmpty();
+    }
+
+    @Test
+    void maybeQueue_systemBypassesPrefs_evenWhenMuted() {
+        User u = userWithAvatarAndAllGroupsOn();
+        u.setNotifySlImMuted(true);
+        Map<String, Object> prefs = new HashMap<>(u.getNotifySlIm());
+        prefs.put("system", false);
+        u.setNotifySlIm(prefs);
+        userRepo.save(u);
+
+        NotificationEvent event = new NotificationEvent(
+            u.getId(), NotificationCategory.SYSTEM_ANNOUNCEMENT, "Heads up", "body",
+            Map.of(), null);
+
+        transactionTemplate.execute(status -> { dispatcher.maybeQueue(event); return null; });
+
+        assertThat(repo.findAll()).hasSize(1);
+    }
+
+    @Test
+    void maybeQueue_repeatedSameKey_coalescesToSingleRow() {
+        User u = userWithAvatarAndAllGroupsOn();
+        String key = "outbid:" + u.getId() + ":42";
+
+        for (int i = 1; i <= 5; i++) {
+            int currentBidL = 1000 + i * 100;
+            NotificationEvent event = new NotificationEvent(
+                u.getId(), NotificationCategory.OUTBID,
+                "You've been outbid", "Current bid is L$" + currentBidL,
+                Map.of("auctionId", 42, "currentBidL", (long) currentBidL,
+                    "isProxyOutbid", false, "parcelName", "Hampton",
+                    "endsAt", "2026-04-26T18:00:00Z"),
+                key);
+            transactionTemplate.execute(status -> { dispatcher.maybeQueue(event); return null; });
+        }
+
+        List<SlImMessage> rows = repo.findAll();
+        assertThat(rows).hasSize(1);
+        // Latest body wins:
+        assertThat(rows.get(0).getMessageText()).contains("Current bid is L$1500");
+    }
+
+    @Test
+    void maybeQueueForFanout_propagatesExceptionForCaller() {
+        // Force a failure by passing a non-existent userId so userRepo.findById fails.
+        long missingUserId = 999_999_999L;
+
+        // Direct call (no requires_new wrapper) — caller is "already inside a REQUIRES_NEW".
+        // Verify the exception propagates.
+        assertThatThrownBy(() ->
+            transactionTemplate.execute(status -> {
+                dispatcher.maybeQueueForFanout(missingUserId, NotificationCategory.OUTBID,
+                    "title", "body", Map.of("auctionId", 42), null);
+                return null;
+            }))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("user not found");
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImChannelGateTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImChannelGateTest.java
@@ -1,0 +1,160 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationGroup;
+import com.slparcelauctions.backend.notification.slim.SlImChannelGate.Decision;
+import com.slparcelauctions.backend.user.User;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SlImChannelGateTest {
+
+    private final SlImChannelGate gate = new SlImChannelGate();
+
+    @Test
+    void noAvatar_isSkipNoAvatar_evenForSystem() {
+        User u = userWithoutAvatar();
+        assertThat(gate.decide(u, NotificationCategory.SYSTEM_ANNOUNCEMENT))
+            .isEqualTo(Decision.SKIP_NO_AVATAR);
+        assertThat(gate.decide(u, NotificationCategory.OUTBID))
+            .isEqualTo(Decision.SKIP_NO_AVATAR);
+    }
+
+    @Test
+    void systemCategory_bypassesMuteAndGroupPrefs_whenAvatarPresent() {
+        User u = userWithAvatar();
+        u.setNotifySlImMuted(true);
+        u.setNotifySlIm(allGroupsOff());
+
+        assertThat(gate.decide(u, NotificationCategory.SYSTEM_ANNOUNCEMENT))
+            .isEqualTo(Decision.QUEUE_BYPASS_PREFS);
+    }
+
+    @Test
+    void mutedUser_isSkipMuted_forNonSystemCategories() {
+        User u = userWithAvatar();
+        u.setNotifySlImMuted(true);
+        u.setNotifySlIm(allGroupsOn());
+
+        assertThat(gate.decide(u, NotificationCategory.OUTBID))
+            .isEqualTo(Decision.SKIP_MUTED);
+        assertThat(gate.decide(u, NotificationCategory.ESCROW_FUNDED))
+            .isEqualTo(Decision.SKIP_MUTED);
+    }
+
+    @Test
+    void groupOff_isSkipGroupDisabled() {
+        User u = userWithAvatar();
+        u.setNotifySlImMuted(false);
+        Map<String, Object> prefs = allGroupsOn();
+        prefs.put("bidding", false);
+        u.setNotifySlIm(prefs);
+
+        assertThat(gate.decide(u, NotificationCategory.OUTBID))
+            .isEqualTo(Decision.SKIP_GROUP_DISABLED);
+        // Other groups still queue:
+        assertThat(gate.decide(u, NotificationCategory.ESCROW_FUNDED))
+            .isEqualTo(Decision.QUEUE);
+    }
+
+    @Test
+    void groupAbsent_isSkipGroupDisabled() {
+        User u = userWithAvatar();
+        u.setNotifySlImMuted(false);
+        u.setNotifySlIm(new HashMap<>()); // no keys
+
+        assertThat(gate.decide(u, NotificationCategory.OUTBID))
+            .isEqualTo(Decision.SKIP_GROUP_DISABLED);
+    }
+
+    @Test
+    void allGroupsOnUnmutedWithAvatar_isQueue() {
+        User u = userWithAvatar();
+        u.setNotifySlImMuted(false);
+        u.setNotifySlIm(allGroupsOn());
+
+        for (NotificationCategory c : NotificationCategory.values()) {
+            if (c.getGroup() == NotificationGroup.SYSTEM) {
+                assertThat(gate.decide(u, c)).isEqualTo(Decision.QUEUE_BYPASS_PREFS);
+            } else {
+                assertThat(gate.decide(u, c)).isEqualTo(Decision.QUEUE);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("matrixCases")
+    void matrix(boolean hasAvatar, boolean muted, boolean groupOn,
+                NotificationCategory category, Decision expected) {
+        User u = hasAvatar ? userWithAvatar() : userWithoutAvatar();
+        u.setNotifySlImMuted(muted);
+        Map<String, Object> prefs = allGroupsOn();
+        if (!groupOn) {
+            prefs.put(category.getGroup().name().toLowerCase(), false);
+        }
+        u.setNotifySlIm(prefs);
+
+        assertThat(gate.decide(u, category)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> matrixCases() {
+        // (hasAvatar, muted, groupOn, category, expected)
+        return Stream.of(
+            // No avatar always wins
+            Arguments.of(false, false, true,  NotificationCategory.OUTBID,            Decision.SKIP_NO_AVATAR),
+            Arguments.of(false, true,  false, NotificationCategory.OUTBID,            Decision.SKIP_NO_AVATAR),
+            Arguments.of(false, false, true,  NotificationCategory.SYSTEM_ANNOUNCEMENT, Decision.SKIP_NO_AVATAR),
+            // SYSTEM bypasses prefs (when avatar present)
+            Arguments.of(true,  true,  false, NotificationCategory.SYSTEM_ANNOUNCEMENT, Decision.QUEUE_BYPASS_PREFS),
+            Arguments.of(true,  false, true,  NotificationCategory.SYSTEM_ANNOUNCEMENT, Decision.QUEUE_BYPASS_PREFS),
+            // Muted wins over group prefs (non-SYSTEM)
+            Arguments.of(true,  true,  true,  NotificationCategory.OUTBID,            Decision.SKIP_MUTED),
+            // Group off when not muted
+            Arguments.of(true,  false, false, NotificationCategory.OUTBID,            Decision.SKIP_GROUP_DISABLED),
+            // Happy path
+            Arguments.of(true,  false, true,  NotificationCategory.OUTBID,            Decision.QUEUE),
+            Arguments.of(true,  false, true,  NotificationCategory.AUCTION_WON,       Decision.QUEUE),
+            Arguments.of(true,  false, true,  NotificationCategory.ESCROW_FUNDED,     Decision.QUEUE)
+        );
+    }
+
+    private User userWithoutAvatar() {
+        User u = User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash")
+            .build();
+        u.setSlAvatarUuid(null);
+        u.setNotifySlIm(allGroupsOn());
+        return u;
+    }
+
+    private User userWithAvatar() {
+        User u = userWithoutAvatar();
+        u.setSlAvatarUuid(UUID.randomUUID());
+        return u;
+    }
+
+    private Map<String, Object> allGroupsOn() {
+        Map<String, Object> m = new HashMap<>();
+        for (NotificationGroup g : NotificationGroup.values()) {
+            m.put(g.name().toLowerCase(), true);
+        }
+        return m;
+    }
+
+    private Map<String, Object> allGroupsOff() {
+        Map<String, Object> m = new HashMap<>();
+        for (NotificationGroup g : NotificationGroup.values()) {
+            m.put(g.name().toLowerCase(), false);
+        }
+        return m;
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImCleanupJobTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImCleanupJobTest.java
@@ -1,0 +1,174 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=true",
+    "slpa.notifications.sl-im.cleanup.cron=0 0 0 * * *",
+    "slpa.notifications.sl-im.cleanup.expiry-after-hours=48",
+    "slpa.notifications.sl-im.cleanup.retention-after-days=30",
+    "slpa.notifications.sl-im.cleanup.batch-size=1000",
+    "slpa.notifications.sl-im.cleanup.top-users-in-log=10",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class SlImCleanupJobTest {
+
+    @Autowired SlImCleanupJob job;
+    @Autowired SlImMessageDao dao;
+    @Autowired SlImMessageRepository repo;
+    @Autowired UserRepository userRepo;
+    @Autowired JdbcTemplate jdbc;
+
+    @MockitoBean Clock clock;
+
+    @Test
+    void run_expiresPendingOlderThan48h_keepsNewer_deletesTerminalOlderThan30d() {
+        when(clock.instant()).thenReturn(Instant.parse("2026-04-26T08:30:00Z"));
+        when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+
+        User u = userRepo.save(User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash").build());
+        String avatar = UUID.randomUUID().toString();
+
+        // 49h-old PENDING — should expire
+        var stalePending = dao.upsert(u.getId(), avatar, "[SLPA] stale", "k1");
+        forceCreatedAt(stalePending.id(), "2026-04-24T07:00:00Z");
+
+        // 47h-old PENDING — should stay
+        var freshPending = dao.upsert(u.getId(), avatar, "[SLPA] fresh", "k2");
+        forceCreatedAt(freshPending.id(), "2026-04-24T10:00:00Z");
+
+        // 31d-old DELIVERED — should be deleted
+        var oldDelivered = dao.upsert(u.getId(), avatar, "[SLPA] old-d", "k3");
+        forceStatusAndUpdatedAt(oldDelivered.id(), "DELIVERED", "2026-03-25T08:30:00Z");
+
+        // 31d-old FAILED — should be deleted
+        var oldFailed = dao.upsert(u.getId(), avatar, "[SLPA] old-f", "k4");
+        forceStatusAndUpdatedAt(oldFailed.id(), "FAILED", "2026-03-25T08:30:00Z");
+
+        // 31d-old EXPIRED — should be deleted
+        var oldExpired = dao.upsert(u.getId(), avatar, "[SLPA] old-e", "k5");
+        forceStatusAndUpdatedAt(oldExpired.id(), "EXPIRED", "2026-03-25T08:30:00Z");
+
+        // 29d-old DELIVERED — should stay
+        var newishDelivered = dao.upsert(u.getId(), avatar, "[SLPA] newish", "k6");
+        forceStatusAndUpdatedAt(newishDelivered.id(), "DELIVERED", "2026-03-29T08:30:00Z");
+
+        job.run();
+
+        // stalePending → EXPIRED
+        assertThat(repo.findById(stalePending.id()).orElseThrow().getStatus())
+            .isEqualTo(SlImMessageStatus.EXPIRED);
+        // freshPending → still PENDING
+        assertThat(repo.findById(freshPending.id()).orElseThrow().getStatus())
+            .isEqualTo(SlImMessageStatus.PENDING);
+        // 31d terminal-status rows deleted
+        assertThat(repo.findById(oldDelivered.id())).isEmpty();
+        assertThat(repo.findById(oldFailed.id())).isEmpty();
+        assertThat(repo.findById(oldExpired.id())).isEmpty();
+        // 29d DELIVERED — still present
+        assertThat(repo.findById(newishDelivered.id())).isPresent();
+    }
+
+    @Test
+    void run_logsInfoLineWithExpectedFields() {
+        when(clock.instant()).thenReturn(Instant.parse("2026-04-26T08:30:00Z"));
+        when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+
+        User u = userRepo.save(User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash").build());
+        String avatar = UUID.randomUUID().toString();
+
+        var p = dao.upsert(u.getId(), avatar, "[SLPA] stale", null);
+        forceCreatedAt(p.id(), "2026-04-24T07:00:00Z");
+
+        Logger logger = (Logger) LoggerFactory.getLogger(SlImCleanupJob.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            job.run();
+
+            assertThat(appender.list)
+                .extracting(ILoggingEvent::getFormattedMessage)
+                .anyMatch(line ->
+                    line.contains("SL IM cleanup sweep")
+                        && line.contains("expired=1")
+                        && line.contains("deleted=")
+                        && line.contains("expiry_cutoff=")
+                        && line.contains("retention_cutoff=")
+                        && line.contains("top_users=[" + u.getId() + ":1"));
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
+    }
+
+    @Test
+    void run_chunkedDelete_handlesLargeBacklog() {
+        when(clock.instant()).thenReturn(Instant.parse("2026-04-26T08:30:00Z"));
+        when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+
+        User u = userRepo.save(User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash").build());
+        String avatar = UUID.randomUUID().toString();
+
+        // Seed 25 deletable DELIVERED rows; with batch=1000 (default), the loop
+        // runs once and clears all 25, exercising the do-while exit condition.
+        for (int i = 0; i < 25; i++) {
+            var r = dao.upsert(u.getId(), avatar, "[SLPA] msg-" + i, "k" + i);
+            forceStatusAndUpdatedAt(r.id(), "DELIVERED", "2026-03-20T00:00:00Z");
+        }
+
+        job.run();
+
+        // All 25 rows deleted (batch covers them in one shot).
+        long remaining = repo.findAll().stream()
+            .filter(m -> m.getUserId().equals(u.getId())).count();
+        assertThat(remaining).isZero();
+    }
+
+    private void forceCreatedAt(long id, String iso) {
+        jdbc.update("UPDATE sl_im_message SET created_at = ? WHERE id = ?",
+            OffsetDateTime.parse(iso), id);
+    }
+
+    private void forceStatusAndUpdatedAt(long id, String status, String iso) {
+        jdbc.update("UPDATE sl_im_message SET status = ?::varchar, updated_at = ? WHERE id = ?",
+            status, OffsetDateTime.parse(iso), id);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImCoalesceIndexInitializerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImCoalesceIndexInitializerTest.java
@@ -1,0 +1,56 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class SlImCoalesceIndexInitializerTest {
+
+    @Autowired JdbcTemplate jdbc;
+    @Autowired SlImCoalesceIndexInitializer initializer;
+
+    @Test
+    void partialUniqueIndexIsPresentAfterStartup() {
+        // ApplicationReadyEvent fires during @SpringBootTest startup.
+        Integer count = jdbc.queryForObject("""
+            SELECT count(*)
+            FROM pg_indexes
+            WHERE tablename = 'sl_im_message'
+              AND indexname = 'uq_sl_im_pending_coalesce'
+            """, Integer.class);
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void emit_isIdempotent() {
+        // Calling emit() a second time should not throw.
+        initializer.emit();
+        Integer count = jdbc.queryForObject("""
+            SELECT count(*)
+            FROM pg_indexes
+            WHERE tablename = 'sl_im_message'
+              AND indexname = 'uq_sl_im_pending_coalesce'
+            """, Integer.class);
+        assertThat(count).isEqualTo(1);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImLinkResolverTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImLinkResolverTest.java
@@ -1,0 +1,73 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.slparcelauctions.backend.config.SlpaWebProperties;
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SlImLinkResolverTest {
+
+    private static final String BASE = "https://slpa.example.com";
+    private final SlImLinkResolver resolver = new SlImLinkResolver(new SlpaWebProperties(BASE));
+
+    @Test
+    void outbid_resolvesToAuctionPage() {
+        assertThat(resolver.resolve(NotificationCategory.OUTBID, Map.of("auctionId", 42)))
+            .isEqualTo(BASE + "/auction/42");
+    }
+
+    @Test
+    void auctionWon_resolvesToEscrowPage() {
+        assertThat(resolver.resolve(NotificationCategory.AUCTION_WON, Map.of("auctionId", 42)))
+            .isEqualTo(BASE + "/auction/42/escrow");
+    }
+
+    @Test
+    void escrowFunded_resolvesToEscrowPage() {
+        assertThat(resolver.resolve(NotificationCategory.ESCROW_FUNDED,
+                Map.of("auctionId", 42, "escrowId", 100)))
+            .isEqualTo(BASE + "/auction/42/escrow");
+    }
+
+    @Test
+    void listingSuspended_resolvesToDashboardListings() {
+        assertThat(resolver.resolve(NotificationCategory.LISTING_SUSPENDED,
+                Map.of("auctionId", 42, "reason", "test")))
+            .isEqualTo(BASE + "/dashboard/listings");
+    }
+
+    @Test
+    void systemAnnouncement_resolvesToNotificationsFeed() {
+        assertThat(resolver.resolve(NotificationCategory.SYSTEM_ANNOUNCEMENT, Map.of()))
+            .isEqualTo(BASE + "/notifications");
+    }
+
+    @Test
+    void everyCategory_producesAValidUrl() {
+        // Every category must produce a URL starting with the base; ensures the
+        // switch covers all enum values (compile-time guarantee + runtime sanity).
+        Map<String, Object> data = Map.ofEntries(
+            Map.entry("auctionId", 42),
+            Map.entry("escrowId", 100),
+            Map.entry("reviewId", 5),
+            Map.entry("reason", "x"),
+            Map.entry("parcelName", "P"),
+            Map.entry("currentBidL", 1L),
+            Map.entry("isProxyOutbid", false),
+            Map.entry("endsAt", "2026-04-26T18:00:00Z"),
+            Map.entry("winningBidL", 1L),
+            Map.entry("highestBidL", 1L),
+            Map.entry("buyNowL", 1L),
+            Map.entry("transferDeadline", "2026-04-26T18:00:00Z"),
+            Map.entry("payoutL", 1L),
+            Map.entry("reasonCategory", "x"),
+            Map.entry("rating", 5)
+        );
+        for (NotificationCategory c : NotificationCategory.values()) {
+            String url = resolver.resolve(c, data);
+            assertThat(url).startsWith(BASE);
+        }
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImMessageBuilderTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImMessageBuilderTest.java
@@ -1,0 +1,101 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class SlImMessageBuilderTest {
+
+    private final SlImMessageBuilder builder = new SlImMessageBuilder();
+
+    @Test
+    void assemble_shortInputs_returnsExactTemplate() {
+        String result = builder.assemble(
+            "You've been outbid on Hampton Hills",
+            "Current bid is L$2,000.",
+            "https://slpa.example.com/auction/42#bid-panel");
+
+        assertThat(result).isEqualTo(
+            "[SLPA] You've been outbid on Hampton Hills\n\n" +
+            "Current bid is L$2,000.\n\n" +
+            "https://slpa.example.com/auction/42#bid-panel");
+        assertThat(byteLen(result)).isLessThanOrEqualTo(1024);
+    }
+
+    @Test
+    void assemble_multiByteParcelName_keepsDeeplinkIntact() {
+        // Three CJK characters, each 3 bytes UTF-8.
+        String result = builder.assemble(
+            "You've been outbid on 東京タワー Estates",
+            "Current bid is L$2,000.",
+            "https://slpa.example.com/auction/42#bid-panel");
+
+        assertThat(result).contains("東京タワー Estates");
+        assertThat(result).endsWith("https://slpa.example.com/auction/42#bid-panel");
+        assertThat(byteLen(result)).isLessThanOrEqualTo(1024);
+    }
+
+    @Test
+    void assemble_emojiParcelName_keepsDeeplinkIntact() {
+        // 🌸 is a 4-byte UTF-8 character (U+1F338) and a UTF-16 surrogate pair.
+        String result = builder.assemble(
+            "Your auction sold: 🌸 Sakura Plot",
+            "Winning bid: L$5,200.",
+            "https://slpa.example.com/auction/99");
+
+        assertThat(result).contains("🌸 Sakura Plot");
+        assertThat(result).endsWith("https://slpa.example.com/auction/99");
+        assertThat(byteLen(result)).isLessThanOrEqualTo(1024);
+    }
+
+    @Test
+    void assemble_longBody_ellipsizesBodyKeepsDeeplinkIntact() {
+        String longBody = "x".repeat(2000);
+        String deeplink = "https://slpa.example.com/auction/42";
+        String result = builder.assemble("Hampton Hills update", longBody, deeplink);
+
+        assertThat(result).contains("…");
+        assertThat(result).endsWith(deeplink);
+        assertThat(result).startsWith("[SLPA] Hampton Hills update");
+        assertThat(byteLen(result)).isLessThanOrEqualTo(1024);
+    }
+
+    @Test
+    void assemble_longBodyWithMultiByteContent_ellipsizesAtCharBoundary() {
+        // Body of 1500 CJK characters (4500 bytes UTF-8). Must be trimmed; ellipsis
+        // must land at a valid char boundary (no orphaned surrogate halves).
+        String longBody = "東".repeat(1500);
+        String result = builder.assemble("Hampton Hills update", longBody,
+            "https://slpa.example.com/auction/42");
+
+        assertThat(result).endsWith("https://slpa.example.com/auction/42");
+        assertThat(byteLen(result)).isLessThanOrEqualTo(1024);
+        // Decoding round-trips cleanly (no replacement chars from broken sequences):
+        byte[] bytes = result.getBytes(StandardCharsets.UTF_8);
+        String roundTrip = new String(bytes, StandardCharsets.UTF_8);
+        assertThat(roundTrip).isEqualTo(result);
+    }
+
+    @Test
+    void assemble_bodyEmpty_returnsTitleAndDeeplink() {
+        String result = builder.assemble("Title", "", "https://slpa.example.com/x");
+        assertThat(result).isEqualTo("[SLPA] Title\n\n\n\nhttps://slpa.example.com/x");
+        assertThat(byteLen(result)).isLessThanOrEqualTo(1024);
+    }
+
+    @Test
+    void assemble_pathologicalCase_titleAndDeeplinkExceedBudget_dropsBodyTrimsTitle() {
+        // Title alone is 1500 chars + deeplink 50 chars > 1024.
+        String result = builder.assemble("a".repeat(1500), "body content",
+            "https://slpa.example.com/auction/42");
+
+        assertThat(result).endsWith("https://slpa.example.com/auction/42");
+        assertThat(result).contains("…");
+        assertThat(byteLen(result)).isLessThanOrEqualTo(1024);
+    }
+
+    private int byteLen(String s) {
+        return s.getBytes(StandardCharsets.UTF_8).length;
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImMessageDaoTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImMessageDaoTest.java
@@ -1,0 +1,171 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class SlImMessageDaoTest {
+
+    @Autowired SlImMessageDao dao;
+    @Autowired SlImMessageRepository repo;
+    @Autowired UserRepository userRepo;
+    @Autowired DataSource dataSource;
+
+    @AfterEach
+    void cleanup() throws Exception {
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("DELETE FROM sl_im_message");
+                stmt.execute("DELETE FROM users WHERE email LIKE 'u-%@test.local'");
+            }
+        }
+    }
+
+    @Test
+    void upsert_freshKey_insertsRow_returnsWasUpdateFalse() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var result = dao.upsert(u.getId(), avatar, "[SLPA] outbid msg", "outbid:1:42");
+
+        assertThat(result.wasUpdate()).isFalse();
+        assertThat(result.id()).isPositive();
+
+        SlImMessage row = repo.findById(result.id()).orElseThrow();
+        assertThat(row.getUserId()).isEqualTo(u.getId());
+        assertThat(row.getAvatarUuid()).isEqualTo(avatar);
+        assertThat(row.getMessageText()).isEqualTo("[SLPA] outbid msg");
+        assertThat(row.getCoalesceKey()).isEqualTo("outbid:1:42");
+        assertThat(row.getStatus()).isEqualTo(SlImMessageStatus.PENDING);
+        assertThat(row.getAttempts()).isZero();
+    }
+
+    @Test
+    void upsert_secondCallSameKey_updatesPendingRow_returnsWasUpdateTrue() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var first = dao.upsert(u.getId(), avatar, "[SLPA] first", "outbid:1:42");
+        var second = dao.upsert(u.getId(), avatar, "[SLPA] second", "outbid:1:42");
+
+        assertThat(second.wasUpdate()).isTrue();
+        assertThat(second.id()).isEqualTo(first.id());
+
+        SlImMessage row = repo.findById(first.id()).orElseThrow();
+        assertThat(row.getMessageText()).isEqualTo("[SLPA] second");
+        // updated_at bumped past created_at
+        assertThat(row.getUpdatedAt()).isAfterOrEqualTo(row.getCreatedAt());
+    }
+
+    @Test
+    void upsert_afterDelivered_insertsFreshRow() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var first = dao.upsert(u.getId(), avatar, "[SLPA] first", "outbid:1:42");
+
+        // Mark first row DELIVERED via direct repo write (real path is Task 4 controller)
+        SlImMessage delivered = repo.findById(first.id()).orElseThrow();
+        delivered.setStatus(SlImMessageStatus.DELIVERED);
+        repo.save(delivered);
+
+        var second = dao.upsert(u.getId(), avatar, "[SLPA] second", "outbid:1:42");
+        assertThat(second.wasUpdate()).isFalse();
+        assertThat(second.id()).isNotEqualTo(first.id());
+        // Both rows persist; partial index excludes the DELIVERED one from the predicate.
+        assertThat(repo.findAll()).hasSize(2);
+    }
+
+    @Test
+    void upsert_afterExpired_insertsFreshRow() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var first = dao.upsert(u.getId(), avatar, "[SLPA] first", "outbid:1:42");
+
+        SlImMessage expired = repo.findById(first.id()).orElseThrow();
+        expired.setStatus(SlImMessageStatus.EXPIRED);
+        repo.save(expired);
+
+        var second = dao.upsert(u.getId(), avatar, "[SLPA] second", "outbid:1:42");
+        assertThat(second.wasUpdate()).isFalse();
+        assertThat(second.id()).isNotEqualTo(first.id());
+    }
+
+    @Test
+    void upsert_afterFailed_insertsFreshRow() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var first = dao.upsert(u.getId(), avatar, "[SLPA] first", "outbid:1:42");
+
+        SlImMessage failed = repo.findById(first.id()).orElseThrow();
+        failed.setStatus(SlImMessageStatus.FAILED);
+        repo.save(failed);
+
+        var second = dao.upsert(u.getId(), avatar, "[SLPA] second", "outbid:1:42");
+        assertThat(second.wasUpdate()).isFalse();
+        assertThat(second.id()).isNotEqualTo(first.id());
+    }
+
+    @Test
+    void upsert_nullCoalesceKey_neverCollidesWithItself() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var first = dao.upsert(u.getId(), avatar, "[SLPA] one", null);
+        var second = dao.upsert(u.getId(), avatar, "[SLPA] two", null);
+
+        assertThat(first.wasUpdate()).isFalse();
+        assertThat(second.wasUpdate()).isFalse();
+        assertThat(second.id()).isNotEqualTo(first.id());
+        assertThat(repo.findAll()).hasSize(2);
+    }
+
+    @Test
+    void upsert_differentUsersSameKey_doNotCollide() {
+        User a = userRepo.save(testUser());
+        User b = userRepo.save(testUser());
+        String avatarA = UUID.randomUUID().toString();
+        String avatarB = UUID.randomUUID().toString();
+
+        var rA = dao.upsert(a.getId(), avatarA, "[SLPA] A", "outbid:1:42");
+        var rB = dao.upsert(b.getId(), avatarB, "[SLPA] B", "outbid:1:42");
+
+        assertThat(rA.wasUpdate()).isFalse();
+        assertThat(rB.wasUpdate()).isFalse();
+        assertThat(rA.id()).isNotEqualTo(rB.id());
+    }
+
+    private User testUser() {
+        return User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash")
+            .build();
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImMessageRepositoryTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImMessageRepositoryTest.java
@@ -1,0 +1,135 @@
+package com.slparcelauctions.backend.notification.slim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class SlImMessageRepositoryTest {
+
+    @Autowired SlImMessageDao dao;
+    @Autowired SlImMessageRepository repo;
+    @Autowired UserRepository userRepo;
+    @Autowired DataSource dataSource;
+
+    @AfterEach
+    void cleanup() throws Exception {
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("DELETE FROM sl_im_message");
+                stmt.execute("DELETE FROM users WHERE email LIKE 'u-%@test.local'");
+            }
+        }
+    }
+
+    @Test
+    void pollPending_returnsOldestFirst() throws InterruptedException {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var first = dao.upsert(u.getId(), avatar, "[SLPA] first", null);
+        Thread.sleep(20);
+        var second = dao.upsert(u.getId(), avatar, "[SLPA] second", null);
+        Thread.sleep(20);
+        var third = dao.upsert(u.getId(), avatar, "[SLPA] third", null);
+
+        List<SlImMessage> rows = repo.pollPending(10);
+        assertThat(rows).hasSize(3);
+        assertThat(rows.get(0).getId()).isEqualTo(first.id());
+        assertThat(rows.get(1).getId()).isEqualTo(second.id());
+        assertThat(rows.get(2).getId()).isEqualTo(third.id());
+    }
+
+    @Test
+    void pollPending_honorsLimit() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        for (int i = 0; i < 15; i++) {
+            dao.upsert(u.getId(), avatar, "[SLPA] " + i, null);
+        }
+
+        assertThat(repo.pollPending(10)).hasSize(10);
+        assertThat(repo.pollPending(5)).hasSize(5);
+    }
+
+    @Test
+    void pollPending_excludesNonPending() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var pending = dao.upsert(u.getId(), avatar, "[SLPA] pending", null);
+        var delivered = dao.upsert(u.getId(), avatar, "[SLPA] delivered", null);
+        var expired = dao.upsert(u.getId(), avatar, "[SLPA] expired", null);
+        var failed = dao.upsert(u.getId(), avatar, "[SLPA] failed", null);
+
+        SlImMessage d = repo.findById(delivered.id()).orElseThrow();
+        d.setStatus(SlImMessageStatus.DELIVERED);
+        repo.save(d);
+        SlImMessage e = repo.findById(expired.id()).orElseThrow();
+        e.setStatus(SlImMessageStatus.EXPIRED);
+        repo.save(e);
+        SlImMessage f = repo.findById(failed.id()).orElseThrow();
+        f.setStatus(SlImMessageStatus.FAILED);
+        repo.save(f);
+
+        List<SlImMessage> rows = repo.pollPending(10);
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getId()).isEqualTo(pending.id());
+    }
+
+    @Test
+    void countByStatus_returnsAllStatusBuckets() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var p1 = dao.upsert(u.getId(), avatar, "[SLPA] p1", "k1");
+        var p2 = dao.upsert(u.getId(), avatar, "[SLPA] p2", "k2");
+        var d = dao.upsert(u.getId(), avatar, "[SLPA] d", "k3");
+
+        SlImMessage row = repo.findById(d.id()).orElseThrow();
+        row.setStatus(SlImMessageStatus.DELIVERED);
+        repo.save(row);
+
+        Map<SlImMessageStatus, Long> counts = repo.countByStatus().stream()
+            .collect(java.util.stream.Collectors.toMap(
+                arr -> (SlImMessageStatus) arr[0],
+                arr -> ((Number) arr[1]).longValue()));
+
+        assertThat(counts.get(SlImMessageStatus.PENDING)).isEqualTo(2L);
+        assertThat(counts.get(SlImMessageStatus.DELIVERED)).isEqualTo(1L);
+    }
+
+    private User testUser() {
+        return User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash")
+            .build();
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/CancellationFanoutImIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/CancellationFanoutImIntegrationTest.java
@@ -1,0 +1,256 @@
+package com.slparcelauctions.backend.notification.slim.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.Bid;
+import com.slparcelauctions.backend.auction.BidRepository;
+import com.slparcelauctions.backend.auction.BidService;
+import com.slparcelauctions.backend.auction.BidType;
+import com.slparcelauctions.backend.auction.CancellationService;
+import com.slparcelauctions.backend.auction.VerificationMethod;
+import com.slparcelauctions.backend.auction.VerificationTier;
+import com.slparcelauctions.backend.notification.slim.SlImMessage;
+import com.slparcelauctions.backend.notification.slim.SlImMessageRepository;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.parcel.ParcelRepository;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Vertical-slice integration tests for fan-out SL IM delivery on auction cancellation.
+ * Fixture pattern copied from CancellationFanoutIntegrationTest.
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class CancellationFanoutImIntegrationTest {
+
+    @Autowired CancellationService cancellationService;
+    @Autowired BidService bidService;
+    @Autowired SlImMessageRepository slImRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired AuctionRepository auctionRepo;
+    @Autowired BidRepository bidRepo;
+    @Autowired ParcelRepository parcelRepo;
+    @Autowired PlatformTransactionManager txManager;
+    @Autowired DataSource dataSource;
+
+    private Long parcelId;
+    private Long auctionId;
+    private final java.util.List<Long> userIds = new java.util.ArrayList<>();
+
+    @BeforeEach
+    void clean() {
+        slImRepo.deleteAll();
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var st = conn.createStatement()) {
+                if (auctionId != null) {
+                    st.execute("DELETE FROM cancellation_logs WHERE auction_id = " + auctionId);
+                    st.execute("DELETE FROM bids WHERE auction_id = " + auctionId);
+                    st.execute("DELETE FROM auctions WHERE id = " + auctionId);
+                }
+                if (parcelId != null) {
+                    st.execute("DELETE FROM parcels WHERE id = " + parcelId);
+                }
+            }
+        } catch (Exception e) { /* best-effort */ }
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var st = conn.createStatement()) {
+                for (Long id : userIds) {
+                    if (id != null) {
+                        st.execute("DELETE FROM sl_im_message WHERE user_id = " + id);
+                        st.execute("DELETE FROM notification WHERE user_id = " + id);
+                        st.execute("DELETE FROM cancellation_logs WHERE seller_id = " + id);
+                        st.execute("DELETE FROM refresh_tokens WHERE user_id = " + id);
+                        st.execute("DELETE FROM users WHERE id = " + id);
+                    }
+                }
+            }
+        }
+        userIds.clear();
+        auctionId = null;
+        parcelId = null;
+    }
+
+    @Test
+    void cancel_threeActiveBidders_eachGetsOneSlImRow() {
+        User seller = saveUser(false);
+        User a = saveUser(true);
+        User b = saveUser(true);
+        User c = saveUser(true);
+        Auction au = saveAuction(seller, 1000L);
+
+        // Seed bid rows directly (same pattern as CancellationFanoutIntegrationTest)
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            Auction fresh = auctionRepo.findById(auctionId).orElseThrow();
+            bidRepo.save(Bid.builder()
+                .auction(fresh)
+                .bidder(userRepo.findById(a.getId()).orElseThrow())
+                .amount(1500L).bidType(BidType.MANUAL).build());
+            bidRepo.save(Bid.builder()
+                .auction(fresh)
+                .bidder(userRepo.findById(b.getId()).orElseThrow())
+                .amount(2000L).bidType(BidType.MANUAL).build());
+            bidRepo.save(Bid.builder()
+                .auction(fresh)
+                .bidder(userRepo.findById(c.getId()).orElseThrow())
+                .amount(2500L).bidType(BidType.MANUAL).build());
+            // update auction bid count
+            fresh.setBidCount(3);
+            fresh.setCurrentBid(2500L);
+            fresh.setCurrentBidderId(c.getId());
+            auctionRepo.save(fresh);
+        });
+
+        cancellationService.cancel(auctionId, "ownership lost");
+
+        // 3 IM rows, one per active bidder, all LISTING_CANCELLED_BY_SELLER.
+        var rows = slImRepo.findAll();
+        assertThat(rows).hasSize(3);
+        assertThat(rows.stream().map(SlImMessage::getUserId).toList())
+            .containsExactlyInAnyOrder(a.getId(), b.getId(), c.getId());
+        assertThat(rows).allMatch(m -> m.getMessageText().contains("[SLPA] Listing cancelled"));
+        assertThat(rows).allMatch(m -> m.getMessageText().contains("ownership lost"));
+    }
+
+    @Test
+    void cancel_oneBidderListingStatusOff_thatBidderGetsNoSlIm() {
+        User seller = saveUser(false);
+        User a = saveUser(true);
+        User b = saveUser(true);
+        // Disable listing_status group for b
+        Map<String, Object> prefs = new HashMap<>(b.getNotifySlIm());
+        prefs.put("listing_status", false);
+        b.setNotifySlIm(prefs);
+        userRepo.save(b);
+
+        Auction au = saveAuction(seller, 1000L);
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            Auction fresh = auctionRepo.findById(auctionId).orElseThrow();
+            bidRepo.save(Bid.builder()
+                .auction(fresh)
+                .bidder(userRepo.findById(a.getId()).orElseThrow())
+                .amount(1500L).bidType(BidType.MANUAL).build());
+            bidRepo.save(Bid.builder()
+                .auction(fresh)
+                .bidder(userRepo.findById(b.getId()).orElseThrow())
+                .amount(2000L).bidType(BidType.MANUAL).build());
+            fresh.setBidCount(2);
+            fresh.setCurrentBid(2000L);
+            fresh.setCurrentBidderId(b.getId());
+            auctionRepo.save(fresh);
+        });
+
+        cancellationService.cancel(auctionId, "ownership lost");
+
+        var rows = slImRepo.findAll();
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getUserId()).isEqualTo(a.getId());
+    }
+
+    @Test
+    void cancel_emptyActiveBidders_zeroSlImRows() {
+        User seller = saveUser(false);
+        saveAuction(seller, 1000L);
+
+        cancellationService.cancel(auctionId, "no bidders");
+
+        assertThat(slImRepo.findAll()).isEmpty();
+    }
+
+    // --- Fixture helpers (pattern from CancellationFanoutIntegrationTest) ---
+
+    private User saveUser(boolean hasAvatar) {
+        User u = User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash")
+            .displayName("TestUser")
+            .verified(true)
+            .cancelledWithBids(0)
+            .penaltyBalanceOwed(0L)
+            .build();
+        if (hasAvatar) {
+            u.setSlAvatarUuid(UUID.randomUUID());
+        }
+        u.setNotifySlImMuted(false);
+        // Use default notifySlIm which has listing_status=true
+        User saved = new TransactionTemplate(txManager).execute(s -> userRepo.save(u));
+        userIds.add(saved.getId());
+        return saved;
+    }
+
+    private Auction saveAuction(User seller, long startBidL) {
+        return new TransactionTemplate(txManager).execute(s -> {
+            Parcel p = parcelRepo.save(Parcel.builder()
+                .slParcelUuid(UUID.randomUUID())
+                .ownerUuid(seller.getSlAvatarUuid() != null ? seller.getSlAvatarUuid() : UUID.randomUUID())
+                .ownerType("agent")
+                .regionName("CancelImRegion")
+                .continentName("Sansara")
+                .areaSqm(256)
+                .maturityRating("GENERAL")
+                .verified(true)
+                .verifiedAt(OffsetDateTime.now())
+                .build());
+            parcelId = p.getId();
+            Auction a = auctionRepo.save(Auction.builder()
+                .title("Cancellation IM Test Lot")
+                .parcel(p)
+                .seller(seller)
+                .status(AuctionStatus.ACTIVE)
+                .verificationMethod(VerificationMethod.UUID_ENTRY)
+                .verificationTier(VerificationTier.SCRIPT)
+                .startingBid(startBidL)
+                .currentBid(0L)
+                .bidCount(0)
+                .durationHours(168)
+                .snipeProtect(false)
+                .listingFeePaid(true)
+                .consecutiveWorldApiFailures(0)
+                .commissionRate(new BigDecimal("0.05"))
+                .agentFeeRate(BigDecimal.ZERO)
+                .startsAt(OffsetDateTime.now().minusHours(1))
+                .endsAt(OffsetDateTime.now().plusHours(24))
+                .originalEndsAt(OffsetDateTime.now().plusHours(24))
+                .build());
+            auctionId = a.getId();
+            return a;
+        });
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/EscrowImIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/EscrowImIntegrationTest.java
@@ -1,0 +1,213 @@
+package com.slparcelauctions.backend.notification.slim.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.slparcelauctions.backend.notification.NotificationPublisher;
+import com.slparcelauctions.backend.notification.slim.SlImMessage;
+import com.slparcelauctions.backend.notification.slim.SlImMessageRepository;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Vertical-slice integration tests verifying that escrow-event notifications
+ * produce SL IM rows for the correct recipients, with gate conditions respected.
+ *
+ * <p>Rather than driving through EscrowService (which requires terminals,
+ * shared secrets, and complex fixture setup), these tests drive directly through
+ * {@link NotificationPublisher} — the same publish path used by EscrowService
+ * internally. This tests the full chain: publisher → NotificationService.publish
+ * → afterCommit → SlImChannelDispatcher → sl_im_message row.
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class EscrowImIntegrationTest {
+
+    @Autowired NotificationPublisher notificationPublisher;
+    @Autowired SlImMessageRepository slImRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired PlatformTransactionManager txManager;
+    @Autowired DataSource dataSource;
+
+    private final java.util.List<Long> userIds = new java.util.ArrayList<>();
+
+    @BeforeEach
+    void clean() {
+        slImRepo.deleteAll();
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var st = conn.createStatement()) {
+                for (Long id : userIds) {
+                    if (id != null) {
+                        st.execute("DELETE FROM sl_im_message WHERE user_id = " + id);
+                        st.execute("DELETE FROM notification WHERE user_id = " + id);
+                        st.execute("DELETE FROM refresh_tokens WHERE user_id = " + id);
+                        st.execute("DELETE FROM users WHERE id = " + id);
+                    }
+                }
+            }
+        }
+        userIds.clear();
+    }
+
+    // --- Tests ---
+
+    @Test
+    void escrowFunded_queuesSellerOnly_notWinner() {
+        User seller = saveUser(true);
+        User winner = saveUser(true);
+        long auctionId = 1001L;
+        long escrowId  = 2001L;
+
+        // Simulate: winner pays into escrow → seller gets ESCROW_FUNDED notification
+        new TransactionTemplate(txManager).executeWithoutResult(status ->
+            notificationPublisher.escrowFunded(
+                seller.getId(), auctionId, escrowId,
+                "TestParcel", OffsetDateTime.now().plusHours(72)));
+
+        long sellerRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(seller.getId())).count();
+        long winnerRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(winner.getId())).count();
+        assertThat(sellerRows).isEqualTo(1L);
+        assertThat(winnerRows).isZero();
+    }
+
+    @Test
+    void transferConfirmed_queuesBothParties() {
+        User seller = saveUser(true);
+        User winner = saveUser(true);
+        long auctionId = 1002L;
+        long escrowId  = 2002L;
+
+        // Simulate: transfer confirmed → both seller and winner notified
+        new TransactionTemplate(txManager).executeWithoutResult(status -> {
+            notificationPublisher.escrowTransferConfirmed(
+                seller.getId(), auctionId, escrowId, "TestParcel");
+            notificationPublisher.escrowTransferConfirmed(
+                winner.getId(), auctionId, escrowId, "TestParcel");
+        });
+
+        long sellerRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(seller.getId())).count();
+        long winnerRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(winner.getId())).count();
+        assertThat(sellerRows).isEqualTo(1L);
+        assertThat(winnerRows).isEqualTo(1L);
+    }
+
+    @Test
+    void transferConfirmed_winnerMuted_onlySellerGetsIm() {
+        User seller = saveUser(true);
+        User winner = saveUser(true);
+        winner.setNotifySlImMuted(true);
+        userRepo.save(winner);
+
+        long auctionId = 1003L;
+        long escrowId  = 2003L;
+
+        new TransactionTemplate(txManager).executeWithoutResult(status -> {
+            notificationPublisher.escrowTransferConfirmed(
+                seller.getId(), auctionId, escrowId, "TestParcel");
+            notificationPublisher.escrowTransferConfirmed(
+                winner.getId(), auctionId, escrowId, "TestParcel");
+        });
+
+        long sellerRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(seller.getId())).count();
+        long winnerRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(winner.getId())).count();
+        assertThat(sellerRows).isEqualTo(1L);
+        assertThat(winnerRows).isZero();
+    }
+
+    @Test
+    void disputed_queuesBothParties() {
+        User seller = saveUser(true);
+        User winner = saveUser(true);
+        long auctionId = 1004L;
+        long escrowId  = 2004L;
+
+        // Simulate: dispute filed → both parties get ESCROW_DISPUTED notification
+        new TransactionTemplate(txManager).executeWithoutResult(status -> {
+            notificationPublisher.escrowDisputed(
+                seller.getId(), auctionId, escrowId, "TestParcel", "OWNERSHIP_DISPUTE");
+            notificationPublisher.escrowDisputed(
+                winner.getId(), auctionId, escrowId, "TestParcel", "OWNERSHIP_DISPUTE");
+        });
+
+        long sellerRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(seller.getId())).count();
+        long winnerRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(winner.getId())).count();
+        assertThat(sellerRows).isEqualTo(1L);
+        assertThat(winnerRows).isEqualTo(1L);
+    }
+
+    @Test
+    void payout_queuesSellerOnly() {
+        User seller = saveUser(true);
+        User winner = saveUser(true);  // winner not notified of payout
+        long auctionId = 1005L;
+        long escrowId  = 2005L;
+
+        // Simulate: payout completed → seller only gets ESCROW_PAYOUT notification
+        new TransactionTemplate(txManager).executeWithoutResult(status ->
+            notificationPublisher.escrowPayout(
+                seller.getId(), auctionId, escrowId, "TestParcel", 5000L));
+
+        long sellerRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(seller.getId())).count();
+        long winnerRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(winner.getId())).count();
+        assertThat(sellerRows).isEqualTo(1L);
+        assertThat(winnerRows).isZero();
+    }
+
+    // --- Fixture helpers ---
+
+    private User saveUser(boolean hasAvatar) {
+        User u = User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash")
+            .build();
+        if (hasAvatar) {
+            u.setSlAvatarUuid(UUID.randomUUID());
+        }
+        u.setNotifySlImMuted(false);
+        // Use default notifySlIm which has escrow=true
+        User saved = userRepo.save(u);
+        userIds.add(saved.getId());
+        return saved;
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/NoAvatarSkipImIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/NoAvatarSkipImIntegrationTest.java
@@ -1,0 +1,118 @@
+package com.slparcelauctions.backend.notification.slim.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationEvent;
+import com.slparcelauctions.backend.notification.NotificationService;
+import com.slparcelauctions.backend.notification.slim.SlImMessageRepository;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Verifies that users without a linked SL avatar never receive SL IM rows,
+ * regardless of notification category or preferences.
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class NoAvatarSkipImIntegrationTest {
+
+    @Autowired NotificationService notificationService;
+    @Autowired SlImMessageRepository slImRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired PlatformTransactionManager txManager;
+    @Autowired DataSource dataSource;
+
+    private final List<Long> userIds = new java.util.ArrayList<>();
+
+    @BeforeEach
+    void clean() {
+        slImRepo.deleteAll();
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var st = conn.createStatement()) {
+                for (Long id : userIds) {
+                    if (id != null) {
+                        st.execute("DELETE FROM sl_im_message WHERE user_id = " + id);
+                        st.execute("DELETE FROM notification WHERE user_id = " + id);
+                        st.execute("DELETE FROM refresh_tokens WHERE user_id = " + id);
+                        st.execute("DELETE FROM users WHERE id = " + id);
+                    }
+                }
+            }
+        }
+        userIds.clear();
+    }
+
+    @Test
+    void noAvatar_publishingMultipleCategories_zeroSlImRows() {
+        User u = saveUserAllOnButNoAvatar();
+
+        publish(u.getId(), NotificationCategory.OUTBID, "out", "body",
+            Map.of("auctionId", 42), "outbid:" + u.getId() + ":42");
+        publish(u.getId(), NotificationCategory.AUCTION_WON, "won", "body",
+            Map.of("auctionId", 42), null);
+        publish(u.getId(), NotificationCategory.ESCROW_FUNDED, "funded", "body",
+            Map.of("auctionId", 42, "escrowId", 100), null);
+
+        // Three categories published; in-app rows exist but zero SL IM rows.
+        var rows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(u.getId())).toList();
+        assertThat(rows).isEmpty();
+    }
+
+    private void publish(long userId, NotificationCategory category, String title,
+                         String body, Map<String, Object> data, String coalesceKey) {
+        new TransactionTemplate(txManager).executeWithoutResult(status ->
+            notificationService.publish(new NotificationEvent(
+                userId, category, title, body, data, coalesceKey)));
+    }
+
+    private User saveUserAllOnButNoAvatar() {
+        User u = User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash").build();
+        // slAvatarUuid intentionally null
+        u.setNotifySlImMuted(false);
+        Map<String, Object> prefs = new HashMap<>();
+        for (var g : List.of("bidding", "auction_result", "escrow",
+                              "listing_status", "reviews", "system")) {
+            prefs.put(g, true);
+        }
+        u.setNotifySlIm(prefs);
+        User saved = userRepo.save(u);
+        userIds.add(saved.getId());
+        return saved;
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/OutbidImIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/OutbidImIntegrationTest.java
@@ -1,0 +1,255 @@
+package com.slparcelauctions.backend.notification.slim.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.BidRepository;
+import com.slparcelauctions.backend.auction.BidService;
+import com.slparcelauctions.backend.auction.VerificationMethod;
+import com.slparcelauctions.backend.auction.VerificationTier;
+import com.slparcelauctions.backend.notification.slim.SlImMessage;
+import com.slparcelauctions.backend.notification.slim.SlImMessageRepository;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.parcel.ParcelRepository;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Vertical-slice integration tests verifying that bidding events produce
+ * SL IM rows for displaced bidders (or no rows when gate conditions fail).
+ * Fixture pattern copied from BidNotificationIntegrationTest.
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class OutbidImIntegrationTest {
+
+    @Autowired BidService bidService;
+    @Autowired SlImMessageRepository slImRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired AuctionRepository auctionRepo;
+    @Autowired ParcelRepository parcelRepo;
+    @Autowired BidRepository bidRepo;
+    @Autowired PlatformTransactionManager txManager;
+    @Autowired DataSource dataSource;
+
+    private Long parcelId;
+    private Long auctionId;
+    private final java.util.List<Long> userIds = new java.util.ArrayList<>();
+
+    @BeforeEach
+    void clean() {
+        slImRepo.deleteAll();
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        if (auctionId != null) {
+            new TransactionTemplate(txManager).executeWithoutResult(s -> {
+                bidRepo.deleteAllByAuctionId(auctionId);
+                auctionRepo.findById(auctionId).ifPresent(auctionRepo::delete);
+            });
+        }
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var st = conn.createStatement()) {
+                for (Long id : userIds) {
+                    if (id != null) {
+                        st.execute("DELETE FROM sl_im_message WHERE user_id = " + id);
+                        st.execute("DELETE FROM notification WHERE user_id = " + id);
+                        st.execute("DELETE FROM refresh_tokens WHERE user_id = " + id);
+                        st.execute("DELETE FROM users WHERE id = " + id);
+                    }
+                }
+                if (parcelId != null) {
+                    st.execute("DELETE FROM parcels WHERE id = " + parcelId);
+                }
+            }
+        }
+        userIds.clear();
+        auctionId = null;
+        parcelId = null;
+    }
+
+    @Test
+    void outbid_publishesSlImForBidderWithAvatarAndPrefsOn() {
+        User seller = saveUser(/* hasAvatar */ false, /* prefs */ true);
+        User alice  = saveUser(/* hasAvatar */ true,  /* prefs */ true);
+        User bob    = saveUser(/* hasAvatar */ true,  /* prefs */ true);
+        Auction a   = saveAuction(seller, 1000L);
+
+        bidService.placeBid(a.getId(), alice.getId(), 1500L, null);
+        bidService.placeBid(a.getId(), bob.getId(),   2000L, null);
+
+        // Alice was displaced; she should have one PENDING SL IM row.
+        List<SlImMessage> aliceRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(alice.getId()))
+            .toList();
+        assertThat(aliceRows).hasSize(1);
+        assertThat(aliceRows.get(0).getMessageText())
+            .contains("[SLPA] You've been outbid")
+            .contains("L$2,000")
+            .endsWith("/auction/" + a.getId());
+
+        // Bob (the new high bidder) gets nothing on this side.
+        long bobRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(bob.getId())).count();
+        assertThat(bobRows).isZero();
+    }
+
+    @Test
+    void outbidStorm_coalescesIntoSingleRow_latestTextWins() {
+        User seller = saveUser(false, true);
+        User alice  = saveUser(true, true);
+        User bob    = saveUser(true, true);
+        Auction a   = saveAuction(seller, 1000L);
+
+        bidService.placeBid(a.getId(), alice.getId(), 1500L, null);
+        bidService.placeBid(a.getId(), bob.getId(),   2000L, null);
+        bidService.placeBid(a.getId(), alice.getId(), 2500L, null);
+        bidService.placeBid(a.getId(), bob.getId(),   3000L, null);
+        bidService.placeBid(a.getId(), alice.getId(), 3500L, null);
+        bidService.placeBid(a.getId(), bob.getId(),   4000L, null);
+
+        // Alice was displaced 3 times. Coalesce key is the same each time.
+        // Expect ONE PENDING row with the latest text.
+        List<SlImMessage> aliceRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(alice.getId()))
+            .toList();
+        assertThat(aliceRows).hasSize(1);
+        assertThat(aliceRows.get(0).getMessageText()).contains("L$4,000");
+    }
+
+    @Test
+    void outbid_groupDisabled_skipsSlImButKeepsInAppRow() {
+        User seller = saveUser(false, true);
+        User alice  = saveUser(true, /* prefs ON */ true);
+        // Disable bidding group for alice:
+        Map<String, Object> prefs = new HashMap<>(alice.getNotifySlIm());
+        prefs.put("bidding", false);
+        alice.setNotifySlIm(prefs);
+        userRepo.save(alice);
+
+        User bob = saveUser(true, true);
+        Auction a = saveAuction(seller, 1000L);
+
+        bidService.placeBid(a.getId(), alice.getId(), 1500L, null);
+        bidService.placeBid(a.getId(), bob.getId(),   2000L, null);
+
+        // Alice has NO SL IM (group disabled).
+        long aliceImRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(alice.getId())).count();
+        assertThat(aliceImRows).isZero();
+    }
+
+    @Test
+    void outbid_userMuted_skipsSlImButKeepsInAppRow() {
+        User seller = saveUser(false, true);
+        User alice  = saveUser(true, true);
+        alice.setNotifySlImMuted(true);
+        userRepo.save(alice);
+
+        User bob = saveUser(true, true);
+        Auction a = saveAuction(seller, 1000L);
+
+        bidService.placeBid(a.getId(), alice.getId(), 1500L, null);
+        bidService.placeBid(a.getId(), bob.getId(),   2000L, null);
+
+        long aliceImRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(alice.getId())).count();
+        assertThat(aliceImRows).isZero();
+    }
+
+    // --- Fixture helpers (pattern from BidNotificationIntegrationTest) ---
+
+    private User saveUser(boolean hasAvatar, boolean groupPrefsOn) {
+        User u = User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash")
+            .displayName("TestUser")
+            .verified(true)
+            .build();
+        if (hasAvatar) {
+            u.setSlAvatarUuid(UUID.randomUUID());
+        }
+        u.setNotifySlImMuted(false);
+        Map<String, Object> prefs = new HashMap<>();
+        prefs.put("bidding", groupPrefsOn);
+        prefs.put("auction_result", groupPrefsOn);
+        prefs.put("escrow", groupPrefsOn);
+        prefs.put("listing_status", groupPrefsOn);
+        prefs.put("reviews", groupPrefsOn);
+        prefs.put("system", true);
+        u.setNotifySlIm(prefs);
+        User saved = userRepo.save(u);
+        userIds.add(saved.getId());
+        return saved;
+    }
+
+    private Auction saveAuction(User seller, long startBidL) {
+        // Pattern from BidNotificationIntegrationTest.activeAuction
+        Parcel p = parcelRepo.save(Parcel.builder()
+            .slParcelUuid(UUID.randomUUID())
+            .ownerUuid(seller.getSlAvatarUuid() != null ? seller.getSlAvatarUuid() : UUID.randomUUID())
+            .ownerType("agent")
+            .regionName("TestRegion")
+            .continentName("Sansara")
+            .areaSqm(512)
+            .maturityRating("GENERAL")
+            .verified(true)
+            .verifiedAt(OffsetDateTime.now())
+            .build());
+        parcelId = p.getId();
+        OffsetDateTime now = OffsetDateTime.now();
+        Auction a = auctionRepo.save(Auction.builder()
+            .title("SL IM Test Lot")
+            .parcel(p)
+            .seller(seller)
+            .status(AuctionStatus.ACTIVE)
+            .verificationMethod(VerificationMethod.UUID_ENTRY)
+            .verificationTier(VerificationTier.SCRIPT)
+            .startingBid(startBidL)
+            .durationHours(168)
+            .snipeProtect(false)
+            .listingFeePaid(true)
+            .consecutiveWorldApiFailures(0)
+            .commissionRate(new BigDecimal("0.05"))
+            .agentFeeRate(BigDecimal.ZERO)
+            .startsAt(now.minusMinutes(5))
+            .endsAt(now.plusHours(24))
+            .originalEndsAt(now.plusHours(24))
+            .build());
+        auctionId = a.getId();
+        return a;
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/SlImEndToEndIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/SlImEndToEndIntegrationTest.java
@@ -1,0 +1,232 @@
+package com.slparcelauctions.backend.notification.slim.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.BidRepository;
+import com.slparcelauctions.backend.auction.BidService;
+import com.slparcelauctions.backend.auction.VerificationMethod;
+import com.slparcelauctions.backend.auction.VerificationTier;
+import com.slparcelauctions.backend.notification.slim.SlImMessage;
+import com.slparcelauctions.backend.notification.slim.SlImMessageRepository;
+import com.slparcelauctions.backend.notification.slim.SlImMessageStatus;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.parcel.ParcelRepository;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * E2E contract test: event → SL IM queue → polling endpoint → confirmation,
+ * asserting status transitions and idempotent re-confirmation behavior.
+ * Fixture helpers copied from OutbidImIntegrationTest (Task 3).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.notifications.sl-im.dispatcher.shared-secret=test-e2e-secret",
+    "slpa.notifications.sl-im.dispatcher.max-batch-limit=50"
+})
+class SlImEndToEndIntegrationTest {
+
+    @Autowired BidService bidService;
+    @Autowired SlImMessageRepository slImRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired AuctionRepository auctionRepo;
+    @Autowired ParcelRepository parcelRepo;
+    @Autowired BidRepository bidRepo;
+    @Autowired PlatformTransactionManager txManager;
+    @Autowired DataSource dataSource;
+    @Autowired MockMvc mvc;
+
+    private static final String AUTH = "Bearer test-e2e-secret";
+
+    private Long parcelId;
+    private Long auctionId;
+    private final java.util.List<Long> userIds = new java.util.ArrayList<>();
+
+    @BeforeEach
+    void clean() {
+        slImRepo.deleteAll();
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        if (auctionId != null) {
+            new TransactionTemplate(txManager).executeWithoutResult(s -> {
+                bidRepo.deleteAllByAuctionId(auctionId);
+                auctionRepo.findById(auctionId).ifPresent(auctionRepo::delete);
+            });
+        }
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var st = conn.createStatement()) {
+                for (Long id : userIds) {
+                    if (id != null) {
+                        st.execute("DELETE FROM sl_im_message WHERE user_id = " + id);
+                        st.execute("DELETE FROM notification WHERE user_id = " + id);
+                        st.execute("DELETE FROM refresh_tokens WHERE user_id = " + id);
+                        st.execute("DELETE FROM users WHERE id = " + id);
+                    }
+                }
+                if (parcelId != null) {
+                    st.execute("DELETE FROM parcels WHERE id = " + parcelId);
+                }
+            }
+        }
+        userIds.clear();
+        auctionId = null;
+        parcelId = null;
+    }
+
+    @Test
+    void eventThroughTerminalContract_endToEnd() throws Exception {
+        // Driver event: outbid creates an SL IM row for the displaced bidder.
+        User seller = saveUserNoAvatar();
+        User alice  = saveUserWithAvatar();
+        User bob    = saveUserWithAvatar();
+        Auction a   = saveAuction(seller, 1000L);
+
+        bidService.placeBid(a.getId(), alice.getId(), 1500L, "127.0.0.1");
+        bidService.placeBid(a.getId(), bob.getId(),   2000L, "127.0.0.1");
+
+        // Step 1: assert the IM row materializes for alice (the displaced bidder).
+        var aliceRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(alice.getId()))
+            .toList();
+        assertThat(aliceRows).hasSize(1);
+        long imId = aliceRows.get(0).getId();
+        assertThat(aliceRows.get(0).getStatus()).isEqualTo(SlImMessageStatus.PENDING);
+
+        // Step 2: poll endpoint returns it.
+        mvc.perform(get("/api/v1/internal/sl-im/pending?limit=10")
+                .header("Authorization", AUTH))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.messages.length()").value(greaterThanOrEqualTo(1)))
+            .andExpect(jsonPath("$.messages[?(@.id == " + imId + ")]").exists());
+
+        // Step 3: confirm delivered.
+        mvc.perform(post("/api/v1/internal/sl-im/" + imId + "/delivered")
+                .header("Authorization", AUTH))
+            .andExpect(status().isNoContent());
+
+        SlImMessage delivered = slImRepo.findById(imId).orElseThrow();
+        assertThat(delivered.getStatus()).isEqualTo(SlImMessageStatus.DELIVERED);
+        assertThat(delivered.getDeliveredAt()).isNotNull();
+        var deliveredAtFirstCall = delivered.getDeliveredAt();
+
+        // Step 4: idempotent second confirmation — 204, delivered_at NOT re-stamped.
+        mvc.perform(post("/api/v1/internal/sl-im/" + imId + "/delivered")
+                .header("Authorization", AUTH))
+            .andExpect(status().isNoContent());
+
+        SlImMessage afterIdempotent = slImRepo.findById(imId).orElseThrow();
+        assertThat(afterIdempotent.getDeliveredAt()).isEqualTo(deliveredAtFirstCall);
+        assertThat(afterIdempotent.getAttempts()).isEqualTo(1); // not incremented on idempotent
+    }
+
+    // --- Fixture helpers (pattern from OutbidImIntegrationTest) ---
+
+    private User saveUserNoAvatar() {
+        return saveUser(false);
+    }
+
+    private User saveUserWithAvatar() {
+        return saveUser(true);
+    }
+
+    private User saveUser(boolean hasAvatar) {
+        User u = User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash")
+            .displayName("TestUser")
+            .verified(true)
+            .build();
+        if (hasAvatar) {
+            u.setSlAvatarUuid(UUID.randomUUID());
+        }
+        u.setNotifySlImMuted(false);
+        Map<String, Object> prefs = new HashMap<>();
+        prefs.put("bidding", true);
+        prefs.put("auction_result", true);
+        prefs.put("escrow", true);
+        prefs.put("listing_status", true);
+        prefs.put("reviews", true);
+        prefs.put("system", true);
+        u.setNotifySlIm(prefs);
+        User saved = userRepo.save(u);
+        userIds.add(saved.getId());
+        return saved;
+    }
+
+    private Auction saveAuction(User seller, long startBidL) {
+        Parcel p = parcelRepo.save(Parcel.builder()
+            .slParcelUuid(UUID.randomUUID())
+            .ownerUuid(seller.getSlAvatarUuid() != null ? seller.getSlAvatarUuid() : UUID.randomUUID())
+            .ownerType("agent")
+            .regionName("TestRegion")
+            .continentName("Sansara")
+            .areaSqm(512)
+            .maturityRating("GENERAL")
+            .verified(true)
+            .verifiedAt(OffsetDateTime.now())
+            .build());
+        parcelId = p.getId();
+        OffsetDateTime now = OffsetDateTime.now();
+        Auction a = auctionRepo.save(Auction.builder()
+            .title("E2E SL IM Test Lot")
+            .parcel(p)
+            .seller(seller)
+            .status(AuctionStatus.ACTIVE)
+            .verificationMethod(VerificationMethod.UUID_ENTRY)
+            .verificationTier(VerificationTier.SCRIPT)
+            .startingBid(startBidL)
+            .durationHours(168)
+            .snipeProtect(false)
+            .listingFeePaid(true)
+            .consecutiveWorldApiFailures(0)
+            .commissionRate(new BigDecimal("0.05"))
+            .agentFeeRate(BigDecimal.ZERO)
+            .startsAt(now.minusMinutes(5))
+            .endsAt(now.plusHours(24))
+            .originalEndsAt(now.plusHours(24))
+            .build());
+        auctionId = a.getId();
+        return a;
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/SystemBypassImIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/SystemBypassImIntegrationTest.java
@@ -1,0 +1,143 @@
+package com.slparcelauctions.backend.notification.slim.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationEvent;
+import com.slparcelauctions.backend.notification.NotificationService;
+import com.slparcelauctions.backend.notification.slim.SlImMessageRepository;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Verifies that SYSTEM_ANNOUNCEMENT notifications bypass mute / group-disabled preferences
+ * and reach users with avatars, but still skip users without avatars.
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class SystemBypassImIntegrationTest {
+
+    @Autowired NotificationService notificationService;
+    @Autowired SlImMessageRepository slImRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired PlatformTransactionManager txManager;
+    @Autowired DataSource dataSource;
+
+    private final List<Long> userIds = new java.util.ArrayList<>();
+
+    @BeforeEach
+    void clean() {
+        slImRepo.deleteAll();
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var st = conn.createStatement()) {
+                for (Long id : userIds) {
+                    if (id != null) {
+                        st.execute("DELETE FROM sl_im_message WHERE user_id = " + id);
+                        st.execute("DELETE FROM notification WHERE user_id = " + id);
+                        st.execute("DELETE FROM refresh_tokens WHERE user_id = " + id);
+                        st.execute("DELETE FROM users WHERE id = " + id);
+                    }
+                }
+            }
+        }
+        userIds.clear();
+    }
+
+    @Test
+    void systemAnnouncement_mutedUserWithAvatar_getsIm() {
+        User u = saveUserAllOff(true);  // all groups off + has avatar
+        u.setNotifySlImMuted(true);
+        userRepo.save(u);
+
+        publishSystem(u.getId(), "All systems normal", "Everything is fine.");
+
+        var rows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(u.getId())).toList();
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getMessageText()).contains("[SLPA] All systems normal");
+    }
+
+    @Test
+    void systemAnnouncement_mutedUserNoAvatar_skipsIm() {
+        User u = saveUserAllOff(false);  // all groups off + NO avatar
+        u.setNotifySlImMuted(true);
+        userRepo.save(u);
+
+        publishSystem(u.getId(), "All systems normal", "Everything is fine.");
+
+        assertThat(slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(u.getId())).count()).isZero();
+    }
+
+    @Test
+    void systemAnnouncement_groupKeyExplicitlyFalse_stillBypasses() {
+        User u = saveUserAllOff(true);
+        Map<String, Object> prefs = new HashMap<>(u.getNotifySlIm());
+        prefs.put("system", false);  // explicitly false
+        u.setNotifySlIm(prefs);
+        userRepo.save(u);
+
+        publishSystem(u.getId(), "All systems normal", "Everything is fine.");
+
+        // SYSTEM bypasses prefs; the IM is queued.
+        assertThat(slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(u.getId())).count()).isEqualTo(1L);
+    }
+
+    private void publishSystem(long userId, String title, String body) {
+        NotificationEvent event = new NotificationEvent(
+            userId, NotificationCategory.SYSTEM_ANNOUNCEMENT,
+            title, body, Map.of(), /* coalesceKey */ null);
+        new TransactionTemplate(txManager).executeWithoutResult(status ->
+            notificationService.publish(event));
+    }
+
+    private User saveUserAllOff(boolean hasAvatar) {
+        User u = User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash").build();
+        if (hasAvatar) u.setSlAvatarUuid(UUID.randomUUID());
+        u.setNotifySlImMuted(false);
+        Map<String, Object> prefs = new HashMap<>();
+        for (var g : List.of("bidding", "auction_result", "escrow",
+                              "listing_status", "reviews", "system")) {
+            prefs.put(g, false);
+        }
+        u.setNotifySlIm(prefs);
+        User saved = userRepo.save(u);
+        userIds.add(saved.getId());
+        return saved;
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/slim/internal/SlImInternalControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/slim/internal/SlImInternalControllerTest.java
@@ -1,0 +1,225 @@
+package com.slparcelauctions.backend.notification.slim.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.slparcelauctions.backend.notification.slim.SlImMessage;
+import com.slparcelauctions.backend.notification.slim.SlImMessageDao;
+import com.slparcelauctions.backend.notification.slim.SlImMessageRepository;
+import com.slparcelauctions.backend.notification.slim.SlImMessageStatus;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.notifications.sl-im.dispatcher.shared-secret=test-secret-12345",
+    "slpa.notifications.sl-im.dispatcher.max-batch-limit=50"
+})
+class SlImInternalControllerTest {
+
+    @Autowired MockMvc mvc;
+    @Autowired SlImMessageDao dao;
+    @Autowired SlImMessageRepository repo;
+    @Autowired UserRepository userRepo;
+
+    private static final String AUTH = "Bearer test-secret-12345";
+
+    private User user;
+    private String avatar;
+
+    @BeforeEach
+    void seed() {
+        repo.deleteAll();
+        user = userRepo.save(User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash").build());
+        avatar = UUID.randomUUID().toString();
+    }
+
+    // --- /pending ---
+
+    @Test
+    void pending_returnsBatchOldestFirst() throws Exception {
+        var first = dao.upsert(user.getId(), avatar, "[SLPA] first", null);
+        Thread.sleep(10);
+        var second = dao.upsert(user.getId(), avatar, "[SLPA] second", "key2");
+
+        mvc.perform(get("/api/v1/internal/sl-im/pending?limit=10").header("Authorization", AUTH))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.messages.length()").value(2))
+            .andExpect(jsonPath("$.messages[0].id").value((int) first.id()))
+            .andExpect(jsonPath("$.messages[1].id").value((int) second.id()))
+            .andExpect(jsonPath("$.messages[0].messageText").value("[SLPA] first"))
+            .andExpect(jsonPath("$.messages[0].avatarUuid").value(avatar));
+    }
+
+    @Test
+    void pending_limitOverMax_returns400() throws Exception {
+        mvc.perform(get("/api/v1/internal/sl-im/pending?limit=51").header("Authorization", AUTH))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void pending_limitBelowOne_returns400() throws Exception {
+        mvc.perform(get("/api/v1/internal/sl-im/pending?limit=0").header("Authorization", AUTH))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void pending_missingAuth_returns401() throws Exception {
+        mvc.perform(get("/api/v1/internal/sl-im/pending"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void pending_wrongAuth_returns401() throws Exception {
+        mvc.perform(get("/api/v1/internal/sl-im/pending").header("Authorization", "Bearer wrong"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    // --- /delivered state machine ---
+
+    @Test
+    void delivered_pendingRow_transitionsTo204AndSetsDeliveredAt() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/delivered").header("Authorization", AUTH))
+            .andExpect(status().isNoContent());
+
+        SlImMessage row = repo.findById(r.id()).orElseThrow();
+        assertThat(row.getStatus()).isEqualTo(SlImMessageStatus.DELIVERED);
+        assertThat(row.getDeliveredAt()).isNotNull();
+        assertThat(row.getAttempts()).isEqualTo(1);
+    }
+
+    @Test
+    void delivered_alreadyDelivered_idempotent204() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/delivered").header("Authorization", AUTH))
+            .andExpect(status().isNoContent());
+        SlImMessage afterFirst = repo.findById(r.id()).orElseThrow();
+        var deliveredAtBefore = afterFirst.getDeliveredAt();
+
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/delivered").header("Authorization", AUTH))
+            .andExpect(status().isNoContent());
+
+        SlImMessage row = repo.findById(r.id()).orElseThrow();
+        assertThat(row.getStatus()).isEqualTo(SlImMessageStatus.DELIVERED);
+        // delivered_at NOT re-stamped on idempotent call:
+        assertThat(row.getDeliveredAt()).isEqualTo(deliveredAtBefore);
+        // attempts NOT incremented (the WHERE clause excluded DELIVERED):
+        assertThat(row.getAttempts()).isEqualTo(1);
+    }
+
+    @Test
+    void delivered_onFailedRow_returns409() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+        SlImMessage row = repo.findById(r.id()).orElseThrow();
+        row.setStatus(SlImMessageStatus.FAILED);
+        repo.save(row);
+
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/delivered").header("Authorization", AUTH))
+            .andExpect(status().isConflict());
+    }
+
+    @Test
+    void delivered_onExpiredRow_returns409() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+        SlImMessage row = repo.findById(r.id()).orElseThrow();
+        row.setStatus(SlImMessageStatus.EXPIRED);
+        repo.save(row);
+
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/delivered").header("Authorization", AUTH))
+            .andExpect(status().isConflict());
+    }
+
+    @Test
+    void delivered_missing_returns404() throws Exception {
+        mvc.perform(post("/api/v1/internal/sl-im/999999/delivered").header("Authorization", AUTH))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void delivered_unauthorized_returns401() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/delivered"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    // --- /failed state machine ---
+
+    @Test
+    void failed_pendingRow_transitionsTo204() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/failed").header("Authorization", AUTH))
+            .andExpect(status().isNoContent());
+
+        SlImMessage row = repo.findById(r.id()).orElseThrow();
+        assertThat(row.getStatus()).isEqualTo(SlImMessageStatus.FAILED);
+        assertThat(row.getDeliveredAt()).isNull();
+        assertThat(row.getAttempts()).isEqualTo(1);
+    }
+
+    @Test
+    void failed_alreadyFailed_idempotent204() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/failed").header("Authorization", AUTH))
+            .andExpect(status().isNoContent());
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/failed").header("Authorization", AUTH))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void failed_onDeliveredRow_returns409() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+        SlImMessage row = repo.findById(r.id()).orElseThrow();
+        row.setStatus(SlImMessageStatus.DELIVERED);
+        repo.save(row);
+
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/failed").header("Authorization", AUTH))
+            .andExpect(status().isConflict());
+    }
+
+    @Test
+    void failed_onExpiredRow_returns409() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+        SlImMessage row = repo.findById(r.id()).orElseThrow();
+        row.setStatus(SlImMessageStatus.EXPIRED);
+        repo.save(row);
+
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/failed").header("Authorization", AUTH))
+            .andExpect(status().isConflict());
+    }
+
+    @Test
+    void failed_missing_returns404() throws Exception {
+        mvc.perform(post("/api/v1/internal/sl-im/999999/failed").header("Authorization", AUTH))
+            .andExpect(status().isNotFound());
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/ws/AccountStateBroadcasterTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/ws/AccountStateBroadcasterTest.java
@@ -28,7 +28,8 @@ import com.slparcelauctions.backend.notification.ws.envelope.PenaltyClearedEnvel
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class AccountStateBroadcasterTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/ws/NotificationWsBroadcasterTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/ws/NotificationWsBroadcasterTest.java
@@ -36,7 +36,8 @@ import com.slparcelauctions.backend.notification.ws.envelope.ReadStateChangedEnv
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class NotificationWsBroadcasterTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/ws/UserQueueRoutingTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/ws/UserQueueRoutingTest.java
@@ -66,7 +66,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class UserQueueRoutingTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/parcel/ParcelControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/parcel/ParcelControllerIntegrationTest.java
@@ -53,7 +53,8 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class ParcelControllerIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/parcel/dev/MaturityRatingDevTouchUpTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/parcel/dev/MaturityRatingDevTouchUpTest.java
@@ -31,7 +31,8 @@ import jakarta.persistence.PersistenceContext;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class MaturityRatingDevTouchUpTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/parceltag/ParcelTagControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/parceltag/ParcelTagControllerIntegrationTest.java
@@ -30,7 +30,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class ParcelTagControllerIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/CachedRegionResolverTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/CachedRegionResolverTest.java
@@ -33,7 +33,8 @@ import com.slparcelauctions.backend.sl.dto.RegionResolution;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class CachedRegionResolverTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/DevSlSimulateBeanProfileTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/DevSlSimulateBeanProfileTest.java
@@ -54,7 +54,8 @@ import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
         "spring.datasource.password=slpa",
         "spring.data.redis.host=localhost",
         "spring.jpa.hibernate.ddl-auto=update",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class DevSlSimulateBeanProfileTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/DevSlSimulateIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/DevSlSimulateIntegrationTest.java
@@ -32,7 +32,8 @@ import com.slparcelauctions.backend.user.UserRepository;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class DevSlSimulateIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/PenaltyTerminalControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/PenaltyTerminalControllerSliceTest.java
@@ -26,6 +26,7 @@ import com.slparcelauctions.backend.auth.JwtAuthenticationFilter;
 import com.slparcelauctions.backend.auth.JwtService;
 import com.slparcelauctions.backend.auth.config.JwtConfig;
 import com.slparcelauctions.backend.bot.BotSharedSecretAuthorizer;
+import com.slparcelauctions.backend.notification.slim.internal.SlImInternalConfig;
 import com.slparcelauctions.backend.config.SecurityConfig;
 import com.slparcelauctions.backend.sl.dto.PenaltyLookupResponse;
 import com.slparcelauctions.backend.sl.dto.PenaltyPaymentRequest;
@@ -43,7 +44,7 @@ import com.slparcelauctions.backend.user.UserNotFoundException;
  * plan Step 3.
  */
 @WebMvcTest(PenaltyTerminalController.class)
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class,
+@Import({SlImInternalConfig.class, SecurityConfig.class, JwtAuthenticationFilter.class,
         JwtAuthenticationEntryPoint.class, SlExceptionHandler.class})
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/PenaltyTerminalControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/PenaltyTerminalControllerSliceTest.java
@@ -51,7 +51,8 @@ import com.slparcelauctions.backend.user.UserNotFoundException;
         "jwt.secret=dGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdA==",
         "jwt.access-token-lifetime=PT15M",
         "jwt.refresh-token-lifetime=P7D",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class PenaltyTerminalControllerSliceTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/PenaltyTerminalServiceConcurrencyIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/PenaltyTerminalServiceConcurrencyIntegrationTest.java
@@ -54,7 +54,8 @@ import com.slparcelauctions.backend.user.UserRepository;
         "slpa.auction-end.enabled=false",
         "slpa.ownership-monitor.enabled=false",
         "slpa.escrow.ownership-monitor-job.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class PenaltyTerminalServiceConcurrencyIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/SlParcelVerifyControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/SlParcelVerifyControllerIntegrationTest.java
@@ -51,7 +51,8 @@ import reactor.core.publisher.Mono;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class SlParcelVerifyControllerIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/SlVerificationControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/SlVerificationControllerSliceTest.java
@@ -26,7 +26,8 @@ import org.springframework.transaction.annotation.Transactional;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class SlVerificationControllerSliceTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/SlVerificationFlowIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/SlVerificationFlowIntegrationTest.java
@@ -40,7 +40,8 @@ import com.slparcelauctions.backend.verification.dto.ActiveCodeResponse;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class SlVerificationFlowIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/stats/PublicStatsControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/stats/PublicStatsControllerIntegrationTest.java
@@ -27,7 +27,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class PublicStatsControllerIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/user/AvatarUploadFlowIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/user/AvatarUploadFlowIntegrationTest.java
@@ -52,7 +52,8 @@ import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class AvatarUploadFlowIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/user/UpdateUserFlowIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/user/UpdateUserFlowIntegrationTest.java
@@ -25,7 +25,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class UpdateUserFlowIntegrationTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/user/UserControllerAvatarSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/user/UserControllerAvatarSliceTest.java
@@ -38,7 +38,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class UserControllerAvatarSliceTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/user/UserControllerUpdateMeSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/user/UserControllerUpdateMeSliceTest.java
@@ -29,7 +29,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class UserControllerUpdateMeSliceTest {

--- a/backend/src/test/java/com/slparcelauctions/backend/user/UserResponseUnreadCountTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/user/UserResponseUnreadCountTest.java
@@ -29,7 +29,8 @@ import com.slparcelauctions.backend.user.dto.UserResponse;
         "slpa.escrow.timeout-job.enabled=false",
         "slpa.escrow.command-dispatcher-job.enabled=false",
         "slpa.review.scheduler.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class UserResponseUnreadCountTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/verification/VerificationCodeServiceCollisionIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/verification/VerificationCodeServiceCollisionIntegrationTest.java
@@ -43,7 +43,8 @@ import com.slparcelauctions.backend.verification.exception.CodeCollisionExceptio
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class VerificationCodeServiceCollisionIntegrationTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/verification/VerificationControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/verification/VerificationControllerSliceTest.java
@@ -38,7 +38,8 @@ import com.slparcelauctions.backend.config.SecurityConfig;
         "jwt.secret=dGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdA==",
         "jwt.access-token-lifetime=PT15M",
         "jwt.refresh-token-lifetime=P7D",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 class VerificationControllerSliceTest {
 

--- a/backend/src/test/java/com/slparcelauctions/backend/verification/VerificationControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/verification/VerificationControllerSliceTest.java
@@ -17,6 +17,7 @@ import com.slparcelauctions.backend.auth.JwtAuthenticationFilter;
 import com.slparcelauctions.backend.auth.JwtService;
 import com.slparcelauctions.backend.auth.config.JwtConfig;
 import com.slparcelauctions.backend.bot.BotSharedSecretAuthorizer;
+import com.slparcelauctions.backend.notification.slim.internal.SlImInternalConfig;
 import com.slparcelauctions.backend.config.SecurityConfig;
 
 /**
@@ -31,7 +32,7 @@ import com.slparcelauctions.backend.config.SecurityConfig;
  * The slice test here just confirms 401 wiring.
  */
 @WebMvcTest(VerificationController.class)
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class, JwtAuthenticationEntryPoint.class})
+@Import({SlImInternalConfig.class, SecurityConfig.class, JwtAuthenticationFilter.class, JwtAuthenticationEntryPoint.class})
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
         "jwt.secret=dGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdA==",

--- a/backend/src/test/java/com/slparcelauctions/backend/verification/VerificationFlowIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/verification/VerificationFlowIntegrationTest.java
@@ -24,7 +24,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
-        "slpa.notifications.cleanup.enabled=false"
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
 })
 @Transactional
 class VerificationFlowIntegrationTest {

--- a/docs/implementation/DEFERRED_WORK.md
+++ b/docs/implementation/DEFERRED_WORK.md
@@ -293,20 +293,13 @@ When finishing a sub-spec that completes a deferred item, remove the entry.
 - **Notes:** `AuctionTitleDevTouchUp` is the dev-side workaround. `MaturityRatingDevTouchUp` is the same pattern for the maturity_rating canonicalization.
 
 ### Email channel for notifications
-- **From:** Epic 09 sub-spec 1
-- **Why:** Scoped to sub-spec 2. Sub-spec 1 ships in-app only.
-- **When:** Epic 09 sub-spec 2.
-- **Notes:** Per-category templates (HTML + plain text), signed-token unsubscribe, debounce/dedupe matching the coalesce pattern. Email-change flow (deferred from Epic 02 sub-spec 2b) lands at the same time — both depend on the same email plumbing.
-
-### SL IM channel for notifications
-- **From:** Epic 09 sub-spec 1
-- **Why:** Scoped to sub-spec 3. Backend queue + terminal polling endpoint; actual delivery awaits Epic 11 LSL terminal.
-- **When:** Epic 09 sub-spec 3.
-
-### Notification preferences UI
-- **From:** Epic 09 sub-spec 1
-- **Why:** Scoped to sub-spec 2 — lands with the email channel. The User entity already has the `notify_email` / `notify_sl_im` JSONB columns from Epic 02 sub-spec 2b; sub-spec 1 doesn't read them because the in-app channel is always-on. The toggle grid + global mute switches + quiet hours pickers belong with sub-spec 2.
-- **When:** Epic 09 sub-spec 2.
+- **Status:** Removed from roadmap. Re-add only on explicit user request.
+- **Reasoning:** SL natively forwards offline IMs to the user's registered email,
+  so the SL IM channel from Epic 09 sub-spec 3 covers the email use case at zero
+  additional infrastructure cost.
+- **If re-instated:** per-category templates (HTML + plain text), signed-token
+  unsubscribe, debounce/dedupe matching the coalesce pattern, email-change flow
+  (originally pending from Epic 02 sub-spec 2b).
 
 ### REVIEW_RESPONSE_WINDOW_CLOSING notification + scheduler
 - **From:** Epic 09 sub-spec 1
@@ -315,8 +308,43 @@ When finishing a sub-spec that completes a deferred item, remove the entry.
 
 ### ESCROW_TRANSFER_REMINDER scheduler
 - **From:** Epic 09 sub-spec 1
-- **Why:** Sub-spec 1 implements `publisher.escrowTransferReminder(...)` + `NotificationDataBuilder.escrowTransferReminder(...)` + corresponding category and tests. No `@Scheduled` job calls it today — DESIGN.md §729 says the bot service sends this for bot-verified listings (Epic 06 territory). A general non-bot scheduler with an Escrow `reminderSentAt` column for once-per-escrow guarantee is its own scope.
-- **When:** Epic 09 sub-spec 2 or sub-spec 3 — alongside email/IM channels that benefit most from reminders. Touchpoint: Epic 06 bot service can call this method directly for its 24h reminder; the general scheduler is the deferred piece.
+- **Why:** Sub-spec 1 implements `publisher.escrowTransferReminder(...)` +
+  `NotificationDataBuilder.escrowTransferReminder(...)` + corresponding category
+  and tests. No `@Scheduled` job calls it today.
+- **When:** Epic 10 (Admin & Moderation) — paired with REVIEW_RESPONSE_WINDOW_CLOSING
+  scheduler. Both share design DNA (interval-bound + once-per-entity + admin-visible).
+- **Implementation sketch:** new `Escrow.reminderSentAt` column for
+  once-per-escrow guarantee; new `EscrowReminderScheduler` (cron daily, query
+  escrows with FUNDED status approaching transfer deadline, fire
+  `publisher.escrowTransferReminder(...)`).
+
+### Quiet hours UI for SL IM
+- **From:** Epic 09 sub-spec 3
+- **Why:** Columns `slImQuietStart` and `slImQuietEnd` exist on User entity
+  from Epic 02 sub-spec 2b; no UI consumes them and the dispatcher gate
+  ignores them. May tie to a future timezone/account-settings sub-spec; no
+  committed home yet. If unused for >12 months, drop the columns in a
+  dedicated cleanup sub-spec.
+- **When:** No committed phase.
+
+### HTTP-in push from backend to dispatcher for urgency
+- **From:** Epic 09 sub-spec 3
+- **Why:** Current design polls every 60 seconds — fine for the events
+  shipping today (worst case 60 s latency for outbid/won). If outbid latency
+  becomes a UX concern, register the dispatcher's HTTP-in URL with the
+  backend on startup and have the backend `llHTTPRequest` to it on
+  high-priority categories to wake an early poll.
+- **When:** Post-launch enhancement; needs the channel to have real traffic
+  and a real complaint before the complexity earns its keep.
+
+### Sub-day SL IM dispatcher health monitoring
+- **From:** Epic 09 sub-spec 3
+- **Why:** The expiry job's INFO log catches a dark dispatcher within 48 h. If
+  sub-day signal becomes important, options include: a `last_polled_at`
+  timestamp on a singleton `dispatcher_health` row written on each successful
+  poll, with an alarm scheduler that pages on `now - last_polled_at > 5 min`.
+- **When:** No committed phase. Out of scope until operational data shows the
+  48 h canary is insufficient.
 
 ---
 

--- a/docs/implementation/FOOTGUNS.md
+++ b/docs/implementation/FOOTGUNS.md
@@ -1606,3 +1606,78 @@ the DAO whether the operation was insert or update without a second roundtrip.
 This drives the `isUpdate` flag on the `NOTIFICATION_UPSERTED` WS envelope,
 which the frontend uses to decide whether to prepend (insert) or replace-by-id
 (update) in the dropdown cache.
+
+### F.95 — `llInstantMessage` truncates at 1024 BYTES, not characters
+
+The natural Java `String.length()` measures UTF-16 code units; SL's
+`llInstantMessage` truncates the IM at 1024 **bytes** in UTF-8 encoding.
+Multi-byte UTF-8 characters (CJK, emoji, accented Latin) push the byte count
+above the char count. SL silently truncates from the end of the string — no
+error, no warning, no return value — and the deeplink in SLPA's IM template
+lives at the end of the assembled message. A 1023-character string with
+multi-byte content can occupy 1500+ bytes; the deeplink gets cleanly cut off.
+
+`SlImMessageBuilder` measures `text.getBytes(StandardCharsets.UTF_8).length`
+and ellipsizes the body, never the prefix or deeplink. Three mandatory test
+cases (multi-byte parcel name, emoji parcel name, long-body forcing
+truncation) verify the deeplink survives. Adding a new component to the
+assembled message (e.g., a timestamp) requires updating the byte-budget
+accounting in `SlImMessageBuilder` — the budget assumes exactly
+`PREFIX + title + SEPARATOR + body + SEPARATOR + deeplink`.
+
+### F.96 — Single-recipient publish path is afterCommit-then-REQUIRES_NEW; fan-out path is in-the-REQUIRES_NEW
+
+The two notification dispatch sites have different reliability postures and
+different transaction structures.
+
+**Single-recipient path** (`NotificationService.publish`): in-app row commits
+first as part of the parent transaction, then `afterCommit` runs
+`slImChannelDispatcher.maybeQueue` which opens its own REQUIRES_NEW. If the
+IM-queue write fails, the in-app row already committed, the parent business
+event already committed, and the only loss is the IM. **In-app guaranteed,
+IM best-effort.**
+
+**Fan-out path** (`NotificationPublisherImpl.listingCancelledBySellerFanout`):
+per-recipient REQUIRES_NEW lambda contains the in-app DAO upsert AND the IM
+queue write as siblings. If the IM-queue write fails, that recipient's
+in-app row also rolls back; the per-recipient try-catch isolates this from
+sibling recipients. **In-app + IM atomic per recipient; sibling recipients
+independent.**
+
+Mixing these mental models produces either:
+- "One bad bidder kills the cancellation" — if you put fan-out atomic with the parent transaction.
+- "In-app row exists but IM never queued because the dispatcher hook failed silently" — if you inline the dispatcher into the single-recipient path's parent transaction.
+
+Future contributors adding a new fan-out method must follow the existing
+pattern: per-recipient REQUIRES_NEW lambda containing all per-recipient writes
+as siblings, with a per-recipient try-catch wrapping the lambda. Name with a
+`Fanout` suffix (sub-spec 1's convention).
+
+### F.97 — Adding a new terminal status to `sl_im_message` requires updating the cleanup predicate
+
+`SlImCleanupJob` stage 2 deletes rows via `WHERE status IN ('DELIVERED',
+'EXPIRED', 'FAILED') AND updated_at < retention_cutoff`. The IN-list
+enumerates terminal statuses. Adding a new one (e.g., a future
+`RETRY_SCHEDULED` for a deferred retry primitive) without updating the IN-list
+means those rows accumulate forever — defeating the very `SELECT status,
+count(*) FROM sl_im_message GROUP BY status` query the rolling 30-day window
+was supposed to keep meaningful. Add the new status to the predicate in the
+same commit that introduces the status.
+
+### F.98 — LSL `llInstantMessage` is fire-and-forget; `/failed` has no LSL caller
+
+The `sl-im-dispatcher` script unconditionally calls
+`POST /api/v1/internal/sl-im/{id}/delivered` after every `llInstantMessage`
+because LSL provides no delivery signal — `llInstantMessage` returns `void`,
+raises no event on failure, and produces no observable side effect when the
+recipient UUID is invalid or offline-unreachable.
+
+This means FAILED rows in `sl_im_message` only appear via:
+1. Manual operator intervention — direct SQL UPDATE in production (rare;
+   usually for support clearing a stuck row).
+2. A future revision of `dispatcher.lsl` that pre-validates avatar UUIDs
+   (e.g., `llRequestAgentData` against `DATA_ONLINE` before sending, or a
+   `NULL_KEY` guard).
+
+If support runs `SELECT status, count(*) FROM sl_im_message GROUP BY status`
+and sees zero FAILED rows, that's correct behavior. Not a missing pipeline.

--- a/docs/initial-design/DESIGN.md
+++ b/docs/initial-design/DESIGN.md
@@ -1845,6 +1845,25 @@ Users configure per-category preferences for two optional channels:
 - **Coalesce primitive.** Rows can carry an optional `coalesce_key`; events with the same key on an unread row UPSERT into that row rather than inserting a fresh one (Postgres `ON CONFLICT (user_id, coalesce_key) WHERE read = false DO UPDATE`). OUTBID is the first consumer — repeated outbids on the same auction collapse into one row, keeping the feed clean. See FOOTGUNS §F.94 for the xmax/insert-vs-update detection pattern.
 - **User-destination security pattern.** Clients subscribe to `/user/queue/notifications` and `/user/queue/account` — never a path that embeds a literal user id. The backend publishes via `convertAndSendToUser(String.valueOf(userId), "/queue/...", payload)`. Spring's `UserDestinationResolver` resolves the principal from the STOMP session established on CONNECT. Including a literal user id in the subscription path is a security hole. See FOOTGUNS §F.92.
 
+**Notes (Epic 09 sub-spec 3):**
+- The SL IM channel reuses the in-app coalesce key namespace; rows in
+  `sl_im_message` collapse during pendency (`WHERE status = 'PENDING'`),
+  with the same partial-unique-index pattern.
+- `SYSTEM` group bypasses preferences and master-mute, but never bypasses the
+  no-avatar floor.
+- `llInstantMessage` truncates at 1024 BYTES (UTF-8), not characters. The
+  backend's `SlImMessageBuilder` enforces this with body ellipsis, never
+  trimming the prefix or deeplink.
+- The polling/confirmation contract (`/api/v1/internal/sl-im/*`) uses a
+  shared secret distinct from the existing escrow-terminal secret. State
+  machines for `/delivered` and `/failed` are symmetric: PENDING →
+  terminal-status, idempotent on the matching status, 409 on the other
+  terminal statuses (FAILED/EXPIRED).
+- The system relies on SL's native offline-IM-to-email forwarding to cover
+  the email use case. Users with active SL email forwarding receive SLPA
+  notifications by email; users with disabled forwarding receive only
+  in-world IMs when online. The email channel is intentionally not built.
+
 ---
 
 ## 12. Revenue & Economics

--- a/docs/superpowers/plans/2026-04-26-epic-09-sub-3-sl-im-and-preferences.md
+++ b/docs/superpowers/plans/2026-04-26-epic-09-sub-3-sl-im-and-preferences.md
@@ -1,0 +1,5279 @@
+# Epic 09 sub-spec 3 — SL IM Channel & Notification Preferences UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the SL IM channel end-to-end (queue + dispatcher endpoints + LSL polling object) plus a preferences UI at `/settings/notifications`, with a per-recipient gate that consults user preferences fresh on every dispatch and a 48 h expiry job whose INFO log is the operational canary for a dark dispatcher.
+
+**Architecture:** A new `sl_im_message` queue table is populated by an afterCommit hook in `NotificationService.publish()` (single-recipient path) and by a sibling call inside the existing per-recipient `REQUIRES_NEW` lambda in `NotificationPublisherImpl.listingCancelledBySellerFanout` (fan-out path). A pure-function `SlImChannelGate` decides per (User, Category) whether to queue, with a discriminated `Decision` enum logged at DEBUG. Internal endpoints under `/api/v1/internal/sl-im/*` (shared-secret auth) feed an LSL dispatcher object that polls every 60 s, batches up to 10 IMs with 2 s spacing, and confirms each via `POST /{id}/delivered`. Preferences live under a new `/settings` route tree backed by `GET`/`PUT /api/v1/users/me/notification-preferences` with closed-shape validation.
+
+**Tech Stack:** Spring Boot 4 / Java 26, Hibernate `ddl-auto: update`, Postgres `ON CONFLICT` upsert with `xmax` insert/update detection, partial unique index emitted by an initializer, Spring Scheduling with zoned cron, Spring Security with a custom `OncePerRequestFilter` for terminal auth, Next.js 16 / React 19, TanStack Query v5 (optimistic mutation + rollback), Tailwind CSS 4, Headless UI, Vitest + MSW 2, TestContainers Postgres, LSL.
+
+---
+
+## Pre-implementation findings
+
+Hard-won corrections from sub-spec 1 to apply throughout. Verify each by reading the noted neighbor file before deviating.
+
+1. **Principal type is `AuthPrincipal`, not `AuthUser`.** Controllers use `@AuthenticationPrincipal AuthPrincipal caller`. Verify against `NotificationController.java` (sub-spec 1, Task 2 commit `bda6450`).
+
+2. **`@MockitoBean`, not `@MockBean`.** Spring Boot 3.4+. Verify against `NotificationPublisherImplTest.java` (sub-spec 1, Task 3 commit `2d61d4b`).
+
+3. **Real scheduler-disable property names** that every new `@SpringBootTest` + `@TestPropertySource` test must include (sweep existing tests; these are the canonical set used in `NotificationServiceTest`, `NotificationControllerIntegrationTest`, `NotificationPublisherImplTest`):
+   ```
+   "slpa.notifications.cleanup.enabled=false",
+   "slpa.notifications.sl-im.cleanup.enabled=false",   ← NEW in this sub-spec, Task 5 sweep
+   "slpa.escrow.scheduler.enabled=false",
+   "slpa.escrow.timeout-job.enabled=false",
+   "slpa.escrow.command-dispatcher-job.enabled=false",
+   "slpa.escrow.ownership-monitor-job.enabled=false",
+   "slpa.review.scheduler.enabled=false",
+   "slpa.refresh-token-cleanup.enabled=false",
+   "auth.cleanup.enabled=false",
+   "slpa.auction-end.enabled=false",
+   "slpa.ownership-monitor.enabled=false"
+   ```
+
+4. **JWT issuance in tests** uses `JwtService.issueAccessToken(AuthPrincipal)` directly with `new AuthPrincipal(user.getId(), user.getEmail(), user.getTokenVersion())`. No HTTP register-then-extract pattern needed for tests that aren't testing the auth flow itself.
+
+5. **`testUser(...)` helper does not exist as a shared fixture.** Construct users inline with `User.builder().email(uniqueEmail).passwordHash("hash").build()` and `userRepo.save(...)`. Use UUID-suffixed emails to avoid uniqueness collisions across tests. See `NotificationPublisherImplTest` for the exact pattern.
+
+6. **`@RequiredArgsConstructor` does not propagate `@Qualifier` from fields to the generated constructor.** When you need `@Qualifier("requiresNewTxTemplate")` on a constructor parameter, write the constructor explicitly. See `NotificationPublisherImpl` constructor (Task 3 commit `2d61d4b`).
+
+7. **`requiresNewTxTemplate` bean already exists** in `NotificationConfig.java` (sub-spec 1, Task 3). Reuse it via `@Qualifier("requiresNewTxTemplate") TransactionTemplate`. Do not declare a second bean.
+
+8. **JSONB integer/long deserialization gotcha.** Postgres JSONB → Java integers come back as `Integer` (boxed), not `Long`, when the value fits in 32 bits. When asserting on numeric values from the `data` map use `((Number) data.get(key)).longValue()`.
+
+9. **`ddl-auto: update` cannot emit partial unique indexes.** Use the initializer pattern (see `NotificationCoalesceIndexInitializer.java` from sub-spec 1, Task 1). Match its style for `SlImCoalesceIndexInitializer`.
+
+10. **Pre-commit hook reads conversation transcripts** counting native TaskCreate vs TaskUpdate(completed) calls. If you create per-task TodoWrite entries, mark them all completed before running `git commit` — or the commit gets rejected. The actual progress tracking happens via git commits per task; the in-session task list is dispatch-coordination only.
+
+11. **`docs/superpowers/`** is in the global `~/.gitignore` (`**/superpowers/`). Existing files there are tracked from prior sub-specs; new files there require `git add -f`. The plan and spec for this sub-spec are already committed via `git add -f`. Future docs touches in `docs/implementation/` and `docs/initial-design/` are unaffected.
+
+12. **No `import React`** in any frontend file. Use named imports only (`import { useState, useEffect } from "react"`). For type-only imports use `import type { ReactNode } from "react"`.
+
+13. **Do not run `npm run dev`.** The user keeps a dev server running in another terminal. Frontend verification is via `npm test -- --run` and `npm run lint`.
+
+14. **The visual companion server's session directory** for this sub-spec is `.superpowers/brainstorm/24679-1777214512/` — gitignored at the project level. Do not touch.
+
+## Reference patterns from sub-spec 1
+
+Patterns to copy or extend, with specific neighbor files to read first.
+
+| Pattern | Neighbor reference | Used in this sub-spec by |
+| --- | --- | --- |
+| Native ON CONFLICT upsert with `xmax != 0` insert/update detection | `NotificationDao.java` (sub-spec 1, Task 1) | Task 1 — `SlImMessageDao` |
+| `@EventListener(ApplicationReadyEvent)` initializer for partial unique index | `NotificationCoalesceIndexInitializer.java` (Task 1) | Task 1 — `SlImCoalesceIndexInitializer` |
+| Split filtered/unfiltered repository queries (avoiding HQL-on-Collection-IS-NULL) | `NotificationRepository.java` (Task 1) | Not needed in this sub-spec — repository has only one query and one count |
+| `@ConfigurationProperties` record with JSR-303 validation | `CancellationPenaltyProperties.java` | Task 5 — `SlImCleanupProperties`; Task 4 — `SlImInternalProperties` |
+| `@Scheduled` job + `@ConditionalOnProperty` for test-disable | `NotificationCleanupJob.java` (Task 2) | Task 5 — `SlImCleanupJob` (zoned cron via `zone = "America/Los_Angeles"`) |
+| `requiresNewTxTemplate` bean (PROPAGATION_REQUIRES_NEW) | `NotificationConfig.java` (Task 3) | Task 3 — reused by `SlImChannelDispatcher` |
+| afterCommit registration on `TransactionSynchronizationManager` | `NotificationService.java` (Task 1) | Task 3 — extends `publish()` to register a second hook |
+| Per-recipient REQUIRES_NEW lambda with try-catch isolation | `NotificationPublisherImpl.listingCancelledBySellerFanout` (Task 3) | Task 3 — sibling call added inside the lambda |
+| `OncePerRequestFilter` registered before JWT chain | `JwtAuthenticationFilter` + `WebSecurityConfig` | Task 4 — `SlImTerminalAuthFilter` |
+| `LogCaptor` for asserting on log lines | Existing tests (search for `LogCaptor.forClass`) | Task 5 — `SlImCleanupJobTest` |
+| TanStack Query v5 cache key factory | `frontend/src/lib/notifications/queryKeys.ts` (Task 6) | Task 7 — extend with `preferences()` |
+| Optimistic mutation with rollback | `frontend/src/hooks/notifications/useMarkRead.ts` (Task 6) | Task 7 — `useUpdateNotificationPreferences` |
+| MSW 2 handler conventions + seed/clear test helpers | `frontend/src/test/msw/handlers.ts` (Task 6) | Task 7 — extend with prefs handlers |
+| Headless UI Popover for dropdown | `frontend/src/components/notifications/NotificationDropdown.tsx` (Task 7) | Task 8 — bell dropdown footer gear icon (no new Popover, just add to existing) |
+| `RequireAuth` wrapper for authenticated pages | `frontend/src/app/notifications/page.tsx` (Task 8) | Task 8 — `/settings/notifications/page.tsx` |
+| `formatRelativeTime` from `@/lib/time/relativeTime` | Sub-spec 1, Task 7 | Not needed in this sub-spec — preferences UI shows no times |
+
+## Footguns to avoid
+
+1. **`llInstantMessage` truncates at 1024 BYTES, not characters.** UTF-8 multi-byte characters (CJK, emoji, accented Latin) push the byte count above the char count. SL silently truncates from the end — and the deeplink lives at the end. `SlImMessageBuilder` MUST measure `getBytes(StandardCharsets.UTF_8).length`. Three test cases mandatory: multi-byte parcel name, emoji parcel name, long-body forcing actual truncation. All three assert deeplink intact and total ≤ 1024 bytes.
+
+2. **Single-recipient publish path is afterCommit-then-REQUIRES_NEW; fan-out path is in-the-REQUIRES_NEW.** See spec §2.1 and §2.2. The two have different reliability postures and cannot be unified. A new fan-out method must follow the fan-out pattern (sibling call inside the per-recipient REQUIRES_NEW lambda); a new single-recipient method must follow the publish() pattern (afterCommit hook → maybeQueue → its own REQUIRES_NEW).
+
+3. **Adding a new terminal status to `sl_im_message` requires updating the cleanup predicate.** `SlImCleanupJob` stage 2's `WHERE status IN (...)` enumerates terminal states. New status = predicate update in the same commit, or rows accumulate forever and the GROUP BY status triage query loses its rolling-window meaning.
+
+4. **LSL `llInstantMessage` is fire-and-forget; the dispatcher script never calls `/failed`.** FAILED rows in production come from manual operator intervention only. README's "Limits" section makes this explicit so a support engineer running `SELECT status, count(*) FROM sl_im_message GROUP BY status` doesn't think a missing FAILED bucket means a missing pipeline.
+
+5. **The User entity load in the dispatcher must be inside the REQUIRES_NEW transaction**, not at the originating call site. This guarantees read-your-writes after a preferences PUT — no stale-cache window.
+
+6. **`top_users` for the cleanup INFO log must be captured BEFORE the UPDATE to EXPIRED.** Otherwise the `WHERE status = 'PENDING'` filter no longer matches the rows that just transitioned. Two queries instead of one is the correct shape.
+
+7. **`SlImInternalController.pending()` is NOT @Transactional.** The `FOR UPDATE SKIP LOCKED` on the polling query releases the lock the moment the query returns. This is the correct shape for the current single-dispatcher design. Add a code comment on the line so future contributors don't mistake it for working multi-poller dedup.
+
+8. **Closed-shape validation on PUT preferences.** The `slIm` map keys must be exactly `{ bidding, auction_result, escrow, listing_status, reviews }` — no more, no fewer. `SYSTEM`, `REALTY_GROUP`, and `MARKETING` keys are rejected with 400.
+
+9. **Master mute does NOT clear per-group state.** When `slImMuted=true`, group toggles render disabled with their underlying `notifySlIm[group]` value still showing. Toggling mute off restores them visually with no API roundtrip.
+
+10. **Fan-out path's `maybeQueueForFanout` does NOT wrap in REQUIRES_NEW** (caller already did) and does NOT swallow exceptions (caller's per-recipient try-catch handles isolation). Only `maybeQueue` (single-recipient) does both.
+
+## Branch setup
+
+The branch already exists: `task/09-sub-3-sl-im-and-preferences`, branched from `dev`, with the spec committed at `952956d` and the FOR UPDATE SKIP LOCKED clarification at `e6642f2`. Confirm with `git status` and `git log --oneline -3` before starting Task 1.
+
+```bash
+git status                    # expect: clean working tree
+git log --oneline -3          # expect tip: e6642f2 docs(epic-09): sub-spec 3 — clarify FOR UPDATE SKIP LOCKED is advisory
+git rev-parse --abbrev-ref HEAD  # expect: task/09-sub-3-sl-im-and-preferences
+```
+
+If any expectation fails, `git checkout task/09-sub-3-sl-im-and-preferences` and pull from origin if it's been pushed.
+
+---
+
+## Task 1 — Backend foundation: entity + DAO + repository + index initializer
+
+**Goal:** Land the persistence layer for `sl_im_message` — entity, status enum, native ON CONFLICT upsert DAO, repository with the polling query, and the partial-unique-index initializer. No service or dispatcher logic yet (Task 3). No internal endpoints yet (Task 4). Mirror the `NotificationDao` / `NotificationRepository` / `NotificationCoalesceIndexInitializer` patterns from sub-spec 1.
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessage.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessageStatus.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessageDao.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessageRepository.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImCoalesceIndexInitializer.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImMessageDaoTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImMessageRepositoryTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImCoalesceIndexInitializerTest.java`
+
+### Steps
+
+- [ ] **Step 1: Create the `SlImMessageStatus` enum**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+public enum SlImMessageStatus {
+    PENDING,
+    DELIVERED,
+    EXPIRED,
+    FAILED
+}
+```
+
+- [ ] **Step 2: Create the `SlImMessage` JPA entity**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import jakarta.persistence.*;
+import java.time.OffsetDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(
+    name = "sl_im_message",
+    indexes = {
+        @Index(name = "ix_sl_im_status_created", columnList = "status, created_at"),
+        @Index(name = "ix_sl_im_user_status", columnList = "user_id, status")
+    }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+public class SlImMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "avatar_uuid", nullable = false, length = 36)
+    private String avatarUuid;
+
+    @Column(name = "coalesce_key", length = 128)
+    private String coalesceKey;
+
+    @Column(name = "message_text", nullable = false, length = 1024)
+    private String messageText;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private SlImMessageStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @Column(name = "delivered_at")
+    private OffsetDateTime deliveredAt;
+
+    @Column(nullable = false)
+    private int attempts;
+}
+```
+
+- [ ] **Step 3: Run the application context once to let `ddl-auto: update` create the table**
+
+Run: `cd backend && ./mvnw spring-boot:run` for ~10 seconds, then Ctrl+C. Verify the table was created:
+
+```bash
+psql -h localhost -U slpa -d slpa -c "\d sl_im_message"
+```
+
+Expected output: table exists with columns matching the entity. Do not commit yet.
+
+- [ ] **Step 4: Create `SlImMessageDao` with native ON CONFLICT upsert**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Native-SQL DAO for the SL IM message upsert path.
+ *
+ * <p>Uses {@code ON CONFLICT (user_id, coalesce_key) WHERE status = 'PENDING' DO UPDATE}
+ * to collapse repeated deliveries of the same logical event (e.g., repeated OUTBID
+ * notifications on the same auction) into a single PENDING row that the dispatcher
+ * delivers as one IM with the latest text.
+ *
+ * <p>The {@code xmax != 0} trick is a Postgres-native way to know whether INSERT
+ * (xmax = 0) or UPDATE (xmax holds updating tx ID) executed without a second roundtrip.
+ *
+ * <p>The partial unique index {@code uq_sl_im_pending_coalesce} is created at
+ * startup by {@link SlImCoalesceIndexInitializer} (Hibernate's ddl-auto cannot
+ * emit partial indexes). Without that index the ON CONFLICT clause has nothing
+ * to match and every call becomes a plain INSERT.
+ *
+ * <p>NULL coalesce_key never matches itself in Postgres unique constraints
+ * (NULL ≠ NULL semantics), so the same query handles coalescing and
+ * non-coalescing categories with no service-layer branching.
+ */
+@Component
+@RequiredArgsConstructor
+public class SlImMessageDao {
+
+    private final JdbcTemplate jdbc;
+
+    public record UpsertResult(
+        long id,
+        boolean wasUpdate,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
+    ) {}
+
+    public UpsertResult upsert(
+        long userId,
+        String avatarUuid,
+        String messageText,
+        String coalesceKey
+    ) {
+        String sql = """
+            INSERT INTO sl_im_message
+              (user_id, avatar_uuid, coalesce_key, message_text,
+               status, attempts, created_at, updated_at)
+            VALUES (?, ?, ?, ?, 'PENDING', 0, now(), now())
+            ON CONFLICT (user_id, coalesce_key) WHERE status = 'PENDING'
+            DO UPDATE SET
+              message_text = EXCLUDED.message_text,
+              avatar_uuid  = EXCLUDED.avatar_uuid,
+              updated_at   = now()
+            RETURNING id, (xmax != 0) AS was_update, created_at, updated_at
+            """;
+        Map<String, Object> row = jdbc.queryForMap(
+            sql, userId, avatarUuid, coalesceKey, messageText);
+        return new UpsertResult(
+            ((Number) row.get("id")).longValue(),
+            (Boolean) row.get("was_update"),
+            ((java.sql.Timestamp) row.get("created_at")).toInstant().atOffset(ZoneOffset.UTC),
+            ((java.sql.Timestamp) row.get("updated_at")).toInstant().atOffset(ZoneOffset.UTC)
+        );
+    }
+}
+```
+
+- [ ] **Step 5: Create `SlImMessageRepository`**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SlImMessageRepository extends JpaRepository<SlImMessage, Long> {
+
+    @Query(value = """
+        SELECT * FROM sl_im_message
+        WHERE status = 'PENDING'
+        ORDER BY created_at ASC
+        LIMIT :limit
+        FOR UPDATE SKIP LOCKED
+        """, nativeQuery = true)
+    List<SlImMessage> pollPending(@Param("limit") int limit);
+
+    @Query("SELECT m.status, count(m) FROM SlImMessage m GROUP BY m.status")
+    List<Object[]> countByStatus();
+}
+```
+
+- [ ] **Step 6: Create `SlImCoalesceIndexInitializer`**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Emits the partial unique index that backs the ON CONFLICT clause in
+ * {@link SlImMessageDao}. Hibernate's ddl-auto cannot emit partial unique
+ * indexes, so we add it via an {@code ApplicationReadyEvent} listener that
+ * runs idempotent DDL.
+ *
+ * <p>Without this index the ON CONFLICT clause has nothing to match and every
+ * upsert call becomes a plain INSERT — coalescing silently breaks.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SlImCoalesceIndexInitializer {
+
+    private final JdbcTemplate jdbc;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void emit() {
+        jdbc.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_sl_im_pending_coalesce
+            ON sl_im_message (user_id, coalesce_key)
+            WHERE status = 'PENDING'
+            """);
+        log.info("SL IM partial unique index ensured: uq_sl_im_pending_coalesce");
+    }
+}
+```
+
+- [ ] **Step 7: Write `SlImMessageDaoTest`**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class SlImMessageDaoTest {
+
+    @Autowired SlImMessageDao dao;
+    @Autowired SlImMessageRepository repo;
+    @Autowired UserRepository userRepo;
+
+    @Test
+    void upsert_freshKey_insertsRow_returnsWasUpdateFalse() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var result = dao.upsert(u.getId(), avatar, "[SLPA] outbid msg", "outbid:1:42");
+
+        assertThat(result.wasUpdate()).isFalse();
+        assertThat(result.id()).isPositive();
+
+        SlImMessage row = repo.findById(result.id()).orElseThrow();
+        assertThat(row.getUserId()).isEqualTo(u.getId());
+        assertThat(row.getAvatarUuid()).isEqualTo(avatar);
+        assertThat(row.getMessageText()).isEqualTo("[SLPA] outbid msg");
+        assertThat(row.getCoalesceKey()).isEqualTo("outbid:1:42");
+        assertThat(row.getStatus()).isEqualTo(SlImMessageStatus.PENDING);
+        assertThat(row.getAttempts()).isZero();
+    }
+
+    @Test
+    void upsert_secondCallSameKey_updatesPendingRow_returnsWasUpdateTrue() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var first = dao.upsert(u.getId(), avatar, "[SLPA] first", "outbid:1:42");
+        var second = dao.upsert(u.getId(), avatar, "[SLPA] second", "outbid:1:42");
+
+        assertThat(second.wasUpdate()).isTrue();
+        assertThat(second.id()).isEqualTo(first.id());
+
+        SlImMessage row = repo.findById(first.id()).orElseThrow();
+        assertThat(row.getMessageText()).isEqualTo("[SLPA] second");
+        // updated_at bumped past created_at
+        assertThat(row.getUpdatedAt()).isAfterOrEqualTo(row.getCreatedAt());
+    }
+
+    @Test
+    void upsert_afterDelivered_insertsFreshRow() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var first = dao.upsert(u.getId(), avatar, "[SLPA] first", "outbid:1:42");
+
+        // Mark first row DELIVERED via direct repo write (real path is Task 4 controller)
+        SlImMessage delivered = repo.findById(first.id()).orElseThrow();
+        delivered.setStatus(SlImMessageStatus.DELIVERED);
+        repo.save(delivered);
+
+        var second = dao.upsert(u.getId(), avatar, "[SLPA] second", "outbid:1:42");
+        assertThat(second.wasUpdate()).isFalse();
+        assertThat(second.id()).isNotEqualTo(first.id());
+        // Both rows persist; partial index excludes the DELIVERED one from the predicate.
+        assertThat(repo.findAll()).hasSize(2);
+    }
+
+    @Test
+    void upsert_afterExpired_insertsFreshRow() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var first = dao.upsert(u.getId(), avatar, "[SLPA] first", "outbid:1:42");
+
+        SlImMessage expired = repo.findById(first.id()).orElseThrow();
+        expired.setStatus(SlImMessageStatus.EXPIRED);
+        repo.save(expired);
+
+        var second = dao.upsert(u.getId(), avatar, "[SLPA] second", "outbid:1:42");
+        assertThat(second.wasUpdate()).isFalse();
+        assertThat(second.id()).isNotEqualTo(first.id());
+    }
+
+    @Test
+    void upsert_afterFailed_insertsFreshRow() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var first = dao.upsert(u.getId(), avatar, "[SLPA] first", "outbid:1:42");
+
+        SlImMessage failed = repo.findById(first.id()).orElseThrow();
+        failed.setStatus(SlImMessageStatus.FAILED);
+        repo.save(failed);
+
+        var second = dao.upsert(u.getId(), avatar, "[SLPA] second", "outbid:1:42");
+        assertThat(second.wasUpdate()).isFalse();
+        assertThat(second.id()).isNotEqualTo(first.id());
+    }
+
+    @Test
+    void upsert_nullCoalesceKey_neverCollidesWithItself() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var first = dao.upsert(u.getId(), avatar, "[SLPA] one", null);
+        var second = dao.upsert(u.getId(), avatar, "[SLPA] two", null);
+
+        assertThat(first.wasUpdate()).isFalse();
+        assertThat(second.wasUpdate()).isFalse();
+        assertThat(second.id()).isNotEqualTo(first.id());
+        assertThat(repo.findAll()).hasSize(2);
+    }
+
+    @Test
+    void upsert_differentUsersSameKey_doNotCollide() {
+        User a = userRepo.save(testUser());
+        User b = userRepo.save(testUser());
+        String avatarA = UUID.randomUUID().toString();
+        String avatarB = UUID.randomUUID().toString();
+
+        var rA = dao.upsert(a.getId(), avatarA, "[SLPA] A", "outbid:1:42");
+        var rB = dao.upsert(b.getId(), avatarB, "[SLPA] B", "outbid:1:42");
+
+        assertThat(rA.wasUpdate()).isFalse();
+        assertThat(rB.wasUpdate()).isFalse();
+        assertThat(rA.id()).isNotEqualTo(rB.id());
+    }
+
+    private User testUser() {
+        return User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash")
+            .build();
+    }
+}
+```
+
+- [ ] **Step 8: Run the DAO tests — expect green**
+
+Run: `cd backend && ./mvnw test -Dtest=SlImMessageDaoTest`
+Expected: 7 tests pass.
+
+- [ ] **Step 9: Write `SlImMessageRepositoryTest`**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class SlImMessageRepositoryTest {
+
+    @Autowired SlImMessageDao dao;
+    @Autowired SlImMessageRepository repo;
+    @Autowired UserRepository userRepo;
+
+    @Test
+    void pollPending_returnsOldestFirst() throws InterruptedException {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var first = dao.upsert(u.getId(), avatar, "[SLPA] first", null);
+        Thread.sleep(20);
+        var second = dao.upsert(u.getId(), avatar, "[SLPA] second", null);
+        Thread.sleep(20);
+        var third = dao.upsert(u.getId(), avatar, "[SLPA] third", null);
+
+        List<SlImMessage> rows = repo.pollPending(10);
+        assertThat(rows).hasSize(3);
+        assertThat(rows.get(0).getId()).isEqualTo(first.id());
+        assertThat(rows.get(1).getId()).isEqualTo(second.id());
+        assertThat(rows.get(2).getId()).isEqualTo(third.id());
+    }
+
+    @Test
+    void pollPending_honorsLimit() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        for (int i = 0; i < 15; i++) {
+            dao.upsert(u.getId(), avatar, "[SLPA] " + i, null);
+        }
+
+        assertThat(repo.pollPending(10)).hasSize(10);
+        assertThat(repo.pollPending(5)).hasSize(5);
+    }
+
+    @Test
+    void pollPending_excludesNonPending() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var pending = dao.upsert(u.getId(), avatar, "[SLPA] pending", null);
+        var delivered = dao.upsert(u.getId(), avatar, "[SLPA] delivered", null);
+        var expired = dao.upsert(u.getId(), avatar, "[SLPA] expired", null);
+        var failed = dao.upsert(u.getId(), avatar, "[SLPA] failed", null);
+
+        SlImMessage d = repo.findById(delivered.id()).orElseThrow();
+        d.setStatus(SlImMessageStatus.DELIVERED);
+        repo.save(d);
+        SlImMessage e = repo.findById(expired.id()).orElseThrow();
+        e.setStatus(SlImMessageStatus.EXPIRED);
+        repo.save(e);
+        SlImMessage f = repo.findById(failed.id()).orElseThrow();
+        f.setStatus(SlImMessageStatus.FAILED);
+        repo.save(f);
+
+        List<SlImMessage> rows = repo.pollPending(10);
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getId()).isEqualTo(pending.id());
+    }
+
+    @Test
+    void countByStatus_returnsAllStatusBuckets() {
+        User u = userRepo.save(testUser());
+        String avatar = UUID.randomUUID().toString();
+
+        var p1 = dao.upsert(u.getId(), avatar, "[SLPA] p1", "k1");
+        var p2 = dao.upsert(u.getId(), avatar, "[SLPA] p2", "k2");
+        var d = dao.upsert(u.getId(), avatar, "[SLPA] d", "k3");
+
+        SlImMessage row = repo.findById(d.id()).orElseThrow();
+        row.setStatus(SlImMessageStatus.DELIVERED);
+        repo.save(row);
+
+        Map<SlImMessageStatus, Long> counts = repo.countByStatus().stream()
+            .collect(java.util.stream.Collectors.toMap(
+                arr -> (SlImMessageStatus) arr[0],
+                arr -> ((Number) arr[1]).longValue()));
+
+        assertThat(counts.get(SlImMessageStatus.PENDING)).isEqualTo(2L);
+        assertThat(counts.get(SlImMessageStatus.DELIVERED)).isEqualTo(1L);
+    }
+
+    private User testUser() {
+        return User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash")
+            .build();
+    }
+}
+```
+
+- [ ] **Step 10: Run repository tests — expect green**
+
+Run: `cd backend && ./mvnw test -Dtest=SlImMessageRepositoryTest`
+Expected: 4 tests pass.
+
+- [ ] **Step 11: Write `SlImCoalesceIndexInitializerTest`**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class SlImCoalesceIndexInitializerTest {
+
+    @Autowired JdbcTemplate jdbc;
+    @Autowired SlImCoalesceIndexInitializer initializer;
+
+    @Test
+    void partialUniqueIndexIsPresentAfterStartup() {
+        // ApplicationReadyEvent fires during @SpringBootTest startup.
+        Integer count = jdbc.queryForObject("""
+            SELECT count(*)
+            FROM pg_indexes
+            WHERE tablename = 'sl_im_message'
+              AND indexname = 'uq_sl_im_pending_coalesce'
+            """, Integer.class);
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void emit_isIdempotent() {
+        // Calling emit() a second time should not throw.
+        initializer.emit();
+        Integer count = jdbc.queryForObject("""
+            SELECT count(*)
+            FROM pg_indexes
+            WHERE tablename = 'sl_im_message'
+              AND indexname = 'uq_sl_im_pending_coalesce'
+            """, Integer.class);
+        assertThat(count).isEqualTo(1);
+    }
+}
+```
+
+- [ ] **Step 12: Run initializer tests — expect green**
+
+Run: `cd backend && ./mvnw test -Dtest=SlImCoalesceIndexInitializerTest`
+Expected: 2 tests pass.
+
+- [ ] **Step 13: Run the full backend suite to verify no regressions**
+
+Run: `cd backend && ./mvnw test`
+Expected: previous baseline + 13 new tests, 0 failures.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessage.java \
+        backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessageStatus.java \
+        backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessageDao.java \
+        backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessageRepository.java \
+        backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImCoalesceIndexInitializer.java \
+        backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImMessageDaoTest.java \
+        backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImMessageRepositoryTest.java \
+        backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImCoalesceIndexInitializerTest.java
+git commit -m "feat(sl-im): entity + DAO + repository + partial-index initializer"
+```
+
+---
+
+## Task 2 — Backend gate + link resolver + message builder
+
+**Goal:** Land the three pure-logic helpers: `SlImChannelGate` (the discriminated decision function), `SlImLinkResolver` (category → URL), `SlImMessageBuilder` (assembled message text with the byte-budget enforcement that prevents deeplinks from being truncated by SL's 1024-byte IM limit). All three are stateless `@Component` beans for injectability + Mockito-friendliness; tests are pure unit (no `@SpringBootTest`).
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImChannelGate.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImLinkResolver.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessageBuilder.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/config/SlpaWebProperties.java` (if not already present)
+- Modify: `backend/src/main/resources/application.yml` (add `slpa.web.base-url`)
+- Test: `backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImChannelGateTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImLinkResolverTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImMessageBuilderTest.java`
+
+### Steps
+
+- [ ] **Step 1: Check whether `SlpaWebProperties` exists**
+
+Run: `cd backend && find src/main/java -name "*WebProperties*" -o -name "*BaseUrl*"`
+
+If it exists, note the existing prefix and use it. If it doesn't, create:
+
+```java
+package com.slparcelauctions.backend.config;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties(prefix = "slpa.web")
+@Validated
+public record SlpaWebProperties(
+    @NotBlank String baseUrl
+) {}
+```
+
+If it had to be created, also register it in whichever class has `@ConfigurationPropertiesScan` (probably `SlpaApplication.java` — verify). Most projects have the scan annotation that auto-registers all `@ConfigurationProperties` records, so a one-line creation is the typical case.
+
+- [ ] **Step 2: Add `slpa.web.base-url` to application.yml**
+
+Open `backend/src/main/resources/application.yml`. Find the `slpa:` block. Add:
+
+```yaml
+slpa:
+  # ... existing keys ...
+  web:
+    base-url: ${SLPA_WEB_BASE_URL:http://localhost:3000}
+```
+
+The dev default points at the local Next.js port; staging/prod override via env var.
+
+- [ ] **Step 3: Create `SlImChannelGate`**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationGroup;
+import com.slparcelauctions.backend.user.User;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/**
+ * Pure decision function for "should we queue an SL IM for this user/category?"
+ *
+ * <p>Stateless. Returns a discriminated {@link Decision} so callers can log the
+ * reason at DEBUG, which makes "I didn't get an IM" support tickets resolvable
+ * from logs alone without DB archaeology.
+ *
+ * <p>Order of checks (no-avatar is the universal floor — applies even to SYSTEM):
+ * <ol>
+ *   <li>{@link User#getSlAvatarUuid()} == null  → {@link Decision#SKIP_NO_AVATAR}</li>
+ *   <li>category.group == SYSTEM                → {@link Decision#QUEUE_BYPASS_PREFS}</li>
+ *   <li>{@link User#isNotifySlImMuted()} true   → {@link Decision#SKIP_MUTED}</li>
+ *   <li>notifySlIm[group] false or absent       → {@link Decision#SKIP_GROUP_DISABLED}</li>
+ *   <li>otherwise                               → {@link Decision#QUEUE}</li>
+ * </ol>
+ */
+@Component
+public class SlImChannelGate {
+
+    public enum Decision {
+        QUEUE,
+        QUEUE_BYPASS_PREFS,
+        SKIP_NO_AVATAR,
+        SKIP_MUTED,
+        SKIP_GROUP_DISABLED
+    }
+
+    public Decision decide(User user, NotificationCategory category) {
+        if (user.getSlAvatarUuid() == null) {
+            return Decision.SKIP_NO_AVATAR;
+        }
+
+        boolean isSystem = category.getGroup() == NotificationGroup.SYSTEM;
+        if (isSystem) {
+            return Decision.QUEUE_BYPASS_PREFS;
+        }
+
+        if (user.isNotifySlImMuted()) {
+            return Decision.SKIP_MUTED;
+        }
+
+        Map<String, Boolean> prefs = user.getNotifySlIm();
+        String groupKey = category.getGroup().name().toLowerCase();
+        Boolean groupOn = prefs == null ? null : prefs.get(groupKey);
+        if (groupOn == null || !groupOn) {
+            return Decision.SKIP_GROUP_DISABLED;
+        }
+
+        return Decision.QUEUE;
+    }
+}
+```
+
+- [ ] **Step 4: Write `SlImChannelGateTest` — parameterized matrix**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationGroup;
+import com.slparcelauctions.backend.notification.slim.SlImChannelGate.Decision;
+import com.slparcelauctions.backend.user.User;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SlImChannelGateTest {
+
+    private final SlImChannelGate gate = new SlImChannelGate();
+
+    @Test
+    void noAvatar_isSkipNoAvatar_evenForSystem() {
+        User u = userWithoutAvatar();
+        assertThat(gate.decide(u, NotificationCategory.SYSTEM_ANNOUNCEMENT))
+            .isEqualTo(Decision.SKIP_NO_AVATAR);
+        assertThat(gate.decide(u, NotificationCategory.OUTBID))
+            .isEqualTo(Decision.SKIP_NO_AVATAR);
+    }
+
+    @Test
+    void systemCategory_bypassesMuteAndGroupPrefs_whenAvatarPresent() {
+        User u = userWithAvatar();
+        u.setNotifySlImMuted(true);
+        u.setNotifySlIm(allGroupsOff());
+
+        assertThat(gate.decide(u, NotificationCategory.SYSTEM_ANNOUNCEMENT))
+            .isEqualTo(Decision.QUEUE_BYPASS_PREFS);
+    }
+
+    @Test
+    void mutedUser_isSkipMuted_forNonSystemCategories() {
+        User u = userWithAvatar();
+        u.setNotifySlImMuted(true);
+        u.setNotifySlIm(allGroupsOn());
+
+        assertThat(gate.decide(u, NotificationCategory.OUTBID))
+            .isEqualTo(Decision.SKIP_MUTED);
+        assertThat(gate.decide(u, NotificationCategory.ESCROW_FUNDED))
+            .isEqualTo(Decision.SKIP_MUTED);
+    }
+
+    @Test
+    void groupOff_isSkipGroupDisabled() {
+        User u = userWithAvatar();
+        u.setNotifySlImMuted(false);
+        Map<String, Boolean> prefs = allGroupsOn();
+        prefs.put("bidding", false);
+        u.setNotifySlIm(prefs);
+
+        assertThat(gate.decide(u, NotificationCategory.OUTBID))
+            .isEqualTo(Decision.SKIP_GROUP_DISABLED);
+        // Other groups still queue:
+        assertThat(gate.decide(u, NotificationCategory.ESCROW_FUNDED))
+            .isEqualTo(Decision.QUEUE);
+    }
+
+    @Test
+    void groupAbsent_isSkipGroupDisabled() {
+        User u = userWithAvatar();
+        u.setNotifySlImMuted(false);
+        u.setNotifySlIm(new HashMap<>()); // no keys
+
+        assertThat(gate.decide(u, NotificationCategory.OUTBID))
+            .isEqualTo(Decision.SKIP_GROUP_DISABLED);
+    }
+
+    @Test
+    void allGroupsOnUnmutedWithAvatar_isQueue() {
+        User u = userWithAvatar();
+        u.setNotifySlImMuted(false);
+        u.setNotifySlIm(allGroupsOn());
+
+        for (NotificationCategory c : NotificationCategory.values()) {
+            if (c.getGroup() == NotificationGroup.SYSTEM) {
+                assertThat(gate.decide(u, c)).isEqualTo(Decision.QUEUE_BYPASS_PREFS);
+            } else {
+                assertThat(gate.decide(u, c)).isEqualTo(Decision.QUEUE);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("matrixCases")
+    void matrix(boolean hasAvatar, boolean muted, boolean groupOn,
+                NotificationCategory category, Decision expected) {
+        User u = hasAvatar ? userWithAvatar() : userWithoutAvatar();
+        u.setNotifySlImMuted(muted);
+        Map<String, Boolean> prefs = allGroupsOn();
+        if (!groupOn) {
+            prefs.put(category.getGroup().name().toLowerCase(), false);
+        }
+        u.setNotifySlIm(prefs);
+
+        assertThat(gate.decide(u, category)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> matrixCases() {
+        // (hasAvatar, muted, groupOn, category, expected)
+        return Stream.of(
+            // No avatar always wins
+            Arguments.of(false, false, true,  NotificationCategory.OUTBID,            Decision.SKIP_NO_AVATAR),
+            Arguments.of(false, true,  false, NotificationCategory.OUTBID,            Decision.SKIP_NO_AVATAR),
+            Arguments.of(false, false, true,  NotificationCategory.SYSTEM_ANNOUNCEMENT, Decision.SKIP_NO_AVATAR),
+            // SYSTEM bypasses prefs (when avatar present)
+            Arguments.of(true,  true,  false, NotificationCategory.SYSTEM_ANNOUNCEMENT, Decision.QUEUE_BYPASS_PREFS),
+            Arguments.of(true,  false, true,  NotificationCategory.SYSTEM_ANNOUNCEMENT, Decision.QUEUE_BYPASS_PREFS),
+            // Muted wins over group prefs (non-SYSTEM)
+            Arguments.of(true,  true,  true,  NotificationCategory.OUTBID,            Decision.SKIP_MUTED),
+            // Group off when not muted
+            Arguments.of(true,  false, false, NotificationCategory.OUTBID,            Decision.SKIP_GROUP_DISABLED),
+            // Happy path
+            Arguments.of(true,  false, true,  NotificationCategory.OUTBID,            Decision.QUEUE),
+            Arguments.of(true,  false, true,  NotificationCategory.AUCTION_WON,       Decision.QUEUE),
+            Arguments.of(true,  false, true,  NotificationCategory.ESCROW_FUNDED,     Decision.QUEUE)
+        );
+    }
+
+    private User userWithoutAvatar() {
+        User u = User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash")
+            .build();
+        u.setSlAvatarUuid(null);
+        u.setNotifySlIm(allGroupsOn());
+        return u;
+    }
+
+    private User userWithAvatar() {
+        User u = userWithoutAvatar();
+        u.setSlAvatarUuid(UUID.randomUUID().toString());
+        return u;
+    }
+
+    private Map<String, Boolean> allGroupsOn() {
+        Map<String, Boolean> m = new HashMap<>();
+        for (NotificationGroup g : NotificationGroup.values()) {
+            m.put(g.name().toLowerCase(), true);
+        }
+        return m;
+    }
+
+    private Map<String, Boolean> allGroupsOff() {
+        Map<String, Boolean> m = new HashMap<>();
+        for (NotificationGroup g : NotificationGroup.values()) {
+            m.put(g.name().toLowerCase(), false);
+        }
+        return m;
+    }
+}
+```
+
+- [ ] **Step 5: Run gate tests — expect green**
+
+Run: `cd backend && ./mvnw test -Dtest=SlImChannelGateTest`
+Expected: 16 tests pass (6 explicit + 10 parameterized).
+
+- [ ] **Step 6: Create `SlImLinkResolver`**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import com.slparcelauctions.backend.config.SlpaWebProperties;
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Maps a notification category and its data blob to a deeplink URL for inclusion
+ * in the SL IM message. Mirrors the frontend {@code categoryMap.deeplink} logic
+ * — the duplication is intentional. Embedding the URL in the in-app row's data
+ * blob would couple in-app rows to a specific channel's URL semantics and make
+ * URL changes a data migration.
+ */
+@Component
+@RequiredArgsConstructor
+public class SlImLinkResolver {
+
+    private final SlpaWebProperties webProps;
+
+    public String resolve(NotificationCategory category, Map<String, Object> data) {
+        String base = webProps.baseUrl();
+        return switch (category) {
+            case OUTBID, PROXY_EXHAUSTED, AUCTION_LOST,
+                 AUCTION_ENDED_RESERVE_NOT_MET, AUCTION_ENDED_NO_BIDS,
+                 AUCTION_ENDED_BOUGHT_NOW, AUCTION_ENDED_SOLD,
+                 LISTING_VERIFIED, LISTING_CANCELLED_BY_SELLER,
+                 REVIEW_RECEIVED ->
+                base + "/auction/" + data.get("auctionId");
+            case AUCTION_WON ->
+                base + "/auction/" + data.get("auctionId") + "/escrow";
+            case ESCROW_FUNDED, ESCROW_TRANSFER_CONFIRMED, ESCROW_PAYOUT,
+                 ESCROW_EXPIRED, ESCROW_DISPUTED, ESCROW_FROZEN,
+                 ESCROW_PAYOUT_STALLED, ESCROW_TRANSFER_REMINDER ->
+                base + "/auction/" + data.get("auctionId") + "/escrow";
+            case LISTING_SUSPENDED, LISTING_REVIEW_REQUIRED ->
+                base + "/dashboard/listings";
+            case SYSTEM_ANNOUNCEMENT ->
+                base + "/notifications";
+        };
+    }
+}
+```
+
+- [ ] **Step 7: Write `SlImLinkResolverTest`**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.slparcelauctions.backend.config.SlpaWebProperties;
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SlImLinkResolverTest {
+
+    private static final String BASE = "https://slpa.example.com";
+    private final SlImLinkResolver resolver = new SlImLinkResolver(new SlpaWebProperties(BASE));
+
+    @Test
+    void outbid_resolvesToAuctionPage() {
+        assertThat(resolver.resolve(NotificationCategory.OUTBID, Map.of("auctionId", 42)))
+            .isEqualTo(BASE + "/auction/42");
+    }
+
+    @Test
+    void auctionWon_resolvesToEscrowPage() {
+        assertThat(resolver.resolve(NotificationCategory.AUCTION_WON, Map.of("auctionId", 42)))
+            .isEqualTo(BASE + "/auction/42/escrow");
+    }
+
+    @Test
+    void escrowFunded_resolvesToEscrowPage() {
+        assertThat(resolver.resolve(NotificationCategory.ESCROW_FUNDED,
+                Map.of("auctionId", 42, "escrowId", 100)))
+            .isEqualTo(BASE + "/auction/42/escrow");
+    }
+
+    @Test
+    void listingSuspended_resolvesToDashboardListings() {
+        assertThat(resolver.resolve(NotificationCategory.LISTING_SUSPENDED,
+                Map.of("auctionId", 42, "reason", "test")))
+            .isEqualTo(BASE + "/dashboard/listings");
+    }
+
+    @Test
+    void systemAnnouncement_resolvesToNotificationsFeed() {
+        assertThat(resolver.resolve(NotificationCategory.SYSTEM_ANNOUNCEMENT, Map.of()))
+            .isEqualTo(BASE + "/notifications");
+    }
+
+    @Test
+    void everyCategory_producesAValidUrl() {
+        // Every category must produce a URL starting with the base; ensures the
+        // switch covers all enum values (compile-time guarantee + runtime sanity).
+        for (NotificationCategory c : NotificationCategory.values()) {
+            String url = resolver.resolve(c, Map.of(
+                "auctionId", 42, "escrowId", 100, "reviewId", 5,
+                "reason", "x", "parcelName", "P", "currentBidL", 1L,
+                "isProxyOutbid", false, "endsAt", "2026-04-26T18:00:00Z",
+                "winningBidL", 1L, "highestBidL", 1L, "buyNowL", 1L,
+                "transferDeadline", "2026-04-26T18:00:00Z", "payoutL", 1L,
+                "reasonCategory", "x", "rating", 5));
+            assertThat(url).startsWith(BASE);
+        }
+    }
+}
+```
+
+- [ ] **Step 8: Run resolver tests — expect green**
+
+Run: `cd backend && ./mvnw test -Dtest=SlImLinkResolverTest`
+Expected: 6 tests pass (5 individual + 1 enum coverage).
+
+- [ ] **Step 9: Create `SlImMessageBuilder` with byte-budget enforcement**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import java.nio.charset.StandardCharsets;
+import org.springframework.stereotype.Component;
+
+/**
+ * Assembles the final SL IM text from (title, body, deeplink) components,
+ * enforcing the SL {@code llInstantMessage} 1024-BYTE limit.
+ *
+ * <p>The deeplink, the {@code [SLPA] } prefix, and the title are non-negotiable
+ * — they are reserved first and never trimmed. Only the body is ellipsizable.
+ *
+ * <p>SL truncates IMs that exceed 1024 bytes silently, from the end. If the
+ * deeplink lands at the end (it does), it gets cleanly cut off. UTF-8 multi-byte
+ * characters (CJK, emoji, accented Latin) push byte counts above char counts —
+ * a 1023-character message can occupy 1500+ bytes. Hence the byte-aware budget.
+ *
+ * <p>Trim algorithm: progressively shorten the body by Java {@code char} from
+ * the end until the assembled string fits. If a trim boundary lands on a high
+ * surrogate (would split a UTF-16 surrogate pair, producing an invalid
+ * sequence), back off one more char.
+ */
+@Component
+public class SlImMessageBuilder {
+
+    private static final int MAX_BYTES = 1024;
+    private static final String PREFIX = "[SLPA] ";
+    private static final String SEPARATOR = "\n\n";
+    private static final String ELLIPSIS = "…";  // 3 bytes UTF-8
+
+    public String assemble(String title, String body, String deeplink) {
+        String candidate = PREFIX + title + SEPARATOR + body + SEPARATOR + deeplink;
+        if (utf8Bytes(candidate) <= MAX_BYTES) {
+            return candidate;
+        }
+
+        int reservedBytes = utf8Bytes(PREFIX + title + SEPARATOR + SEPARATOR + deeplink + ELLIPSIS);
+        int availableForBody = MAX_BYTES - reservedBytes;
+
+        if (availableForBody <= 0) {
+            return assembleWithoutBody(title, deeplink);
+        }
+
+        int k = body.length();
+        String trimmedBody = null;
+        while (k > 0) {
+            int boundary = k;
+            if (Character.isHighSurrogate(body.charAt(boundary - 1))) {
+                boundary -= 1;
+            }
+            if (boundary <= 0) {
+                break;
+            }
+            String attempt = body.substring(0, boundary) + ELLIPSIS;
+            if (utf8Bytes(attempt) <= availableForBody) {
+                trimmedBody = attempt;
+                break;
+            }
+            k = boundary - 1;
+        }
+        if (trimmedBody == null) {
+            return assembleWithoutBody(title, deeplink);
+        }
+        return PREFIX + title + SEPARATOR + trimmedBody + SEPARATOR + deeplink;
+    }
+
+    private String assembleWithoutBody(String title, String deeplink) {
+        // Last-resort: no body, just title + deeplink. If even that exceeds the
+        // budget, trim the title. Deeplink stays whole.
+        String candidate = PREFIX + title + SEPARATOR + deeplink;
+        if (utf8Bytes(candidate) <= MAX_BYTES) {
+            return candidate;
+        }
+        int reserved = utf8Bytes(PREFIX + SEPARATOR + deeplink + ELLIPSIS);
+        int availableForTitle = MAX_BYTES - reserved;
+        int k = title.length();
+        while (k > 0) {
+            int boundary = k;
+            if (Character.isHighSurrogate(title.charAt(boundary - 1))) {
+                boundary -= 1;
+            }
+            if (boundary <= 0) {
+                break;
+            }
+            String attempt = title.substring(0, boundary) + ELLIPSIS;
+            if (utf8Bytes(attempt) <= availableForTitle) {
+                return PREFIX + attempt + SEPARATOR + deeplink;
+            }
+            k = boundary - 1;
+        }
+        // If even an empty-title fallback exceeds the budget, the deeplink itself
+        // is too long. Return the deeplink alone — truncated to MAX_BYTES.
+        byte[] bytes = deeplink.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length > MAX_BYTES) {
+            return new String(bytes, 0, MAX_BYTES, StandardCharsets.UTF_8);
+        }
+        return deeplink;
+    }
+
+    private static int utf8Bytes(String s) {
+        return s.getBytes(StandardCharsets.UTF_8).length;
+    }
+}
+```
+
+- [ ] **Step 10: Write `SlImMessageBuilderTest` — including the three mandatory byte-vs-char cases**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class SlImMessageBuilderTest {
+
+    private final SlImMessageBuilder builder = new SlImMessageBuilder();
+
+    @Test
+    void assemble_shortInputs_returnsExactTemplate() {
+        String result = builder.assemble(
+            "You've been outbid on Hampton Hills",
+            "Current bid is L$2,000.",
+            "https://slpa.example.com/auction/42#bid-panel");
+
+        assertThat(result).isEqualTo(
+            "[SLPA] You've been outbid on Hampton Hills\n\n" +
+            "Current bid is L$2,000.\n\n" +
+            "https://slpa.example.com/auction/42#bid-panel");
+        assertThat(byteLen(result)).isLessThanOrEqualTo(1024);
+    }
+
+    @Test
+    void assemble_multiByteParcelName_keepsDeeplinkIntact() {
+        // Three CJK characters, each 3 bytes UTF-8.
+        String result = builder.assemble(
+            "You've been outbid on 東京タワー Estates",
+            "Current bid is L$2,000.",
+            "https://slpa.example.com/auction/42#bid-panel");
+
+        assertThat(result).contains("東京タワー Estates");
+        assertThat(result).endsWith("https://slpa.example.com/auction/42#bid-panel");
+        assertThat(byteLen(result)).isLessThanOrEqualTo(1024);
+    }
+
+    @Test
+    void assemble_emojiParcelName_keepsDeeplinkIntact() {
+        // 🌸 is a 4-byte UTF-8 character (U+1F338) and a UTF-16 surrogate pair.
+        String result = builder.assemble(
+            "Your auction sold: 🌸 Sakura Plot",
+            "Winning bid: L$5,200.",
+            "https://slpa.example.com/auction/99");
+
+        assertThat(result).contains("🌸 Sakura Plot");
+        assertThat(result).endsWith("https://slpa.example.com/auction/99");
+        assertThat(byteLen(result)).isLessThanOrEqualTo(1024);
+    }
+
+    @Test
+    void assemble_longBody_ellipsizesBodyKeepsDeeplinkIntact() {
+        String longBody = "x".repeat(2000);
+        String deeplink = "https://slpa.example.com/auction/42";
+        String result = builder.assemble("Hampton Hills update", longBody, deeplink);
+
+        assertThat(result).contains("…");
+        assertThat(result).endsWith(deeplink);
+        assertThat(result).startsWith("[SLPA] Hampton Hills update");
+        assertThat(byteLen(result)).isLessThanOrEqualTo(1024);
+    }
+
+    @Test
+    void assemble_longBodyWithMultiByteContent_ellipsizesAtCharBoundary() {
+        // Body of 1500 CJK characters (4500 bytes UTF-8). Must be trimmed; ellipsis
+        // must land at a valid char boundary (no orphaned surrogate halves).
+        String longBody = "東".repeat(1500);
+        String result = builder.assemble("Hampton Hills update", longBody,
+            "https://slpa.example.com/auction/42");
+
+        assertThat(result).endsWith("https://slpa.example.com/auction/42");
+        assertThat(byteLen(result)).isLessThanOrEqualTo(1024);
+        // Decoding round-trips cleanly (no replacement chars from broken sequences):
+        byte[] bytes = result.getBytes(StandardCharsets.UTF_8);
+        String roundTrip = new String(bytes, StandardCharsets.UTF_8);
+        assertThat(roundTrip).isEqualTo(result);
+    }
+
+    @Test
+    void assemble_bodyEmpty_returnsTitleAndDeeplink() {
+        String result = builder.assemble("Title", "", "https://slpa.example.com/x");
+        assertThat(result).isEqualTo("[SLPA] Title\n\n\n\nhttps://slpa.example.com/x");
+        assertThat(byteLen(result)).isLessThanOrEqualTo(1024);
+    }
+
+    @Test
+    void assemble_pathologicalCase_titleAndDeeplinkExceedBudget_dropsBodyTrimsTitle() {
+        // Title alone is 1500 chars + deeplink 50 chars > 1024.
+        String result = builder.assemble("a".repeat(1500), "body content",
+            "https://slpa.example.com/auction/42");
+
+        assertThat(result).endsWith("https://slpa.example.com/auction/42");
+        assertThat(result).contains("…");
+        assertThat(byteLen(result)).isLessThanOrEqualTo(1024);
+    }
+
+    private int byteLen(String s) {
+        return s.getBytes(StandardCharsets.UTF_8).length;
+    }
+}
+```
+
+- [ ] **Step 11: Run builder tests — expect green**
+
+Run: `cd backend && ./mvnw test -Dtest=SlImMessageBuilderTest`
+Expected: 7 tests pass.
+
+- [ ] **Step 12: Run the full backend suite to confirm no regressions**
+
+Run: `cd backend && ./mvnw test`
+Expected: previous (Task 1) baseline + 29 new tests, 0 failures.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImChannelGate.java \
+        backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImLinkResolver.java \
+        backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImMessageBuilder.java \
+        backend/src/main/java/com/slparcelauctions/backend/config/SlpaWebProperties.java \
+        backend/src/main/resources/application.yml \
+        backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImChannelGateTest.java \
+        backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImLinkResolverTest.java \
+        backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImMessageBuilderTest.java
+git commit -m "feat(sl-im): channel gate + link resolver + byte-budget message builder"
+```
+
+---
+
+## Task 3 — Backend dispatcher + integration with NotificationService.publish + fan-out integration
+
+**Goal:** Land the `SlImChannelDispatcher` with two entry points — `maybeQueue` (single-recipient, called from `NotificationService.publish`'s afterCommit hook) and `maybeQueueForFanout` (called inside the per-recipient REQUIRES_NEW lambda in `NotificationPublisherImpl.listingCancelledBySellerFanout`). Wire both call sites. Add 5 vertical-slice integration tests covering OUTBID coalesce + gate, escrow recipient routing, fan-out partial failure, SYSTEM bypass, no-avatar skip.
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImChannelDispatcher.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationService.java` (add second afterCommit hook)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java` (sibling call inside fan-out REQUIRES_NEW lambda)
+- Test: `backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImChannelDispatcherTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/OutbidImIntegrationTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/EscrowImIntegrationTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/CancellationFanoutImIntegrationTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/SystemBypassImIntegrationTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/NoAvatarSkipImIntegrationTest.java`
+
+### Steps
+
+- [ ] **Step 1: Create `SlImChannelDispatcher`**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationEvent;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Two entry points for queueing an SL IM:
+ * <ul>
+ *   <li>{@link #maybeQueue(NotificationEvent)} — single-recipient. Caller has
+ *       registered this as an afterCommit hook on the parent transaction; we
+ *       open our own REQUIRES_NEW so failures don't propagate.</li>
+ *   <li>{@link #maybeQueueForFanout(long, NotificationCategory, String, String, Map, String)}
+ *       — fan-out. Caller is already inside a REQUIRES_NEW per-recipient lambda;
+ *       this writes as a sibling, atomic with the in-app row for that recipient.
+ *       Failures here propagate (caller's per-recipient try-catch isolates).</li>
+ * </ul>
+ *
+ * <p>Both paths read User fresh inside their respective transactions so a
+ * preferences PUT before the dispatch has read-your-writes semantics.
+ */
+@Component
+@Slf4j
+public class SlImChannelDispatcher {
+
+    private final UserRepository userRepo;
+    private final SlImChannelGate gate;
+    private final SlImMessageBuilder messageBuilder;
+    private final SlImLinkResolver linkResolver;
+    private final SlImMessageDao dao;
+    private final TransactionTemplate requiresNewTx;
+
+    // Explicit constructor — @RequiredArgsConstructor doesn't propagate @Qualifier
+    // (see sub-spec 1 Task 3 deviation note).
+    public SlImChannelDispatcher(
+        UserRepository userRepo,
+        SlImChannelGate gate,
+        SlImMessageBuilder messageBuilder,
+        SlImLinkResolver linkResolver,
+        SlImMessageDao dao,
+        @Qualifier("requiresNewTxTemplate") TransactionTemplate requiresNewTx
+    ) {
+        this.userRepo = userRepo;
+        this.gate = gate;
+        this.messageBuilder = messageBuilder;
+        this.linkResolver = linkResolver;
+        this.dao = dao;
+        this.requiresNewTx = requiresNewTx;
+    }
+
+    public void maybeQueue(NotificationEvent event) {
+        try {
+            requiresNewTx.execute(status -> {
+                doQueue(event.userId(), event.category(),
+                    event.title(), event.body(), event.data(), event.coalesceKey());
+                return null;
+            });
+        } catch (Exception ex) {
+            log.warn("SL IM dispatch failed for userId={} category={}: {}",
+                event.userId(), event.category(), ex.toString());
+        }
+    }
+
+    /**
+     * Fan-out variant. Caller (inside a per-recipient REQUIRES_NEW) gets atomic
+     * commit semantics: in-app row + IM queue row commit together or neither
+     * does. Caller's try-catch isolates this recipient's failure from siblings.
+     */
+    public void maybeQueueForFanout(
+        long userId, NotificationCategory category,
+        String title, String body, Map<String, Object> data, String coalesceKey
+    ) {
+        doQueue(userId, category, title, body, data, coalesceKey);
+    }
+
+    private void doQueue(
+        long userId, NotificationCategory category,
+        String title, String body, Map<String, Object> data, String coalesceKey
+    ) {
+        User user = userRepo.findById(userId)
+            .orElseThrow(() -> new IllegalStateException("user not found: " + userId));
+
+        SlImChannelGate.Decision decision = gate.decide(user, category);
+        log.debug("SL IM gate decision userId={} category={}: {}", userId, category, decision);
+
+        switch (decision) {
+            case QUEUE, QUEUE_BYPASS_PREFS -> {
+                String deeplink = linkResolver.resolve(category, data);
+                String messageText = messageBuilder.assemble(title, body, deeplink);
+                dao.upsert(userId, user.getSlAvatarUuid(), messageText, coalesceKey);
+            }
+            case SKIP_NO_AVATAR, SKIP_MUTED, SKIP_GROUP_DISABLED -> {
+                // intentional no-op; decision logged at DEBUG above
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Modify `NotificationService.publish` to register the second afterCommit hook**
+
+Open `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationService.java`. Find the existing afterCommit registration for `wsBroadcaster.broadcastUpsert`. Add a sibling registration right after it for the SL IM dispatcher.
+
+```java
+// Add to imports if not present:
+import com.slparcelauctions.backend.notification.slim.SlImChannelDispatcher;
+
+// Add the new field to the class (with the existing @RequiredArgsConstructor):
+private final SlImChannelDispatcher slImChannelDispatcher;
+
+// In publish(NotificationEvent event), after the existing
+// TransactionSynchronizationManager.registerSynchronization for the WS broadcast,
+// register a second one for SL IM:
+
+TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+    @Override
+    public void afterCommit() {
+        slImChannelDispatcher.maybeQueue(event);
+    }
+});
+```
+
+The exact placement: read the existing `publish(...)` method, locate the existing `registerSynchronization` block, add the new one immediately after it. Constructor injection happens automatically via Lombok's `@RequiredArgsConstructor` — the new field is added in declaration order matching where you place it in the class body.
+
+- [ ] **Step 3: Modify `NotificationPublisherImpl.listingCancelledBySellerFanout` for sibling call**
+
+Open `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java`. Find `listingCancelledBySellerFanout(...)`. The current per-recipient loop wraps `notificationDao.upsert` in `requiresNewTxTemplate.execute(...)`. Add `slImChannelDispatcher.maybeQueueForFanout(...)` as a sibling call inside the same lambda:
+
+```java
+// Add to imports:
+import com.slparcelauctions.backend.notification.slim.SlImChannelDispatcher;
+
+// The constructor already takes a TransactionTemplate via @Qualifier (see Task 1
+// deviation in sub-spec 1). Add SlImChannelDispatcher as a constructor parameter:
+private final SlImChannelDispatcher slImChannelDispatcher;
+
+// Update the constructor parameter list to include slImChannelDispatcher.
+
+// In the listingCancelledBySellerFanout method, modify the loop body:
+TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+    @Override
+    public void afterCommit() {
+        for (Long bidderId : bidderUserIds) {
+            try {
+                UpsertResult result = requiresNewTxTemplate.execute(status -> {
+                    UpsertResult r = notificationDao.upsert(
+                        bidderId, NotificationCategory.LISTING_CANCELLED_BY_SELLER,
+                        title, body, data, /* coalesceKey */ null);
+                    slImChannelDispatcher.maybeQueueForFanout(    // ← NEW
+                        bidderId, NotificationCategory.LISTING_CANCELLED_BY_SELLER,
+                        title, body, data, /* coalesceKey */ null);
+                    return r;
+                });
+                wsBroadcaster.broadcastUpsert(bidderId, result, dtoFor(bidderId, result, data, title, body));
+            } catch (Exception ex) {
+                log.warn("Fan-out notification failed for userId={} auctionId={} category=LISTING_CANCELLED_BY_SELLER: {}",
+                    bidderId, auctionId, ex.toString());
+            }
+        }
+    }
+});
+```
+
+The lambda inside `requiresNewTxTemplate.execute` now does both DAO upsert AND dispatcher call. If the dispatcher throws, the entire REQUIRES_NEW for that recipient rolls back (in-app row + IM row both lost). Sibling recipients are unaffected because the outer `try-catch` catches before the next loop iteration.
+
+- [ ] **Step 4: Run existing notification tests to confirm the wiring change didn't break anything**
+
+Run: `cd backend && ./mvnw test -Dtest='NotificationServiceTest,NotificationPublisherImplTest'`
+Expected: previous baseline still green. The new dispatcher field is autowired but `@MockitoBean SlImChannelDispatcher` has not been added to existing tests — they'll inject the real bean which will try to write to the real `sl_im_message` table. That's fine; the existing tests don't exercise the dispatcher path because they don't use SL avatars or set prefs (default User state has no `slAvatarUuid`, so `gate.decide` returns `SKIP_NO_AVATAR` and no-op).
+
+If existing tests fail because of the wiring, the most likely cause is that `User.builder()...build()` constructs users with default `notifySlIm` somehow throwing — read the failure stack trace and confirm the User entity's defaults are non-null. The dispatcher catches exceptions in `maybeQueue` and only logs WARN; nothing should propagate to fail an existing test.
+
+- [ ] **Step 5: Write `SlImChannelDispatcherTest` — focused tests**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationEvent;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class SlImChannelDispatcherTest {
+
+    @Autowired SlImChannelDispatcher dispatcher;
+    @Autowired SlImMessageRepository repo;
+    @Autowired UserRepository userRepo;
+    @Autowired TransactionTemplate transactionTemplate;
+
+    private User userWithAvatarAndAllGroupsOn() {
+        User u = User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash")
+            .build();
+        u.setSlAvatarUuid(UUID.randomUUID().toString());
+        u.setNotifySlImMuted(false);
+        Map<String, Boolean> prefs = new HashMap<>();
+        prefs.put("bidding", true);
+        prefs.put("auction_result", true);
+        prefs.put("escrow", true);
+        prefs.put("listing_status", true);
+        prefs.put("reviews", true);
+        prefs.put("system", true);
+        u.setNotifySlIm(prefs);
+        return userRepo.save(u);
+    }
+
+    @BeforeEach
+    void clean() {
+        repo.deleteAll();
+    }
+
+    @Test
+    void maybeQueue_happyPath_insertsRowWithBuiltMessage() {
+        User u = userWithAvatarAndAllGroupsOn();
+        Map<String, Object> data = Map.of("auctionId", 42, "parcelName", "Hampton",
+            "currentBidL", 2000L, "isProxyOutbid", false, "endsAt", "2026-04-26T18:00:00Z");
+        NotificationEvent event = new NotificationEvent(
+            u.getId(), NotificationCategory.OUTBID,
+            "You've been outbid on Hampton", "Current bid is L$2,000.",
+            data, "outbid:" + u.getId() + ":42");
+
+        // Run inside a transaction so the dispatcher's REQUIRES_NEW commits independently.
+        transactionTemplate.execute(status -> {
+            dispatcher.maybeQueue(event);
+            return null;
+        });
+
+        List<SlImMessage> rows = repo.findAll();
+        assertThat(rows).hasSize(1);
+        SlImMessage row = rows.get(0);
+        assertThat(row.getUserId()).isEqualTo(u.getId());
+        assertThat(row.getAvatarUuid()).isEqualTo(u.getSlAvatarUuid());
+        assertThat(row.getStatus()).isEqualTo(SlImMessageStatus.PENDING);
+        assertThat(row.getMessageText()).startsWith("[SLPA] You've been outbid on Hampton");
+        assertThat(row.getMessageText()).contains("Current bid is L$2,000.");
+        assertThat(row.getMessageText()).endsWith("/auction/42");
+        assertThat(row.getCoalesceKey()).isEqualTo("outbid:" + u.getId() + ":42");
+    }
+
+    @Test
+    void maybeQueue_userMuted_doesNotQueue() {
+        User u = userWithAvatarAndAllGroupsOn();
+        u.setNotifySlImMuted(true);
+        userRepo.save(u);
+
+        NotificationEvent event = new NotificationEvent(
+            u.getId(), NotificationCategory.OUTBID, "title", "body",
+            Map.of("auctionId", 42), null);
+
+        transactionTemplate.execute(status -> { dispatcher.maybeQueue(event); return null; });
+
+        assertThat(repo.findAll()).isEmpty();
+    }
+
+    @Test
+    void maybeQueue_groupDisabled_doesNotQueue() {
+        User u = userWithAvatarAndAllGroupsOn();
+        Map<String, Boolean> prefs = new HashMap<>(u.getNotifySlIm());
+        prefs.put("bidding", false);
+        u.setNotifySlIm(prefs);
+        userRepo.save(u);
+
+        NotificationEvent event = new NotificationEvent(
+            u.getId(), NotificationCategory.OUTBID, "title", "body",
+            Map.of("auctionId", 42), null);
+
+        transactionTemplate.execute(status -> { dispatcher.maybeQueue(event); return null; });
+
+        assertThat(repo.findAll()).isEmpty();
+    }
+
+    @Test
+    void maybeQueue_noAvatar_doesNotQueue() {
+        User u = userWithAvatarAndAllGroupsOn();
+        u.setSlAvatarUuid(null);
+        userRepo.save(u);
+
+        NotificationEvent event = new NotificationEvent(
+            u.getId(), NotificationCategory.OUTBID, "title", "body",
+            Map.of("auctionId", 42), null);
+
+        transactionTemplate.execute(status -> { dispatcher.maybeQueue(event); return null; });
+
+        assertThat(repo.findAll()).isEmpty();
+    }
+
+    @Test
+    void maybeQueue_systemBypassesPrefs_evenWhenMuted() {
+        User u = userWithAvatarAndAllGroupsOn();
+        u.setNotifySlImMuted(true);
+        Map<String, Boolean> prefs = new HashMap<>(u.getNotifySlIm());
+        prefs.put("system", false);
+        u.setNotifySlIm(prefs);
+        userRepo.save(u);
+
+        NotificationEvent event = new NotificationEvent(
+            u.getId(), NotificationCategory.SYSTEM_ANNOUNCEMENT, "Heads up", "body",
+            Map.of(), null);
+
+        transactionTemplate.execute(status -> { dispatcher.maybeQueue(event); return null; });
+
+        assertThat(repo.findAll()).hasSize(1);
+    }
+
+    @Test
+    void maybeQueue_repeatedSameKey_coalescesToSingleRow() {
+        User u = userWithAvatarAndAllGroupsOn();
+        String key = "outbid:" + u.getId() + ":42";
+
+        for (int i = 1; i <= 5; i++) {
+            int currentBidL = 1000 + i * 100;
+            NotificationEvent event = new NotificationEvent(
+                u.getId(), NotificationCategory.OUTBID,
+                "You've been outbid", "Current bid is L$" + currentBidL,
+                Map.of("auctionId", 42, "currentBidL", (long) currentBidL,
+                    "isProxyOutbid", false, "parcelName", "Hampton",
+                    "endsAt", "2026-04-26T18:00:00Z"),
+                key);
+            transactionTemplate.execute(status -> { dispatcher.maybeQueue(event); return null; });
+        }
+
+        List<SlImMessage> rows = repo.findAll();
+        assertThat(rows).hasSize(1);
+        // Latest body wins:
+        assertThat(rows.get(0).getMessageText()).contains("Current bid is L$1500");
+    }
+
+    @Test
+    void maybeQueueForFanout_propagatesExceptionForCaller() {
+        User u = userWithAvatarAndAllGroupsOn();
+
+        // Force a failure inside doQueue by passing data missing the key the
+        // resolver needs. linkResolver.resolve(OUTBID, ...) reads data.get("auctionId")
+        // and concatenates it; missing key produces "/auction/null" — not a failure.
+        // Instead, force failure by passing a non-existent userId so userRepo.findById fails.
+        long missingUserId = 999_999_999L;
+
+        // Direct call (no requires_new wrapper) — caller is "already inside a REQUIRES_NEW".
+        // For this test we just verify the exception propagates.
+        org.assertj.core.api.Assertions.assertThatThrownBy(() ->
+            transactionTemplate.execute(status -> {
+                dispatcher.maybeQueueForFanout(missingUserId, NotificationCategory.OUTBID,
+                    "title", "body", Map.of("auctionId", 42), null);
+                return null;
+            }))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("user not found");
+    }
+}
+```
+
+- [ ] **Step 6: Run dispatcher tests — expect green**
+
+Run: `cd backend && ./mvnw test -Dtest=SlImChannelDispatcherTest`
+Expected: 7 tests pass.
+
+- [ ] **Step 7: Write `OutbidImIntegrationTest`**
+
+```java
+package com.slparcelauctions.backend.notification.slim.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.bid.BidService;
+import com.slparcelauctions.backend.notification.slim.SlImMessage;
+import com.slparcelauctions.backend.notification.slim.SlImMessageRepository;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+// Add other imports needed by the tests' fixture setup — copy from
+// BidPlacementIntegrationTest for the auction setup pattern.
+
+@SpringBootTest
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class OutbidImIntegrationTest {
+
+    @Autowired BidService bidService;
+    @Autowired SlImMessageRepository slImRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired AuctionRepository auctionRepo;
+
+    @BeforeEach
+    void clean() {
+        slImRepo.deleteAll();
+    }
+
+    @Test
+    void outbid_publishesSlImForBidderWithAvatarAndPrefsOn() {
+        User seller = saveUser(/* hasAvatar */ false, /* prefs */ true);
+        User alice = saveUser(/* hasAvatar */ true, /* prefs */ true);
+        User bob   = saveUser(/* hasAvatar */ true, /* prefs */ true);
+        Auction a = saveAuction(seller, 1000L);
+
+        bidService.placeBid(alice.getId(), a.getId(), 1500L);
+        bidService.placeBid(bob.getId(),   a.getId(), 2000L);
+
+        // Alice was displaced; she should have one PENDING SL IM row.
+        List<SlImMessage> aliceRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(alice.getId()))
+            .toList();
+        assertThat(aliceRows).hasSize(1);
+        assertThat(aliceRows.get(0).getMessageText())
+            .contains("[SLPA] You've been outbid")
+            .contains("L$2,000")
+            .endsWith("/auction/" + a.getId());
+
+        // Bob (the new high bidder) gets nothing on this side.
+        long bobRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(bob.getId())).count();
+        assertThat(bobRows).isZero();
+    }
+
+    @Test
+    void outbidStorm_coalescesIntoSingleRow_latestTextWins() {
+        User seller = saveUser(false, true);
+        User alice = saveUser(true, true);
+        User bob   = saveUser(true, true);
+        Auction a = saveAuction(seller, 1000L);
+
+        bidService.placeBid(alice.getId(), a.getId(), 1500L);
+        bidService.placeBid(bob.getId(),   a.getId(), 2000L);
+        bidService.placeBid(alice.getId(), a.getId(), 2500L);
+        bidService.placeBid(bob.getId(),   a.getId(), 3000L);
+        bidService.placeBid(alice.getId(), a.getId(), 3500L);
+        bidService.placeBid(bob.getId(),   a.getId(), 4000L);
+
+        // Alice was displaced 3 times. Coalesce key is the same each time.
+        // Expect ONE PENDING row with the latest text.
+        List<SlImMessage> aliceRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(alice.getId()))
+            .toList();
+        assertThat(aliceRows).hasSize(1);
+        assertThat(aliceRows.get(0).getMessageText()).contains("L$4,000");
+    }
+
+    @Test
+    void outbid_groupDisabled_skipsSlImButKeepsInAppRow() {
+        User seller = saveUser(false, true);
+        User alice = saveUser(true, /* prefs ON */ true);
+        // Disable bidding group for alice:
+        Map<String, Boolean> prefs = new HashMap<>(alice.getNotifySlIm());
+        prefs.put("bidding", false);
+        alice.setNotifySlIm(prefs);
+        userRepo.save(alice);
+
+        User bob = saveUser(true, true);
+        Auction a = saveAuction(seller, 1000L);
+
+        bidService.placeBid(alice.getId(), a.getId(), 1500L);
+        bidService.placeBid(bob.getId(),   a.getId(), 2000L);
+
+        // Alice has NO SL IM (group disabled), but she does have an in-app row
+        // (covered by sub-spec 1's notification table; not asserted here).
+        long aliceImRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(alice.getId())).count();
+        assertThat(aliceImRows).isZero();
+    }
+
+    @Test
+    void outbid_userMuted_skipsSlImButKeepsInAppRow() {
+        User seller = saveUser(false, true);
+        User alice = saveUser(true, true);
+        alice.setNotifySlImMuted(true);
+        userRepo.save(alice);
+
+        User bob = saveUser(true, true);
+        Auction a = saveAuction(seller, 1000L);
+
+        bidService.placeBid(alice.getId(), a.getId(), 1500L);
+        bidService.placeBid(bob.getId(),   a.getId(), 2000L);
+
+        long aliceImRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(alice.getId())).count();
+        assertThat(aliceImRows).isZero();
+    }
+
+    // --- Fixture helpers ---
+
+    private User saveUser(boolean hasAvatar, boolean groupPrefsOn) {
+        User u = User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash")
+            .build();
+        if (hasAvatar) {
+            u.setSlAvatarUuid(UUID.randomUUID().toString());
+        }
+        u.setNotifySlImMuted(false);
+        Map<String, Boolean> prefs = new HashMap<>();
+        prefs.put("bidding", groupPrefsOn);
+        prefs.put("auction_result", groupPrefsOn);
+        prefs.put("escrow", groupPrefsOn);
+        prefs.put("listing_status", groupPrefsOn);
+        prefs.put("reviews", groupPrefsOn);
+        prefs.put("system", true);
+        u.setNotifySlIm(prefs);
+        return userRepo.save(u);
+    }
+
+    private Auction saveAuction(User seller, long startBidL) {
+        // Copy this from BidPlacementIntegrationTest's fixture pattern. Adjust
+        // for your actual Auction entity API. The auction must be in OPEN
+        // state with a parcel + endsAt in the future.
+        // (Implementer: read backend/src/test/java/com/slparcelauctions/backend/auction/BidPlacementIntegrationTest.java
+        // and copy the exact fixture pattern that works in this repo.)
+        throw new UnsupportedOperationException(
+            "Implementer: copy Auction fixture from BidPlacementIntegrationTest.java");
+    }
+}
+```
+
+**Note for the implementer:** the `saveAuction(...)` helper at the bottom is intentionally left as a marker. Read `backend/src/test/java/com/slparcelauctions/backend/auction/BidPlacementIntegrationTest.java` (or whichever existing file successfully drives `bidService.placeBid` end-to-end) and copy its fixture pattern. The Auction setup is intricate (parcel, OPEN state, endsAt, currency precision); reusing the existing pattern is the right move.
+
+- [ ] **Step 8: Run the OUTBID integration test — expect green**
+
+Run: `cd backend && ./mvnw test -Dtest=OutbidImIntegrationTest`
+Expected: 4 tests pass.
+
+If `saveAuction` throws because the implementer skipped wiring it, fix it now by copying from the neighbor file.
+
+- [ ] **Step 9: Write `EscrowImIntegrationTest`**
+
+```java
+package com.slparcelauctions.backend.notification.slim.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// imports...
+
+@SpringBootTest
+@TestPropertySource(properties = { /* canonical disable set, see Task 1 Step 7 */ })
+class EscrowImIntegrationTest {
+
+    @Autowired EscrowService escrowService;
+    @Autowired SlImMessageRepository slImRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired AuctionRepository auctionRepo;
+    // ... other repos
+
+    @BeforeEach
+    void clean() { slImRepo.deleteAll(); }
+
+    @Test
+    void escrowFunded_queuesSellerOnly_notWinner() {
+        User seller = saveUser(true);
+        User winner = saveUser(true);
+        Auction a = saveSoldAuction(seller, winner, 5000L);
+        Escrow e = saveEscrow(a, /* status = AWAITING_PAYMENT */);
+
+        // Drive: winner pays into escrow
+        escrowService.markFunded(e.getId());
+
+        // Seller gets the IM, winner does not.
+        long sellerRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(seller.getId())).count();
+        long winnerRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(winner.getId())).count();
+        assertThat(sellerRows).isEqualTo(1L);
+        assertThat(winnerRows).isZero();
+    }
+
+    @Test
+    void transferConfirmed_queuesBothParties() {
+        User seller = saveUser(true);
+        User winner = saveUser(true);
+        Auction a = saveSoldAuction(seller, winner, 5000L);
+        Escrow e = saveEscrow(a, /* status = FUNDED */);
+
+        escrowService.markTransferConfirmed(e.getId());
+
+        long sellerRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(seller.getId())).count();
+        long winnerRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(winner.getId())).count();
+        assertThat(sellerRows).isEqualTo(1L);
+        assertThat(winnerRows).isEqualTo(1L);
+    }
+
+    @Test
+    void transferConfirmed_winnerMuted_onlySellerGetsIm() {
+        User seller = saveUser(true);
+        User winner = saveUser(true);
+        winner.setNotifySlImMuted(true);
+        userRepo.save(winner);
+
+        Auction a = saveSoldAuction(seller, winner, 5000L);
+        Escrow e = saveEscrow(a, /* status = FUNDED */);
+
+        escrowService.markTransferConfirmed(e.getId());
+
+        long sellerRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(seller.getId())).count();
+        long winnerRows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(winner.getId())).count();
+        assertThat(sellerRows).isEqualTo(1L);
+        assertThat(winnerRows).isZero();
+    }
+
+    @Test
+    void disputed_queuesBothParties() {
+        // Same shape — seller and winner both get an IM.
+        // Drive: escrowService.dispute(...) per the actual API signature.
+        // Assert: 2 IM rows, one per party.
+    }
+
+    @Test
+    void payout_queuesSellerOnly() {
+        // Drive: escrowService.markPayoutCompleted(...) (or equivalent).
+        // Assert: seller has 1 IM, winner has 0.
+    }
+
+    // --- Fixture helpers (copy from EscrowEndToEndIntegrationTest or
+    //     EscrowCreateOnAuctionEndIntegrationTest) ---
+    private User saveUser(boolean hasAvatar) { /* ... */ throw new UnsupportedOperationException("copy pattern"); }
+    private Auction saveSoldAuction(User seller, User winner, long winningBidL) { /* ... */ throw new UnsupportedOperationException("copy pattern"); }
+    private Escrow saveEscrow(Auction a /*, status */) { /* ... */ throw new UnsupportedOperationException("copy pattern"); }
+}
+```
+
+**Note for the implementer:** the helper bodies are markers. Read `EscrowEndToEndIntegrationTest.java` or `EscrowCreateOnAuctionEndIntegrationTest.java` and copy the working fixture pattern. The existing tests already drive escrows into specific states — reuse their setup verbatim.
+
+- [ ] **Step 10: Run the escrow integration test — expect green**
+
+Run: `cd backend && ./mvnw test -Dtest=EscrowImIntegrationTest`
+Expected: 5 tests pass.
+
+- [ ] **Step 11: Write `CancellationFanoutImIntegrationTest`**
+
+```java
+package com.slparcelauctions.backend.notification.slim.integration;
+
+// imports...
+
+@SpringBootTest
+@TestPropertySource(properties = { /* canonical disable set */ })
+class CancellationFanoutImIntegrationTest {
+
+    @Autowired CancellationService cancellationService;
+    @Autowired BidService bidService;
+    @Autowired SlImMessageRepository slImRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired AuctionRepository auctionRepo;
+
+    @BeforeEach
+    void clean() { slImRepo.deleteAll(); }
+
+    @Test
+    void cancel_threeActiveBidders_eachGetsOneSlImRow() {
+        User seller = saveUser(false);  // seller doesn't need avatar
+        User a = saveUser(true), b = saveUser(true), c = saveUser(true);
+        Auction au = saveAuction(seller, 1000L);
+
+        bidService.placeBid(a.getId(),  au.getId(), 1500L);
+        bidService.placeBid(b.getId(),  au.getId(), 2000L);
+        bidService.placeBid(c.getId(),  au.getId(), 2500L);
+        slImRepo.deleteAll();  // clear OUTBID rows from the bid placements
+
+        cancellationService.cancel(au.getId(), seller.getId(), "ownership lost");
+
+        // 3 IM rows, one per active bidder, all LISTING_CANCELLED_BY_SELLER.
+        var rows = slImRepo.findAll();
+        assertThat(rows).hasSize(3);
+        assertThat(rows.stream().map(m -> m.getUserId()).toList())
+            .containsExactlyInAnyOrder(a.getId(), b.getId(), c.getId());
+        assertThat(rows).allMatch(m -> m.getMessageText().contains("[SLPA] Listing cancelled"));
+        assertThat(rows).allMatch(m -> m.getMessageText().contains("ownership lost"));
+    }
+
+    @Test
+    void cancel_oneBidderListingStatusOff_thatBidderGetsNoSlIm() {
+        User seller = saveUser(false);
+        User a = saveUser(true);
+        User b = saveUser(true);
+        Map<String, Boolean> prefs = new HashMap<>(b.getNotifySlIm());
+        prefs.put("listing_status", false);
+        b.setNotifySlIm(prefs);
+        userRepo.save(b);
+
+        Auction au = saveAuction(seller, 1000L);
+        bidService.placeBid(a.getId(), au.getId(), 1500L);
+        bidService.placeBid(b.getId(), au.getId(), 2000L);
+        slImRepo.deleteAll();
+
+        cancellationService.cancel(au.getId(), seller.getId(), "ownership lost");
+
+        var rows = slImRepo.findAll();
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getUserId()).isEqualTo(a.getId());
+    }
+
+    @Test
+    void cancel_emptyActiveBidders_zeroSlImRows() {
+        User seller = saveUser(false);
+        Auction au = saveAuction(seller, 1000L);
+
+        cancellationService.cancel(au.getId(), seller.getId(), "no bidders");
+
+        assertThat(slImRepo.findAll()).isEmpty();
+    }
+
+    // --- Fixture helpers — copy from CancellationServiceTest or similar ---
+    private User saveUser(boolean hasAvatar) { /* ... */ throw new UnsupportedOperationException("copy pattern"); }
+    private Auction saveAuction(User seller, long startBidL) { /* ... */ throw new UnsupportedOperationException("copy pattern"); }
+}
+```
+
+- [ ] **Step 12: Run the fan-out integration test — expect green**
+
+Run: `cd backend && ./mvnw test -Dtest=CancellationFanoutImIntegrationTest`
+Expected: 3 tests pass.
+
+- [ ] **Step 13: Write `SystemBypassImIntegrationTest`**
+
+```java
+package com.slparcelauctions.backend.notification.slim.integration;
+
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationEvent;
+import com.slparcelauctions.backend.notification.NotificationService;
+// imports...
+
+@SpringBootTest
+@TestPropertySource(properties = { /* canonical disable set */ })
+class SystemBypassImIntegrationTest {
+
+    @Autowired NotificationService notificationService;
+    @Autowired SlImMessageRepository slImRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired TransactionTemplate tx;
+
+    @BeforeEach
+    void clean() { slImRepo.deleteAll(); }
+
+    @Test
+    void systemAnnouncement_mutedUserWithAvatar_getsIm() {
+        User u = saveUserAllOff(true);  // muted, all groups off, has avatar
+        u.setNotifySlImMuted(true);
+        userRepo.save(u);
+
+        publishSystem(u.getId(), "All systems normal", "Everything is fine.");
+
+        var rows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(u.getId())).toList();
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getMessageText()).contains("[SLPA] All systems normal");
+    }
+
+    @Test
+    void systemAnnouncement_mutedUserNoAvatar_skipsIm() {
+        User u = saveUserAllOff(false);  // muted, all groups off, NO avatar
+        u.setNotifySlImMuted(true);
+        userRepo.save(u);
+
+        publishSystem(u.getId(), "All systems normal", "Everything is fine.");
+
+        assertThat(slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(u.getId())).count()).isZero();
+    }
+
+    @Test
+    void systemAnnouncement_groupKeyExplicitlyFalse_stillBypasses() {
+        User u = saveUserAllOff(true);
+        Map<String, Boolean> prefs = new HashMap<>(u.getNotifySlIm());
+        prefs.put("system", false);  // explicitly false
+        u.setNotifySlIm(prefs);
+        userRepo.save(u);
+
+        publishSystem(u.getId(), "All systems normal", "Everything is fine.");
+
+        // SYSTEM bypasses prefs; the IM is queued.
+        assertThat(slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(u.getId())).count()).isEqualTo(1L);
+    }
+
+    private void publishSystem(long userId, String title, String body) {
+        // Synthetic SYSTEM_ANNOUNCEMENT publish via NotificationService directly.
+        // No publisher method exists for SYSTEM_ANNOUNCEMENT (Epic 10 trigger);
+        // tests construct the event inline.
+        NotificationEvent event = new NotificationEvent(
+            userId, NotificationCategory.SYSTEM_ANNOUNCEMENT,
+            title, body, Map.of(), /* coalesceKey */ null);
+        tx.execute(status -> {
+            notificationService.publish(event);
+            return null;
+        });
+    }
+
+    private User saveUserAllOff(boolean hasAvatar) {
+        User u = User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash").build();
+        if (hasAvatar) u.setSlAvatarUuid(UUID.randomUUID().toString());
+        u.setNotifySlImMuted(false);
+        Map<String, Boolean> prefs = new HashMap<>();
+        for (var g : List.of("bidding", "auction_result", "escrow",
+                              "listing_status", "reviews", "system")) {
+            prefs.put(g, false);
+        }
+        u.setNotifySlIm(prefs);
+        return userRepo.save(u);
+    }
+}
+```
+
+- [ ] **Step 14: Run the system-bypass test — expect green**
+
+Run: `cd backend && ./mvnw test -Dtest=SystemBypassImIntegrationTest`
+Expected: 3 tests pass.
+
+- [ ] **Step 15: Write `NoAvatarSkipImIntegrationTest`**
+
+```java
+package com.slparcelauctions.backend.notification.slim.integration;
+
+// imports...
+
+@SpringBootTest
+@TestPropertySource(properties = { /* canonical disable set */ })
+class NoAvatarSkipImIntegrationTest {
+
+    @Autowired NotificationService notificationService;
+    @Autowired SlImMessageRepository slImRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired TransactionTemplate tx;
+
+    @BeforeEach
+    void clean() { slImRepo.deleteAll(); }
+
+    @Test
+    void noAvatar_publishingMultipleCategories_zeroSlImRows() {
+        User u = saveUserAllOnButNoAvatar();
+
+        publish(u.getId(), NotificationCategory.OUTBID, "out", "body",
+            Map.of("auctionId", 42), "outbid:" + u.getId() + ":42");
+        publish(u.getId(), NotificationCategory.AUCTION_WON, "won", "body",
+            Map.of("auctionId", 42), null);
+        publish(u.getId(), NotificationCategory.ESCROW_FUNDED, "funded", "body",
+            Map.of("auctionId", 42, "escrowId", 100), null);
+
+        // Three categories published; in-app rows exist (sub-spec 1 territory).
+        // Zero SL IM rows because no avatar.
+        var rows = slImRepo.findAll().stream()
+            .filter(m -> m.getUserId().equals(u.getId())).toList();
+        assertThat(rows).isEmpty();
+    }
+
+    private void publish(long userId, NotificationCategory category, String title,
+                         String body, Map<String, Object> data, String coalesceKey) {
+        tx.execute(status -> {
+            notificationService.publish(new NotificationEvent(
+                userId, category, title, body, data, coalesceKey));
+            return null;
+        });
+    }
+
+    private User saveUserAllOnButNoAvatar() {
+        User u = User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash").build();
+        // slAvatarUuid intentionally null
+        u.setNotifySlImMuted(false);
+        Map<String, Boolean> prefs = new HashMap<>();
+        for (var g : List.of("bidding", "auction_result", "escrow",
+                              "listing_status", "reviews", "system")) {
+            prefs.put(g, true);
+        }
+        u.setNotifySlIm(prefs);
+        return userRepo.save(u);
+    }
+}
+```
+
+- [ ] **Step 16: Run the no-avatar test — expect green**
+
+Run: `cd backend && ./mvnw test -Dtest=NoAvatarSkipImIntegrationTest`
+Expected: 1 test passes.
+
+- [ ] **Step 17: Run the full backend suite — no regressions**
+
+Run: `cd backend && ./mvnw test`
+Expected: previous baseline (Task 2) + ~20 new tests, 0 failures.
+
+- [ ] **Step 18: Commit**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImChannelDispatcher.java \
+        backend/src/main/java/com/slparcelauctions/backend/notification/NotificationService.java \
+        backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java \
+        backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImChannelDispatcherTest.java \
+        backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/
+git commit -m "feat(sl-im): channel dispatcher + integration with publish() and fan-out"
+```
+
+---
+
+## Task 4 — Backend internal endpoints + terminal auth filter
+
+**Goal:** Land the three internal endpoints (`GET /pending`, `POST /{id}/delivered`, `POST /{id}/failed`) with the symmetric state machines, the shared-secret auth filter, the configuration properties, and full controller test coverage of the state machine matrix.
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/notification/slim/internal/SlImInternalProperties.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/notification/slim/internal/SlImTerminalAuthFilter.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/notification/slim/internal/SlImInternalController.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/config/WebSecurityConfig.java` (register filter + permitAll for internal path)
+- Modify: `backend/src/main/resources/application.yml` (shared secret + max batch limit)
+- Test: `backend/src/test/java/com/slparcelauctions/backend/notification/slim/internal/SlImInternalControllerTest.java`
+
+### Steps
+
+- [ ] **Step 1: Create `SlImInternalProperties`**
+
+```java
+package com.slparcelauctions.backend.notification.slim.internal;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties(prefix = "slpa.notifications.sl-im.dispatcher")
+@Validated
+public record SlImInternalProperties(
+    @NotBlank String sharedSecret,
+    @Positive @Max(50) int maxBatchLimit
+) {}
+```
+
+- [ ] **Step 2: Add the config block to application.yml**
+
+```yaml
+slpa:
+  # ... existing ...
+  notifications:
+    sl-im:
+      dispatcher:
+        shared-secret: ${SL_IM_DISPATCHER_SECRET:dev-only-secret-do-not-use-in-prod}
+        max-batch-limit: 50
+```
+
+- [ ] **Step 3: Create `SlImTerminalAuthFilter`**
+
+```java
+package com.slparcelauctions.backend.notification.slim.internal;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Shared-secret auth filter for {@code /api/v1/internal/sl-im/**}. Constant-time
+ * comparison via {@link MessageDigest#isEqual(byte[], byte[])} prevents secret
+ * inference via response timing.
+ */
+@Component
+@RequiredArgsConstructor
+public class SlImTerminalAuthFilter extends OncePerRequestFilter {
+
+    private final SlImInternalProperties props;
+    private static final String PATH_PREFIX = "/api/v1/internal/sl-im/";
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest req) {
+        return !req.getRequestURI().startsWith(PATH_PREFIX);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+        throws IOException, ServletException {
+        String header = req.getHeader("Authorization");
+        String expected = "Bearer " + props.sharedSecret();
+        boolean ok = header != null && MessageDigest.isEqual(
+            header.getBytes(StandardCharsets.UTF_8),
+            expected.getBytes(StandardCharsets.UTF_8));
+        if (!ok) {
+            res.setStatus(HttpStatus.UNAUTHORIZED.value());
+            res.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
+            res.getWriter().write(
+                "{\"type\":\"about:blank\",\"title\":\"Unauthorized\",\"status\":401}");
+            return;
+        }
+        chain.doFilter(req, res);
+    }
+}
+```
+
+- [ ] **Step 4: Register the filter in `WebSecurityConfig`**
+
+Open `backend/src/main/java/com/slparcelauctions/backend/config/WebSecurityConfig.java`. Find the `SecurityFilterChain` bean. Modify it to:
+
+1. Add `/api/v1/internal/sl-im/**` to the `permitAll()` matcher (so JWT processing doesn't reject the request — the shared-secret filter has already authenticated it).
+2. Add `/api/v1/internal/sl-im/**` to the CSRF-disabled matcher (no browser origin).
+3. Register `SlImTerminalAuthFilter` before `JwtAuthenticationFilter` (or whatever the existing JWT filter is named).
+
+The exact code depends on your existing security config. Pattern:
+
+```java
+// In SecurityFilterChain bean:
+http
+    .csrf(csrf -> csrf
+        .ignoringRequestMatchers("/api/v1/internal/**", /* ... existing ... */))
+    .authorizeHttpRequests(auth -> auth
+        .requestMatchers("/api/v1/internal/sl-im/**").permitAll()
+        // ... existing matchers ...
+    )
+    .addFilterBefore(slImTerminalAuthFilter, JwtAuthenticationFilter.class);
+```
+
+Read the existing config file before editing to avoid disturbing the existing structure. Constructor-inject `SlImTerminalAuthFilter` into the config class.
+
+- [ ] **Step 5: Create `SlImInternalController`**
+
+```java
+package com.slparcelauctions.backend.notification.slim.internal;
+
+import com.slparcelauctions.backend.notification.slim.SlImMessage;
+import com.slparcelauctions.backend.notification.slim.SlImMessageRepository;
+import com.slparcelauctions.backend.notification.slim.SlImMessageStatus;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/internal/sl-im")
+@RequiredArgsConstructor
+public class SlImInternalController {
+
+    private final SlImMessageRepository repo;
+    private final JdbcTemplate jdbc;
+    private final SlImInternalProperties props;
+
+    public record PendingItem(long id, String avatarUuid, String messageText) {}
+    public record PendingResponse(List<PendingItem> messages) {}
+
+    @GetMapping("/pending")
+    public PendingResponse pending(@RequestParam(defaultValue = "10") int limit) {
+        if (limit > props.maxBatchLimit() || limit < 1) {
+            throw new IllegalArgumentException(
+                "limit must be in [1, " + props.maxBatchLimit() + "]");
+        }
+        // FOR UPDATE SKIP LOCKED in pollPending() is advisory: this method isn't
+        // @Transactional, so the row lock releases when the query returns —
+        // before the LSL script delivers. Real multi-dispatcher dedup would need
+        // a PENDING → IN_PROGRESS → DELIVERED status transition.
+        List<SlImMessage> rows = repo.pollPending(limit);
+        List<PendingItem> items = rows.stream()
+            .map(m -> new PendingItem(m.getId(), m.getAvatarUuid(), m.getMessageText()))
+            .toList();
+        return new PendingResponse(items);
+    }
+
+    @PostMapping("/{id}/delivered")
+    public ResponseEntity<Void> delivered(@PathVariable long id) {
+        return transition(id, SlImMessageStatus.DELIVERED);
+    }
+
+    @PostMapping("/{id}/failed")
+    public ResponseEntity<Void> failed(@PathVariable long id) {
+        return transition(id, SlImMessageStatus.FAILED);
+    }
+
+    /**
+     * State machine for /delivered:
+     *   PENDING   → DELIVERED (204, set delivered_at)
+     *   DELIVERED → 204 no-op
+     *   FAILED    → 409
+     *   EXPIRED   → 409
+     *   missing   → 404
+     *
+     * State machine for /failed:
+     *   PENDING   → FAILED (204)
+     *   FAILED    → 204 no-op
+     *   DELIVERED → 409
+     *   EXPIRED   → 409
+     *   missing   → 404
+     *
+     * Implemented as a single conditional UPDATE returning affected rows count,
+     * with a follow-up read on the no-op path to determine the response.
+     */
+    private ResponseEntity<Void> transition(long id, SlImMessageStatus target) {
+        String sql = (target == SlImMessageStatus.DELIVERED)
+            ? """
+                UPDATE sl_im_message
+                SET status = 'DELIVERED',
+                    delivered_at = COALESCE(delivered_at, now()),
+                    updated_at = now(),
+                    attempts = attempts + 1
+                WHERE id = ? AND status = 'PENDING'
+                """
+            : """
+                UPDATE sl_im_message
+                SET status = 'FAILED',
+                    updated_at = now(),
+                    attempts = attempts + 1
+                WHERE id = ? AND status = 'PENDING'
+                """;
+        int updated = jdbc.update(sql, id);
+        if (updated == 1) {
+            return ResponseEntity.noContent().build();
+        }
+
+        Optional<SlImMessage> opt = repo.findById(id);
+        if (opt.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+        SlImMessageStatus current = opt.get().getStatus();
+        if (current == target) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    }
+}
+```
+
+- [ ] **Step 6: Write `SlImInternalControllerTest`**
+
+```java
+package com.slparcelauctions.backend.notification.slim.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.slparcelauctions.backend.notification.slim.SlImMessage;
+import com.slparcelauctions.backend.notification.slim.SlImMessageDao;
+import com.slparcelauctions.backend.notification.slim.SlImMessageRepository;
+import com.slparcelauctions.backend.notification.slim.SlImMessageStatus;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.notifications.sl-im.dispatcher.shared-secret=test-secret-12345",
+    "slpa.notifications.sl-im.dispatcher.max-batch-limit=50"
+})
+class SlImInternalControllerTest {
+
+    @Autowired MockMvc mvc;
+    @Autowired SlImMessageDao dao;
+    @Autowired SlImMessageRepository repo;
+    @Autowired UserRepository userRepo;
+
+    private static final String AUTH = "Bearer test-secret-12345";
+
+    private User user;
+    private String avatar;
+
+    @BeforeEach
+    void seed() {
+        repo.deleteAll();
+        user = userRepo.save(User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash").build());
+        avatar = UUID.randomUUID().toString();
+    }
+
+    // --- /pending ---
+
+    @Test
+    void pending_returnsBatchOldestFirst() throws Exception {
+        var first = dao.upsert(user.getId(), avatar, "[SLPA] first", null);
+        Thread.sleep(10);
+        var second = dao.upsert(user.getId(), avatar, "[SLPA] second", null);
+
+        mvc.perform(get("/api/v1/internal/sl-im/pending?limit=10").header("Authorization", AUTH))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.messages.length()").value(2))
+            .andExpect(jsonPath("$.messages[0].id").value((int) first.id()))
+            .andExpect(jsonPath("$.messages[1].id").value((int) second.id()))
+            .andExpect(jsonPath("$.messages[0].messageText").value("[SLPA] first"))
+            .andExpect(jsonPath("$.messages[0].avatarUuid").value(avatar));
+    }
+
+    @Test
+    void pending_limitOverMax_returns400() throws Exception {
+        mvc.perform(get("/api/v1/internal/sl-im/pending?limit=51").header("Authorization", AUTH))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void pending_limitBelowOne_returns400() throws Exception {
+        mvc.perform(get("/api/v1/internal/sl-im/pending?limit=0").header("Authorization", AUTH))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void pending_missingAuth_returns401() throws Exception {
+        mvc.perform(get("/api/v1/internal/sl-im/pending"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void pending_wrongAuth_returns401() throws Exception {
+        mvc.perform(get("/api/v1/internal/sl-im/pending").header("Authorization", "Bearer wrong"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    // --- /delivered state machine ---
+
+    @Test
+    void delivered_pendingRow_transitionsTo204AndSetsDeliveredAt() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/delivered").header("Authorization", AUTH))
+            .andExpect(status().isNoContent());
+
+        SlImMessage row = repo.findById(r.id()).orElseThrow();
+        assertThat(row.getStatus()).isEqualTo(SlImMessageStatus.DELIVERED);
+        assertThat(row.getDeliveredAt()).isNotNull();
+        assertThat(row.getAttempts()).isEqualTo(1);
+    }
+
+    @Test
+    void delivered_alreadyDelivered_idempotent204() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/delivered").header("Authorization", AUTH))
+            .andExpect(status().isNoContent());
+        SlImMessage afterFirst = repo.findById(r.id()).orElseThrow();
+        var deliveredAtBefore = afterFirst.getDeliveredAt();
+
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/delivered").header("Authorization", AUTH))
+            .andExpect(status().isNoContent());
+
+        SlImMessage row = repo.findById(r.id()).orElseThrow();
+        assertThat(row.getStatus()).isEqualTo(SlImMessageStatus.DELIVERED);
+        // delivered_at NOT re-stamped on idempotent call:
+        assertThat(row.getDeliveredAt()).isEqualTo(deliveredAtBefore);
+        // attempts NOT incremented (the WHERE clause excluded DELIVERED):
+        assertThat(row.getAttempts()).isEqualTo(1);
+    }
+
+    @Test
+    void delivered_onFailedRow_returns409() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+        SlImMessage row = repo.findById(r.id()).orElseThrow();
+        row.setStatus(SlImMessageStatus.FAILED);
+        repo.save(row);
+
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/delivered").header("Authorization", AUTH))
+            .andExpect(status().isConflict());
+    }
+
+    @Test
+    void delivered_onExpiredRow_returns409() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+        SlImMessage row = repo.findById(r.id()).orElseThrow();
+        row.setStatus(SlImMessageStatus.EXPIRED);
+        repo.save(row);
+
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/delivered").header("Authorization", AUTH))
+            .andExpect(status().isConflict());
+    }
+
+    @Test
+    void delivered_missing_returns404() throws Exception {
+        mvc.perform(post("/api/v1/internal/sl-im/999999/delivered").header("Authorization", AUTH))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void delivered_unauthorized_returns401() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/delivered"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    // --- /failed state machine ---
+
+    @Test
+    void failed_pendingRow_transitionsTo204() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/failed").header("Authorization", AUTH))
+            .andExpect(status().isNoContent());
+
+        SlImMessage row = repo.findById(r.id()).orElseThrow();
+        assertThat(row.getStatus()).isEqualTo(SlImMessageStatus.FAILED);
+        assertThat(row.getDeliveredAt()).isNull();
+        assertThat(row.getAttempts()).isEqualTo(1);
+    }
+
+    @Test
+    void failed_alreadyFailed_idempotent204() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/failed").header("Authorization", AUTH))
+            .andExpect(status().isNoContent());
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/failed").header("Authorization", AUTH))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void failed_onDeliveredRow_returns409() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+        SlImMessage row = repo.findById(r.id()).orElseThrow();
+        row.setStatus(SlImMessageStatus.DELIVERED);
+        repo.save(row);
+
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/failed").header("Authorization", AUTH))
+            .andExpect(status().isConflict());
+    }
+
+    @Test
+    void failed_onExpiredRow_returns409() throws Exception {
+        var r = dao.upsert(user.getId(), avatar, "[SLPA] x", null);
+        SlImMessage row = repo.findById(r.id()).orElseThrow();
+        row.setStatus(SlImMessageStatus.EXPIRED);
+        repo.save(row);
+
+        mvc.perform(post("/api/v1/internal/sl-im/" + r.id() + "/failed").header("Authorization", AUTH))
+            .andExpect(status().isConflict());
+    }
+
+    @Test
+    void failed_missing_returns404() throws Exception {
+        mvc.perform(post("/api/v1/internal/sl-im/999999/failed").header("Authorization", AUTH))
+            .andExpect(status().isNotFound());
+    }
+}
+```
+
+- [ ] **Step 7: Run controller tests — expect green**
+
+Run: `cd backend && ./mvnw test -Dtest=SlImInternalControllerTest`
+Expected: 16 tests pass.
+
+- [ ] **Step 8: Run the full backend suite — no regressions**
+
+Run: `cd backend && ./mvnw test`
+Expected: previous (Task 3) baseline + 16 new tests, 0 failures.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/notification/slim/internal/ \
+        backend/src/main/java/com/slparcelauctions/backend/config/WebSecurityConfig.java \
+        backend/src/main/resources/application.yml \
+        backend/src/test/java/com/slparcelauctions/backend/notification/slim/internal/SlImInternalControllerTest.java
+git commit -m "feat(sl-im): internal endpoints + shared-secret auth filter"
+```
+
+---
+
+## Task 5 — Backend cleanup job + properties + test sweep
+
+**Goal:** Land `SlImCleanupJob` running daily at 03:30 SLT (Spring zoned cron), with stage 1 PENDING→EXPIRED and stage 2 chunked DELETE for terminal-status rows past 30d retention. The INFO log captures `expired`, `deleted`, both cutoffs, and `top_users` (queried BEFORE the UPDATE). Sweep all existing `@SpringBootTest` files to add `slpa.notifications.sl-im.cleanup.enabled=false`.
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImCleanupProperties.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImCleanupJob.java`
+- Modify: `backend/src/main/resources/application.yml` (cleanup config block)
+- Modify: ALL existing `@SpringBootTest`+`@TestPropertySource` files (sweep — add the new disable property)
+- Test: `backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImCleanupJobTest.java`
+
+### Steps
+
+- [ ] **Step 1: Create `SlImCleanupProperties`**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties(prefix = "slpa.notifications.sl-im.cleanup")
+@Validated
+public record SlImCleanupProperties(
+    boolean enabled,
+    @NotBlank String cron,
+    @Positive int expiryAfterHours,
+    @Positive int retentionAfterDays,
+    @Positive int batchSize,
+    @Min(0) @Max(20) int topUsersInLog
+) {}
+```
+
+- [ ] **Step 2: Add the cleanup config block to application.yml**
+
+```yaml
+slpa:
+  # ... existing ...
+  notifications:
+    # ... existing notifications.cleanup ...
+    sl-im:
+      # ... existing dispatcher block from Task 4 ...
+      cleanup:
+        enabled: true
+        cron: "0 30 3 * * *"        # 03:30 daily, in zone below
+        expiry-after-hours: 48
+        retention-after-days: 30
+        batch-size: 1000
+        top-users-in-log: 10
+```
+
+- [ ] **Step 3: Create `SlImCleanupJob`**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "slpa.notifications.sl-im.cleanup",
+                       name = "enabled", havingValue = "true", matchIfMissing = false)
+@Slf4j
+public class SlImCleanupJob {
+
+    private final JdbcTemplate jdbc;
+    private final SlImCleanupProperties properties;
+    private final Clock clock;
+
+    @Scheduled(cron = "${slpa.notifications.sl-im.cleanup.cron}",
+               zone = "America/Los_Angeles")
+    public void run() {
+        OffsetDateTime expiryCutoff = OffsetDateTime.now(clock)
+            .minusHours(properties.expiryAfterHours());
+        OffsetDateTime retentionCutoff = OffsetDateTime.now(clock)
+            .minusDays(properties.retentionAfterDays());
+
+        // Capture top users BEFORE the UPDATE (otherwise the WHERE clause no
+        // longer matches the rows that just transitioned).
+        List<Map<String, Object>> topUsers = jdbc.queryForList("""
+            SELECT user_id, COUNT(*) AS n
+            FROM sl_im_message
+            WHERE status = 'PENDING' AND created_at < ?
+            GROUP BY user_id
+            ORDER BY n DESC
+            LIMIT ?
+            """, expiryCutoff, properties.topUsersInLog());
+
+        int expired = jdbc.update("""
+            UPDATE sl_im_message
+            SET status = 'EXPIRED', updated_at = now()
+            WHERE status = 'PENDING' AND created_at < ?
+            """, expiryCutoff);
+
+        int totalDeleted = 0;
+        int deletedThisChunk;
+        do {
+            deletedThisChunk = jdbc.update("""
+                DELETE FROM sl_im_message
+                WHERE id IN (
+                    SELECT id FROM sl_im_message
+                    WHERE status IN ('DELIVERED','EXPIRED','FAILED')
+                      AND updated_at < ?
+                    LIMIT ?
+                )
+                """, retentionCutoff, properties.batchSize());
+            totalDeleted += deletedThisChunk;
+        } while (deletedThisChunk == properties.batchSize());
+
+        String topUsersStr = topUsers.stream()
+            .map(r -> r.get("user_id") + ":" + r.get("n"))
+            .collect(Collectors.joining(", "));
+        log.info("SL IM cleanup sweep: expired={} deleted={} expiry_cutoff={} retention_cutoff={} top_users=[{}]",
+            expired, totalDeleted, expiryCutoff, retentionCutoff, topUsersStr);
+    }
+}
+```
+
+- [ ] **Step 4: Sweep existing tests to add the new disable property**
+
+Find every `@SpringBootTest` + `@TestPropertySource` test file:
+
+Run: `cd backend && grep -lr "@TestPropertySource" src/test/java`
+
+For EACH file in the output that uses `properties = { ... }`, open it and add `"slpa.notifications.sl-im.cleanup.enabled=false",` to the array. Do not remove or reorder existing properties — only add the new one.
+
+This sweep is the toll for adding a new `@Scheduled` job. Sub-spec 1 went through the same exercise for `slpa.notifications.cleanup.enabled=false`. Same pattern.
+
+After the sweep, run: `cd backend && ./mvnw test -Dtest='*Test' -DfailIfNoTests=false`
+Expected: all tests still green.
+
+- [ ] **Step 5: Write `SlImCleanupJobTest`**
+
+```java
+package com.slparcelauctions.backend.notification.slim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import nl.altindag.log.LogCaptor;  // verify the project's LogCaptor library + version
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockitoBean;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=true",
+    "slpa.notifications.sl-im.cleanup.cron=0 0 0 * * *",  // never fires during test
+    "slpa.notifications.sl-im.cleanup.expiry-after-hours=48",
+    "slpa.notifications.sl-im.cleanup.retention-after-days=30",
+    "slpa.notifications.sl-im.cleanup.batch-size=1000",
+    "slpa.notifications.sl-im.cleanup.top-users-in-log=10",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class SlImCleanupJobTest {
+
+    @Autowired SlImCleanupJob job;
+    @Autowired SlImMessageDao dao;
+    @Autowired SlImMessageRepository repo;
+    @Autowired UserRepository userRepo;
+    @Autowired JdbcTemplate jdbc;
+
+    @MockitoBean Clock clock;
+
+    @Test
+    void run_expiresPendingOlderThan48h_keepsNewer_deletesTerminalOlderThan30d() {
+        when(clock.instant()).thenReturn(Instant.parse("2026-04-26T08:30:00Z"));
+        when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+
+        User u = userRepo.save(User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash").build());
+        String avatar = UUID.randomUUID().toString();
+
+        // 49h-old PENDING — should expire
+        var stalePending = dao.upsert(u.getId(), avatar, "[SLPA] stale", "k1");
+        forceCreatedAt(stalePending.id(), "2026-04-24T07:00:00Z");
+
+        // 47h-old PENDING — should stay
+        var freshPending = dao.upsert(u.getId(), avatar, "[SLPA] fresh", "k2");
+        forceCreatedAt(freshPending.id(), "2026-04-24T10:00:00Z");
+
+        // 31d-old DELIVERED — should be deleted
+        var oldDelivered = dao.upsert(u.getId(), avatar, "[SLPA] old-d", "k3");
+        forceStatusAndUpdatedAt(oldDelivered.id(), "DELIVERED", "2026-03-25T08:30:00Z");
+
+        // 31d-old FAILED — should be deleted
+        var oldFailed = dao.upsert(u.getId(), avatar, "[SLPA] old-f", "k4");
+        forceStatusAndUpdatedAt(oldFailed.id(), "FAILED", "2026-03-25T08:30:00Z");
+
+        // 31d-old EXPIRED — should be deleted
+        var oldExpired = dao.upsert(u.getId(), avatar, "[SLPA] old-e", "k5");
+        forceStatusAndUpdatedAt(oldExpired.id(), "EXPIRED", "2026-03-25T08:30:00Z");
+
+        // 29d-old DELIVERED — should stay
+        var newishDelivered = dao.upsert(u.getId(), avatar, "[SLPA] newish", "k6");
+        forceStatusAndUpdatedAt(newishDelivered.id(), "DELIVERED", "2026-03-29T08:30:00Z");
+
+        job.run();
+
+        // stalePending → EXPIRED
+        assertThat(repo.findById(stalePending.id()).orElseThrow().getStatus())
+            .isEqualTo(SlImMessageStatus.EXPIRED);
+        // freshPending → still PENDING
+        assertThat(repo.findById(freshPending.id()).orElseThrow().getStatus())
+            .isEqualTo(SlImMessageStatus.PENDING);
+        // 31d terminal-status rows deleted
+        assertThat(repo.findById(oldDelivered.id())).isEmpty();
+        assertThat(repo.findById(oldFailed.id())).isEmpty();
+        assertThat(repo.findById(oldExpired.id())).isEmpty();
+        // 29d DELIVERED — still present
+        assertThat(repo.findById(newishDelivered.id())).isPresent();
+    }
+
+    @Test
+    void run_logsInfoLineWithExpectedFields() {
+        when(clock.instant()).thenReturn(Instant.parse("2026-04-26T08:30:00Z"));
+        when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+
+        User u = userRepo.save(User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash").build());
+        String avatar = UUID.randomUUID().toString();
+
+        var p = dao.upsert(u.getId(), avatar, "[SLPA] stale", null);
+        forceCreatedAt(p.id(), "2026-04-24T07:00:00Z");
+
+        try (LogCaptor captor = LogCaptor.forClass(SlImCleanupJob.class)) {
+            job.run();
+
+            assertThat(captor.getInfoLogs()).anyMatch(line ->
+                line.contains("SL IM cleanup sweep")
+                    && line.contains("expired=1")
+                    && line.contains("deleted=")
+                    && line.contains("expiry_cutoff=")
+                    && line.contains("retention_cutoff=")
+                    && line.contains("top_users=[" + u.getId() + ":1"));
+        }
+    }
+
+    @Test
+    void run_chunkedDelete_handlesLargeBacklog() {
+        when(clock.instant()).thenReturn(Instant.parse("2026-04-26T08:30:00Z"));
+        when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+
+        User u = userRepo.save(User.builder()
+            .email("u-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash").build());
+        String avatar = UUID.randomUUID().toString();
+
+        // Seed 25 deletable DELIVERED rows with batch_size = 10 (override via @TestPropertySource
+        // would be cleanest; here we exercise the loop with the default batch).
+        // Instead, with batch=1000 (default), assert the loop just runs once and clears all 25.
+        for (int i = 0; i < 25; i++) {
+            var r = dao.upsert(u.getId(), avatar, "[SLPA] msg-" + i, "k" + i);
+            forceStatusAndUpdatedAt(r.id(), "DELIVERED", "2026-03-20T00:00:00Z");
+        }
+
+        job.run();
+
+        // All 25 rows deleted (batch covers them).
+        long remaining = repo.findAll().stream()
+            .filter(m -> m.getUserId().equals(u.getId())).count();
+        assertThat(remaining).isZero();
+    }
+
+    private void forceCreatedAt(long id, String iso) {
+        jdbc.update("UPDATE sl_im_message SET created_at = ? WHERE id = ?",
+            OffsetDateTime.parse(iso), id);
+    }
+
+    private void forceStatusAndUpdatedAt(long id, String status, String iso) {
+        jdbc.update("UPDATE sl_im_message SET status = ?::varchar, updated_at = ? WHERE id = ?",
+            status, OffsetDateTime.parse(iso), id);
+    }
+}
+```
+
+**Note:** verify `LogCaptor` is the library used by the existing tests. Search: `grep -r "LogCaptor" backend/src/test`. Match the import (`nl.altindag.log.LogCaptor` is the most common Java LogCaptor). If a different log-capture library is in use, swap to that.
+
+- [ ] **Step 6: Run cleanup tests — expect green**
+
+Run: `cd backend && ./mvnw test -Dtest=SlImCleanupJobTest`
+Expected: 3 tests pass.
+
+- [ ] **Step 7: Run the full backend suite — confirm sweep didn't break anything**
+
+Run: `cd backend && ./mvnw test`
+Expected: previous baseline (Task 4) + 3 new tests, 0 failures across all swept files.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImCleanupJob.java \
+        backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImCleanupProperties.java \
+        backend/src/main/resources/application.yml \
+        backend/src/test/java/com/slparcelauctions/backend/notification/slim/SlImCleanupJobTest.java \
+        backend/src/test/java/com/slparcelauctions/backend/  # all swept test files
+git commit -m "feat(sl-im): cleanup job + 30d retention + INFO canary log"
+```
+
+---
+
+## Task 6 — Backend preferences controller
+
+**Goal:** Land `GET`/`PUT /api/v1/users/me/notification-preferences` with closed-shape validation. Reject `system`, `realty_group`, and `marketing` keys with 400. Preserve non-visible JSONB keys on PUT (merge, don't replace).
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/notification/preferences/NotificationPreferencesController.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/notification/preferences/PreferencesDto.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/notification/preferences/NotificationPreferencesControllerTest.java`
+
+### Steps
+
+- [ ] **Step 1: Create `PreferencesDto`**
+
+```java
+package com.slparcelauctions.backend.notification.preferences;
+
+import java.util.Map;
+
+public record PreferencesDto(
+    boolean slImMuted,
+    Map<String, Boolean> slIm
+) {}
+```
+
+- [ ] **Step 2: Create `NotificationPreferencesController`**
+
+```java
+package com.slparcelauctions.backend.notification.preferences;
+
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.common.exception.BadRequestException;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users/me/notification-preferences")
+@RequiredArgsConstructor
+@PreAuthorize("isAuthenticated()")
+public class NotificationPreferencesController {
+
+    private final UserRepository userRepo;
+
+    /**
+     * The closed set of group keys the UI can edit. SYSTEM is delivered
+     * regardless; REALTY_GROUP and MARKETING have no shipping categories yet.
+     * Server is the source of truth for what's user-mutable.
+     */
+    private static final Set<String> ALLOWED_GROUP_KEYS = Set.of(
+        "bidding", "auction_result", "escrow", "listing_status", "reviews");
+
+    @GetMapping
+    public PreferencesDto get(@AuthenticationPrincipal AuthPrincipal caller) {
+        User user = userRepo.findById(caller.userId()).orElseThrow();
+        Map<String, Boolean> filtered = ALLOWED_GROUP_KEYS.stream()
+            .collect(Collectors.toMap(
+                k -> k,
+                k -> user.getNotifySlIm() == null
+                    ? false
+                    : user.getNotifySlIm().getOrDefault(k, false)
+            ));
+        return new PreferencesDto(user.isNotifySlImMuted(), filtered);
+    }
+
+    @PutMapping
+    @Transactional
+    public PreferencesDto put(
+        @AuthenticationPrincipal AuthPrincipal caller,
+        @RequestBody PreferencesDto body
+    ) {
+        if (body.slIm() == null || !body.slIm().keySet().equals(ALLOWED_GROUP_KEYS)) {
+            throw new BadRequestException(
+                "slIm must contain exactly these keys: " + ALLOWED_GROUP_KEYS);
+        }
+        // Map<String,Boolean> via Jackson rejects non-boolean values at deserialization.
+
+        User user = userRepo.findById(caller.userId()).orElseThrow();
+        user.setNotifySlImMuted(body.slImMuted());
+
+        // Merge into existing map: preserve keys we don't expose (system,
+        // realty_group, marketing) at their existing/default values.
+        Map<String, Boolean> merged = user.getNotifySlIm() == null
+            ? new HashMap<>()
+            : new HashMap<>(user.getNotifySlIm());
+        merged.putAll(body.slIm());
+        user.setNotifySlIm(merged);
+        userRepo.save(user);
+
+        return get(caller);
+    }
+}
+```
+
+If `BadRequestException` doesn't exist in `common.exception`, check what existing controllers use for 400-on-validation. Likely candidates: `IllegalArgumentException` (handled by `GlobalExceptionHandler` from sub-spec 1, Task 2), or a project-specific `BadRequestException`. Match the existing codebase pattern.
+
+- [ ] **Step 3: Write `NotificationPreferencesControllerTest`**
+
+```java
+package com.slparcelauctions.backend.notification.preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.escrow.scheduler.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.refresh-token-cleanup.enabled=false",
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false"
+})
+class NotificationPreferencesControllerTest {
+
+    @Autowired MockMvc mvc;
+    @Autowired UserRepository userRepo;
+    @Autowired JwtService jwt;
+    @Autowired ObjectMapper objectMapper;
+
+    private User alice;
+    private User bob;
+    private String aliceJwt;
+    private String bobJwt;
+
+    @BeforeEach
+    void seed() {
+        alice = userRepo.save(User.builder()
+            .email("alice-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash").build());
+        bob = userRepo.save(User.builder()
+            .email("bob-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("hash").build());
+
+        aliceJwt = jwt.issueAccessToken(new AuthPrincipal(
+            alice.getId(), alice.getEmail(), alice.getTokenVersion())).token();
+        bobJwt = jwt.issueAccessToken(new AuthPrincipal(
+            bob.getId(), bob.getEmail(), bob.getTokenVersion())).token();
+    }
+
+    @Test
+    void get_returnsClosedShapeMap() throws Exception {
+        mvc.perform(get("/api/v1/users/me/notification-preferences")
+                .header("Authorization", "Bearer " + aliceJwt))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.slImMuted").value(false))
+            .andExpect(jsonPath("$.slIm.bidding").exists())
+            .andExpect(jsonPath("$.slIm.auction_result").exists())
+            .andExpect(jsonPath("$.slIm.escrow").exists())
+            .andExpect(jsonPath("$.slIm.listing_status").exists())
+            .andExpect(jsonPath("$.slIm.reviews").exists())
+            .andExpect(jsonPath("$.slIm.system").doesNotExist())
+            .andExpect(jsonPath("$.slIm.realty_group").doesNotExist())
+            .andExpect(jsonPath("$.slIm.marketing").doesNotExist());
+    }
+
+    @Test
+    void put_happyPath_persistsAndReturnsNewState() throws Exception {
+        Map<String, Object> body = Map.of(
+            "slImMuted", false,
+            "slIm", Map.of(
+                "bidding", true,
+                "auction_result", true,
+                "escrow", true,
+                "listing_status", false,
+                "reviews", true
+            )
+        );
+
+        mvc.perform(put("/api/v1/users/me/notification-preferences")
+                .header("Authorization", "Bearer " + aliceJwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.slIm.listing_status").value(false))
+            .andExpect(jsonPath("$.slIm.reviews").value(true));
+
+        // Persisted on User entity
+        User updated = userRepo.findById(alice.getId()).orElseThrow();
+        assertThat(updated.getNotifySlIm().get("listing_status")).isFalse();
+        assertThat(updated.getNotifySlIm().get("reviews")).isTrue();
+    }
+
+    @Test
+    void put_preservesUnexposedKeys() throws Exception {
+        // Pre-set system=true on alice (matches default).
+        Map<String, Boolean> initial = new HashMap<>(alice.getNotifySlIm());
+        initial.put("system", true);
+        initial.put("realty_group", false);
+        alice.setNotifySlIm(initial);
+        userRepo.save(alice);
+
+        Map<String, Object> body = Map.of(
+            "slImMuted", false,
+            "slIm", Map.of(
+                "bidding", false,
+                "auction_result", true,
+                "escrow", true,
+                "listing_status", true,
+                "reviews", true
+            )
+        );
+
+        mvc.perform(put("/api/v1/users/me/notification-preferences")
+                .header("Authorization", "Bearer " + aliceJwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)))
+            .andExpect(status().isOk());
+
+        User updated = userRepo.findById(alice.getId()).orElseThrow();
+        // Visible keys updated:
+        assertThat(updated.getNotifySlIm().get("bidding")).isFalse();
+        // Unexposed keys preserved:
+        assertThat(updated.getNotifySlIm().get("system")).isTrue();
+        assertThat(updated.getNotifySlIm().get("realty_group")).isFalse();
+    }
+
+    @Test
+    void put_systemKey_returns400() throws Exception {
+        Map<String, Object> body = Map.of(
+            "slImMuted", false,
+            "slIm", Map.of(
+                "bidding", true,
+                "auction_result", true,
+                "escrow", true,
+                "listing_status", true,
+                "reviews", true,
+                "system", false  // ← rejected
+            )
+        );
+
+        mvc.perform(put("/api/v1/users/me/notification-preferences")
+                .header("Authorization", "Bearer " + aliceJwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void put_realtyGroupKey_returns400() throws Exception {
+        Map<String, Object> body = Map.of(
+            "slImMuted", false,
+            "slIm", Map.of(
+                "bidding", true,
+                "auction_result", true,
+                "escrow", true,
+                "listing_status", true,
+                "reviews", true,
+                "realty_group", true
+            )
+        );
+
+        mvc.perform(put("/api/v1/users/me/notification-preferences")
+                .header("Authorization", "Bearer " + aliceJwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void put_missingKey_returns400() throws Exception {
+        Map<String, Object> body = Map.of(
+            "slImMuted", false,
+            "slIm", Map.of(
+                "bidding", true,
+                "auction_result", true,
+                "escrow", true,
+                "listing_status", true
+                // missing "reviews"
+            )
+        );
+
+        mvc.perform(put("/api/v1/users/me/notification-preferences")
+                .header("Authorization", "Bearer " + aliceJwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void put_nonBooleanValue_returns400() throws Exception {
+        // Send raw JSON with a string where a boolean is expected.
+        String rawBody = """
+            {
+              "slImMuted": false,
+              "slIm": {
+                "bidding": "true",
+                "auction_result": true,
+                "escrow": true,
+                "listing_status": true,
+                "reviews": true
+              }
+            }""";
+
+        mvc.perform(put("/api/v1/users/me/notification-preferences")
+                .header("Authorization", "Bearer " + aliceJwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(rawBody))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void get_unauthenticated_returns401() throws Exception {
+        mvc.perform(get("/api/v1/users/me/notification-preferences"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void put_unauthenticated_returns401() throws Exception {
+        mvc.perform(put("/api/v1/users/me/notification-preferences")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void crossUser_aliceCannotAccessBobsPreferences() throws Exception {
+        // Bob's PUT updates Bob's prefs, not Alice's. Same endpoint path; the
+        // principal is the discriminator.
+        Map<String, Object> body = Map.of(
+            "slImMuted", true,
+            "slIm", Map.of(
+                "bidding", false, "auction_result", false,
+                "escrow", false, "listing_status", false, "reviews", false
+            )
+        );
+
+        mvc.perform(put("/api/v1/users/me/notification-preferences")
+                .header("Authorization", "Bearer " + bobJwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)))
+            .andExpect(status().isOk());
+
+        User aliceFresh = userRepo.findById(alice.getId()).orElseThrow();
+        User bobFresh = userRepo.findById(bob.getId()).orElseThrow();
+        assertThat(aliceFresh.isNotifySlImMuted()).isFalse();  // unchanged
+        assertThat(bobFresh.isNotifySlImMuted()).isTrue();      // updated
+    }
+}
+```
+
+- [ ] **Step 4: Run preferences tests — expect green**
+
+Run: `cd backend && ./mvnw test -Dtest=NotificationPreferencesControllerTest`
+Expected: 10 tests pass.
+
+- [ ] **Step 5: Run the full backend suite**
+
+Run: `cd backend && ./mvnw test`
+Expected: previous (Task 5) baseline + 10 new tests, 0 failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/notification/preferences/ \
+        backend/src/test/java/com/slparcelauctions/backend/notification/preferences/
+git commit -m "feat(sl-im): notification preferences controller + closed-shape PUT validation"
+```
+
+---
+
+## Task 7 — Frontend foundations: types, queryKeys, REST client, hooks, MSW
+
+**Goal:** Land non-UI frontend infrastructure: TypeScript types matching the backend DTO, queryKey extension, the REST client for prefs, two hooks (`useNotificationPreferences`, `useUpdateNotificationPreferences` with optimistic + rollback), MSW handlers + fixtures.
+
+**Files:**
+- Create: `frontend/src/lib/notifications/preferencesTypes.ts`
+- Create: `frontend/src/lib/notifications/preferencesApi.ts`
+- Modify: `frontend/src/lib/notifications/queryKeys.ts` (extend with `preferences()`)
+- Create: `frontend/src/hooks/notifications/useNotificationPreferences.ts`
+- Create: `frontend/src/hooks/notifications/useUpdateNotificationPreferences.ts`
+- Modify: `frontend/src/test/msw/handlers.ts` (add prefs handlers + helpers)
+- Modify: `frontend/src/test/msw/fixtures.ts` (add default prefs fixture)
+- Test: `frontend/src/hooks/notifications/useNotificationPreferences.test.tsx`
+- Test: `frontend/src/hooks/notifications/useUpdateNotificationPreferences.test.tsx`
+
+### Steps
+
+- [ ] **Step 1: Create `lib/notifications/preferencesTypes.ts`**
+
+```ts
+import type { NotificationGroup } from "./types";
+
+// Closed shape: exactly the user-mutable groups. SYSTEM/REALTY_GROUP/MARKETING
+// are excluded by server contract — sending them returns 400.
+export type EditableGroup =
+  | "bidding" | "auction_result" | "escrow" | "listing_status" | "reviews";
+
+export interface PreferencesDto {
+  slImMuted: boolean;
+  slIm: Record<EditableGroup, boolean>;
+}
+
+export const EDITABLE_GROUPS: EditableGroup[] = [
+  "bidding", "auction_result", "escrow", "listing_status", "reviews",
+];
+
+export const GROUP_LABELS: Record<EditableGroup, string> = {
+  bidding: "Bidding",
+  auction_result: "Auction Result",
+  escrow: "Escrow",
+  listing_status: "Listings",
+  reviews: "Reviews",
+};
+
+export const GROUP_SUBTEXT: Record<EditableGroup, string> = {
+  bidding: "Outbid, proxy exhausted",
+  auction_result: "Won, lost, ended (sold/reserve/no-bids/buy-now)",
+  escrow: "Funded, transfer confirmed, payout, expired, disputed, frozen, payout stalled",
+  listing_status: "Verified, suspended, review required, cancelled by seller",
+  reviews: "New review received",
+};
+```
+
+- [ ] **Step 2: Extend `lib/notifications/queryKeys.ts`**
+
+Open the existing file from sub-spec 1's Task 6. Add:
+
+```ts
+export const notificationKeys = {
+  // ... existing entries ...
+  preferences: () => [...notificationKeys.all, "preferences"] as const,
+};
+```
+
+- [ ] **Step 3: Create `lib/notifications/preferencesApi.ts`**
+
+```ts
+import { api } from "@/lib/api";
+import type { PreferencesDto } from "./preferencesTypes";
+
+export async function getNotificationPreferences(): Promise<PreferencesDto> {
+  return api.get<PreferencesDto>("/api/v1/users/me/notification-preferences");
+}
+
+export async function putNotificationPreferences(
+  body: PreferencesDto
+): Promise<PreferencesDto> {
+  return api.put<PreferencesDto>("/api/v1/users/me/notification-preferences", body);
+}
+```
+
+- [ ] **Step 4: Create `hooks/notifications/useNotificationPreferences.ts`**
+
+```ts
+import { useQuery } from "@tanstack/react-query";
+import { getNotificationPreferences } from "@/lib/notifications/preferencesApi";
+import { notificationKeys } from "@/lib/notifications/queryKeys";
+
+export function useNotificationPreferences() {
+  return useQuery({
+    queryKey: notificationKeys.preferences(),
+    queryFn: () => getNotificationPreferences(),
+    staleTime: 60_000,
+  });
+}
+```
+
+- [ ] **Step 5: Create `hooks/notifications/useUpdateNotificationPreferences.ts`**
+
+```ts
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { putNotificationPreferences } from "@/lib/notifications/preferencesApi";
+import { notificationKeys } from "@/lib/notifications/queryKeys";
+import type { PreferencesDto } from "@/lib/notifications/preferencesTypes";
+import { useToast } from "@/components/ui/Toast";
+
+export function useUpdateNotificationPreferences() {
+  const qc = useQueryClient();
+  const toast = useToast();
+  return useMutation({
+    mutationFn: (payload: PreferencesDto) => putNotificationPreferences(payload),
+    onMutate: async (payload) => {
+      await qc.cancelQueries({ queryKey: notificationKeys.preferences() });
+      const prev = qc.getQueryData<PreferencesDto>(notificationKeys.preferences());
+      qc.setQueryData(notificationKeys.preferences(), payload);
+      return { prev };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.prev) {
+        qc.setQueryData(notificationKeys.preferences(), ctx.prev);
+      }
+      toast.push("error", "Couldn't save preferences");
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: notificationKeys.preferences() });
+      qc.invalidateQueries({ queryKey: ["currentUser"] });
+    },
+  });
+}
+```
+
+- [ ] **Step 6: Extend MSW handlers**
+
+Open `frontend/src/test/msw/handlers.ts`. Add:
+
+```ts
+import type { PreferencesDto, EditableGroup } from "@/lib/notifications/preferencesTypes";
+
+const DEFAULT_PREFERENCES: PreferencesDto = {
+  slImMuted: false,
+  slIm: {
+    bidding: true,
+    auction_result: true,
+    escrow: true,
+    listing_status: true,
+    reviews: false,
+  },
+};
+
+let currentPreferences: PreferencesDto = { ...DEFAULT_PREFERENCES };
+const ALLOWED: Set<string> = new Set(
+  ["bidding", "auction_result", "escrow", "listing_status", "reviews"]);
+
+export const preferencesHandlers = [
+  http.get("/api/v1/users/me/notification-preferences", () => {
+    return HttpResponse.json(currentPreferences);
+  }),
+  http.put("/api/v1/users/me/notification-preferences", async ({ request }) => {
+    const body = (await request.json()) as PreferencesDto;
+    if (!body.slIm) {
+      return new HttpResponse(null, { status: 400 });
+    }
+    const keys = new Set(Object.keys(body.slIm));
+    if (keys.size !== ALLOWED.size || ![...keys].every((k) => ALLOWED.has(k))) {
+      return new HttpResponse(null, { status: 400 });
+    }
+    for (const v of Object.values(body.slIm)) {
+      if (typeof v !== "boolean") {
+        return new HttpResponse(null, { status: 400 });
+      }
+    }
+    if (typeof body.slImMuted !== "boolean") {
+      return new HttpResponse(null, { status: 400 });
+    }
+    currentPreferences = body;
+    return HttpResponse.json(currentPreferences);
+  }),
+];
+
+export function seedPreferences(p: PreferencesDto) {
+  currentPreferences = { ...p };
+}
+
+export function resetPreferences() {
+  currentPreferences = { ...DEFAULT_PREFERENCES };
+}
+```
+
+Then ensure `preferencesHandlers` is included in the array exported to `setupServer(...)` in `frontend/src/test/msw/server.ts` (or wherever the handlers are wired). If the existing module exports a single combined `handlers` array, append `...preferencesHandlers` to it.
+
+- [ ] **Step 7: Extend MSW fixtures**
+
+Open `frontend/src/test/msw/fixtures.ts`. Add the default user fixture with the new prefs:
+
+```ts
+// (After the existing currentUser fixture export, ensure unreadNotificationCount
+// is already present from sub-spec 1; no further changes needed here. The prefs
+// live in their own handler state, not on the user fixture.)
+```
+
+If the user fixture is reused for `/me` responses and prefs are accessed elsewhere in tests, verify the integration. The prefs come from their own endpoint, not from `/me`, so no fixture change is strictly required.
+
+- [ ] **Step 8: Write `useNotificationPreferences.test.tsx`**
+
+```tsx
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, test, beforeEach } from "vitest";
+import { useNotificationPreferences } from "./useNotificationPreferences";
+import { resetPreferences, seedPreferences } from "@/test/msw/handlers";
+import type { ReactNode } from "react";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe("useNotificationPreferences", () => {
+  beforeEach(() => {
+    resetPreferences();
+  });
+
+  test("fetches preferences from the GET endpoint", async () => {
+    seedPreferences({
+      slImMuted: false,
+      slIm: {
+        bidding: true, auction_result: true, escrow: true,
+        listing_status: false, reviews: false,
+      },
+    });
+
+    const { result } = renderHook(() => useNotificationPreferences(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual({
+      slImMuted: false,
+      slIm: {
+        bidding: true, auction_result: true, escrow: true,
+        listing_status: false, reviews: false,
+      },
+    });
+  });
+
+  test("returns reviews=false by default", async () => {
+    const { result } = renderHook(() => useNotificationPreferences(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.slIm.reviews).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 9: Write `useUpdateNotificationPreferences.test.tsx`**
+
+```tsx
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, test, beforeEach, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/msw/server";
+import { useUpdateNotificationPreferences } from "./useUpdateNotificationPreferences";
+import { useNotificationPreferences } from "./useNotificationPreferences";
+import { resetPreferences, seedPreferences } from "@/test/msw/handlers";
+import type { ReactNode } from "react";
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  }
+  return { qc, Wrapper };
+}
+
+describe("useUpdateNotificationPreferences", () => {
+  beforeEach(() => {
+    resetPreferences();
+  });
+
+  test("optimistically updates the cache before server confirms", async () => {
+    seedPreferences({
+      slImMuted: false,
+      slIm: { bidding: true, auction_result: true, escrow: true,
+              listing_status: true, reviews: false },
+    });
+    const { qc, Wrapper } = makeWrapper();
+
+    const { result: query } = renderHook(() => useNotificationPreferences(), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(query.current.isSuccess).toBe(true));
+
+    const { result: mut } = renderHook(() => useUpdateNotificationPreferences(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      mut.current.mutate({
+        slImMuted: false,
+        slIm: { bidding: false, auction_result: true, escrow: true,
+                listing_status: true, reviews: false },
+      });
+    });
+
+    // Cache should reflect optimistic value immediately, before the request settles.
+    await waitFor(() => {
+      const cached = qc.getQueryData(["notifications", "preferences"]) as any;
+      expect(cached.slIm.bidding).toBe(false);
+    });
+  });
+
+  test("reverts cache + shows toast on server 4xx", async () => {
+    seedPreferences({
+      slImMuted: false,
+      slIm: { bidding: true, auction_result: true, escrow: true,
+              listing_status: true, reviews: false },
+    });
+
+    // Override PUT to 400 for this test
+    server.use(
+      http.put("/api/v1/users/me/notification-preferences", () =>
+        new HttpResponse(null, { status: 400 }))
+    );
+
+    const { qc, Wrapper } = makeWrapper();
+    const { result: query } = renderHook(() => useNotificationPreferences(), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(query.current.isSuccess).toBe(true));
+
+    const { result: mut } = renderHook(() => useUpdateNotificationPreferences(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      mut.current.mutate({
+        slImMuted: false,
+        slIm: { bidding: false, auction_result: true, escrow: true,
+                listing_status: true, reviews: false },
+      });
+    });
+
+    await waitFor(() => expect(mut.current.isError).toBe(true));
+
+    // Cache reverted to prior value
+    const cached = qc.getQueryData(["notifications", "preferences"]) as any;
+    expect(cached.slIm.bidding).toBe(true);
+  });
+});
+```
+
+If `server.use(...)` isn't the existing pattern, copy whatever override mechanism the project uses for per-test handler overrides.
+
+- [ ] **Step 10: Run frontend tests for the new hooks**
+
+Run: `cd frontend && npm test -- --run hooks/notifications/useNotificationPreferences hooks/notifications/useUpdateNotificationPreferences`
+Expected: 4 tests pass.
+
+- [ ] **Step 11: Run full frontend suite**
+
+Run: `cd frontend && npm test -- --run && npm run lint`
+Expected: previous baseline + 4 new tests, 0 failures, lint clean.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add frontend/src/lib/notifications/preferencesTypes.ts \
+        frontend/src/lib/notifications/preferencesApi.ts \
+        frontend/src/lib/notifications/queryKeys.ts \
+        frontend/src/hooks/notifications/useNotificationPreferences.ts \
+        frontend/src/hooks/notifications/useUpdateNotificationPreferences.ts \
+        frontend/src/hooks/notifications/useNotificationPreferences.test.tsx \
+        frontend/src/hooks/notifications/useUpdateNotificationPreferences.test.tsx \
+        frontend/src/test/msw/handlers.ts \
+        frontend/src/test/msw/fixtures.ts
+git commit -m "feat(sl-im): preferences types + REST client + hooks + MSW handlers"
+```
+
+---
+
+## Task 8 — Frontend preferences UI + settings entry points
+
+**Goal:** Land the `/settings` route tree (layout + index redirect + `/settings/notifications`), the `NotificationPreferencesPage` with banner, master mute, and 5 group toggle rows, plus settings entry points from the bell dropdown footer and the `/notifications` feed-page header.
+
+**Files:**
+- Create: `frontend/src/app/settings/layout.tsx`
+- Create: `frontend/src/app/settings/page.tsx` (redirect)
+- Create: `frontend/src/app/settings/notifications/page.tsx`
+- Create: `frontend/src/app/settings/notifications/page.test.tsx`
+- Create: `frontend/src/components/notifications/preferences/NotificationPreferencesPage.tsx`
+- Create: `frontend/src/components/notifications/preferences/ChannelInfoBanner.tsx`
+- Create: `frontend/src/components/notifications/preferences/MasterMuteRow.tsx`
+- Create: `frontend/src/components/notifications/preferences/GroupToggleRow.tsx`
+- Create: `frontend/src/components/notifications/preferences/*.test.tsx`
+- Modify: `frontend/src/components/notifications/NotificationDropdown.tsx` (add gear icon to footer)
+- Modify: `frontend/src/components/notifications/feed/FeedShell.tsx` (add gear icon to feed page header)
+- Modify: `frontend/src/components/ui/icons.ts` (export `Settings` if not present)
+
+### Steps
+
+- [ ] **Step 1: Create `/settings/layout.tsx`**
+
+```tsx
+import type { ReactNode } from "react";
+
+export default function SettingsLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <h1 className="text-headline-md font-display font-bold mb-6">Settings</h1>
+      {children}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create `/settings/page.tsx` (server-component redirect)**
+
+```tsx
+import { redirect } from "next/navigation";
+
+export default function SettingsIndexPage() {
+  redirect("/settings/notifications");
+}
+```
+
+- [ ] **Step 3: Verify Settings icon exists in barrel**
+
+Run: `grep -E "Settings|SlidersHorizontal" frontend/src/components/ui/icons.ts`
+
+If neither is exported, add to the barrel:
+
+```ts
+// frontend/src/components/ui/icons.ts — append
+export { Settings } from "lucide-react";
+```
+
+- [ ] **Step 4: Create `ChannelInfoBanner.tsx`**
+
+```tsx
+"use client";
+
+export function ChannelInfoBanner() {
+  return (
+    <div className="bg-primary-container/30 border border-primary/20 rounded-lg p-4 mb-6 text-body-sm text-on-surface">
+      <p>
+        In-app and system notifications always deliver. Settings below control
+        SL IM for the rest. SL natively forwards in-game IMs to your registered
+        email when you're offline.
+      </p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Create `MasterMuteRow.tsx`**
+
+```tsx
+"use client";
+
+export interface MasterMuteRowProps {
+  value: boolean;
+  onChange: (next: boolean) => void;
+}
+
+export function MasterMuteRow({ value, onChange }: MasterMuteRowProps) {
+  return (
+    <div className="flex items-center justify-between py-4 border-b border-outline-variant mb-4">
+      <div>
+        <div className="text-title-sm font-semibold text-on-surface">
+          Mute all SL IM notifications
+        </div>
+        <div className="text-body-sm text-on-surface-variant mt-1">
+          Master switch — overrides everything below.
+        </div>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={value}
+        onClick={() => onChange(!value)}
+        className={
+          "relative inline-flex h-6 w-11 items-center rounded-full transition-colors " +
+          (value ? "bg-primary" : "bg-surface-container-high border border-outline")
+        }
+        aria-label="Mute all SL IM notifications"
+      >
+        <span
+          className={
+            "inline-block h-4 w-4 transform rounded-full bg-on-primary transition-transform " +
+            (value ? "translate-x-6" : "translate-x-1")
+          }
+        />
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Create `GroupToggleRow.tsx`** — with the disabled-state preservation invariant
+
+```tsx
+"use client";
+import { cn } from "@/lib/cn";
+
+export interface GroupToggleRowProps {
+  group: string;
+  label: string;
+  subtext: string;
+  value: boolean;
+  mutedDisabled: boolean;
+  onChange: (next: boolean) => void;
+}
+
+export function GroupToggleRow({
+  group, label, subtext, value, mutedDisabled, onChange
+}: GroupToggleRowProps) {
+  const handleClick = () => {
+    if (mutedDisabled) return;  // no-op when muted; preserve underlying state
+    onChange(!value);
+  };
+
+  return (
+    <div className="flex items-center justify-between py-4 border-b border-outline-variant last:border-0">
+      <div className="flex-1 mr-4">
+        <div className="text-body-md font-medium text-on-surface">{label}</div>
+        <div className="text-body-sm text-on-surface-variant mt-0.5">{subtext}</div>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={value}
+        disabled={mutedDisabled}
+        onClick={handleClick}
+        className={cn(
+          "relative inline-flex h-6 w-11 items-center rounded-full transition-colors",
+          value ? "bg-primary" : "bg-surface-container-high border border-outline",
+          mutedDisabled && "opacity-50 cursor-not-allowed"
+        )}
+        aria-label={`${label} — ${value ? "on" : "off"}${mutedDisabled ? " (muted)" : ""}`}
+        data-testid={`group-toggle-${group}`}
+      >
+        <span
+          className={cn(
+            "inline-block h-4 w-4 transform rounded-full bg-on-primary transition-transform",
+            value ? "translate-x-6" : "translate-x-1"
+          )}
+        />
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 7: Create `NotificationPreferencesPage.tsx`**
+
+```tsx
+"use client";
+import { useState, useEffect } from "react";
+import { useNotificationPreferences } from "@/hooks/notifications/useNotificationPreferences";
+import { useUpdateNotificationPreferences } from "@/hooks/notifications/useUpdateNotificationPreferences";
+import { ChannelInfoBanner } from "./ChannelInfoBanner";
+import { MasterMuteRow } from "./MasterMuteRow";
+import { GroupToggleRow } from "./GroupToggleRow";
+import {
+  EDITABLE_GROUPS, GROUP_LABELS, GROUP_SUBTEXT,
+  type EditableGroup, type PreferencesDto,
+} from "@/lib/notifications/preferencesTypes";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+
+export function NotificationPreferencesPage() {
+  const { data, isPending } = useNotificationPreferences();
+  const update = useUpdateNotificationPreferences();
+
+  // Local state mirrors server state for immediate UI feedback. Master mute
+  // does NOT mutate per-group state — disabled is purely presentational.
+  const [local, setLocal] = useState<PreferencesDto | null>(null);
+
+  useEffect(() => {
+    if (data) setLocal(data);
+  }, [data]);
+
+  if (isPending || !local) {
+    return <div className="flex justify-center p-8"><LoadingSpinner /></div>;
+  }
+
+  const handleMasterMute = (next: boolean) => {
+    const updated = { ...local, slImMuted: next };
+    setLocal(updated);
+    update.mutate(updated);
+  };
+
+  const handleGroupToggle = (group: EditableGroup, next: boolean) => {
+    const updated = {
+      ...local,
+      slIm: { ...local.slIm, [group]: next },
+    };
+    setLocal(updated);
+    update.mutate(updated);
+  };
+
+  return (
+    <div>
+      <ChannelInfoBanner />
+
+      <MasterMuteRow value={local.slImMuted} onChange={handleMasterMute} />
+
+      <div className="mb-2 text-label-sm uppercase tracking-wide text-on-surface-variant font-semibold">
+        Send via SL IM
+      </div>
+
+      <div className="bg-surface border border-outline rounded-xl">
+        {EDITABLE_GROUPS.map((g) => (
+          <GroupToggleRow
+            key={g}
+            group={g}
+            label={GROUP_LABELS[g]}
+            subtext={GROUP_SUBTEXT[g]}
+            value={local.slIm[g]}
+            mutedDisabled={local.slImMuted}
+            onChange={(next) => handleGroupToggle(g, next)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 8: Create `/settings/notifications/page.tsx`**
+
+```tsx
+import { RequireAuth } from "@/components/auth/RequireAuth";
+import { NotificationPreferencesPage } from "@/components/notifications/preferences/NotificationPreferencesPage";
+
+export default function NotificationSettingsPage() {
+  return (
+    <RequireAuth>
+      <NotificationPreferencesPage />
+    </RequireAuth>
+  );
+}
+```
+
+If the project uses a different auth-gate pattern (e.g., layout-level), match that instead.
+
+- [ ] **Step 9: Add gear icon to bell dropdown footer**
+
+Open `frontend/src/components/notifications/NotificationDropdown.tsx`. Find the existing footer with the "View all notifications" link. Modify:
+
+```tsx
+import { Settings } from "@/components/ui/icons";
+
+// In the footer section:
+<footer className="border-t border-outline-variant px-4 py-2 flex items-center justify-between bg-surface-container">
+  <Link
+    href="/notifications"
+    onClick={onClose}
+    className="text-label-md text-primary hover:underline"
+  >
+    View all notifications
+  </Link>
+  <Link
+    href="/settings/notifications"
+    onClick={onClose}
+    className="text-on-surface-variant hover:text-on-surface"
+    aria-label="Notification settings"
+  >
+    <Settings className="size-4" />
+  </Link>
+</footer>
+```
+
+The exact JSX changes depend on the existing footer structure. Read it first.
+
+- [ ] **Step 10: Add gear icon to `/notifications` page header**
+
+Open `frontend/src/components/notifications/feed/FeedShell.tsx`. Find the existing page title/header. Add a gear icon top-right linking to `/settings/notifications`:
+
+```tsx
+import { Settings } from "@/components/ui/icons";
+import Link from "next/link";
+
+// At the top of the page (replace the existing <h1>...</h1> block):
+<div className="flex items-center justify-between mb-2">
+  <h1 className="text-headline-md font-display font-bold">Notifications</h1>
+  <Link
+    href="/settings/notifications"
+    className="p-2 text-on-surface-variant hover:text-on-surface rounded-md hover:bg-surface-container"
+    aria-label="Notification settings"
+  >
+    <Settings className="size-5" />
+  </Link>
+</div>
+```
+
+- [ ] **Step 11: Write `MasterMuteRow.test.tsx`**
+
+```tsx
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { MasterMuteRow } from "./MasterMuteRow";
+
+describe("MasterMuteRow", () => {
+  test("renders aria-checked reflecting value=false", () => {
+    render(<MasterMuteRow value={false} onChange={() => {}} />);
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+  });
+
+  test("renders aria-checked reflecting value=true", () => {
+    render(<MasterMuteRow value={true} onChange={() => {}} />);
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+  });
+
+  test("calls onChange with the inverted value on click", () => {
+    const onChange = vi.fn();
+    render(<MasterMuteRow value={false} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+});
+```
+
+- [ ] **Step 12: Write `GroupToggleRow.test.tsx`** — including the disabled-state preservation invariant
+
+```tsx
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { GroupToggleRow } from "./GroupToggleRow";
+
+describe("GroupToggleRow", () => {
+  test("renders label and subtext", () => {
+    render(<GroupToggleRow
+      group="bidding" label="Bidding" subtext="Outbid, proxy exhausted"
+      value={true} mutedDisabled={false} onChange={() => {}} />);
+    expect(screen.getByText("Bidding")).toBeInTheDocument();
+    expect(screen.getByText("Outbid, proxy exhausted")).toBeInTheDocument();
+  });
+
+  test("aria-checked reflects value when not muted", () => {
+    render(<GroupToggleRow
+      group="bidding" label="Bidding" subtext="x"
+      value={true} mutedDisabled={false} onChange={() => {}} />);
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+  });
+
+  test("click fires onChange when not muted", () => {
+    const onChange = vi.fn();
+    render(<GroupToggleRow
+      group="bidding" label="Bidding" subtext="x"
+      value={false} mutedDisabled={false} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  test("disabled state preserves checked value (the load-bearing invariant)", () => {
+    render(<GroupToggleRow
+      group="bidding" label="Bidding" subtext="x"
+      value={true} mutedDisabled={true} onChange={() => {}} />);
+    const sw = screen.getByRole("switch");
+    expect(sw).toHaveAttribute("aria-checked", "true");
+    expect(sw).toBeDisabled();
+  });
+
+  test("click does NOT fire onChange when mutedDisabled", () => {
+    const onChange = vi.fn();
+    render(<GroupToggleRow
+      group="bidding" label="Bidding" subtext="x"
+      value={true} mutedDisabled={true} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 13: Write `NotificationPreferencesPage.test.tsx`**
+
+```tsx
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, test, beforeEach, vi } from "vitest";
+import { NotificationPreferencesPage } from "./NotificationPreferencesPage";
+import { resetPreferences, seedPreferences } from "@/test/msw/handlers";
+import type { ReactNode } from "react";
+
+function renderWithProviders(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+describe("NotificationPreferencesPage", () => {
+  beforeEach(() => resetPreferences());
+
+  test("renders banner and 5 group toggle rows (no SYSTEM/REALTY_GROUP/MARKETING)", async () => {
+    renderWithProviders(<NotificationPreferencesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/In-app and system notifications always deliver/i))
+        .toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Bidding")).toBeInTheDocument();
+    expect(screen.getByText("Auction Result")).toBeInTheDocument();
+    expect(screen.getByText("Escrow")).toBeInTheDocument();
+    expect(screen.getByText("Listings")).toBeInTheDocument();
+    expect(screen.getByText("Reviews")).toBeInTheDocument();
+    // None of these should appear:
+    expect(screen.queryByText("System")).not.toBeInTheDocument();
+    expect(screen.queryByText("Realty Group")).not.toBeInTheDocument();
+    expect(screen.queryByText("Marketing")).not.toBeInTheDocument();
+  });
+
+  test("Reviews defaults to OFF for fresh user", async () => {
+    renderWithProviders(<NotificationPreferencesPage />);
+
+    await waitFor(() => {
+      const reviewsToggle = screen.getByTestId("group-toggle-reviews");
+      expect(reviewsToggle).toHaveAttribute("aria-checked", "false");
+    });
+  });
+
+  test("master mute disables group toggles but preserves underlying values", async () => {
+    seedPreferences({
+      slImMuted: false,
+      slIm: { bidding: true, auction_result: true, escrow: true,
+              listing_status: true, reviews: false },
+    });
+    renderWithProviders(<NotificationPreferencesPage />);
+
+    // Wait for initial render
+    await waitFor(() => {
+      expect(screen.getByTestId("group-toggle-bidding"))
+        .toHaveAttribute("aria-checked", "true");
+    });
+
+    // Find the master mute switch by its aria-label and click
+    const masterMute = screen.getByLabelText("Mute all SL IM notifications");
+    fireEvent.click(masterMute);
+
+    await waitFor(() => {
+      expect(masterMute).toHaveAttribute("aria-checked", "true");
+    });
+
+    // Group toggles should now be disabled but values unchanged
+    const biddingToggle = screen.getByTestId("group-toggle-bidding");
+    expect(biddingToggle).toBeDisabled();
+    expect(biddingToggle).toHaveAttribute("aria-checked", "true");
+
+    const reviewsToggle = screen.getByTestId("group-toggle-reviews");
+    expect(reviewsToggle).toBeDisabled();
+    expect(reviewsToggle).toHaveAttribute("aria-checked", "false");
+
+    // Click bidding toggle while muted — should be no-op
+    fireEvent.click(biddingToggle);
+    expect(biddingToggle).toHaveAttribute("aria-checked", "true");
+
+    // Toggle master mute off
+    fireEvent.click(masterMute);
+    await waitFor(() => {
+      expect(masterMute).toHaveAttribute("aria-checked", "false");
+    });
+
+    // Group toggles re-enabled, values preserved
+    expect(biddingToggle).not.toBeDisabled();
+    expect(biddingToggle).toHaveAttribute("aria-checked", "true");
+    expect(reviewsToggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  test("clicking a group toggle when not muted updates the toggle state", async () => {
+    seedPreferences({
+      slImMuted: false,
+      slIm: { bidding: true, auction_result: true, escrow: true,
+              listing_status: true, reviews: false },
+    });
+    renderWithProviders(<NotificationPreferencesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("group-toggle-bidding"))
+        .toHaveAttribute("aria-checked", "true");
+    });
+
+    fireEvent.click(screen.getByTestId("group-toggle-bidding"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("group-toggle-bidding"))
+        .toHaveAttribute("aria-checked", "false");
+    });
+  });
+});
+```
+
+- [ ] **Step 14: Write `app/settings/notifications/page.test.tsx`**
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import NotificationSettingsPage from "./page";
+// Plus whatever providers (QueryClientProvider, etc.) the project's test setup uses for pages.
+
+describe("/settings/notifications page", () => {
+  test("renders the preferences page title (via layout) when authenticated", async () => {
+    // Render with whatever auth context the project's tests use to mock
+    // an authenticated session. Match the pattern from
+    // frontend/src/app/notifications/page.test.tsx (sub-spec 1's existing test).
+    render(<NotificationSettingsPage />);
+    expect(await screen.findByText(/In-app and system notifications/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 15: Run frontend tests**
+
+Run: `cd frontend && npm test -- --run components/notifications/preferences app/settings`
+Expected: tests pass.
+
+- [ ] **Step 16: Run full frontend suite + lint**
+
+Run: `cd frontend && npm test -- --run && npm run lint`
+Expected: previous (Task 7) baseline + new component tests, 0 failures, lint clean.
+
+- [ ] **Step 17: Commit**
+
+```bash
+git add frontend/src/app/settings/ \
+        frontend/src/components/notifications/preferences/ \
+        frontend/src/components/notifications/NotificationDropdown.tsx \
+        frontend/src/components/notifications/feed/FeedShell.tsx \
+        frontend/src/components/ui/icons.ts
+git commit -m "feat(sl-im): /settings/notifications UI + bell + feed-page entry points"
+```
+
+---
+
+## Task 9 — LSL script + lsl-scripts/ directory tree
+
+**Goal:** Land the `lsl-scripts/` top-level directory with a contributor-rule README, plus `lsl-scripts/sl-im-dispatcher/` with the dispatcher LSL script, the config notecard template, and a comprehensive per-script README. No automated tests; manual deployment + verification covered in the PR's manual test plan.
+
+**Files:**
+- Create: `lsl-scripts/README.md`
+- Create: `lsl-scripts/sl-im-dispatcher/README.md`
+- Create: `lsl-scripts/sl-im-dispatcher/dispatcher.lsl`
+- Create: `lsl-scripts/sl-im-dispatcher/config.notecard.example`
+
+### Steps
+
+- [ ] **Step 1: Create `lsl-scripts/README.md` (top-level index)**
+
+```markdown
+# LSL Scripts
+
+In-world Linden Scripting Language (LSL) code that consumes SLPA's backend APIs.
+Each script is the in-world half of an end-to-end integration; the matching
+backend code lives under `backend/src/main/java/com/slparcelauctions/backend/`.
+
+## Contributor rules
+
+**Each new script gets its own subdirectory with its own README.** Updates to
+any script's behavior, deployment, or configuration must be reflected in that
+script's README in the same commit. The top-level index below updates only on
+add / remove / rename.
+
+A script's README must cover:
+
+- **Purpose** — what the script does and what backend system it integrates with.
+- **Architecture summary** — high-level flow (events, timers, HTTP calls).
+- **Deployment** — step-by-step in-world deployment, prim setup, permissions.
+- **Configuration** — notecard format, where to obtain secrets, rotation procedure.
+- **Operations** — what owner-say / chat output to expect; how to verify health.
+- **Troubleshooting** — common failure modes and their signatures.
+- **Limits** — SL platform constraints the script depends on (HTTP throttles,
+  IM byte limits, etc.) and any known operational caveats.
+- **Security** — secret-handling expectations and access-control notes.
+
+## Scripts
+
+- [`sl-im-dispatcher/`](sl-im-dispatcher/) — Polls SLPA backend for pending
+  SL IM notifications and delivers them via `llInstantMessage`. SLPA-team-deployed
+  (one instance per environment); not user-deployed.
+```
+
+- [ ] **Step 2: Create `lsl-scripts/sl-im-dispatcher/dispatcher.lsl`**
+
+```lsl
+// SLPA SL IM Dispatcher
+//
+// Polls SLPA backend for pending notification IMs and delivers them via
+// llInstantMessage. Single state machine with two cadences:
+//   - 60-second poll interval when idle
+//   - 2-second per-IM tick when delivering a batch
+//
+// Configuration is loaded from a notecard named "config" in the same prim.
+// See README.md for deployment and operations details.
+
+// === Configuration loaded from notecard ===
+string POLL_URL = "";
+string CONFIRM_URL_BASE = "";
+string SHARED_SECRET = "";
+integer DEBUG_OWNER_SAY = TRUE;
+
+// === Cadences ===
+float POLL_INTERVAL = 60.0;
+float IM_INTERVAL = 2.0;
+
+// === Batch state during delivery ===
+list batchIds = [];
+list batchUuids = [];
+list batchTexts = [];
+integer batchIndex = 0;
+integer deliveringBatch = FALSE;
+
+// === HTTP request tracking ===
+key pollRequestId = NULL_KEY;
+
+// === Notecard reading state ===
+key notecardLineRequest = NULL_KEY;
+integer notecardLineNum = 0;
+
+readNotecardLine(integer n) {
+    notecardLineNum = n;
+    notecardLineRequest = llGetNotecardLine("config", n);
+}
+
+parseConfigLine(string line) {
+    if (llStringLength(line) == 0) return;
+    if (llSubStringIndex(line, "#") == 0) return;  // comment
+
+    integer eq = llSubStringIndex(line, "=");
+    if (eq < 1) return;
+
+    string key = llStringTrim(llGetSubString(line, 0, eq - 1), STRING_TRIM);
+    string val = llStringTrim(llGetSubString(line, eq + 1, -1), STRING_TRIM);
+
+    if (key == "POLL_URL") POLL_URL = val;
+    else if (key == "CONFIRM_URL_BASE") CONFIRM_URL_BASE = val;
+    else if (key == "SHARED_SECRET") SHARED_SECRET = val;
+    else if (key == "DEBUG_OWNER_SAY") DEBUG_OWNER_SAY = (val == "true" || val == "TRUE" || val == "1");
+}
+
+deliverNextInBatch() {
+    if (batchIndex >= llGetListLength(batchIds)) {
+        // Batch complete; reset state and return to slow cadence.
+        deliveringBatch = FALSE;
+        batchIds = [];
+        batchUuids = [];
+        batchTexts = [];
+        llSetTimerEvent(POLL_INTERVAL);
+        return;
+    }
+
+    string id = llList2String(batchIds, batchIndex);
+    string uuid = llList2String(batchUuids, batchIndex);
+    string text = llList2String(batchTexts, batchIndex);
+
+    llInstantMessage((key)uuid, text);
+    llHTTPRequest(
+        CONFIRM_URL_BASE + id + "/delivered",
+        [HTTP_METHOD, "POST",
+         HTTP_CUSTOM_HEADER, "Authorization", "Bearer " + SHARED_SECRET,
+         HTTP_BODY_MAXLENGTH, 4096],
+        ""
+    );
+    batchIndex += 1;
+}
+
+integer parseAndStoreBatch(string body) {
+    // body is JSON: { "messages": [ {id, avatarUuid, messageText}, ... ] }
+    string messagesJson = llJsonGetValue(body, ["messages"]);
+    if (messagesJson == JSON_INVALID || messagesJson == "") return 0;
+
+    list keys = llJson2List(messagesJson);
+    integer i;
+    integer n = llGetListLength(keys);
+    for (i = 0; i < n; ++i) {
+        string item = llList2String(keys, i);
+        string id = llJsonGetValue(item, ["id"]);
+        string uuid = llJsonGetValue(item, ["avatarUuid"]);
+        string text = llJsonGetValue(item, ["messageText"]);
+        if (id != JSON_INVALID && uuid != JSON_INVALID && text != JSON_INVALID) {
+            batchIds += [id];
+            batchUuids += [uuid];
+            batchTexts += [text];
+        }
+    }
+    return llGetListLength(batchIds);
+}
+
+default {
+    state_entry() {
+        POLL_URL = "";
+        CONFIRM_URL_BASE = "";
+        SHARED_SECRET = "";
+        readNotecardLine(0);
+    }
+
+    dataserver(key requested, string data) {
+        if (requested != notecardLineRequest) return;
+        if (data == NAK) {
+            llOwnerSay("SL IM dispatcher: notecard 'config' missing or unreadable");
+            return;
+        }
+        if (data == EOF) {
+            // Notecard fully read; validate config.
+            if (POLL_URL == "" || CONFIRM_URL_BASE == "" || SHARED_SECRET == "") {
+                llOwnerSay("SL IM dispatcher: incomplete config — POLL_URL / CONFIRM_URL_BASE / SHARED_SECRET required");
+                return;
+            }
+            if (DEBUG_OWNER_SAY) llOwnerSay("SL IM dispatcher: ready (poll=" + POLL_URL + ")");
+            llSetTimerEvent(POLL_INTERVAL);
+            return;
+        }
+        parseConfigLine(data);
+        readNotecardLine(notecardLineNum + 1);
+    }
+
+    timer() {
+        if (deliveringBatch) {
+            deliverNextInBatch();
+        } else {
+            // Slow-cadence poll cycle.
+            pollRequestId = llHTTPRequest(
+                POLL_URL + "?limit=10",
+                [HTTP_METHOD, "GET",
+                 HTTP_CUSTOM_HEADER, "Authorization", "Bearer " + SHARED_SECRET,
+                 HTTP_BODY_MAXLENGTH, 16384],
+                ""
+            );
+        }
+    }
+
+    http_response(key requestId, integer status, list meta, string body) {
+        if (requestId == pollRequestId) {
+            pollRequestId = NULL_KEY;
+            if (status != 200) {
+                if (DEBUG_OWNER_SAY) llOwnerSay("SL IM poll failed: " + (string)status);
+                return;
+            }
+            integer count = parseAndStoreBatch(body);
+            if (count > 0) {
+                if (DEBUG_OWNER_SAY) llOwnerSay("SL IM batch=" + (string)count);
+                deliveringBatch = TRUE;
+                batchIndex = 0;
+                llSetTimerEvent(IM_INTERVAL);
+                deliverNextInBatch();  // immediately fire the first IM
+            } else {
+                if (DEBUG_OWNER_SAY) llOwnerSay("SL IM poll: 0 messages");
+            }
+            return;
+        }
+        // Confirmation responses; log only on non-2xx.
+        if (status >= 400) {
+            llOwnerSay("SL IM confirm failed: status=" + (string)status);
+        }
+    }
+
+    on_rez(integer start_param) {
+        llResetScript();
+    }
+
+    changed(integer change) {
+        if (change & CHANGED_INVENTORY) {
+            // Notecard may have been re-edited; reload.
+            llResetScript();
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Create `lsl-scripts/sl-im-dispatcher/config.notecard.example`**
+
+```
+# SL IM Dispatcher configuration
+# Copy this file to a notecard named "config" in the same prim, then edit
+# values for your environment.
+
+POLL_URL=https://slpa.example.com/api/v1/internal/sl-im/pending
+CONFIRM_URL_BASE=https://slpa.example.com/api/v1/internal/sl-im/
+SHARED_SECRET=<obtain from server config: slpa.notifications.sl-im.dispatcher.shared-secret>
+DEBUG_OWNER_SAY=true
+```
+
+- [ ] **Step 4: Create `lsl-scripts/sl-im-dispatcher/README.md`**
+
+```markdown
+# SL IM Dispatcher
+
+In-world component of the SLPA SL IM notification channel. Polls the SLPA
+backend for pending IMs and delivers them via `llInstantMessage`.
+
+## Architecture summary
+
+- **Polling cadence:** 60 seconds when idle.
+- **Per-IM cadence:** 2 seconds (matches SL's `llInstantMessage` floor).
+- **Batch size:** up to 10 messages per poll, sized to fit comfortably within
+  SL's 20-second HTTP request window.
+- **Confirmation:** for each delivered IM, the script POSTs
+  `/api/v1/internal/sl-im/{id}/delivered` to mark the row DELIVERED.
+- **Authentication:** shared-secret bearer token, loaded from the `config`
+  notecard at script start.
+
+## Deployment
+
+This is a **SLPA-team-deployed object**, one per environment. Not user-deployed.
+
+1. Rez a generic prim somewhere with reliable land permissions (group land or
+   owner-controlled). Outbound HTTP must be permitted on that parcel.
+2. Drop `dispatcher.lsl` into the prim.
+3. Drop a copy of `config.notecard.example` renamed to **`config`** (no extension).
+   Edit the values to match the target environment.
+4. Reset the script (right-click → Edit → Reset Scripts in Selection).
+5. Watch local chat for the startup message: `SL IM dispatcher: ready (poll=...)`.
+
+Object ownership and modify permissions should be tightly scoped to SLPA-team
+avatars only. The shared secret is in the notecard, visible to anyone with
+edit-rights on the object.
+
+## Configuration
+
+The `config` notecard format is `key=value` pairs, one per line. Lines starting
+with `#` are comments. Whitespace is trimmed. Required keys:
+
+| Key | Description |
+| --- | --- |
+| `POLL_URL` | Full URL of the backend's pending-messages endpoint. |
+| `CONFIRM_URL_BASE` | URL prefix for delivery-confirmation posts. The script appends `{id}/delivered` to this base. |
+| `SHARED_SECRET` | The bearer-token secret. Obtain from the server's `slpa.notifications.sl-im.dispatcher.shared-secret` configuration property. |
+| `DEBUG_OWNER_SAY` | `true` to enable per-poll owner chat (default); `false` to silence. Recommended `true` in prod for observability. |
+
+### Rotating the shared secret
+
+1. Update the deployment's secrets store with the new value.
+2. Restart the SLPA backend so it picks up the new secret.
+3. Edit the `config` notecard with the new `SHARED_SECRET` value.
+4. Reset the script (the `changed(CHANGED_INVENTORY)` handler also auto-resets,
+   but a manual reset is faster).
+
+In-flight pending rows are unaffected; the next poll uses the new secret.
+
+## Operations
+
+In steady state, with `DEBUG_OWNER_SAY=true`, you'll see one of these every
+60 seconds:
+
+- `SL IM poll: 0 messages` — nothing pending; healthy.
+- `SL IM batch=N` — N messages found; per-IM cadence kicks in.
+- `SL IM confirm failed: status=N` — a confirmation HTTP call failed; the IM
+  was still sent, the row in the backend may end up EXPIRED via the cleanup
+  job. Investigate if these are frequent.
+- `SL IM poll failed: N` — the poll HTTP call failed. Common causes: 401
+  (secret mismatch), 500 (backend issue), 0 (network / permissions).
+
+If you go silent for >5 minutes (no startup ping, no poll output), something is
+wrong. Most common: notecard missing, notecard malformed, or the prim landed
+on a parcel without outbound HTTP permission.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| Startup says `incomplete config` | Notecard missing one of `POLL_URL`, `CONFIRM_URL_BASE`, `SHARED_SECRET`. |
+| Startup says `notecard 'config' missing or unreadable` | Notecard not in the prim, or named something other than exactly `config`. |
+| Periodic `SL IM poll failed: 401` | Shared secret in notecard doesn't match the backend's configured value. |
+| Periodic `SL IM poll failed: 500` | Backend issue. Check server logs. |
+| `SL IM poll failed: 0` (no HTTP response) | Land permissions blocking outbound HTTP, or no-script land. Move the object. |
+| Long silence in owner chat | Script may have wedged. Right-click → Edit → Reset Scripts. |
+| Backend shows growing PENDING count | Dispatcher is dark. Check that the object is rezzed, not on no-script land, has the right script + notecard. |
+
+## Limits
+
+Three load-bearing notes:
+
+- **Hard byte limit on IM text.** `llInstantMessage` truncates at 1024 BYTES
+  (not characters). The backend's `SlImMessageBuilder` enforces this; the
+  script trusts the messages it receives. **Operators should never modify
+  `messageText` in the script.**
+- **No `/failed` caller in this script.** `llInstantMessage` is fire-and-forget
+  — no return value, no error, no way to distinguish "delivered" from "UUID
+  doesn't exist." The script unconditionally calls `/{id}/delivered` after every
+  IM. So FAILED rows in the database only ever come from manual operator
+  intervention or a future revision of this script that adds UUID
+  pre-validation (e.g., `llRequestAgentData` against `DATA_ONLINE` before
+  sending). If `SELECT status, count(*) FROM sl_im_message GROUP BY status`
+  shows zero FAILED rows, that's correct behavior, not a missing pipeline.
+- **Batch size 10 with 2-second spacing fits the 20-second SL HTTP window.**
+  Increasing batch size beyond 10 risks the script's confirmation requests
+  racing the next poll cycle's request limits. Don't increase without verifying
+  the math.
+
+## Security
+
+The shared secret is a deployment artifact; treat it like a database password.
+Notecard contents are visible to anyone with object-edit rights, so the
+dispatcher prim's ownership and modify permissions should be SLPA-team-only.
+A leaked shared secret means an attacker can pull the entire pending IM queue
+and confirm-mark messages as DELIVERED, blocking real delivery — rotate
+immediately if compromise is suspected.
+```
+
+- [ ] **Step 5: Verify the LSL script syntax (best-effort visual review)**
+
+LSL has no command-line linter. Open `dispatcher.lsl` in any LSL-aware editor
+(Firestorm, the in-world editor, an LSL-syntax VS Code extension) and verify
+no syntax errors. The script is small; visual review is sufficient.
+
+Specific things to check:
+- Every `string`/`integer`/`list`/`key` declaration before use.
+- All `llHTTPRequest` calls have matching brackets and a final `""` body argument.
+- The `dataserver` event handler reads consecutive notecard lines and stops on
+  `EOF`.
+- `llResetScript()` on `on_rez` and `changed(CHANGED_INVENTORY)`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lsl-scripts/
+git commit -m "feat(sl-im): lsl-scripts/sl-im-dispatcher polling object + per-script README"
+```
+
+---
+
+## Task 10 — Cross-cutting cleanup: DEFERRED + FOOTGUNS + DESIGN.md + CLAUDE.md + PR
+
+**Goal:** Update the running ledgers (close 2, modify 2, add 3 in DEFERRED_WORK; add 4 entries to FOOTGUNS), append the sub-spec 3 follow-on subsection to DESIGN.md §11, add the `lsl-scripts/` paragraph to root CLAUDE.md, run the full backend + frontend suites once, then push and open the PR. **Do not auto-merge.**
+
+**Files:**
+- Modify: `docs/implementation/DEFERRED_WORK.md`
+- Modify: `docs/implementation/FOOTGUNS.md`
+- Modify: `docs/initial-design/DESIGN.md` (extend Notes (Epic 09 sub-spec 1) section)
+- Modify: `CLAUDE.md` (root)
+
+### Steps
+
+- [ ] **Step 1: Update `docs/implementation/DEFERRED_WORK.md`**
+
+Open the file. Find and **remove** these closed entries (full block per entry):
+- `### SL IM channel for notifications`
+- `### Notification preferences UI`
+
+Find and **modify** these entries:
+
+For `### Email channel for notifications`, replace the existing body with:
+
+```markdown
+### Email channel for notifications
+- **Status:** Removed from roadmap. Re-add only on explicit user request.
+- **Reasoning:** SL natively forwards offline IMs to the user's registered email,
+  so the SL IM channel from Epic 09 sub-spec 3 covers the email use case at zero
+  additional infrastructure cost.
+- **If re-instated:** per-category templates (HTML + plain text), signed-token
+  unsubscribe, debounce/dedupe matching the coalesce pattern, email-change flow
+  (originally pending from Epic 02 sub-spec 2b).
+```
+
+For `### ESCROW_TRANSFER_REMINDER scheduler`, replace the body with:
+
+```markdown
+### ESCROW_TRANSFER_REMINDER scheduler
+- **From:** Epic 09 sub-spec 1
+- **Why:** Sub-spec 1 implements `publisher.escrowTransferReminder(...)` +
+  `NotificationDataBuilder.escrowTransferReminder(...)` + corresponding category
+  and tests. No `@Scheduled` job calls it today.
+- **When:** Epic 10 (Admin & Moderation) — paired with REVIEW_RESPONSE_WINDOW_CLOSING
+  scheduler. Both share design DNA (interval-bound + once-per-entity + admin-visible).
+- **Implementation sketch:** new `Escrow.reminderSentAt` column for
+  once-per-escrow guarantee; new `EscrowReminderScheduler` (cron daily, query
+  escrows with FUNDED status approaching transfer deadline, fire
+  `publisher.escrowTransferReminder(...)`).
+```
+
+**Add** these new entries (append to the file's "Current Deferred Items" section
+or wherever existing entries live):
+
+```markdown
+### Quiet hours UI for SL IM
+- **From:** Epic 09 sub-spec 3
+- **Why:** Columns `slImQuietStart` and `slImQuietEnd` exist on User entity
+  from Epic 02 sub-spec 2b; no UI consumes them and the dispatcher gate
+  ignores them. May tie to a future timezone/account-settings sub-spec; no
+  committed home yet. If unused for >12 months, drop the columns in a
+  dedicated cleanup sub-spec.
+- **When:** No committed phase.
+
+### HTTP-in push from backend to dispatcher for urgency
+- **From:** Epic 09 sub-spec 3
+- **Why:** Current design polls every 60 seconds — fine for the events
+  shipping today (worst case 60 s latency for outbid/won). If outbid latency
+  becomes a UX concern, register the dispatcher's HTTP-in URL with the
+  backend on startup and have the backend `llHTTPRequest` to it on
+  high-priority categories to wake an early poll.
+- **When:** Post-launch enhancement; needs the channel to have real traffic
+  and a real complaint before the complexity earns its keep.
+
+### Sub-day SL IM dispatcher health monitoring
+- **From:** Epic 09 sub-spec 3
+- **Why:** The expiry job's INFO log catches a dark dispatcher within 48 h. If
+  sub-day signal becomes important, options include: a `last_polled_at`
+  timestamp on a singleton `dispatcher_health` row written on each successful
+  poll, with an alarm scheduler that pages on `now - last_polled_at > 5 min`.
+- **When:** No committed phase. Out of scope until operational data shows the
+  48 h canary is insufficient.
+```
+
+- [ ] **Step 2: Update `docs/implementation/FOOTGUNS.md`**
+
+Open the file. Find the next sequential `F.NN` number from the file's tail.
+
+Append four new entries:
+
+```markdown
+### F.NN — `llInstantMessage` truncates at 1024 BYTES, not characters
+
+The natural Java `String.length()` measures UTF-16 code units; SL's
+`llInstantMessage` truncates the IM at 1024 **bytes** in UTF-8 encoding.
+Multi-byte UTF-8 characters (CJK, emoji, accented Latin) push the byte count
+above the char count. SL silently truncates from the end of the string — no
+error, no warning, no return value — and the deeplink in SLPA's IM template
+lives at the end of the assembled message. A 1023-character string with
+multi-byte content can occupy 1500+ bytes; the deeplink gets cleanly cut off.
+
+`SlImMessageBuilder` measures `text.getBytes(StandardCharsets.UTF_8).length`
+and ellipsizes the body, never the prefix or deeplink. Three mandatory test
+cases (multi-byte parcel name, emoji parcel name, long-body forcing
+truncation) verify the deeplink survives. Adding a new component to the
+assembled message (e.g., a timestamp) requires updating the byte-budget
+accounting in `SlImMessageBuilder` — the budget assumes exactly
+`PREFIX + title + SEPARATOR + body + SEPARATOR + deeplink`.
+
+### F.NN — Single-recipient publish path is afterCommit-then-REQUIRES_NEW; fan-out path is in-the-REQUIRES_NEW
+
+The two notification dispatch sites have different reliability postures and
+different transaction structures.
+
+**Single-recipient path** (`NotificationService.publish`): in-app row commits
+first as part of the parent transaction, then `afterCommit` runs
+`slImChannelDispatcher.maybeQueue` which opens its own REQUIRES_NEW. If the
+IM-queue write fails, the in-app row already committed, the parent business
+event already committed, and the only loss is the IM. **In-app guaranteed,
+IM best-effort.**
+
+**Fan-out path** (`NotificationPublisherImpl.listingCancelledBySellerFanout`):
+per-recipient REQUIRES_NEW lambda contains the in-app DAO upsert AND the IM
+queue write as siblings. If the IM-queue write fails, that recipient's
+in-app row also rolls back; the per-recipient try-catch isolates this from
+sibling recipients. **In-app + IM atomic per recipient; sibling recipients
+independent.**
+
+Mixing these mental models produces either:
+- "One bad bidder kills the cancellation" — if you put fan-out atomic with the parent transaction.
+- "In-app row exists but IM never queued because the dispatcher hook failed silently" — if you inline the dispatcher into the single-recipient path's parent transaction.
+
+Future contributors adding a new fan-out method must follow the existing
+pattern: per-recipient REQUIRES_NEW lambda containing all per-recipient writes
+as siblings, with a per-recipient try-catch wrapping the lambda. Name with a
+`Fanout` suffix (sub-spec 1's convention).
+
+### F.NN — Adding a new terminal status to `sl_im_message` requires updating the cleanup predicate
+
+`SlImCleanupJob` stage 2 deletes rows via `WHERE status IN ('DELIVERED',
+'EXPIRED', 'FAILED') AND updated_at < retention_cutoff`. The IN-list
+enumerates terminal statuses. Adding a new one (e.g., a future
+`RETRY_SCHEDULED` for a deferred retry primitive) without updating the IN-list
+means those rows accumulate forever — defeating the very `SELECT status,
+count(*) FROM sl_im_message GROUP BY status` query the rolling 30-day window
+was supposed to keep meaningful. Add the new status to the predicate in the
+same commit that introduces the status.
+
+### F.NN — LSL `llInstantMessage` is fire-and-forget; `/failed` has no LSL caller
+
+The `sl-im-dispatcher` script unconditionally calls
+`POST /api/v1/internal/sl-im/{id}/delivered` after every `llInstantMessage`
+because LSL provides no delivery signal — `llInstantMessage` returns `void`,
+raises no event on failure, and produces no observable side effect when the
+recipient UUID is invalid or offline-unreachable.
+
+This means FAILED rows in `sl_im_message` only appear via:
+1. Manual operator intervention — direct SQL UPDATE in production (rare;
+   usually for support clearing a stuck row).
+2. A future revision of `dispatcher.lsl` that pre-validates avatar UUIDs
+   (e.g., `llRequestAgentData` against `DATA_ONLINE` before sending, or a
+   `NULL_KEY` guard).
+
+If support runs `SELECT status, count(*) FROM sl_im_message GROUP BY status`
+and sees zero FAILED rows, that's correct behavior. Not a missing pipeline.
+```
+
+Replace `F.NN` with the actual sequential numbers (check the file's last entry
+and increment).
+
+- [ ] **Step 3: Update `docs/initial-design/DESIGN.md` §11**
+
+Find the existing "Notes (Epic 09 sub-spec 1)" subsection at the bottom of §11.
+Append a follow-on subsection:
+
+```markdown
+**Notes (Epic 09 sub-spec 3):**
+- The SL IM channel reuses the in-app coalesce key namespace; rows in
+  `sl_im_message` collapse during pendency (`WHERE status = 'PENDING'`),
+  with the same partial-unique-index pattern.
+- `SYSTEM` group bypasses preferences and master-mute, but never bypasses the
+  no-avatar floor.
+- `llInstantMessage` truncates at 1024 BYTES (UTF-8), not characters. The
+  backend's `SlImMessageBuilder` enforces this with body ellipsis, never
+  trimming the prefix or deeplink.
+- The polling/confirmation contract (`/api/v1/internal/sl-im/*`) uses a
+  shared secret distinct from the existing escrow-terminal secret. State
+  machines for `/delivered` and `/failed` are symmetric: PENDING →
+  terminal-status, idempotent on the matching status, 409 on the other
+  terminal statuses (FAILED/EXPIRED).
+- The system relies on SL's native offline-IM-to-email forwarding to cover
+  the email use case. Users with active SL email forwarding receive SLPA
+  notifications by email; users with disabled forwarding receive only
+  in-world IMs when online. The email channel is intentionally not built.
+```
+
+- [ ] **Step 4: Update root `CLAUDE.md`**
+
+Open `/Users/heath/Repos/personal/slparcelauctions/CLAUDE.md`. Find the
+"Second Life Integration Notes" section (or the closest equivalent — read the
+file first). Append:
+
+```markdown
+**In-world LSL code lives in `lsl-scripts/`.** Each script gets its own
+subdirectory with its own README covering deployment, configuration,
+operations, and limits. Updates to a script's behavior, deployment, or
+configuration must update that script's README in the same commit. The
+top-level `lsl-scripts/README.md` is an index — updates only on add / remove
+/ rename.
+```
+
+- [ ] **Step 5: Run the full backend test suite**
+
+Run: `cd backend && ./mvnw test`
+Expected: previous (Task 9) baseline + all earlier task additions, 0 failures.
+
+- [ ] **Step 6: Run the full frontend test suite + lint**
+
+Run: `cd frontend && npm test -- --run && npm run lint`
+Expected: previous (Task 9) baseline + all earlier task additions, 0 failures, lint clean.
+
+- [ ] **Step 7: Commit the docs cleanup**
+
+```bash
+git add docs/implementation/DEFERRED_WORK.md \
+        docs/implementation/FOOTGUNS.md \
+        docs/initial-design/DESIGN.md \
+        CLAUDE.md
+git commit -m "docs(sl-im): close 2 deferred entries, modify 2, add 3; FOOTGUNS x4; DESIGN.md notes"
+```
+
+- [ ] **Step 8: Push the branch**
+
+```bash
+git push -u origin task/09-sub-3-sl-im-and-preferences
+```
+
+- [ ] **Step 9: Open the PR**
+
+Verify the base branch by checking how recent PRs target (`gh pr list --state merged --limit 5`). Should be `dev`.
+
+```bash
+gh pr create --title "Epic 09 sub-spec 3: SL IM channel + notification preferences UI" --body "$(cat <<'EOF'
+## Summary
+
+Ships the SL IM channel + notification preferences UI end-to-end:
+
+- New `sl_im_message` queue with ON CONFLICT coalescing during pendency, partial unique index on `(user_id, coalesce_key) WHERE status = 'PENDING'`.
+- `SlImChannelGate` discriminated decision logic (no-avatar floor, SYSTEM bypass, master mute, group prefs).
+- Dispatch via afterCommit hook on `NotificationService.publish` (single-recipient) and sibling call inside `listingCancelledBySellerFanout`'s per-recipient REQUIRES_NEW lambda (fan-out).
+- Internal endpoints `/api/v1/internal/sl-im/{pending, {id}/delivered, {id}/failed}` with shared-secret auth, symmetric state machines (PENDING → terminal, idempotent on match, 409 on other terminal statuses).
+- 48h expiry job at 03:30 SLT with INFO canary log (`expired`, `deleted`, `top_users`).
+- `/settings/notifications` UI: banner + master mute + 5 group toggles. Master mute disables group toggles visually but preserves their state. Closed-shape PUT validation (rejects SYSTEM/REALTY_GROUP/MARKETING).
+- `lsl-scripts/sl-im-dispatcher/` LSL polling object (60s polls, 2s per-IM throttle, batch ≤10).
+- Settings entry points from bell dropdown footer and `/notifications` feed page header.
+
+Closes deferred-ledger entries:
+- SL IM channel for notifications
+- Notification preferences UI
+
+Email channel: removed from the roadmap. SL's native offline-IM-to-email forwarding covers the email use case via the SL IM channel.
+
+## Test plan
+
+- [ ] Backend: `./mvnw test -pl backend` → green (≥ baseline + ~80 new tests)
+- [ ] Frontend: `cd frontend && npm test -- --run` → green
+- [ ] Frontend: `npm run lint` → clean
+- [ ] Two browser sessions, two users; one with linked SL avatar, one without. Drive an OUTBID for each. Verify: linked user has a PENDING `sl_im_message` row; unlinked user has none. Both users still see in-app + WS push.
+- [ ] In `/settings/notifications`, mute Bidding for the linked user. Drive another OUTBID. Verify in-app row created, no new IM row queued.
+- [ ] Toggle master mute on. Verify group toggles render disabled with checked-states preserved. Toggle off. States return without API roundtrip.
+- [ ] `curl -H "Authorization: Bearer ${SECRET}" GET /api/v1/internal/sl-im/pending?limit=10`. Verify assembled `messageText` matches template; multi-byte parcel name preserves the deeplink.
+- [ ] `curl -H "Authorization: Bearer ${SECRET}" -X POST /api/v1/internal/sl-im/{id}/delivered`. Verify status transitions; second curl returns 204; manually mark a row FAILED then curl `/delivered` — expect 409.
+- [ ] Deploy `sl-im-dispatcher` in beta sim with staging URL. Drive a notification for a test user with an avatar. Verify the alt account receives the IM with correct text and clickable deeplink. Watch owner-say for poll cadence.
+- [ ] Stop the dispatcher object. Wait 49 hours. Verify the cleanup job's INFO log includes `expired > 0` and a `top_users` entry naming the test account.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+After `gh pr create` returns the PR URL, **report it back**.
+
+- [ ] **Step 10: Stop. Do not auto-merge.**
+
+The user reviews and merges manually. Do not run `gh pr merge`.
+
+---
+
+## Self-review
+
+After writing the complete plan, this is a fresh-eyes pass against the spec.
+
+### Spec coverage
+
+- [x] **§1 Goal & scope** — Tasks 1–10 collectively implement the goal. Out-of-scope items are documented in DEFERRED_WORK updates (Task 10 Step 1) and FOOTGUNS (Task 10 Step 2).
+- [x] **§2.1 afterCommit + REQUIRES_NEW for single-recipient** — Task 3 Steps 1, 2 (dispatcher + NotificationService modification).
+- [x] **§2.2 Sibling call inside fan-out's REQUIRES_NEW lambda** — Task 3 Step 3 (NotificationPublisherImpl modification).
+- [x] **§2.3 Coalesce key shared with in-app** — Task 1 (DAO uses passed-through key); Task 3 (dispatcher passes through `event.coalesceKey()`).
+- [x] **§3.1 Package layout** — files in Tasks 1–6 match the layout spec.
+- [x] **§3.2 SlImMessage entity** — Task 1 Step 2.
+- [x] **§3.3 SlImMessageStatus enum** — Task 1 Step 1.
+- [x] **§3.4 SlImMessageDao with `xmax != 0` ON CONFLICT upsert** — Task 1 Step 4.
+- [x] **§3.5 SlImMessageRepository with FOR UPDATE SKIP LOCKED** — Task 1 Step 5; Task 4 Step 5 (controller comment).
+- [x] **§3.6 SlImChannelGate with discriminated Decision** — Task 2 Step 3.
+- [x] **§3.7 SlImChannelDispatcher with two entry points** — Task 3 Step 1.
+- [x] **§3.8 SlImLinkResolver per-category** — Task 2 Step 6.
+- [x] **§3.9 SlImMessageBuilder with byte-budget enforcement** — Task 2 Step 9, with three mandatory test cases at Step 10.
+- [x] **§3.10 SlImCleanupJob with stage 1 + stage 2 + INFO log + top_users-before-update** — Task 5 Step 3.
+- [x] **§3.11 SlImTerminalAuthFilter** — Task 4 Step 3.
+- [x] **§3.12 SlImInternalController state machines** — Task 4 Step 5.
+- [x] **§3.13 NotificationPreferencesController closed-shape validation** — Task 6 Step 2.
+- [x] **§3.14 SlImCoalesceIndexInitializer** — Task 1 Step 6.
+- [x] **§3.15 NotificationService.publish modification** — Task 3 Step 2.
+- [x] **§3.16 listingCancelledBySellerFanout modification** — Task 3 Step 3.
+- [x] **§4.1 /settings route tree** — Task 8 Steps 1, 2, 8.
+- [x] **§4.2 NotificationPreferencesPage layout** — Task 8 Step 7.
+- [x] **§4.3 Disabled-state preservation invariant** — Task 8 Step 6 (component) + Step 12 (test) + Step 13 (page-level test).
+- [x] **§4.4 Hooks** — Task 7 Steps 4, 5.
+- [x] **§4.5 REST client** — Task 7 Step 3.
+- [x] **§4.6 Settings entry points** — Task 8 Steps 9, 10.
+- [x] **§4.7 MSW handlers** — Task 7 Step 6.
+- [x] **§5.1–5.5 LSL script + READMEs** — Task 9 Steps 1–4.
+- [x] **§6 Data flow scenarios** — implicit in the test coverage of Task 3 (5 vertical-slice integration tests covering all five scenarios) and Task 5 (cleanup canary).
+- [x] **§7 API surface (5 endpoints + state machines)** — Task 4 Step 5 (internal controller); Task 6 Step 2 (preferences controller).
+- [x] **§8 Error handling** — implicit in test coverage; explicit notes in dispatcher's try-catch (Task 3 Step 1) and controller's transition logic (Task 4 Step 5).
+- [x] **§9 Testing strategy (4 tiers + e2e)** — Tier 1: Tasks 1, 2 (unit). Tier 2: Task 1 (DAO + repo + initializer). Tier 3: Task 3 (vertical-slice). Tier 4: Tasks 4, 6 (controller). Cleanup: Task 5 (with LogCaptor). Frontend: Tasks 7, 8.
+- [x] **§10 Sub-spec boundaries** — Task 10 Step 1 (DEFERRED updates).
+- [x] **§11 Deferred ledger updates** — Task 10 Step 1.
+- [x] **§12 FOOTGUNS additions (4 entries)** — Task 10 Step 2.
+- [x] **§13 Documentation updates (DESIGN.md §11, lsl-scripts READMEs, root CLAUDE.md)** — Task 10 Steps 3, 4; Task 9 Steps 1, 4.
+- [x] **§13.7 Manual test plan** — Task 10 Step 9 (PR body).
+
+**E2E contract test (`SlImEndToEndIntegrationTest`)** — spec §9.7 calls for one end-to-end test. **Gap:** the plan doesn't have a dedicated step for this. Add it as a Task 4 Step 8 follow-on or as a final integration test in Task 6. *Decision: add a Step in Task 4 after the controller tests are green, since it requires the controller endpoints to exist.*
+
+To address the gap, here's the new step (insert into Task 4 between Step 7 and the existing Step 8/9):
+
+> **Step 7b: Write `SlImEndToEndIntegrationTest`**
+>
+> An end-to-end contract test driving an OUTBID through `BidService.placeBid()`, then asserting (1) the IM row exists in `sl_im_message`, (2) `GET /pending` returns it via the controller, (3) `POST /{id}/delivered` transitions the row, (4) idempotent second `/delivered` returns 204 without re-stamping `delivered_at`. One test, slow (full Spring context + real Postgres + auction fixture from sub-spec 1's `BidPlacementIntegrationTest`), but the canary for "the contract from event → terminal works."
+>
+> The test file: `backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/SlImEndToEndIntegrationTest.java`. Reuse the auction-fixture pattern from Task 3's `OutbidImIntegrationTest` (which itself copies from `BidPlacementIntegrationTest`).
+
+The implementer should add this step's test file when they reach Task 4. The plan as written already has the building blocks; this self-review note flags that the e2e test file should be created and added to the Task 4 commit's `git add` list.
+
+### Placeholder scan
+
+Scanned the plan for the prohibited patterns. The deliberate `throw new UnsupportedOperationException("copy pattern")` markers in Task 3's integration test fixtures (Steps 7, 9, 11) are **not** placeholders in the No-Placeholders sense — they are explicit instructions to the implementer to read the named neighbor file and copy its fixture pattern. The plan provides the test logic; the fixture-construction helpers are codebase-specific and reading the actual neighbor is the right move. Each marker has a "Note for the implementer" paragraph explaining what to copy and from where.
+
+The `// ... existing keys ...` and `// ... existing matchers ...` comments in Tasks 4 and 5 (application.yml additions, WebSecurityConfig modification) are **not** placeholders — they document where to insert into existing files without rewriting the entire file. The implementer reads the existing file first; the plan tells them what to add and where.
+
+`F.NN` in Task 10 Step 2 is a deliberate placeholder for the implementer to fill in based on the file's actual last-numbered entry. Spec §12 acknowledges this.
+
+### Type consistency
+
+- `SlImMessage` entity (Task 1) → `SlImMessageDao.UpsertResult` (Task 1) → `SlImMessageRepository.pollPending(int)` (Task 1) → `SlImInternalController.PendingItem` / `PendingResponse` (Task 4). Field names consistent.
+- `SlImChannelGate.Decision` enum (Task 2) → `SlImChannelDispatcher.doQueue` switch (Task 3). All 5 enum values handled.
+- `PreferencesDto` Java record (Task 6) → `PreferencesDto` TypeScript interface (Task 7). Field names match (`slImMuted`, `slIm`).
+- `EditableGroup` TS type (Task 7) → `ALLOWED_GROUP_KEYS` Java set (Task 6) → MSW `ALLOWED` set (Task 7). All three list the same 5 keys.
+- `NotificationEvent` record from sub-spec 1 → consumed by `SlImChannelDispatcher.maybeQueue` (Task 3 Step 1). Signatures match the existing record (`userId`, `category`, `title`, `body`, `data`, `coalesceKey`).
+- `requiresNewTxTemplate` qualifier — sub-spec 1's `NotificationConfig` defines it; Task 3's `SlImChannelDispatcher` constructor uses the same qualifier name. Reused, not duplicated.
+
+No drift detected.
+
+### Consistency with brainstorm session
+
+Every decision from the brainstorm landed in the plan:
+- ✅ Option B for scope (backend + frontend + LSL in one sub-spec).
+- ✅ lsl-scripts/ directory at project root with per-script READMEs.
+- ✅ Quiet hours dropped (columns dormant).
+- ✅ Coalescing option A (collapse during pendency).
+- ✅ Skip queue if no avatar UUID.
+- ✅ 48h TTL with INFO logging (`top_users` query before UPDATE).
+- ✅ Architecture B (afterCommit hook).
+- ✅ Preferences UI structure C (single column with banner).
+- ✅ Hide SYSTEM / REALTY_GROUP / MARKETING from toggle grid.
+- ✅ Reviews defaults to OFF.
+- ✅ Route placement A (`/settings/notifications`).
+- ✅ Message format `[SLPA] {title}\n\n{body}\n\n{deeplink}`.
+- ✅ FAILED option β (separate enum value for triage).
+- ✅ Stage 2 DELETE includes FAILED with 30d retention.
+- ✅ Symmetric state machines for `/delivered` and `/failed` (sticky FAILED + EXPIRED → 409).
+- ✅ Byte-budget builder with surrogate handling and 3 mandatory test cases.
+- ✅ ESCROW_TRANSFER_REMINDER → Epic 10 (option β).
+- ✅ FOR UPDATE SKIP LOCKED clarified as advisory + code comment requirement.
+
+---
+
+## Plan complete
+
+Saved to `docs/superpowers/plans/2026-04-26-epic-09-sub-3-sl-im-and-preferences.md`.
+
+10 tasks, ~80 new backend tests, ~25 new frontend tests, 1 LSL script + 2 READMEs + 1 config notecard template. Final commit on Task 10 Step 9 opens the PR; Step 10 explicitly stops short of merge.

--- a/docs/superpowers/specs/2026-04-26-epic-09-sub-3-sl-im-and-preferences.md
+++ b/docs/superpowers/specs/2026-04-26-epic-09-sub-3-sl-im-and-preferences.md
@@ -1,0 +1,1790 @@
+# Epic 09 sub-spec 3 — SL IM Channel & Notification Preferences UI
+
+**Date:** 2026-04-26
+**Branch (planned):** `task/09-sub-3-sl-im-and-preferences`
+**Depends on:** Epic 09 sub-spec 1 (in-app + real-time push), Epic 02 sub-spec 2b (User entity preference columns)
+**Successor:** Epic 09 is functionally complete after this sub-spec, modulo deferred items in §10.
+
+---
+
+## 1. Goal & scope
+
+Ship the **SL IM channel** end-to-end as the second user-facing notification channel alongside in-app, plus a **preferences UI** at `/settings/notifications` that lets users control which notification groups deliver via SL IM and master-mute the channel.
+
+The SL IM channel doubles as the email channel: SL natively forwards in-game IMs to the user's registered email when their avatar is offline. Users with active SL email forwarding receive SLPA notifications by email without SLPA building any email infrastructure.
+
+End-to-end means three parts in a single shippable unit:
+
+- **Backend.** A new `SlImMessage` queue table, an `afterCommit` hook in `NotificationService.publish()` plus a sibling call inside the cancellation fan-out's per-recipient `REQUIRES_NEW` lambda, internal polling/confirmation endpoints under `/api/v1/internal/sl-im/*` for the in-world dispatcher, a 48h expiry job with operator-grade INFO logging, a preferences read/write endpoint, and per-recipient gating that reads user preferences fresh on every dispatch.
+- **Frontend.** A `/settings` route tree with `/settings/notifications` as its first occupant — banner-style hybrid layout, single column of per-group SL IM toggles with category subtext, a master-mute row that visually disables but does not erase per-group state. Settings entry points from the bell-dropdown footer and the `/notifications` feed-page header.
+- **LSL.** A new `lsl-scripts/` directory at the project root with a top-level index README and `lsl-scripts/sl-im-dispatcher/` containing the polling object that delivers via `llInstantMessage`, a config notecard template, and a comprehensive per-script README covering deployment, configuration, operations, and the inherent fire-and-forget limits of `llInstantMessage`.
+
+### Explicitly out of scope
+
+- **Email channel.** Removed from the roadmap; not "coming soon," not deferred. SL IM via offline-IM-to-email forwarding covers the email use case. Re-add only on explicit user request.
+- **`SYSTEM_ANNOUNCEMENT` publisher method, admin endpoint, or fan-out-to-all-users mechanism.** The category enum, frontend renderer, and channel gate's bypass-prefs logic all exist or land here, but the trigger is Epic 10 (Admin & Moderation) scope. Sub-spec 3 unit-tests the SYSTEM bypass with a synthetic event; no production code path emits a SYSTEM_ANNOUNCEMENT in this sub-spec.
+- **`ESCROW_TRANSFER_REMINDER` scheduler.** The publisher method, category, data builder, and frontend renderer exist from sub-spec 1 with no caller. The scheduler that fires once per escrow ~24h before transfer deadline retargets to Epic 10 alongside the response-window scheduler.
+- **HTTP-in push from backend → dispatcher** for low-latency delivery of urgent notifications. Polling-only at 60 s cadence is the design here. Push is a post-launch enhancement once the channel has real traffic and a real latency complaint.
+- **Quiet hours.** The User entity's `slImQuietStart` and `slImQuietEnd` columns exist from Epic 02 sub-spec 2b and stay dormant. No scheduling, no held-until logic. A future sub-spec may either expose them in a UI or drop the columns; both options are tracked in the deferred ledger.
+- **Multi-avatar accounts.** SLPA models one `slAvatarUuid` per user. Sub-spec 3 doesn't change that.
+- **Retry semantics for failed deliveries.** EXPIRED rows are never retried; FAILED rows are not retried (and the dispatcher script doesn't call `/failed` anyway — see §5.5). If retry is wanted later, it's a separate enum value, a separate job, and a separate sub-spec.
+- **Notification preferences UI editing the email channel.** The `notifyEmail` JSONB column on User stays in the schema unchanged but is invisible in this sub-spec's UI. When email lands later (if ever), the prefs page grows a section without restructuring.
+- **Removing the unused `notifyEmail` column or the dormant quiet-hours columns.** Cheaper to leave them than migrate now; if either stays unused for >12 months, drop them in a dedicated cleanup sub-spec.
+
+### Production-grade posture
+
+This sub-spec ships for full production launch. No "good enough for MVP" choices. The dispatch path is failure-isolated per recipient, the expiry job logs operator-grade pipeline-health signals, the preferences PUT validates a closed shape so frontend bugs surface as 400s instead of silent drops, and the message builder enforces SL's actual byte limit so non-ASCII parcel names don't truncate the deeplink off the bottom of an IM.
+
+---
+
+## 2. Architecture
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  Existing event source (BidService, EscrowService, etc.)           │
+│      └─ publisher.<category>(...)                                  │
+│           └─ NotificationService.publish(event)  ◄── @MANDATORY    │
+│                ├─ DAO upsert (in-app row)                          │
+│                ├─ register afterCommit:                            │
+│                │     wsBroadcaster.broadcastUpsert(...)            │
+│                └─ register afterCommit:        ◄── NEW             │
+│                      slImChannelDispatcher.maybeQueue(event)       │
+└────────────────────────────────────────────────────────────────────┘
+                                │ afterCommit
+                                ▼
+┌────────────────────────────────────────────────────────────────────┐
+│  SlImChannelDispatcher.maybeQueue(event)                           │
+│  Inside REQUIRES_NEW per recipient:                                │
+│   1. Load User fresh (read your committed prefs)                   │
+│   2. Channel gate decision (no-avatar is the universal floor):     │
+│        if user.slAvatarUuid==null     ─→ SKIP_NO_AVATAR            │
+│        else if category.group == SYSTEM ─→ QUEUE_BYPASS_PREFS      │
+│        else if user.notifySlImMuted   ─→ SKIP_MUTED                │
+│        else if !notifySlIm[group]     ─→ SKIP_GROUP_DISABLED       │
+│        else                           ─→ QUEUE                     │
+│   3. Build messageText: "[SLPA] {title}\n\n{body}\n\n{deeplink}"   │
+│      (byte-budget ≤ 1024 UTF-8 bytes; ellipsize body if needed)    │
+│   4. UPSERT into sl_im_message                                     │
+│        ON CONFLICT (user_id, coalesce_key) WHERE status='PENDING'  │
+└────────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌────────────────────────────────────────────────────────────────────┐
+│  sl_im_message table                                               │
+│   id, user_id, avatar_uuid, coalesce_key (nullable),               │
+│   message_text, status (PENDING/DELIVERED/EXPIRED/FAILED),         │
+│   created_at, updated_at, delivered_at, attempts                   │
+│   Partial unique idx: (user_id, coalesce_key) WHERE PENDING        │
+│   Index: (status, created_at) for the polling query                │
+└────────────────────────────────────────────────────────────────────┘
+                                ▲ ▼
+┌────────────────────────────────────────────────────────────────────┐
+│  /api/v1/internal/sl-im/*  (shared-secret auth via                 │
+│                              SlImTerminalAuthFilter)               │
+│   GET   /pending?limit=10  → batch (oldest PENDING first,          │
+│                                FOR UPDATE SKIP LOCKED)             │
+│   POST  /{id}/delivered    → state machine: PENDING→DELIVERED,     │
+│                                idempotent on DELIVERED, 409 on     │
+│                                FAILED/EXPIRED                      │
+│   POST  /{id}/failed       → state machine: PENDING→FAILED,        │
+│                                idempotent on FAILED, 409 on        │
+│                                DELIVERED/EXPIRED                   │
+└────────────────────────────────────────────────────────────────────┘
+                                ▲
+                                │ poll every 60 s, batch ≤10, 2 s spacing
+┌────────────────────────────────────────────────────────────────────┐
+│  In-world: lsl-scripts/sl-im-dispatcher/dispatcher.lsl             │
+│   timer → llHTTPRequest(POLL_URL)                                  │
+│      └─ http_response → for each msg in batch:                     │
+│            llInstantMessage(uuid, text); per-IM 2 s timer tick;    │
+│            llHTTPRequest(CONFIRM_URL/{id}/delivered)               │
+└────────────────────────────────────────────────────────────────────┘
+
+Cleanup job (daily, 03:30 SLT — Spring's zoned cron):
+  Stage 1: UPDATE sl_im_message SET status='EXPIRED'
+           WHERE status='PENDING' AND created_at < (now - 48h)
+  Stage 2: DELETE sl_im_message
+           WHERE status IN ('DELIVERED','EXPIRED','FAILED')
+             AND updated_at < (now - 30d)
+  log INFO: "SL IM expiry sweep: expired={n} deleted={n}
+            cutoff={ts} top_users={user_id:count, ...}"
+```
+
+Three load-bearing decisions visible in this picture:
+
+### 2.1 afterCommit + REQUIRES_NEW per recipient (single-recipient path)
+
+Same lesson as the cancellation fan-out from sub-spec 1: an IM-queue failure (FK violation, transient DB hiccup, prefs lookup race) must never roll back the originating bid/escrow/cancellation. `NotificationService.publish()` registers the dispatcher's `maybeQueue` call as an afterCommit hook on the parent transaction. Inside the hook, the dispatcher uses the existing `requiresNewTxTemplate` bean (defined in `NotificationConfig` from sub-spec 1, propagation `REQUIRES_NEW`) to wrap the user-fetch + gate-decision + DAO upsert in its own transaction. If the dispatcher tx fails, the in-app row already committed, the parent business event already committed, and the only loss is the IM that wouldn't have queued.
+
+Reliability posture: **in-app guaranteed, IM best-effort.**
+
+### 2.2 Sibling call inside the fan-out's per-recipient REQUIRES_NEW (fan-out path)
+
+`NotificationPublisherImpl.listingCancelledBySellerFanout(...)` from sub-spec 1 calls `notificationDao.upsert()` directly inside a per-recipient REQUIRES_NEW lambda — never touching `NotificationService.publish()`. An `afterCommit` hook attached only to `publish()` would silently miss every `LISTING_CANCELLED_BY_SELLER` IM.
+
+Fix: `slImChannelDispatcher.maybeQueue(...)` is added as a sibling call inside the same per-recipient REQUIRES_NEW lambda, between the DAO upsert and the WS broadcast. Both writes commit atomically per recipient; the per-recipient try-catch already isolates failures from sibling recipients.
+
+```java
+// NotificationPublisherImpl.listingCancelledBySellerFanout — modified
+for (Long bidderId : bidderUserIds) {
+    try {
+        UpsertResult result = requiresNewTxTemplate.execute(status -> {
+            UpsertResult r = notificationDao.upsert(bidderId,
+                NotificationCategory.LISTING_CANCELLED_BY_SELLER,
+                title, body, data, /* coalesceKey */ null);
+            slImChannelDispatcher.maybeQueueForFanout(    // ← NEW
+                bidderId, NotificationCategory.LISTING_CANCELLED_BY_SELLER,
+                title, body, data, /* coalesceKey */ null);
+            return r;
+        });
+        wsBroadcaster.broadcastUpsert(bidderId, result, dtoFor(...));
+    } catch (Exception ex) {
+        log.warn("Fan-out notification failed for userId={}: {}", bidderId, ex.toString());
+    }
+}
+```
+
+Reliability posture: **in-app + IM atomic per recipient** (both write or neither does), with sibling recipients unaffected.
+
+The two postures are different but both correct, and the difference is the kind of trap a future contributor will hit if they refactor either path. It gets a FOOTGUNS entry (§12).
+
+### 2.3 Coalesce key shared with in-app
+
+The `sl_im_message` table reuses the same coalesce key string the in-app `NotificationDao` uses — `outbid:{userId}:{auctionId}`, `proxy_exhausted:{userId}:{auctionId}`, `transfer_reminder:{userId}:{escrowId}`. Different table, different lifecycle (`status='PENDING'` vs `read=false`), but same key namespace and same partial-unique-index pattern. Categories without an in-app coalesce key get no IM coalescing either; that's correct (AUCTION_WON shouldn't collapse). The dispatcher never invents new keys; it passes through whatever key the publisher set.
+
+---
+
+## 3. Backend design
+
+### 3.1 Package layout
+
+```
+backend/src/main/java/com/slparcelauctions/backend/notification/slim/
+├── SlImMessage.java                       // JPA entity
+├── SlImMessageStatus.java                 // enum: PENDING, DELIVERED, EXPIRED, FAILED
+├── SlImMessageDao.java                    // native ON CONFLICT upsert
+├── SlImMessageRepository.java             // JpaRepository + polling query
+├── SlImChannelDispatcher.java             // maybeQueue / maybeQueueForFanout entry points
+├── SlImChannelGate.java                   // pure decision function
+├── SlImChannelGate.Decision               // discriminated decision enum
+├── SlImLinkResolver.java                  // category → URL string
+├── SlImMessageBuilder.java                // (title, body, link) → final UTF-8-byte-bounded text
+├── SlImCleanupJob.java                    // daily expiry + retention sweep with INFO log
+├── SlImCleanupProperties.java             // @ConfigurationProperties
+├── SlImCoalesceIndexInitializer.java      // partial unique index DDL at startup
+└── ws/                                    // (no new files; sub-spec 1 already wired channels)
+
+backend/src/main/java/com/slparcelauctions/backend/notification/slim/internal/
+├── SlImInternalController.java            // GET /pending, POST /{id}/delivered, POST /{id}/failed
+├── SlImTerminalAuthFilter.java            // shared-secret filter on /api/v1/internal/sl-im/**
+└── SlImInternalProperties.java            // @ConfigurationProperties (shared secret, limit cap)
+
+backend/src/main/java/com/slparcelauctions/backend/notification/preferences/
+├── NotificationPreferencesController.java // GET/PUT /api/v1/users/me/notification-preferences
+└── NotificationPreferencesDto.java        // record { boolean slImMuted; Map<String,Boolean> slIm }
+```
+
+The SL IM dispatcher and gate logic live in a `slim/` sub-package because they're one cohesive subsystem with internal coupling that doesn't need to leak into other notification code. The internal endpoints are further nested in `slim/internal/` to make their non-user-facing nature obvious to readers grepping for endpoint surface area. Preferences live in their own sub-package because the responsibility (read/write user prefs) is distinct from the SL IM channel itself — the same prefs would govern email or any future channel.
+
+### 3.2 `SlImMessage` entity
+
+```java
+@Entity
+@Table(name = "sl_im_message",
+       indexes = {
+         @Index(name = "ix_sl_im_status_created", columnList = "status, created_at"),
+         @Index(name = "ix_sl_im_user_status", columnList = "user_id, status")
+       })
+@Getter @Setter @NoArgsConstructor
+public class SlImMessage {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "avatar_uuid", nullable = false, length = 36)
+    private String avatarUuid;     // denormalized at queue time; user.slAvatarUuid at moment of dispatch
+
+    @Column(name = "coalesce_key", length = 128)
+    private String coalesceKey;    // nullable; partial unique index emitted by initializer
+
+    @Column(name = "message_text", nullable = false, length = 1024)
+    private String messageText;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private SlImMessageStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @Column(name = "delivered_at")
+    private OffsetDateTime deliveredAt;
+
+    @Column(nullable = false)
+    private int attempts;          // bumped on each /delivered call (mostly 1)
+}
+```
+
+The avatar UUID is denormalized into the row at queue time (rather than joined at poll time) for two reasons: the polling query stays a single-table read with no join (predictable plan, easy `FOR UPDATE SKIP LOCKED`), and re-resolving the UUID at poll time would create a race where a user changes their avatar mid-flight and gets messages routed to the wrong UUID. The intended-recipient UUID at the moment of intent is the right value to deliver to.
+
+The `attempts` column exists for triage; in steady state it's always 1 (terminal calls `/delivered` once per send), but if a future enhancement adds retry semantics it's already wired. Bumped via the conditional UPDATE in the controller, not via JPA dirty tracking.
+
+### 3.3 `SlImMessageStatus` enum
+
+```java
+public enum SlImMessageStatus {
+    PENDING,    // queued, not yet sent by dispatcher
+    DELIVERED,  // dispatcher confirmed via POST /delivered
+    EXPIRED,    // cleanup job promoted PENDING → EXPIRED after 48h
+    FAILED      // operator/manual intervention or future pre-validation revision
+}
+```
+
+### 3.4 `SlImMessageDao`
+
+Mirrors `NotificationDao` from sub-spec 1's Task 1. Native `ON CONFLICT (user_id, coalesce_key) WHERE status = 'PENDING' DO UPDATE` upsert, with the `xmax = 0` trick in the `RETURNING` clause to distinguish insert from update without a second roundtrip:
+
+```java
+@Component
+@RequiredArgsConstructor
+public class SlImMessageDao {
+
+    private final JdbcTemplate jdbc;
+
+    public record UpsertResult(
+        long id,
+        boolean wasUpdate,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
+    ) {}
+
+    public UpsertResult upsert(
+        long userId,
+        String avatarUuid,
+        String messageText,
+        String coalesceKey
+    ) {
+        String sql = """
+            INSERT INTO sl_im_message
+              (user_id, avatar_uuid, coalesce_key, message_text,
+               status, attempts, created_at, updated_at)
+            VALUES (?, ?, ?, ?, 'PENDING', 0, now(), now())
+            ON CONFLICT (user_id, coalesce_key) WHERE status = 'PENDING'
+            DO UPDATE SET
+              message_text = EXCLUDED.message_text,
+              avatar_uuid  = EXCLUDED.avatar_uuid,
+              updated_at   = now()
+            RETURNING id, (xmax != 0) AS was_update, created_at, updated_at
+            """;
+        Map<String, Object> row = jdbc.queryForMap(
+            sql, userId, avatarUuid, coalesceKey, messageText);
+        return new UpsertResult(
+            ((Number) row.get("id")).longValue(),
+            (Boolean) row.get("was_update"),
+            ((java.sql.Timestamp) row.get("created_at")).toInstant().atOffset(ZoneOffset.UTC),
+            ((java.sql.Timestamp) row.get("updated_at")).toInstant().atOffset(ZoneOffset.UTC)
+        );
+    }
+}
+```
+
+A `null` coalesce key never matches itself in Postgres unique constraints (NULL ≠ NULL), so the same query handles coalescing and non-coalescing categories with no service-layer branching.
+
+### 3.5 `SlImMessageRepository`
+
+```java
+public interface SlImMessageRepository extends JpaRepository<SlImMessage, Long> {
+
+    @Query(value = """
+        SELECT * FROM sl_im_message
+        WHERE status = 'PENDING'
+        ORDER BY created_at ASC
+        LIMIT :limit
+        FOR UPDATE SKIP LOCKED
+        """, nativeQuery = true)
+    List<SlImMessage> pollPending(@Param("limit") int limit);
+
+    @Query("SELECT m.status, count(m) FROM SlImMessage m GROUP BY m.status")
+    List<Object[]> countByStatus();
+}
+```
+
+`FOR UPDATE SKIP LOCKED` matters because if a future enhancement deploys a fallback dispatcher (e.g., a spare object), concurrent pollers each grab disjoint batches without serializing on a single row. Costs nothing now to future-proof.
+
+### 3.6 `SlImChannelGate`
+
+A pure function: `(User, NotificationCategory) → Decision`. Stateless, instantiated as a `@Component` so it's injectable and Mockito-friendly, but no internal mutable state.
+
+```java
+@Component
+public class SlImChannelGate {
+
+    public enum Decision {
+        QUEUE,                  // normal queue path
+        QUEUE_BYPASS_PREFS,     // SYSTEM: skip prefs, still verify avatar
+        SKIP_NO_AVATAR,         // user.slAvatarUuid == null
+        SKIP_MUTED,             // user.notifySlImMuted == true
+        SKIP_GROUP_DISABLED     // user.notifySlIm[group] == false
+    }
+
+    public Decision decide(User user, NotificationCategory category) {
+        boolean isSystem = category.getGroup() == NotificationGroup.SYSTEM;
+
+        // No-avatar check: hard floor, applies even to SYSTEM.
+        if (user.getSlAvatarUuid() == null) {
+            return Decision.SKIP_NO_AVATAR;
+        }
+
+        if (isSystem) {
+            return Decision.QUEUE_BYPASS_PREFS;
+        }
+
+        if (user.isNotifySlImMuted()) {
+            return Decision.SKIP_MUTED;
+        }
+
+        Map<String, Boolean> prefs = user.getNotifySlIm();
+        String groupKey = category.getGroup().name().toLowerCase();
+        Boolean groupOn = prefs.get(groupKey);
+        if (groupOn == null || !groupOn) {
+            return Decision.SKIP_GROUP_DISABLED;
+        }
+
+        return Decision.QUEUE;
+    }
+}
+```
+
+Returning a discriminated `Decision` (instead of a boolean) means the dispatcher logs the reason at DEBUG, which makes "I didn't get an IM" support tickets resolvable from logs alone.
+
+### 3.7 `SlImChannelDispatcher`
+
+Two entry points: `maybeQueue` (single-recipient, called from `NotificationService.publish`'s afterCommit hook) and `maybeQueueForFanout` (called from inside the per-recipient REQUIRES_NEW lambda in `NotificationPublisherImpl.listingCancelledBySellerFanout`). Both share core logic.
+
+```java
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SlImChannelDispatcher {
+
+    private final UserRepository userRepo;
+    private final SlImChannelGate gate;
+    private final SlImMessageBuilder messageBuilder;
+    private final SlImLinkResolver linkResolver;
+    private final SlImMessageDao dao;
+    @Qualifier("requiresNewTxTemplate")
+    private final TransactionTemplate requiresNewTx;
+
+    /**
+     * Single-recipient entry point. Caller is in afterCommit; we open our own
+     * REQUIRES_NEW transaction so a failure here doesn't roll back anything else.
+     */
+    public void maybeQueue(NotificationEvent event) {
+        try {
+            requiresNewTx.execute(status -> {
+                doQueue(event.userId(), event.category(),
+                        event.title(), event.body(), event.data(), event.coalesceKey());
+                return null;
+            });
+        } catch (Exception ex) {
+            log.warn("SL IM dispatch failed for userId={} category={}: {}",
+                event.userId(), event.category(), ex.toString());
+        }
+    }
+
+    /**
+     * Fan-out entry point. Caller is already inside a REQUIRES_NEW per-recipient
+     * lambda; this writes as a sibling, atomic with the in-app row for that recipient.
+     * Failures here propagate and roll back that recipient's in-app row too.
+     */
+    public void maybeQueueForFanout(
+        long userId, NotificationCategory category,
+        String title, String body, Map<String, Object> data, String coalesceKey
+    ) {
+        doQueue(userId, category, title, body, data, coalesceKey);
+    }
+
+    private void doQueue(
+        long userId, NotificationCategory category,
+        String title, String body, Map<String, Object> data, String coalesceKey
+    ) {
+        User user = userRepo.findById(userId)
+            .orElseThrow(() -> new IllegalStateException("user not found: " + userId));
+
+        SlImChannelGate.Decision decision = gate.decide(user, category);
+        log.debug("SL IM gate decision userId={} category={}: {}", userId, category, decision);
+
+        switch (decision) {
+            case QUEUE, QUEUE_BYPASS_PREFS -> {
+                String deeplink = linkResolver.resolve(category, data);
+                String messageText = messageBuilder.assemble(title, body, deeplink);
+                dao.upsert(userId, user.getSlAvatarUuid(), messageText, coalesceKey);
+            }
+            case SKIP_NO_AVATAR, SKIP_MUTED, SKIP_GROUP_DISABLED -> {
+                // intentional no-op; decision logged at DEBUG above
+            }
+        }
+    }
+}
+```
+
+The fan-out variant intentionally does NOT wrap in REQUIRES_NEW (the caller already did), and intentionally does NOT swallow exceptions (the caller's per-recipient try-catch handles isolation). The single-recipient variant does both, because it runs in afterCommit on the parent's transaction and any failure must not propagate.
+
+### 3.8 `SlImLinkResolver`
+
+```java
+@Component
+@RequiredArgsConstructor
+public class SlImLinkResolver {
+
+    private final SlpaWebProperties webProps;  // exposes slpa.web.base-url
+
+    public String resolve(NotificationCategory category, Map<String, Object> data) {
+        String base = webProps.baseUrl();  // e.g. "https://slpa.example.com"
+        return switch (category) {
+            case OUTBID, PROXY_EXHAUSTED, AUCTION_LOST,
+                 AUCTION_ENDED_RESERVE_NOT_MET, AUCTION_ENDED_NO_BIDS,
+                 AUCTION_ENDED_BOUGHT_NOW, AUCTION_ENDED_SOLD,
+                 LISTING_VERIFIED, LISTING_CANCELLED_BY_SELLER,
+                 REVIEW_RECEIVED ->
+                base + "/auction/" + data.get("auctionId");
+            case AUCTION_WON ->
+                base + "/auction/" + data.get("auctionId") + "/escrow";
+            case ESCROW_FUNDED, ESCROW_TRANSFER_CONFIRMED, ESCROW_PAYOUT,
+                 ESCROW_EXPIRED, ESCROW_DISPUTED, ESCROW_FROZEN,
+                 ESCROW_PAYOUT_STALLED, ESCROW_TRANSFER_REMINDER ->
+                base + "/auction/" + data.get("auctionId") + "/escrow";
+            case LISTING_SUSPENDED, LISTING_REVIEW_REQUIRED ->
+                base + "/dashboard/listings";
+            case SYSTEM_ANNOUNCEMENT ->
+                base + "/notifications";
+        };
+    }
+}
+```
+
+This duplicates the deeplink logic that lives in the frontend `categoryMap` (`frontend/src/lib/notifications/categoryMap.ts`). The duplication is intentional — the alternative would be to embed the URL in the in-app `Notification.data` JSON blob at publish time, which couples the in-app row to a specific channel's URL semantics and makes URL changes a data migration. Twenty-line switch in two languages is fine.
+
+The `SlpaWebProperties` `@ConfigurationProperties` record (`slpa.web.base-url`) is read from `application.yml` and must be set per-environment. Defaulting to `https://slpa.example.com` in dev / staging / prod values is appropriate.
+
+### 3.9 `SlImMessageBuilder` (with byte-budget enforcement)
+
+```java
+@Component
+public class SlImMessageBuilder {
+
+    private static final int MAX_BYTES = 1024;        // SL llInstantMessage hard limit
+    private static final String PREFIX = "[SLPA] ";
+    private static final String SEPARATOR = "\n\n";
+    private static final String ELLIPSIS = "…";       // 3 bytes UTF-8
+
+    public String assemble(String title, String body, String deeplink) {
+        // The deeplink and prefix and title are non-negotiable; only body ellipsizes.
+        String trimmedBody = body;
+        String candidate = PREFIX + title + SEPARATOR + trimmedBody + SEPARATOR + deeplink;
+
+        if (candidate.getBytes(StandardCharsets.UTF_8).length <= MAX_BYTES) {
+            return candidate;
+        }
+
+        // Reserve everything except the body, then trim the body to fit.
+        int reservedBytes = (PREFIX + title + SEPARATOR + SEPARATOR + deeplink + ELLIPSIS)
+            .getBytes(StandardCharsets.UTF_8).length;
+        int availableForBody = MAX_BYTES - reservedBytes;
+        if (availableForBody <= 0) {
+            // Pathological: title + deeplink alone exceed the budget. Fall back to
+            // PREFIX + truncated-title + SEPARATOR + deeplink, dropping the body.
+            return assembleWithoutBody(title, deeplink);
+        }
+
+        // Trim body by Java char from the end; back off one extra char if the trim
+        // boundary lands on a high surrogate to avoid invalid UTF-16.
+        int k = trimmedBody.length();
+        while (k > 0) {
+            String attempt = trimmedBody.substring(0, k) + ELLIPSIS;
+            int bytes = attempt.getBytes(StandardCharsets.UTF_8).length;
+            if (bytes <= availableForBody) {
+                if (k > 0 && Character.isHighSurrogate(trimmedBody.charAt(k - 1))) {
+                    k -= 1;
+                    continue;
+                }
+                trimmedBody = attempt;
+                break;
+            }
+            k -= 1;
+        }
+        if (k == 0) {
+            return assembleWithoutBody(title, deeplink);
+        }
+        return PREFIX + title + SEPARATOR + trimmedBody + SEPARATOR + deeplink;
+    }
+
+    private String assembleWithoutBody(String title, String deeplink) {
+        // Last-resort fallback. Title also trimmed if it's the cause.
+        // ... bounded similar trim loop on title ...
+        return PREFIX + title + SEPARATOR + deeplink;
+    }
+}
+```
+
+The byte-budget enforcement is the single most fragile piece of this sub-spec. SL's `llInstantMessage` truncates at 1024 **bytes**, not characters, and silently — there is no error, no warning, no return value. A parcel name like `東京タワー Estates` contains 5 multi-byte CJK characters that occupy 15 bytes in UTF-8 versus 5 in UTF-16. Without the byte-aware budget, a 1023-character message could occupy 1500+ UTF-8 bytes, with the deeplink at the bottom getting truncated off cleanly. Users would receive the IM, click on... nothing, and report a "broken notification."
+
+The implementer must match the contract:
+- Measure with `getBytes(StandardCharsets.UTF_8).length`, never `String.length()`.
+- Never trim the deeplink, prefix, or separators — they're load-bearing.
+- Only trim the body. Use a single ellipsis character at the trim point.
+- Back off one char if trimming would split a UTF-16 surrogate pair.
+- Three test cases are mandatory: a multi-byte parcel name (CJK, accented Latin), an emoji-bearing parcel name, and a body so long it triggers actual truncation. All assert the deeplink survives intact and the total byte count ≤ 1024.
+
+### 3.10 `SlImCleanupJob` + `SlImCleanupProperties`
+
+```java
+@ConfigurationProperties(prefix = "slpa.notifications.sl-im.cleanup")
+@Validated
+public record SlImCleanupProperties(
+    boolean enabled,
+    @NotBlank String cron,
+    @Positive int expiryAfterHours,         // default 48
+    @Positive int retentionAfterDays,       // default 30
+    @Positive int batchSize,                // default 1000
+    @Min(0) @Max(20) int topUsersInLog      // default 10
+) {}
+```
+
+```yaml
+slpa:
+  notifications:
+    sl-im:
+      cleanup:
+        enabled: true
+        cron: "0 30 3 * * *"         # 03:30 daily, in zone below
+        expiry-after-hours: 48
+        retention-after-days: 30
+        batch-size: 1000
+        top-users-in-log: 10
+```
+
+```java
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "slpa.notifications.sl-im.cleanup",
+                       name = "enabled", havingValue = "true", matchIfMissing = false)
+@Slf4j
+public class SlImCleanupJob {
+
+    private final JdbcTemplate jdbc;
+    private final SlImCleanupProperties properties;
+    private final Clock clock;
+
+    @Scheduled(cron = "${slpa.notifications.sl-im.cleanup.cron}", zone = "America/Los_Angeles")
+    public void run() {
+        OffsetDateTime expiryCutoff = OffsetDateTime.now(clock)
+            .minusHours(properties.expiryAfterHours());
+        OffsetDateTime retentionCutoff = OffsetDateTime.now(clock)
+            .minusDays(properties.retentionAfterDays());
+
+        // Stage 1: PENDING → EXPIRED, capturing per-user counts BEFORE the update
+        // (so the log line names the affected users).
+        List<Map<String, Object>> topUsers = jdbc.queryForList("""
+            SELECT user_id, COUNT(*) AS n
+            FROM sl_im_message
+            WHERE status = 'PENDING' AND created_at < ?
+            GROUP BY user_id
+            ORDER BY n DESC
+            LIMIT ?
+            """, expiryCutoff, properties.topUsersInLog());
+
+        int expired = jdbc.update("""
+            UPDATE sl_im_message SET status = 'EXPIRED', updated_at = now()
+            WHERE status = 'PENDING' AND created_at < ?
+            """, expiryCutoff);
+
+        // Stage 2: chunked DELETE for terminal-status rows past retention.
+        int totalDeleted = 0;
+        int deletedThisChunk;
+        do {
+            deletedThisChunk = jdbc.update("""
+                DELETE FROM sl_im_message
+                WHERE id IN (
+                    SELECT id FROM sl_im_message
+                    WHERE status IN ('DELIVERED','EXPIRED','FAILED')
+                      AND updated_at < ?
+                    LIMIT ?
+                )
+                """, retentionCutoff, properties.batchSize());
+            totalDeleted += deletedThisChunk;
+        } while (deletedThisChunk == properties.batchSize());
+
+        String topUsersStr = topUsers.stream()
+            .map(r -> r.get("user_id") + ":" + r.get("n"))
+            .collect(Collectors.joining(", "));
+        log.info("SL IM cleanup sweep: expired={} deleted={} expiry_cutoff={} retention_cutoff={} top_users=[{}]",
+            expired, totalDeleted, expiryCutoff, retentionCutoff, topUsersStr);
+    }
+}
+```
+
+The INFO log is the operational canary. Stage 1's `expired` count and `top_users` together name "is the dispatcher dark" (high `expired` across many users) versus "did one user's avatar UUID rot" (high `expired` concentrated on one user). Steady-state values are zero `expired` and small `deleted` (matching the daily delivery volume aged 30 days back).
+
+The `top_users` query is captured BEFORE the UPDATE because once rows are EXPIRED the WHERE clause no longer matches them. Two queries instead of one is acceptable — the first is a small aggregation against an indexed column and partial index, the second is the bulk update.
+
+### 3.11 `SlImTerminalAuthFilter`
+
+A `OncePerRequestFilter` registered in the security chain via a custom `WebSecurityConfig` adjustment:
+
+```java
+@Component
+@RequiredArgsConstructor
+public class SlImTerminalAuthFilter extends OncePerRequestFilter {
+
+    private final SlImInternalProperties props;
+    private static final String PATH_PREFIX = "/api/v1/internal/sl-im/";
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest req) {
+        return !req.getRequestURI().startsWith(PATH_PREFIX);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+        throws IOException, ServletException {
+        String header = req.getHeader("Authorization");
+        String expected = "Bearer " + props.sharedSecret();
+        if (header == null || !MessageDigest.isEqual(
+                header.getBytes(StandardCharsets.UTF_8),
+                expected.getBytes(StandardCharsets.UTF_8))) {
+            res.setStatus(HttpStatus.UNAUTHORIZED.value());
+            res.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
+            res.getWriter().write(
+                "{\"type\":\"about:blank\",\"title\":\"Unauthorized\",\"status\":401}");
+            return;
+        }
+        chain.doFilter(req, res);
+    }
+}
+```
+
+`MessageDigest.isEqual` provides constant-time comparison so the secret cannot be guessed via response timing.
+
+The filter is registered in `WebSecurityConfig` via `.addFilterBefore(slImTerminalAuthFilter, JwtAuthenticationFilter.class)`. Internal endpoints are also added to the `permitAll()` matcher for the JWT chain (so JWT processing doesn't reject them) and to the CSRF-disabled matchers (no browser origin).
+
+```java
+public record SlImInternalProperties(
+    @NotBlank String sharedSecret,
+    @Positive @Max(50) int maxBatchLimit       // hard cap on ?limit query param
+) {}
+```
+
+Configuration:
+```yaml
+slpa:
+  notifications:
+    sl-im:
+      dispatcher:
+        shared-secret: ${SL_IM_DISPATCHER_SECRET:dev-only-secret-do-not-use-in-prod}
+        max-batch-limit: 50
+```
+
+### 3.12 `SlImInternalController`
+
+```java
+@RestController
+@RequestMapping("/api/v1/internal/sl-im")
+@RequiredArgsConstructor
+public class SlImInternalController {
+
+    private final SlImMessageRepository repo;
+    private final JdbcTemplate jdbc;
+    private final SlImInternalProperties props;
+
+    public record PendingItem(long id, String avatarUuid, String messageText) {}
+    public record PendingResponse(List<PendingItem> messages) {}
+
+    @GetMapping("/pending")
+    public PendingResponse pending(@RequestParam(defaultValue = "10") int limit) {
+        if (limit > props.maxBatchLimit() || limit < 1) {
+            throw new IllegalArgumentException("limit must be in [1, " + props.maxBatchLimit() + "]");
+        }
+        List<SlImMessage> rows = repo.pollPending(limit);
+        List<PendingItem> items = rows.stream()
+            .map(m -> new PendingItem(m.getId(), m.getAvatarUuid(), m.getMessageText()))
+            .toList();
+        return new PendingResponse(items);
+    }
+
+    @PostMapping("/{id}/delivered")
+    public ResponseEntity<Void> delivered(@PathVariable long id) {
+        return transition(id, SlImMessageStatus.DELIVERED);
+    }
+
+    @PostMapping("/{id}/failed")
+    public ResponseEntity<Void> failed(@PathVariable long id) {
+        return transition(id, SlImMessageStatus.FAILED);
+    }
+
+    /**
+     * State machine for both endpoints:
+     *
+     *   /delivered:  PENDING   → DELIVERED (204, set delivered_at)
+     *                DELIVERED → 204 no-op
+     *                FAILED    → 409
+     *                EXPIRED   → 409
+     *                missing   → 404
+     *
+     *   /failed:     PENDING   → FAILED (204)
+     *                FAILED    → 204 no-op
+     *                DELIVERED → 409
+     *                EXPIRED   → 409
+     *                missing   → 404
+     */
+    private ResponseEntity<Void> transition(long id, SlImMessageStatus target) {
+        // Conditional UPDATE. Returns affected count.
+        // Note: delivered_at is only set on the PENDING→DELIVERED transition;
+        // idempotent calls don't re-stamp it.
+        String sql;
+        if (target == SlImMessageStatus.DELIVERED) {
+            sql = """
+                UPDATE sl_im_message
+                SET status = 'DELIVERED',
+                    delivered_at = COALESCE(delivered_at, now()),
+                    updated_at = now(),
+                    attempts = attempts + 1
+                WHERE id = ? AND status = 'PENDING'
+                """;
+        } else {
+            sql = """
+                UPDATE sl_im_message
+                SET status = 'FAILED', updated_at = now(), attempts = attempts + 1
+                WHERE id = ? AND status = 'PENDING'
+                """;
+        }
+        int updated = jdbc.update(sql, id);
+        if (updated == 1) {
+            return ResponseEntity.noContent().build();
+        }
+
+        // No row updated. Read current state to decide the response.
+        Optional<SlImMessage> opt = repo.findById(id);
+        if (opt.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+        SlImMessageStatus current = opt.get().getStatus();
+        if (current == target) {
+            // idempotent no-op
+            return ResponseEntity.noContent().build();
+        }
+        // current is one of the other terminal statuses → 409
+        return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    }
+}
+```
+
+The conditional UPDATE returning affected-rows count, combined with a single follow-up read on the no-op path, gives the state machine in §7 with one round trip in the happy path and two round trips on idempotent / conflict paths. The follow-up read is lock-free; we already know the row's not in the target state we wrote.
+
+### 3.13 `NotificationPreferencesController`
+
+```java
+@RestController
+@RequestMapping("/api/v1/users/me/notification-preferences")
+@RequiredArgsConstructor
+@PreAuthorize("isAuthenticated()")
+public class NotificationPreferencesController {
+
+    private final UserRepository userRepo;
+
+    public record PreferencesDto(
+        boolean slImMuted,
+        Map<String, Boolean> slIm
+    ) {}
+
+    private static final Set<String> ALLOWED_GROUP_KEYS = Set.of(
+        "bidding", "auction_result", "escrow", "listing_status", "reviews");
+
+    @GetMapping
+    public PreferencesDto get(@AuthenticationPrincipal AuthPrincipal caller) {
+        User user = userRepo.findById(caller.userId()).orElseThrow();
+        Map<String, Boolean> filtered = ALLOWED_GROUP_KEYS.stream()
+            .collect(Collectors.toMap(
+                k -> k,
+                k -> user.getNotifySlIm().getOrDefault(k, false)
+            ));
+        return new PreferencesDto(user.isNotifySlImMuted(), filtered);
+    }
+
+    @PutMapping
+    @Transactional
+    public PreferencesDto put(
+        @AuthenticationPrincipal AuthPrincipal caller,
+        @RequestBody PreferencesDto body
+    ) {
+        // Closed-shape validation: keys must be exactly ALLOWED_GROUP_KEYS.
+        if (body.slIm == null || !body.slIm.keySet().equals(ALLOWED_GROUP_KEYS)) {
+            throw new BadRequestException(
+                "slIm must contain exactly these keys: " + ALLOWED_GROUP_KEYS);
+        }
+        // (Map<String,Boolean> via Jackson rejects non-boolean values at deserialization.)
+
+        User user = userRepo.findById(caller.userId()).orElseThrow();
+        user.setNotifySlImMuted(body.slImMuted);
+        // Merge into existing map: preserve keys we don't expose (system, realty_group,
+        // marketing) at their existing/default values. Only update visible keys.
+        Map<String, Boolean> merged = new HashMap<>(user.getNotifySlIm());
+        merged.putAll(body.slIm);
+        user.setNotifySlIm(merged);
+        userRepo.save(user);
+
+        return get(caller);   // return reconciled state for optimistic mutation reconcile
+    }
+}
+```
+
+The PUT body's shape is validated as a closed set: exactly the five user-mutable group keys, no more, no fewer. Sending `{"slIm": {"system": false, ...}}` returns 400. This is intentional — the server is the source of truth for what's user-mutable, and frontend bugs that send unexpected keys should be loud.
+
+The merge logic preserves keys we don't expose (`system`, `realty_group`, `marketing`) at their existing values, so a user who has never touched their prefs still has their `User.defaultNotifySlIm()` defaults intact for groups not on the page.
+
+### 3.14 `SlImCoalesceIndexInitializer`
+
+Mirrors `NotificationCoalesceIndexInitializer` from sub-spec 1's Task 1. Hibernate's `ddl-auto: update` cannot emit partial unique indexes, so we add it via an `@EventListener(ApplicationReadyEvent)` that runs idempotent DDL:
+
+```java
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SlImCoalesceIndexInitializer {
+
+    private final JdbcTemplate jdbc;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void emit() {
+        jdbc.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_sl_im_pending_coalesce
+            ON sl_im_message (user_id, coalesce_key)
+            WHERE status = 'PENDING'
+            """);
+        log.info("SL IM partial unique index ensured: uq_sl_im_pending_coalesce");
+    }
+}
+```
+
+`CREATE UNIQUE INDEX IF NOT EXISTS` is idempotent in Postgres ≥ 9.5.
+
+### 3.15 Integration with `NotificationService.publish` (the afterCommit hook)
+
+`NotificationService.publish(NotificationEvent event)` from sub-spec 1 already registers an afterCommit hook for the WS broadcast. Adding the SL IM dispatcher hook is a one-line change — adjacent to the existing one:
+
+```java
+// NotificationService.publish — extended
+@Transactional(propagation = Propagation.MANDATORY)
+public UpsertResult publish(NotificationEvent event) {
+    UpsertResult result = dao.upsert(/* ... */);
+
+    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+        @Override
+        public void afterCommit() {
+            wsBroadcaster.broadcastUpsert(event.userId(), result, NotificationDto.from(/* ... */));
+        }
+    });
+
+    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+        @Override
+        public void afterCommit() {
+            slImChannelDispatcher.maybeQueue(event);    // NEW
+        }
+    });
+
+    return result;
+}
+```
+
+`slImChannelDispatcher` is constructor-injected. It's a `@Component`; the existing `@RequiredArgsConstructor` Lombok annotation picks it up.
+
+### 3.16 Integration with `listingCancelledBySellerFanout` (sibling call inside REQUIRES_NEW)
+
+Per §2.2, the fan-out path doesn't go through `publish()` and therefore doesn't fire the afterCommit hook from §3.15. The dispatcher's fan-out variant `maybeQueueForFanout` is added as a sibling call inside the per-recipient REQUIRES_NEW lambda, between the in-app DAO upsert and the WS broadcast. See the code in §2.2.
+
+This is the only existing fan-out method in the codebase. If a future fan-out is added (the FOOTGUNS guidance from sub-spec 1 names a `Fanout` suffix convention), the same sibling-call pattern applies.
+
+---
+
+## 4. Frontend design
+
+### 4.1 `/settings` route tree
+
+```
+frontend/src/app/settings/
+├── layout.tsx          // <h1>Settings</h1> + body slot; ready to grow a sidebar
+├── page.tsx            // server-component redirect → /settings/notifications
+└── notifications/
+    ├── page.tsx        // <RequireAuth><NotificationPreferencesPage /></RequireAuth>
+    └── page.test.tsx
+```
+
+`/settings/page.tsx`:
+
+```tsx
+import { redirect } from "next/navigation";
+export default function SettingsIndexPage() {
+  redirect("/settings/notifications");
+}
+```
+
+When a second settings page lands, this index becomes a real list page; the `/settings/notifications` URL stays stable. `/settings/layout.tsx` carries an `<h1>Settings</h1>` and a root container; sidebar navigation is added in the sub-spec that introduces a second settings page, not now.
+
+### 4.2 `NotificationPreferencesPage` layout
+
+```
+frontend/src/components/notifications/preferences/
+├── NotificationPreferencesPage.tsx
+├── ChannelInfoBanner.tsx
+├── MasterMuteRow.tsx
+├── GroupToggleRow.tsx
+├── *.test.tsx
+```
+
+`NotificationPreferencesPage.tsx` composes:
+
+1. `ChannelInfoBanner` — the disclosure callout.
+2. `MasterMuteRow` — the channel-master-mute toggle, header-styled.
+3. A vertical list of `GroupToggleRow` for each user-mutable group (in order: bidding, auction_result, escrow, listing_status, reviews).
+
+Banner copy:
+
+> *In-app and system notifications always deliver. Settings below control SL IM for the rest. SL natively forwards in-game IMs to your registered email when you're offline.*
+
+Master mute row:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Mute all SL IM notifications                       ⚪──● │
+│  Master switch — overrides everything below.            │
+└─────────────────────────────────────────────────────────┘
+```
+
+Group toggle row (one per visible group):
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Bidding                                            ●──⚪ │
+│  Outbid, proxy exhausted                                │
+└─────────────────────────────────────────────────────────┘
+```
+
+Per-group category subtext (rendered under the group label, smaller text, on-surface-variant color):
+
+| Group | Subtext |
+| --- | --- |
+| Bidding | Outbid, proxy exhausted |
+| Auction Result | Won, lost, ended (sold/reserve/no-bids/buy-now) |
+| Escrow | Funded, transfer confirmed, payout, expired, disputed, frozen, payout stalled |
+| Listings | Verified, suspended, review required, cancelled by seller |
+| Reviews | New review received |
+
+### 4.3 `GroupToggleRow` and `MasterMuteRow` components — disabled-state preservation
+
+The most subtle invariant in the entire frontend: when `notifySlImMuted` is `true`, the per-group toggles render with `disabled + opacity-50 + cursor-not-allowed`, but their **checked state reflects the underlying `notifySlIm[group]` value unchanged**. The mute toggle is the only control whose state changes during muted mode; per-group writes are gated client-side (the click handler is a no-op when muted). Toggling mute back to off restores the visible/active state with no API roundtrip — the values were always there.
+
+Implementation contract for the implementer:
+
+- `GroupToggleRow` receives `{ group, label, subtext, value, mutedDisabled, onChange }`.
+- When `mutedDisabled` is `true`: set `disabled` on the underlying `<button role="switch">`, apply the disabled visual classes, and short-circuit the click handler (no state change, no `onChange` fired). The `aria-checked` attribute still reflects `value`.
+- Underlying React state (in the parent page) holds `value` and is **never mutated** in response to a master-mute change. The mute toggle only flips its own state.
+- The PUT request fires only when an actual visible toggle changes (master mute or, when mute is off, a group toggle). No "save" button — it's an immediate-write UI.
+
+`MasterMuteRow` is the same atom but with no `subtext`, header-style typography, and no disabled state of its own.
+
+### 4.4 Hooks
+
+```
+frontend/src/hooks/notifications/
+├── useNotificationPreferences.ts
+├── useUpdateNotificationPreferences.ts
+└── *.test.tsx
+```
+
+```ts
+// useNotificationPreferences.ts
+export function useNotificationPreferences() {
+  return useQuery({
+    queryKey: notificationKeys.preferences(),
+    queryFn: () => getNotificationPreferences(),
+    staleTime: 60_000,
+  });
+}
+```
+
+```ts
+// useUpdateNotificationPreferences.ts
+export function useUpdateNotificationPreferences() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: PreferencesDto) => putNotificationPreferences(payload),
+    onMutate: async (payload) => {
+      await qc.cancelQueries({ queryKey: notificationKeys.preferences() });
+      const prev = qc.getQueryData<PreferencesDto>(notificationKeys.preferences());
+      qc.setQueryData(notificationKeys.preferences(), payload);
+      return { prev };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.prev) qc.setQueryData(notificationKeys.preferences(), ctx.prev);
+      toast.push("error", "Couldn't save preferences");
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: notificationKeys.preferences() });
+      // Also invalidate /me — the User entity in the cached current-user
+      // response includes the same JSONB columns.
+      qc.invalidateQueries({ queryKey: ["currentUser"] });
+    },
+  });
+}
+```
+
+`notificationKeys.preferences()` is a new entry in the query-key factory file from sub-spec 1's Task 6.
+
+### 4.5 REST client
+
+```ts
+// frontend/src/lib/notifications/preferencesApi.ts
+export interface PreferencesDto {
+  slImMuted: boolean;
+  slIm: {
+    bidding: boolean;
+    auction_result: boolean;
+    escrow: boolean;
+    listing_status: boolean;
+    reviews: boolean;
+  };
+}
+
+export async function getNotificationPreferences(): Promise<PreferencesDto> {
+  return api.get<PreferencesDto>("/api/v1/users/me/notification-preferences");
+}
+
+export async function putNotificationPreferences(body: PreferencesDto): Promise<PreferencesDto> {
+  return api.put<PreferencesDto>("/api/v1/users/me/notification-preferences", body);
+}
+```
+
+### 4.6 Settings entry points
+
+- **Bell dropdown footer.** The existing footer has a single "View all notifications" link. Add a small gear icon on the right side of the same row, linking to `/settings/notifications`. Two visual elements in one footer row, separated by the natural gap.
+- **`/notifications` feed page header.** Add a gear icon top-right of the page title, aligned with the existing "Mark all read" action. Same icon, same destination.
+
+Both icons reuse `Settings` (or `SlidersHorizontal`) from `@/components/ui/icons`. If neither is in the barrel, add it (one-line change to `icons.ts`).
+
+### 4.7 MSW handlers (test fixtures)
+
+`frontend/src/test/msw/handlers.ts` from sub-spec 1's Task 6 grows two new handlers:
+
+```ts
+http.get("/api/v1/users/me/notification-preferences", () => {
+  return HttpResponse.json(currentPreferences);
+}),
+http.put("/api/v1/users/me/notification-preferences", async ({ request }) => {
+  const body = await request.json() as PreferencesDto;
+  // Validate closed shape; 400 on violation.
+  const validKeys = new Set(["bidding", "auction_result", "escrow", "listing_status", "reviews"]);
+  if (!body.slIm || !setEqual(new Set(Object.keys(body.slIm)), validKeys)) {
+    return new HttpResponse(null, { status: 400 });
+  }
+  currentPreferences = body;
+  return HttpResponse.json(currentPreferences);
+}),
+```
+
+Plus a `seedPreferences(...)` and `resetPreferences()` test helper in the same module.
+
+---
+
+## 5. LSL script: `lsl-scripts/sl-im-dispatcher/`
+
+### 5.1 Directory structure
+
+```
+lsl-scripts/                                   ← new top-level directory
+├── README.md                                  ← index of all scripts; updated on add/remove only
+└── sl-im-dispatcher/
+    ├── README.md                              ← deployment + ops + troubleshooting for THIS script
+    ├── dispatcher.lsl                         ← the script
+    └── config.notecard.example                ← notecard template, committed with placeholders
+```
+
+### 5.2 Top-level `lsl-scripts/README.md`
+
+Short index:
+
+- Purpose of the directory (in-world LSL code consumed by SLPA's backend).
+- Contributor rule (verbatim, load-bearing): *"Each new script gets its own subdirectory with its own README. Updates to any script's behavior, deployment, or configuration must be reflected in that script's README in the same commit. The top-level index updates only on add/remove/rename."*
+- One-line summary per script with a relative link to its README.
+
+Initial entry:
+- `sl-im-dispatcher/` — Polls SLPA backend for pending notification IMs and delivers via `llInstantMessage`. SLPA-team-deployed; one instance per environment.
+
+### 5.3 `sl-im-dispatcher/dispatcher.lsl` architecture
+
+Single-state design with two time scales tracked by counters. The state machine reuses the `default` state and the `timer` event for both polling cadence (60 s) and per-IM throttle (2 s), switching cadences via `llSetTimerEvent` calls in the event handlers:
+
+```lsl
+// Configuration loaded at state_entry from config.notecard
+string POLL_URL;
+string CONFIRM_URL_BASE;
+string SHARED_SECRET;
+integer DEBUG_OWNER_SAY = TRUE;
+
+// Polling cadence (slow) and per-IM throttle (fast)
+float POLL_INTERVAL = 60.0;
+float IM_INTERVAL = 2.0;
+
+// Batch state during delivery
+list batchIds = [];
+list batchUuids = [];
+list batchTexts = [];
+integer batchIndex = 0;
+integer deliveringBatch = FALSE;
+
+// HTTP request tracking
+key pollRequestId = NULL_KEY;
+
+default {
+    state_entry() {
+        // Load config from notecard (synchronously via dataserver in real script)
+        // ... read POLL_URL, CONFIRM_URL_BASE, SHARED_SECRET, DEBUG_OWNER_SAY ...
+        if (DEBUG_OWNER_SAY) llOwnerSay("SL IM dispatcher starting (poll=" + POLL_URL + ")");
+        llSetTimerEvent(POLL_INTERVAL);
+    }
+
+    timer() {
+        if (deliveringBatch) {
+            // Per-IM tick: send the next message in the batch.
+            if (batchIndex >= llGetListLength(batchIds)) {
+                deliveringBatch = FALSE;
+                batchIds = [];
+                batchUuids = [];
+                batchTexts = [];
+                llSetTimerEvent(POLL_INTERVAL);
+                return;
+            }
+            string id = llList2String(batchIds, batchIndex);
+            string uuid = llList2String(batchUuids, batchIndex);
+            string text = llList2String(batchTexts, batchIndex);
+            llInstantMessage((key)uuid, text);
+            llHTTPRequest(
+                CONFIRM_URL_BASE + id + "/delivered",
+                [HTTP_METHOD, "POST",
+                 HTTP_CUSTOM_HEADER, "Authorization", "Bearer " + SHARED_SECRET,
+                 HTTP_BODY_MAXLENGTH, 4096],
+                ""
+            );
+            batchIndex += 1;
+            // stay on IM_INTERVAL timer
+        } else {
+            // Poll cycle.
+            pollRequestId = llHTTPRequest(
+                POLL_URL + "?limit=10",
+                [HTTP_METHOD, "GET",
+                 HTTP_CUSTOM_HEADER, "Authorization", "Bearer " + SHARED_SECRET,
+                 HTTP_BODY_MAXLENGTH, 16384],
+                ""
+            );
+        }
+    }
+
+    http_response(key requestId, integer status, list meta, string body) {
+        if (requestId == pollRequestId) {
+            pollRequestId = NULL_KEY;
+            if (status != 200) {
+                if (DEBUG_OWNER_SAY) llOwnerSay("SL IM poll failed: " + (string)status);
+                return;
+            }
+            // Parse JSON: { "messages": [{id, avatarUuid, messageText}, ...] }
+            // (LSL JSON parsing details elided here; see actual script)
+            integer count = parseAndStoreBatch(body);
+            if (count > 0) {
+                if (DEBUG_OWNER_SAY) llOwnerSay("SL IM batch=" + (string)count);
+                deliveringBatch = TRUE;
+                batchIndex = 0;
+                // Switch to fast cadence and immediately fire first IM.
+                llSetTimerEvent(IM_INTERVAL);
+                // Manually fire the first one without waiting for the tick.
+                string id = llList2String(batchIds, 0);
+                string uuid = llList2String(batchUuids, 0);
+                string text = llList2String(batchTexts, 0);
+                llInstantMessage((key)uuid, text);
+                llHTTPRequest(CONFIRM_URL_BASE + id + "/delivered", [...], "");
+                batchIndex = 1;
+            } else if (DEBUG_OWNER_SAY) {
+                llOwnerSay("SL IM poll: 0 messages");
+            }
+        }
+        // Confirmation responses ignored unless non-2xx (then log)
+        else if (status >= 400) {
+            llOwnerSay("SL IM confirm failed: " + (string)status);
+        }
+    }
+}
+```
+
+The actual script will be longer (notecard-reading via `llGetNotecardLine` is an async dataserver pattern, JSON parsing uses `llJsonGetValue`, and there's housekeeping for state reset on `on_rez` / script reset). The above is the architectural skeleton; the implementation lands in `lsl-scripts/sl-im-dispatcher/dispatcher.lsl` with full bodies.
+
+### 5.4 `config.notecard.example`
+
+```
+POLL_URL=https://slpa.example.com/api/v1/internal/sl-im/pending
+CONFIRM_URL_BASE=https://slpa.example.com/api/v1/internal/sl-im/
+SHARED_SECRET=<obtain from server config: slpa.notifications.sl-im.dispatcher.shared-secret>
+DEBUG_OWNER_SAY=true
+```
+
+Committed verbatim. Operators copy to `config` (rename, no extension), edit values, drop into the same prim as the script. Notecard is read once at `state_entry`; rotating the secret means editing the notecard and resetting the script.
+
+### 5.5 Per-script `sl-im-dispatcher/README.md`
+
+Sections (load-bearing content for each):
+
+- **Purpose.** In-world component of the SL IM channel; polls SLPA backend for pending IMs and delivers via `llInstantMessage`. SLPA-team-deployed (one per environment); not user-deployed.
+
+- **Architecture summary.** 60 s polling cadence, batches of up to 10, per-IM 2 s throttle (matching SL's `llInstantMessage` floor), confirmation callback per delivered IM. Single state machine.
+
+- **Deployment.** Steps: rez a generic prim somewhere with reliable land permissions (group land or owner-controlled), drop `dispatcher.lsl` into the prim, drop a copy of `config.notecard.example` renamed to `config` and edited with real values, reset script. Ownership and modify permissions should be SLPA-team-only — the shared secret is in the notecard.
+
+- **Configuration.** Notecard format (key=value, one per line, no quotes). Where to obtain the shared secret (server's `slpa.notifications.sl-im.dispatcher.shared-secret` configuration property; check the deployment's secrets store). How to rotate (edit notecard, reset script — running connections aren't affected because each poll is a fresh request).
+
+- **Operations.** What owner-say messages to expect (poll cadence pings, batch sizes, error codes). How to verify health from chat: `llOwnerSay`-tagged messages every 60 s in steady state. Reset procedure if the script wedges (right-click → Edit → Reset script).
+
+- **Troubleshooting.** Common failure modes:
+  - `SL IM poll failed: 401` → secret mismatch; check notecard, check server config.
+  - `SL IM poll failed: 500` → backend issue; check server logs.
+  - `SL IM poll failed: 0` (no HTTP response) → land permissions blocking outbound HTTP, or the prim is on no-script land; relocate.
+  - No messages ever, no errors → backend has nothing pending; verify by manually triggering a notification for a user with a linked avatar.
+  - Long silences in owner-say → script may have wedged (e.g., the notecard read failed); reset the script.
+
+- **Limits.** Three load-bearing notes:
+  - **Hard byte limit on IM text.** `llInstantMessage` truncates at 1024 BYTES (not characters). The backend's `SlImMessageBuilder` enforces this; the script trusts the messages it receives. Operators should never modify `messageText` in the script.
+  - **No `/failed` caller in this script.** `llInstantMessage` is fire-and-forget — no return value, no error, no way to distinguish "delivered" from "UUID doesn't exist." The script unconditionally calls `/{id}/delivered` after every IM. So FAILED rows in `sl_im_message` only ever come from manual operator intervention or a future script revision that adds UUID pre-validation (e.g., `llRequestAgentData` against `DATA_ONLINE` before sending). Worth knowing: if a support engineer runs `SELECT status, count(*) FROM sl_im_message GROUP BY status` and sees zero FAILED rows, that's correct behavior, not a missing pipeline.
+  - **Batch size 10 with 2 s spacing fits the 20 s SL HTTP window.** Increasing batch size beyond 10 risks the script's confirmation requests racing the next poll cycle's request limits. Don't increase without verifying the math.
+
+- **Security.** The shared secret is a deployment artifact; treat it like a database password. Notecard contents are visible to anyone with object-edit rights, so the dispatcher prim's owner/group should be tightly scoped.
+
+---
+
+## 6. Data flow scenarios
+
+Five load-bearing scenarios; most edge cases live in these.
+
+### 6.1 Single-recipient with coalesce, then redelivery
+
+User offline, gets outbid 5 times in 60 s.
+
+```
+Event 1 (t=0):  publish() → in-app row #100 (PENDING)
+                            afterCommit → dispatcher.maybeQueue
+                            sl_im_message #500 INSERT (PENDING, key=outbid:42:7)
+Event 2 (t=12): publish() → in-app row #100 UPDATE (coalesced via WHERE read=false)
+                            afterCommit → dispatcher.maybeQueue
+                            sl_im_message #500 UPDATE (coalesced via WHERE status=PENDING)
+                            updated_at bumped, message_text replaced with latest
+... (3 more events, all coalesce into the same row)
+
+t=60:  terminal polls /pending?limit=10 → returns [{id=500, text=<latest>}]
+       llInstantMessage → POST /500/delivered → status=DELIVERED
+       Single IM sent for 5 events.
+
+Event 6 (t=120): publish() → in-app upsert
+                              afterCommit → dispatcher.maybeQueue
+                              partial unique index doesn't match (#500 is now DELIVERED)
+                              sl_im_message #501 INSERT (PENDING, key=outbid:42:7)
+                              Fresh row; terminal picks up on next poll.
+```
+
+The ON CONFLICT predicate `WHERE status = 'PENDING'` is what makes "fresh row after delivery" automatic. No service-layer branching.
+
+### 6.2 Fan-out cancellation
+
+Seller cancels listing with 3 active bidders.
+
+```
+CancellationService.cancel() commits → afterCommit registered earlier fires:
+
+For bidder A (REQUIRES_NEW tx):
+  notification_dao.upsert (in-app row)
+  sl_im_dispatcher.maybeQueueForFanout (sibling — atomic with in-app)
+   ↓ commit ↓
+  ws_broadcaster.broadcastUpsert (post-commit, in-memory)
+
+For bidder B (REQUIRES_NEW tx):  ← independent; A's failure can't affect this
+  ... same three steps ...
+
+For bidder C (REQUIRES_NEW tx):
+  ... same three steps ...
+```
+
+If the FK lookup for a stale bidder ID throws, the per-recipient try-catch catches and continues. Real bidders all get their rows; the cancellation transaction itself is long-committed.
+
+### 6.3 SYSTEM bypass + no-avatar interaction
+
+Admin posts a SYSTEM_ANNOUNCEMENT to all users (Epic 10 trigger; in this sub-spec, exercised only in tests).
+
+```
+For each user:
+  publish() → in-app row created
+              afterCommit → dispatcher.maybeQueue
+              gate.decide():
+                user.slAvatarUuid == null   → SKIP_NO_AVATAR    (in-app only)
+                user.slAvatarUuid present   → QUEUE_BYPASS_PREFS (IM + in-app)
+              (mute and group prefs not consulted on QUEUE_BYPASS_PREFS path)
+```
+
+Even SYSTEM cannot deliver without an avatar UUID. The decision enum (`SKIP_NO_AVATAR` vs `QUEUE_BYPASS_PREFS`) is logged at DEBUG so post-incident triage can answer "did this user get the system announcement?" without DB archaeology.
+
+### 6.4 Preference gate flow with master mute interaction
+
+User has muted everything, but receives a SYSTEM_ANNOUNCEMENT alongside an OUTBID.
+
+```
+OUTBID  → group=BIDDING → muted check first → SKIP_MUTED → no IM, in-app only
+SYSTEM  → bypass mute → no-avatar check → QUEUE → IM sent
+```
+
+Reverse case — user toggles `notifySlIm[bidding]` off via `/settings/notifications`, then 5 minutes later gets outbid:
+
+```
+PUT /me/notification-preferences → User.notifySlIm[bidding] = false (committed)
+
+Event: OUTBID for that user
+publish() → in-app row created
+            afterCommit → dispatcher.maybeQueue
+            User loaded fresh inside REQUIRES_NEW (sees committed update)
+            notifySlIm[bidding] == false → SKIP_GROUP_DISABLED
+```
+
+Critical detail: **the User entity load happens inside the dispatcher's REQUIRES_NEW transaction**, not at the originating call site. So the dispatcher always reads the latest committed prefs — no stale-cache window. The cost is one User SELECT per dispatched event; a cache here would be wrong (we want read-your-writes after a preferences PUT) and the join is cheap.
+
+### 6.5 Expiry canary
+
+Terminal goes dark Friday at 18:00 SLT. By Sunday 03:30 SLT it's been silent for 57 hours.
+
+```
+03:30 SLT — SlImCleanupJob runs:
+  Stage 1: capture top users by pending count (BEFORE the UPDATE)
+           UPDATE sl_im_message SET status='EXPIRED'
+           WHERE status='PENDING' AND created_at < (now - 48h)
+           Returns: 237 rows
+  Stage 2: chunked DELETE
+           WHERE status IN ('DELIVERED','EXPIRED','FAILED')
+             AND updated_at < (now - 30d)
+           Returns: small number (matches typical daily delivery aged 30 days back)
+
+  log.info("SL IM cleanup sweep: expired=237 deleted=X " +
+           "expiry_cutoff=2026-04-26T08:30Z retention_cutoff=2026-03-27T08:30Z " +
+           "top_users=[42:89, 71:34, 103:21, ...]")
+```
+
+The top-N user breakdown lets operators distinguish "one user is mass-failing" (account closed, avatar UUID stale) from "everyone's failing" (terminal dark) at a glance. The first time `expired > 0` on a Sunday morning, somebody investigates.
+
+### 6.6 What explicitly does not happen — the absences are spec, too
+
+- **Preference changes don't retroactively cancel queued IMs.** A user toggling reviews off doesn't expire their already-pending review IM. They opted out for *future* events; the in-flight one delivers under the prior intent. Cheap and honest.
+- **EXPIRED rows are never retried.** If you want a retry primitive, that's a separate enum value and a different job; not in scope.
+- **WS broadcast failures are independent of IM queue.** Broker down → in-app row durable, IM row durable, only the live WS push lost. Frontend reconciles on reconnect (sub-spec 1's existing pattern).
+- **`/failed` has no caller in the LSL script** (per §5.5). FAILED rows in production come from operator/manual intervention only.
+- **Quiet hours don't exist.** The columns are dormant; no scheduling, no held-until logic.
+- **EXPIRED rows are observable.** Stage 2 deletes them after 30 days, not stage 1, so the `GROUP BY status` triage query reflects a rolling window of pipeline health, not just steady-state.
+
+---
+
+## 7. API surface
+
+### 7.1 User-facing — preferences
+
+Auth: bearer JWT; `@PreAuthorize("isAuthenticated()")`.
+
+```
+GET /api/v1/users/me/notification-preferences
+200 {
+  "slImMuted": false,
+  "slIm": {
+    "bidding": true, "auction_result": true, "escrow": true,
+    "listing_status": true, "reviews": false
+  }
+}
+```
+
+```
+PUT /api/v1/users/me/notification-preferences
+Content-Type: application/json
+{
+  "slImMuted": false,
+  "slIm": {
+    "bidding": true, "auction_result": true, "escrow": true,
+    "listing_status": true, "reviews": true
+  }
+}
+
+200 — same shape as GET, returns the new state for optimistic-mutation reconcile
+400 — body's slIm map keys are not exactly { bidding, auction_result, escrow, listing_status, reviews }
+400 — body contains non-boolean values (Jackson rejects on deserialization)
+401 — unauthenticated
+```
+
+The closed-shape validation on the `slIm` map is intentional. Sending a key outside the visible-groups set (e.g., `system`, `realty_group`, `marketing`) returns 400 — the server is the source of truth for what's user-mutable, and frontend bugs that send unexpected keys should surface as errors. Server-side, the merge into `User.notifySlIm` JSONB preserves the non-visible keys at their existing values.
+
+### 7.2 Internal — dispatcher polling
+
+Auth: shared secret via `Authorization: Bearer ${slpa.notifications.sl-im.dispatcher.shared-secret}`. NOT a JWT. Enforced by `SlImTerminalAuthFilter` registered before the JWT chain on `/api/v1/internal/sl-im/**`.
+
+```
+GET /api/v1/internal/sl-im/pending?limit=10
+200 {
+  "messages": [
+    {
+      "id": 12345,
+      "avatarUuid": "00000000-0000-0000-0000-000000000000",
+      "messageText": "[SLPA] You've been outbid on Hampton Hills\n\nCurrent bid is L$2,000.\n\nhttps://slpa.example.com/auction/42#bid-panel"
+    }
+  ]
+}
+
+400 — limit > slpa.notifications.sl-im.dispatcher.max-batch-limit (default 50)
+400 — limit < 1
+401 — Authorization header missing
+401 — Authorization header doesn't match shared secret
+```
+
+```
+POST /api/v1/internal/sl-im/{id}/delivered
+204 — PENDING → DELIVERED (sets delivered_at = now()), or DELIVERED → 204 no-op (idempotent)
+404 — message id doesn't exist
+409 — current status is FAILED or EXPIRED (system intervention is sticky)
+401 — auth mismatch
+```
+
+```
+POST /api/v1/internal/sl-im/{id}/failed
+204 — PENDING → FAILED, or FAILED → 204 no-op (idempotent)
+404 — message id doesn't exist
+409 — current status is DELIVERED or EXPIRED (sticky)
+401 — auth mismatch
+```
+
+State machine for `/delivered`:
+```
+PENDING   → DELIVERED (204, set delivered_at)
+DELIVERED → 204 no-op
+FAILED    → 409
+EXPIRED   → 409
+missing   → 404
+```
+
+State machine for `/failed`:
+```
+PENDING   → FAILED (204)
+FAILED    → 204 no-op
+DELIVERED → 409
+EXPIRED   → 409
+missing   → 404
+```
+
+Both implemented as a single conditional UPDATE returning affected-rows count, plus a follow-up read on the no-op path to determine the response (idempotent vs conflict). One round trip on the happy path; two on idempotent/conflict paths.
+
+### 7.3 Auth and security boundaries
+
+- **Internal endpoints have NO session creation.** Stateless requests; the filter doesn't touch `SecurityContext`. CSRF is disabled on the internal path prefix (the path matcher excludes `/api/v1/internal/sl-im/**`).
+- **Internal endpoints serve `application/problem+json` on errors.** No HTML error pages. Predictable for the LSL parser.
+- **The shared secret is environment-scoped.** Different value per dev/staging/prod. Rotation is out-of-band: update the deployment's secrets store, edit the dispatcher's notecard, reset the script. There's no in-app key-rotation flow.
+- **Constant-time secret comparison** (`MessageDigest.isEqual`) so the secret cannot be inferred via response timing.
+- **The shared secret for SL IM dispatch is distinct from the existing escrow-terminal shared secret.** Different blast radius if leaked; different rotation cadence; different operators.
+
+---
+
+## 8. Error handling
+
+The dispatch path's failure modes and their handlers:
+
+| Failure | Where | Handler |
+| --- | --- | --- |
+| User not found in dispatcher | `doQueue` | Throws `IllegalStateException`; in single-recipient path the outer `try` logs WARN and swallows; in fan-out path propagates and rolls back that recipient's REQUIRES_NEW (sibling recipients unaffected). |
+| Channel gate decides SKIP_* | `doQueue` | No-op; logs DEBUG with the decision enum. No row, no error. |
+| `SlImMessageBuilder` budget exhausted (title alone exceeds 1024 bytes) | `doQueue` | Falls back to title-trimmed + deeplink, logs WARN. Row still queued. |
+| DAO upsert throws (FK violation, unique-index race, transient) | `doQueue` | Single-recipient: outer try logs WARN, swallows. Fan-out: propagates, rolls back recipient's REQUIRES_NEW. |
+| afterCommit hook throws in single-recipient path | `NotificationService.publish` | Spring logs the exception via `TransactionSynchronizationManager` default logger; doesn't affect parent. We rely on the outer try in `maybeQueue` to log first, but Spring's safety net catches anything we miss. |
+| WS broadcast fails (broker down) | `NotificationService.publish` afterCommit | Existing sub-spec 1 behavior — caught and logged; in-app row durable, IM row durable. |
+| Cleanup job fails mid-stage 1 | `SlImCleanupJob.run` | `@Scheduled` exception is logged; next day's run picks up where this left off (UPDATE is idempotent and re-runs find the same set of rows). |
+| Cleanup job stage 2 fails partway through chunked DELETE | `SlImCleanupJob.run` | Logs the partial deletion, partial completion. Next day's run completes the rest. |
+| Internal endpoint receives request without/with-wrong Authorization header | `SlImTerminalAuthFilter` | 401 with `application/problem+json` body. |
+| Internal endpoint receives `?limit > maxBatchLimit` | `SlImInternalController` | 400 via `IllegalArgumentException` → `GlobalExceptionHandler` from sub-spec 1 Task 2. |
+| `/delivered` or `/failed` on non-existent id | controller | 404. |
+| `/delivered` on a row currently FAILED or EXPIRED | controller | 409 — operator/system intervention is sticky. |
+| Idempotent `/delivered` on already-DELIVERED row | controller | 204 no-op; `attempts` not incremented (because the conditional UPDATE's WHERE clause excludes DELIVERED). |
+| Preferences PUT with extra/missing keys | `NotificationPreferencesController.put` | `BadRequestException` → 400. |
+| Preferences PUT with non-boolean value | Jackson | `HttpMessageNotReadableException` → 400. |
+
+The expiry canary itself is the operational error-handling story for "dispatcher dark" — see §6.5.
+
+---
+
+## 9. Testing strategy
+
+Four tiers, scaled to where the bugs live, plus an end-to-end test as a contract canary.
+
+### 9.1 Tier 1 — Pure unit (fast, exhaustive)
+
+- **`SlImChannelGateTest`** — parameterized matrix over `(NotificationCategory × { hasAvatar, noAvatar } × { muted, unmuted } × { groupOn, groupOff })`. Asserts the exact `Decision` enum returned. This is the test that catches gate-logic regressions; everything else builds on it. ~200 cases via `@ParameterizedTest` with a method source.
+- **`SlImMessageBuilderTest`** — covers the `[SLPA] {title}\n\n{body}\n\n{deeplink}` template, the 1024-byte ceiling truncation behavior (deeplink preserved, body ellipsized), and at least one test per category to confirm the assembled string fits. **Three mandatory cases for the byte-vs-char bug:**
+  1. Multi-byte parcel name (e.g., `東京タワー Estates`) — assert deeplink intact, total bytes ≤ 1024.
+  2. Emoji-bearing parcel name (e.g., `🌸 Sakura Plot`) — same assertions.
+  3. Body so long it requires actual truncation — assert ellipsis appears, deeplink intact, total bytes ≤ 1024.
+- **`SlImLinkResolverTest`** — one test per category × the data-blob keys it consumes. 22 tests; cheap and exhaustive. Confirms each category produces a well-formed URL with no missing path segments.
+
+### 9.2 Tier 2 — DAO + repository (TestContainers Postgres)
+
+- **`SlImMessageDaoTest`** — ON CONFLICT upsert behavior:
+  - Insert when no PENDING row exists for `(user_id, coalesce_key)`.
+  - Update when one exists (asserts `wasUpdate=true`, `message_text` replaced, `updated_at` bumped).
+  - Fresh insert when the prior row is DELIVERED (asserts the partial index doesn't match).
+  - Fresh insert when the prior row is EXPIRED.
+  - Fresh insert when the prior row is FAILED.
+  - NULL coalesce key never collides with itself (two inserts with `coalesce_key = NULL` produce two distinct rows).
+- **`SlImCoalesceIndexInitializerTest`** — `pg_indexes` reflects the partial unique index after startup; idempotent re-emit on second run (no exception).
+- **`SlImMessageRepositoryTest`** — polling query returns oldest-PENDING-first; `limit` honored; `FOR UPDATE SKIP LOCKED` skips rows held by a concurrent tx (one assertion with a manual second JDBC connection holding a row).
+
+### 9.3 Tier 3 — Vertical-slice integration (`@SpringBootTest` per gate-path cluster)
+
+Five files, NOT 22 (one per category). Coverage strategy is "one test per gate decision + dispatch path":
+
+- **`OutbidImIntegrationTest`** — drives `BidService.placeBid()`'s outbid path; asserts:
+  - IM row created with correct text and avatar UUID.
+  - Coalesce on storm produces single row (5 rapid outbids = 1 PENDING row, latest text).
+  - Gate-disabled (`notifySlIm[bidding] = false`) suppresses IM but keeps in-app row.
+  - Master mute suppresses IM but keeps in-app row.
+- **`EscrowImIntegrationTest`** — one test per recipient pattern:
+  - `ESCROW_FUNDED` (seller only — assert no IM for buyer).
+  - `ESCROW_TRANSFER_CONFIRMED` (both parties — assert 2 IM rows, one per party).
+  - `ESCROW_DISPUTED` (both parties).
+  - `ESCROW_PAYOUT` (seller only).
+  - The "both parties" cases also exercise the gate independently per recipient (e.g., seller muted, winner not).
+- **`CancellationFanoutImIntegrationTest`** — drives `listingCancelledBySellerFanout`; asserts:
+  - One IM row per active bidder (3 bidders → 3 rows).
+  - One bidder with `notifySlIm[listing_status] = false` gets in-app but no IM.
+  - Stale-bidder-id rolls back THAT recipient's REQUIRES_NEW only — others land cleanly.
+  - Auction cancellation commits regardless of any IM-queue failure.
+- **`SystemBypassImIntegrationTest`** — synthetic SYSTEM_ANNOUNCEMENT event constructed inline (no publisher method exists yet); asserts:
+  - Muted user with avatar gets IM (mute bypassed).
+  - Muted user without avatar gets no IM (no-avatar floor wins).
+  - Group toggle off has no effect (prefs bypassed entirely).
+- **`NoAvatarSkipImIntegrationTest`** — user with `slAvatarUuid = null` gets in-app rows for several categories, zero IM rows queued.
+
+### 9.4 Tier 4 — Internal endpoint contract (`@SpringBootTest` + MockMvc)
+
+- **`SlImInternalControllerTest`** — the state machine in §7 explicitly verified:
+  - `/delivered`: PENDING→DELIVERED 204, DELIVERED idempotent 204, FAILED→/delivered returns 409, EXPIRED→/delivered 409, missing 404.
+  - `/failed`: same matrix mirrored.
+  - `?limit` cap (>50 → 400, <1 → 400).
+  - Auth: missing header → 401, wrong header → 401, valid header → 200 / 204 as appropriate.
+  - The `messages` payload shape (id is number, avatarUuid is string UUID, messageText is string).
+  - `delivered_at` is set on PENDING→DELIVERED, NOT re-stamped on idempotent DELIVERED→204.
+- **`NotificationPreferencesControllerTest`** —
+  - GET returns the current closed-shape map.
+  - PUT happy path persists and returns the new state.
+  - PUT with `system` key in `slIm` → 400.
+  - PUT with `realty_group` or `marketing` key → 400.
+  - PUT missing a required key → 400.
+  - PUT with non-boolean value (e.g., string `"true"`) → 400.
+  - Unauthenticated → 401.
+  - Cross-user: User A's session can't read or write User B's prefs (verified by JWT mismatch test).
+
+### 9.5 Cleanup job tests
+
+- **`SlImCleanupJobTest`** — three rows seeded at varied ages and statuses:
+  - 49 h-old PENDING → expected EXPIRED.
+  - 47 h-old PENDING → expected unchanged.
+  - 31 d-old DELIVERED → expected DELETED.
+  - 31 d-old FAILED → expected DELETED.
+  - 31 d-old EXPIRED → expected DELETED.
+  - 29 d-old DELIVERED → expected unchanged.
+
+  Captures log output via `LogCaptor` (existing pattern in the codebase) and asserts the INFO line:
+  - Contains `expired=N` with the correct count.
+  - Contains `deleted=N` with the correct count.
+  - Contains `expiry_cutoff=` and `retention_cutoff=` ISO timestamps.
+  - Contains `top_users=[user_id:count, ...]` with at least one entry when there were any expired rows.
+
+  The log assertion is what guarantees the canary actually fires — without it, regressions could silently turn the operator-grade signal into a useless "swept N rows" line.
+
+### 9.6 Frontend tests
+
+- **`useNotificationPreferences.test.tsx`** — seeds from `useCurrentUser()`, refetches via the dedicated endpoint after mutation success, returns the closed-shape DTO.
+- **`useUpdateNotificationPreferences.test.tsx`** — optimistic flip on click; on 4xx, revert + toast `"Couldn't save preferences"`; on 5xx, same revert + toast.
+- **`NotificationPreferencesPage.test.tsx`** —
+  - Renders banner with the disclosure copy.
+  - Renders 5 group toggles (no SYSTEM, no REALTY_GROUP, no MARKETING).
+  - Reviews defaults to OFF for a fresh user.
+  - Master mute ON greys group toggles, preserves their underlying checked state, toggle mute off → states return without API call.
+  - Clicking a group toggle when not muted fires the PUT with the new shape.
+  - Clicking a group toggle when muted is a no-op (no PUT).
+- **`MasterMuteRow.test.tsx`** — atom-level: renders, fires onChange, accepts `value` prop, no internal state.
+- **`GroupToggleRow.test.tsx`** — atom-level: the disabled-state-preservation invariant. Given `value=true, mutedDisabled=true`: aria-checked is `true`, `disabled` is set, click is a no-op, `onChange` not fired.
+- **Bell dropdown footer.test.tsx update** — settings entry-point assertion: gear icon rendered, link resolves to `/settings/notifications`.
+- **`/notifications` page header.test.tsx update** — settings gear icon rendered, link resolves to `/settings/notifications`.
+
+### 9.7 End-to-end (one test, expensive but valuable)
+
+- **`SlImEndToEndIntegrationTest`** — drives an OUTBID through `BidService.placeBid()`, asserts:
+  1. The IM row exists in `sl_im_message` with the expected coalesce key, avatar UUID, and assembled `messageText`.
+  2. `GET /api/v1/internal/sl-im/pending?limit=10` with the configured shared secret returns the row in its `messages` array.
+  3. `POST /api/v1/internal/sl-im/{id}/delivered` returns 204 and transitions the row to DELIVERED with `delivered_at` set.
+  4. A second `POST /{id}/delivered` returns 204 (idempotent), `delivered_at` unchanged.
+
+  One test, but it's the canary for "the contract from event → terminal works." Slow (full Spring context, real Postgres), so kept singular.
+
+### 9.8 LSL
+
+No unit-test framework. The PR's manual test plan covers it (§13.4).
+
+### 9.9 What's intentionally not tested in this sub-spec
+
+- **WS routing.** Covered exhaustively by sub-spec 1's `UserQueueRoutingTest`. The new dispatcher hook doesn't change WS routing.
+- **In-app row creation correctness.** Covered by sub-spec 1's per-category integration tests. The new dispatcher hook doesn't change in-app row creation.
+- **LSL script behavior** beyond what the manual test plan exercises in beta sim.
+
+---
+
+## 10. Sub-spec boundaries
+
+After this sub-spec ships, **Epic 09 is functionally complete** for the launch the project is targeting, except for items below.
+
+### 10.1 What remains pending in Epic 09 (deferred forward)
+
+- **Email channel.** Removed from the roadmap. Re-add only on explicit user request. Reasoning: SL natively forwards offline IMs to the user's registered email, so the SL IM channel covers the email use-case at zero additional infrastructure cost.
+- **`SYSTEM_ANNOUNCEMENT` publisher and admin trigger.** Gate logic supports it; no production code path emits one in this sub-spec. Trigger lives in Epic 10 (Admin & Moderation).
+- **`REVIEW_RESPONSE_WINDOW_CLOSING` notification + scheduler.** Stays in Epic 10 with the response-window scheduler (shared scheduling DNA).
+- **`ESCROW_TRANSFER_REMINDER` scheduler.** Publisher method, category, data builder, and frontend renderer all exist from sub-spec 1; no `@Scheduled` job calls it. Retargets to Epic 10 alongside the response-window scheduler.
+
+### 10.2 What lives in this sub-spec but is exercised only in tests
+
+- **Channel gate's `QUEUE_BYPASS_PREFS` decision** is unit-tested with synthetic SYSTEM_ANNOUNCEMENT events. There's no production trigger.
+
+### 10.3 What this sub-spec doesn't change
+
+- The User entity's `notifyEmail` JSONB column stays in the schema unchanged.
+- The User entity's `slImQuietStart` and `slImQuietEnd` columns stay in the schema unchanged.
+- The `NotificationCategory` enum's 22 values are unchanged.
+- The in-app channel's lifecycle (publish → afterCommit WS broadcast) is unchanged.
+- The cancellation fan-out's per-recipient REQUIRES_NEW shape is unchanged in structure; a new sibling call is added inside the lambda.
+
+---
+
+## 11. Deferred ledger updates
+
+### 11.1 Close (this sub-spec ships these)
+
+- `SL IM channel for notifications`
+- `Notification preferences UI`
+
+### 11.2 Modify
+
+- `Email channel for notifications`:
+  > **Status:** removed from roadmap. Re-add only on explicit user request. Reasoning: SL natively forwards offline IMs to the user's registered email, so the SL IM channel from Epic 09 sub-spec 3 covers the email use case at zero additional infrastructure cost. Re-instating would mean: per-category templates (HTML + plain text), signed-token unsubscribe, debounce/dedupe matching the coalesce pattern, email-change flow (originally pending from Epic 02 sub-spec 2b).
+- `ESCROW_TRANSFER_REMINDER scheduler`:
+  > **Retargeted from Epic 09 sub-spec 2/3 to Epic 10.** Pairs naturally with the REVIEW_RESPONSE_WINDOW_CLOSING scheduler — shared design DNA (interval-bound + once-per-entity + admin-visible). New entity: `Escrow.reminderSentAt` column for once-per-escrow guarantee. New job: `EscrowReminderScheduler` (cron daily, query escrows with FUNDED status approaching transfer deadline, fire `publisher.escrowTransferReminder(...)`).
+
+### 11.3 Add
+
+- **Quiet hours UI for SL IM.**
+  > Columns `slImQuietStart` and `slImQuietEnd` exist on User entity from Epic 02 sub-spec 2b; no UI consumes them. Will likely tie to a future timezone/account-settings sub-spec; no committed home yet. If unused for >12 months, drop the columns in a dedicated cleanup sub-spec.
+- **HTTP-in push from backend to dispatcher for urgency.**
+  > Current design polls every 60 s — fine for the events shipping today (worst case 60 s latency for outbid/won). If outbid latency becomes a UX concern, register the dispatcher's HTTP-in URL with the backend on startup and have the backend `llHTTPRequest` to it on high-priority categories to wake an early poll. Post-launch enhancement; needs the channel to have real traffic and a real complaint before the complexity earns its keep.
+- **Dispatcher monitoring beyond the expiry canary.**
+  > The expiry job's INFO log catches a dark dispatcher within 48 h. If sub-day signal becomes important, options include: a `last_polled_at` timestamp on a singleton `dispatcher_health` row written on each successful poll, with an alarm scheduler that pages on `now - last_polled_at > 5 min`. Out of scope here.
+
+---
+
+## 12. FOOTGUNS additions
+
+Four new entries.
+
+### 12.1 `llInstantMessage` truncates at 1024 BYTES, not characters
+
+The natural Java `String.length()` measures UTF-16 code units; SL's `llInstantMessage` truncates the IM at 1024 **bytes** in UTF-8 encoding. Multi-byte UTF-8 characters (CJK, emoji, accented Latin) push the byte count above the char count. SL silently truncates from the end of the string — no error, no warning, no return value — and the deeplink in SLPA's IM template lives at the end of the assembled message. A 1023-character string with multi-byte content can occupy 1500+ bytes; the deeplink gets cleanly cut off.
+
+`SlImMessageBuilder` measures `text.getBytes(StandardCharsets.UTF_8).length` and ellipsizes the body, never the prefix or deeplink. Three mandatory test cases (multi-byte parcel name, emoji parcel name, long-body forcing truncation) verify the deeplink survives. Adding a new component to the assembled message (say, a timestamp) requires updating the byte-budget accounting in `SlImMessageBuilder` — the budget is currently computed assuming exactly `PREFIX + title + SEPARATOR + body + SEPARATOR + deeplink`.
+
+### 12.2 Single-recipient publish path is afterCommit-then-REQUIRES_NEW; fan-out path is in-the-REQUIRES_NEW
+
+The two notification dispatch sites have different reliability postures and different transaction structures.
+
+**Single-recipient path** (`NotificationService.publish`): in-app row commits first as part of the parent transaction, then `afterCommit` runs `slImChannelDispatcher.maybeQueue` which opens its own REQUIRES_NEW. If the IM-queue write fails, the in-app row already committed, the parent business event already committed, and the only loss is the IM. **In-app guaranteed, IM best-effort.**
+
+**Fan-out path** (`NotificationPublisherImpl.listingCancelledBySellerFanout`): per-recipient REQUIRES_NEW lambda contains the in-app DAO upsert AND the IM queue write as siblings. If the IM-queue write fails, that recipient's in-app row also rolls back; the per-recipient try-catch isolates this from sibling recipients. **In-app + IM atomic per recipient; sibling recipients independent.**
+
+Mixing these mental models produces either:
+- "One bad bidder kills the cancellation" — if you put fan-out atomic with the parent transaction.
+- "In-app row exists but IM never queued because the dispatcher hook failed silently" — if you inline the dispatcher into the single-recipient path's parent transaction.
+
+Future contributors adding a new fan-out method must follow the existing pattern: per-recipient REQUIRES_NEW lambda containing all per-recipient writes as siblings, with a per-recipient try-catch wrapping the lambda. Name with a `Fanout` suffix (sub-spec 1's convention).
+
+### 12.3 Adding a new terminal status to `sl_im_message` requires updating the cleanup predicate
+
+`SlImCleanupJob` stage 2 deletes rows via `WHERE status IN ('DELIVERED', 'EXPIRED', 'FAILED') AND updated_at < retention_cutoff`. The IN-list enumerates terminal statuses. Adding a new one (say, a future `RETRY_SCHEDULED` for the deferred retry primitive) without updating the IN-list means those rows accumulate forever — defeating the very `SELECT status, count(*) FROM sl_im_message GROUP BY status` query the rolling 30-day window was supposed to keep meaningful. Add the new status to the predicate in the same commit that introduces the status.
+
+### 12.4 LSL `llInstantMessage` is fire-and-forget; `/failed` has no LSL caller
+
+The `sl-im-dispatcher` script unconditionally calls `POST /api/v1/internal/sl-im/{id}/delivered` after every `llInstantMessage` because LSL provides no delivery signal — `llInstantMessage` returns `void`, raises no event on failure, and produces no observable side effect when the recipient UUID is invalid or offline-unreachable.
+
+This means FAILED rows in `sl_im_message` only appear via:
+1. **Manual operator intervention** — direct SQL UPDATE in production (rare; usually for support clearing a stuck row).
+2. **A future revision of `dispatcher.lsl`** that pre-validates avatar UUIDs (e.g., `llRequestAgentData` against `DATA_ONLINE` before sending, or a NULL_KEY guard).
+
+If support runs `SELECT status, count(*) FROM sl_im_message GROUP BY status` and sees zero FAILED rows, that's correct behavior. Not a missing pipeline.
+
+---
+
+## 13. Documentation updates
+
+### 13.1 `docs/initial-design/DESIGN.md` §11
+
+Extend the existing "Notes (Epic 09 sub-spec 1)" subsection with a follow-on for sub-spec 3:
+
+> **Notes (Epic 09 sub-spec 3):**
+> - The SL IM channel reuses the in-app coalesce key namespace; rows in `sl_im_message` collapse during pendency (`WHERE status = 'PENDING'`), with the same partial-unique-index pattern.
+> - `SYSTEM` group bypasses preferences and master-mute, but never bypasses the no-avatar floor.
+> - `llInstantMessage` truncates at 1024 BYTES (UTF-8), not characters. The backend's `SlImMessageBuilder` enforces this with body ellipsis, never trimming the prefix or deeplink.
+> - The polling/confirmation contract (`/api/v1/internal/sl-im/*`) uses a shared secret distinct from the existing escrow-terminal secret. State machines for `/delivered` and `/failed` are symmetric: PENDING → terminal-status, idempotent on the matching status, 409 on the other terminal statuses.
+> - The system relies on SL's native offline-IM-to-email forwarding to cover the email use case. Users with active SL email forwarding receive SLPA notifications by email; users with disabled forwarding receive only in-world IMs when online.
+
+### 13.2 `docs/implementation/DEFERRED_WORK.md`
+
+Per §11 above.
+
+### 13.3 `docs/implementation/FOOTGUNS.md`
+
+Per §12 above. Append four new numbered entries (next sequential numbers from the file's tail).
+
+### 13.4 `lsl-scripts/README.md` (new top-level)
+
+Per §5.2.
+
+### 13.5 `lsl-scripts/sl-im-dispatcher/README.md` (new per-script)
+
+Per §5.5.
+
+### 13.6 Root `CLAUDE.md` — addition under "Second Life Integration Notes"
+
+> **In-world LSL code lives in `lsl-scripts/`.** Each script gets its own subdirectory with its own README covering deployment, configuration, operations, and limits. Updates to a script's behavior, deployment, or configuration must update that script's README in the same commit. The top-level `lsl-scripts/README.md` is an index — updates only on add/remove/rename.
+
+### 13.7 Manual test plan (for the eventual PR)
+
+- Backend (`./mvnw test -pl backend`) and frontend (`cd frontend && npm test -- --run && npm run lint`) suites green.
+- Two browser sessions, two users; one with linked SL avatar, one without. Drive an OUTBID for each. Verify: linked user has a PENDING row in `sl_im_message`; unlinked user has none. Both users see in-app + WS push as before.
+- Toggle preferences in the linked user's `/settings/notifications` (mute Bidding). Drive another OUTBID. Verify: in-app row created, no new IM row queued, gate decision logged at DEBUG.
+- Toggle master mute on. Verify: per-group toggles render disabled but checked-states preserved. Toggle off. Verify: states return without API roundtrip.
+- `curl -H "Authorization: Bearer ${SECRET}" GET /api/v1/internal/sl-im/pending?limit=10`. Verify the assembled `messageText` matches the expected template; verify a multi-byte parcel name (set up a test auction with `東京タワー` in the name) comes through with deeplink intact.
+- `curl -H "Authorization: Bearer ${SECRET}" -X POST /api/v1/internal/sl-im/{id}/delivered`. Verify status transitions; second curl returns 204; manually mark a row FAILED via DB then curl `/delivered` — expect 409.
+- Deploy `sl-im-dispatcher` in beta sim pointed at staging. Drop `dispatcher.lsl` and `config` notecard into a prim, reset script, watch owner-say. Drive a notification for a test user with an avatar. Verify the alt account receives the IM with correct text and a clickable deeplink. Watch owner-say messages for poll cadence.
+- Stop the dispatcher object (delete or no-script land it). Wait 49 hours. Verify the cleanup job's INFO log includes a top_users entry naming the test account, and `expired > 0`.
+
+---

--- a/docs/superpowers/specs/2026-04-26-epic-09-sub-3-sl-im-and-preferences.md
+++ b/docs/superpowers/specs/2026-04-26-epic-09-sub-3-sl-im-and-preferences.md
@@ -315,7 +315,7 @@ public interface SlImMessageRepository extends JpaRepository<SlImMessage, Long> 
 }
 ```
 
-`FOR UPDATE SKIP LOCKED` matters because if a future enhancement deploys a fallback dispatcher (e.g., a spare object), concurrent pollers each grab disjoint batches without serializing on a single row. Costs nothing now to future-proof.
+`FOR UPDATE SKIP LOCKED` is advisory only with the controller's current shape (no `@Transactional`, so the row lock releases the moment the query returns). It costs nothing to keep, and prevents serialization if one poller's transaction *does* span longer (e.g., a future change wraps the controller method). True multi-dispatcher concurrency would require a `PENDING → IN_PROGRESS → DELIVERED` status transition so a second poller skips rows the first poller is mid-delivering — explicitly out of scope here. The implementer should add a code comment on this line capturing the actual semantics so future contributors don't mistake it for working concurrent-poll dedup.
 
 ### 3.6 `SlImChannelGate`
 
@@ -711,6 +711,10 @@ public class SlImInternalController {
         if (limit > props.maxBatchLimit() || limit < 1) {
             throw new IllegalArgumentException("limit must be in [1, " + props.maxBatchLimit() + "]");
         }
+        // FOR UPDATE SKIP LOCKED in pollPending() is advisory: this method isn't
+        // @Transactional, so the row lock releases when the query returns — before
+        // the LSL script delivers. Real multi-dispatcher dedup would need a
+        // PENDING → IN_PROGRESS → DELIVERED status transition.
         List<SlImMessage> rows = repo.pollPending(limit);
         List<PendingItem> items = rows.stream()
             .map(m -> new PendingItem(m.getId(), m.getAvatarUuid(), m.getMessageText()))

--- a/frontend/src/app/settings/layout.tsx
+++ b/frontend/src/app/settings/layout.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react";
+
+export default function SettingsLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <h1 className="text-headline-md font-display font-bold mb-6">Settings</h1>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/app/settings/notifications/page.test.tsx
+++ b/frontend/src/app/settings/notifications/page.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { renderWithProviders, screen } from "@/test/render";
+import { server } from "@/test/msw/server";
+import { authHandlers, preferencesHandlers, resetPreferences } from "@/test/msw/handlers";
+import NotificationSettingsPage from "./page";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/settings/notifications",
+}));
+
+describe("/settings/notifications page", () => {
+  beforeEach(() => {
+    resetPreferences();
+    server.use(authHandlers.refreshSuccess(), ...preferencesHandlers);
+  });
+
+  test("renders the preferences page title (via layout) when authenticated", async () => {
+    renderWithProviders(<NotificationSettingsPage />, { auth: "authenticated" });
+    expect(
+      await screen.findByText(/In-app and system notifications always deliver/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/settings/notifications/page.tsx
+++ b/frontend/src/app/settings/notifications/page.tsx
@@ -1,0 +1,10 @@
+import { RequireAuth } from "@/components/auth/RequireAuth";
+import { NotificationPreferencesPage } from "@/components/notifications/preferences/NotificationPreferencesPage";
+
+export default function NotificationSettingsPage() {
+  return (
+    <RequireAuth>
+      <NotificationPreferencesPage />
+    </RequireAuth>
+  );
+}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function SettingsIndexPage() {
+  redirect("/settings/notifications");
+}

--- a/frontend/src/components/notifications/NotificationDropdown.tsx
+++ b/frontend/src/components/notifications/NotificationDropdown.tsx
@@ -8,6 +8,7 @@ import { useMarkAllRead } from "@/hooks/notifications/useMarkAllRead";
 import { NotificationDropdownRow } from "./NotificationDropdownRow";
 import { FilterChips, type FilterMode } from "./FilterChips";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { Settings } from "@/components/ui/icons";
 
 export interface NotificationDropdownProps {
   onClose: () => void;
@@ -61,13 +62,21 @@ export function NotificationDropdown({ onClose }: NotificationDropdownProps) {
         )}
       </div>
 
-      <footer className="border-t border-outline-variant px-4 py-2 text-center bg-surface-container">
+      <footer className="border-t border-outline-variant px-4 py-2 flex items-center justify-between bg-surface-container">
         <Link
           href="/notifications"
           onClick={onClose}
           className="text-label-md text-primary hover:underline"
         >
           View all notifications
+        </Link>
+        <Link
+          href="/settings/notifications"
+          onClick={onClose}
+          className="text-on-surface-variant hover:text-on-surface"
+          aria-label="Notification settings"
+        >
+          <Settings className="size-4" />
         </Link>
       </footer>
     </PopoverPanel>

--- a/frontend/src/components/notifications/feed/FeedShell.tsx
+++ b/frontend/src/components/notifications/feed/FeedShell.tsx
@@ -1,7 +1,8 @@
 "use client";
 import { useState } from "react";
 import { Disclosure, DisclosureButton, DisclosurePanel } from "@headlessui/react";
-import { FilterIcon } from "@/components/ui/icons";
+import Link from "next/link";
+import { FilterIcon, Settings } from "@/components/ui/icons";
 import { FeedSidebar } from "./FeedSidebar";
 import { FeedList } from "./FeedList";
 import type { FilterMode } from "../FilterChips";
@@ -14,7 +15,16 @@ export function FeedShell() {
 
   return (
     <div className="mx-auto max-w-6xl px-4 py-8">
-      <h1 className="text-headline-md font-display font-bold mb-2">Notifications</h1>
+      <div className="flex items-center justify-between mb-2">
+        <h1 className="text-headline-md font-display font-bold">Notifications</h1>
+        <Link
+          href="/settings/notifications"
+          className="p-2 text-on-surface-variant hover:text-on-surface rounded-md hover:bg-surface-container"
+          aria-label="Notification settings"
+        >
+          <Settings className="size-5" />
+        </Link>
+      </div>
       <p className="text-body-sm text-on-surface-variant mb-6">
         Activity from your bids, listings, and account.
       </p>

--- a/frontend/src/components/notifications/preferences/ChannelInfoBanner.tsx
+++ b/frontend/src/components/notifications/preferences/ChannelInfoBanner.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+export function ChannelInfoBanner() {
+  return (
+    <div className="bg-primary-container/30 border border-primary/20 rounded-lg p-4 mb-6 text-body-sm text-on-surface">
+      <p>
+        In-app and system notifications always deliver. Settings below control
+        SL IM for the rest. SL natively forwards in-game IMs to your registered
+        email when you&apos;re offline.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/notifications/preferences/GroupToggleRow.test.tsx
+++ b/frontend/src/components/notifications/preferences/GroupToggleRow.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { GroupToggleRow } from "./GroupToggleRow";
+
+describe("GroupToggleRow", () => {
+  test("renders label and subtext", () => {
+    render(<GroupToggleRow
+      group="bidding" label="Bidding" subtext="Outbid, proxy exhausted"
+      value={true} mutedDisabled={false} onChange={() => {}} />);
+    expect(screen.getByText("Bidding")).toBeInTheDocument();
+    expect(screen.getByText("Outbid, proxy exhausted")).toBeInTheDocument();
+  });
+
+  test("aria-checked reflects value when not muted", () => {
+    render(<GroupToggleRow
+      group="bidding" label="Bidding" subtext="x"
+      value={true} mutedDisabled={false} onChange={() => {}} />);
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+  });
+
+  test("click fires onChange when not muted", () => {
+    const onChange = vi.fn();
+    render(<GroupToggleRow
+      group="bidding" label="Bidding" subtext="x"
+      value={false} mutedDisabled={false} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  test("disabled state preserves checked value (the load-bearing invariant)", () => {
+    render(<GroupToggleRow
+      group="bidding" label="Bidding" subtext="x"
+      value={true} mutedDisabled={true} onChange={() => {}} />);
+    const sw = screen.getByRole("switch");
+    expect(sw).toHaveAttribute("aria-checked", "true");
+    expect(sw).toBeDisabled();
+  });
+
+  test("click does NOT fire onChange when mutedDisabled", () => {
+    const onChange = vi.fn();
+    render(<GroupToggleRow
+      group="bidding" label="Bidding" subtext="x"
+      value={true} mutedDisabled={true} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/notifications/preferences/GroupToggleRow.tsx
+++ b/frontend/src/components/notifications/preferences/GroupToggleRow.tsx
@@ -1,0 +1,50 @@
+"use client";
+import { cn } from "@/lib/cn";
+
+export interface GroupToggleRowProps {
+  group: string;
+  label: string;
+  subtext: string;
+  value: boolean;
+  mutedDisabled: boolean;
+  onChange: (next: boolean) => void;
+}
+
+export function GroupToggleRow({
+  group, label, subtext, value, mutedDisabled, onChange
+}: GroupToggleRowProps) {
+  const handleClick = () => {
+    if (mutedDisabled) return;  // no-op when muted; preserve underlying state
+    onChange(!value);
+  };
+
+  return (
+    <div className="flex items-center justify-between py-4 border-b border-outline-variant last:border-0">
+      <div className="flex-1 mr-4">
+        <div className="text-body-md font-medium text-on-surface">{label}</div>
+        <div className="text-body-sm text-on-surface-variant mt-0.5">{subtext}</div>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={value}
+        disabled={mutedDisabled}
+        onClick={handleClick}
+        className={cn(
+          "relative inline-flex h-6 w-11 items-center rounded-full transition-colors",
+          value ? "bg-primary" : "bg-surface-container-high border border-outline",
+          mutedDisabled && "opacity-50 cursor-not-allowed"
+        )}
+        aria-label={`${label} — ${value ? "on" : "off"}${mutedDisabled ? " (muted)" : ""}`}
+        data-testid={`group-toggle-${group}`}
+      >
+        <span
+          className={cn(
+            "inline-block h-4 w-4 transform rounded-full bg-on-primary transition-transform",
+            value ? "translate-x-6" : "translate-x-1"
+          )}
+        />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/notifications/preferences/MasterMuteRow.test.tsx
+++ b/frontend/src/components/notifications/preferences/MasterMuteRow.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { MasterMuteRow } from "./MasterMuteRow";
+
+describe("MasterMuteRow", () => {
+  test("renders aria-checked reflecting value=false", () => {
+    render(<MasterMuteRow value={false} onChange={() => {}} />);
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+  });
+
+  test("renders aria-checked reflecting value=true", () => {
+    render(<MasterMuteRow value={true} onChange={() => {}} />);
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+  });
+
+  test("calls onChange with the inverted value on click", () => {
+    const onChange = vi.fn();
+    render(<MasterMuteRow value={false} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/frontend/src/components/notifications/preferences/MasterMuteRow.tsx
+++ b/frontend/src/components/notifications/preferences/MasterMuteRow.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+export interface MasterMuteRowProps {
+  value: boolean;
+  onChange: (next: boolean) => void;
+}
+
+export function MasterMuteRow({ value, onChange }: MasterMuteRowProps) {
+  return (
+    <div className="flex items-center justify-between py-4 border-b border-outline-variant mb-4">
+      <div>
+        <div className="text-title-sm font-semibold text-on-surface">
+          Mute all SL IM notifications
+        </div>
+        <div className="text-body-sm text-on-surface-variant mt-1">
+          Master switch — overrides everything below.
+        </div>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={value}
+        onClick={() => onChange(!value)}
+        className={
+          "relative inline-flex h-6 w-11 items-center rounded-full transition-colors " +
+          (value ? "bg-primary" : "bg-surface-container-high border border-outline")
+        }
+        aria-label="Mute all SL IM notifications"
+      >
+        <span
+          className={
+            "inline-block h-4 w-4 transform rounded-full bg-on-primary transition-transform " +
+            (value ? "translate-x-6" : "translate-x-1")
+          }
+        />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/notifications/preferences/NotificationPreferencesPage.test.tsx
+++ b/frontend/src/components/notifications/preferences/NotificationPreferencesPage.test.tsx
@@ -1,0 +1,112 @@
+import { screen, fireEvent, waitFor, renderWithProviders } from "@/test/render";
+import { describe, expect, test, beforeEach } from "vitest";
+import { NotificationPreferencesPage } from "./NotificationPreferencesPage";
+import { server } from "@/test/msw/server";
+import {
+  preferencesHandlers,
+  resetPreferences,
+  seedPreferences,
+} from "@/test/msw/handlers";
+
+describe("NotificationPreferencesPage", () => {
+  beforeEach(() => {
+    resetPreferences();
+    server.use(...preferencesHandlers);
+  });
+
+  test("renders banner and 5 group toggle rows (no SYSTEM/REALTY_GROUP/MARKETING)", async () => {
+    renderWithProviders(<NotificationPreferencesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/In-app and system notifications always deliver/i))
+        .toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Bidding")).toBeInTheDocument();
+    expect(screen.getByText("Auction Result")).toBeInTheDocument();
+    expect(screen.getByText("Escrow")).toBeInTheDocument();
+    expect(screen.getByText("Listings")).toBeInTheDocument();
+    expect(screen.getByText("Reviews")).toBeInTheDocument();
+    // None of these should appear:
+    expect(screen.queryByText("System")).not.toBeInTheDocument();
+    expect(screen.queryByText("Realty Group")).not.toBeInTheDocument();
+    expect(screen.queryByText("Marketing")).not.toBeInTheDocument();
+  });
+
+  test("Reviews defaults to OFF for fresh user", async () => {
+    renderWithProviders(<NotificationPreferencesPage />);
+
+    await waitFor(() => {
+      const reviewsToggle = screen.getByTestId("group-toggle-reviews");
+      expect(reviewsToggle).toHaveAttribute("aria-checked", "false");
+    });
+  });
+
+  test("master mute disables group toggles but preserves underlying values", async () => {
+    seedPreferences({
+      slImMuted: false,
+      slIm: { bidding: true, auction_result: true, escrow: true,
+              listing_status: true, reviews: false },
+    });
+    renderWithProviders(<NotificationPreferencesPage />);
+
+    // Wait for initial render
+    await waitFor(() => {
+      expect(screen.getByTestId("group-toggle-bidding"))
+        .toHaveAttribute("aria-checked", "true");
+    });
+
+    // Find the master mute switch by its aria-label and click
+    const masterMute = screen.getByLabelText("Mute all SL IM notifications");
+    fireEvent.click(masterMute);
+
+    await waitFor(() => {
+      expect(masterMute).toHaveAttribute("aria-checked", "true");
+    });
+
+    // Group toggles should now be disabled but values unchanged
+    const biddingToggle = screen.getByTestId("group-toggle-bidding");
+    expect(biddingToggle).toBeDisabled();
+    expect(biddingToggle).toHaveAttribute("aria-checked", "true");
+
+    const reviewsToggle = screen.getByTestId("group-toggle-reviews");
+    expect(reviewsToggle).toBeDisabled();
+    expect(reviewsToggle).toHaveAttribute("aria-checked", "false");
+
+    // Click bidding toggle while muted — should be no-op
+    fireEvent.click(biddingToggle);
+    expect(biddingToggle).toHaveAttribute("aria-checked", "true");
+
+    // Toggle master mute off
+    fireEvent.click(masterMute);
+    await waitFor(() => {
+      expect(masterMute).toHaveAttribute("aria-checked", "false");
+    });
+
+    // Group toggles re-enabled, values preserved
+    expect(biddingToggle).not.toBeDisabled();
+    expect(biddingToggle).toHaveAttribute("aria-checked", "true");
+    expect(reviewsToggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  test("clicking a group toggle when not muted updates the toggle state", async () => {
+    seedPreferences({
+      slImMuted: false,
+      slIm: { bidding: true, auction_result: true, escrow: true,
+              listing_status: true, reviews: false },
+    });
+    renderWithProviders(<NotificationPreferencesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("group-toggle-bidding"))
+        .toHaveAttribute("aria-checked", "true");
+    });
+
+    fireEvent.click(screen.getByTestId("group-toggle-bidding"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("group-toggle-bidding"))
+        .toHaveAttribute("aria-checked", "false");
+    });
+  });
+});

--- a/frontend/src/components/notifications/preferences/NotificationPreferencesPage.tsx
+++ b/frontend/src/components/notifications/preferences/NotificationPreferencesPage.tsx
@@ -1,0 +1,71 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useNotificationPreferences } from "@/hooks/notifications/useNotificationPreferences";
+import { useUpdateNotificationPreferences } from "@/hooks/notifications/useUpdateNotificationPreferences";
+import { ChannelInfoBanner } from "./ChannelInfoBanner";
+import { MasterMuteRow } from "./MasterMuteRow";
+import { GroupToggleRow } from "./GroupToggleRow";
+import {
+  EDITABLE_GROUPS, GROUP_LABELS, GROUP_SUBTEXT,
+  type EditableGroup, type PreferencesDto,
+} from "@/lib/notifications/preferencesTypes";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+
+export function NotificationPreferencesPage() {
+  const { data, isPending } = useNotificationPreferences();
+  const update = useUpdateNotificationPreferences();
+
+  // Local state mirrors server state for immediate UI feedback. Master mute
+  // does NOT mutate per-group state — disabled is purely presentational.
+  const [local, setLocal] = useState<PreferencesDto | null>(null);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- server preferences are the external source of truth; seeding local optimistic state on first fetch so edits are instant without round-trips.
+    if (data) setLocal(data);
+  }, [data]);
+
+  if (isPending || !local) {
+    return <div className="flex justify-center p-8"><LoadingSpinner /></div>;
+  }
+
+  const handleMasterMute = (next: boolean) => {
+    const updated = { ...local, slImMuted: next };
+    setLocal(updated);
+    update.mutate(updated);
+  };
+
+  const handleGroupToggle = (group: EditableGroup, next: boolean) => {
+    const updated = {
+      ...local,
+      slIm: { ...local.slIm, [group]: next },
+    };
+    setLocal(updated);
+    update.mutate(updated);
+  };
+
+  return (
+    <div>
+      <ChannelInfoBanner />
+
+      <MasterMuteRow value={local.slImMuted} onChange={handleMasterMute} />
+
+      <div className="mb-2 text-label-sm uppercase tracking-wide text-on-surface-variant font-semibold">
+        Send via SL IM
+      </div>
+
+      <div className="bg-surface border border-outline rounded-xl">
+        {EDITABLE_GROUPS.map((g) => (
+          <GroupToggleRow
+            key={g}
+            group={g}
+            label={GROUP_LABELS[g]}
+            subtext={GROUP_SUBTEXT[g]}
+            value={local.slIm[g]}
+            mutedDisabled={local.slImMuted}
+            onChange={(next) => handleGroupToggle(g, next)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/notifications/useNotificationPreferences.test.tsx
+++ b/frontend/src/hooks/notifications/useNotificationPreferences.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "next-themes";
+import type { ReactElement, ReactNode } from "react";
+import { ToastProvider } from "@/components/ui/Toast";
+import { server } from "@/test/msw/server";
+import {
+  preferencesHandlers,
+  resetPreferences,
+  seedPreferences,
+} from "@/test/msw/handlers";
+import { useNotificationPreferences } from "./useNotificationPreferences";
+
+function makeWrapper(): {
+  client: QueryClient;
+  wrapper: (props: { children: ReactNode }) => ReactElement;
+} {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }): ReactElement => (
+    <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
+      <QueryClientProvider client={client}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    </ThemeProvider>
+  );
+
+  return { client, wrapper };
+}
+
+describe("useNotificationPreferences", () => {
+  beforeEach(() => {
+    resetPreferences();
+    server.use(...preferencesHandlers);
+  });
+
+  it("fetches preferences from the GET endpoint", async () => {
+    seedPreferences({
+      slImMuted: false,
+      slIm: {
+        bidding: true,
+        auction_result: true,
+        escrow: true,
+        listing_status: false,
+        reviews: false,
+      },
+    });
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useNotificationPreferences(), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual({
+      slImMuted: false,
+      slIm: {
+        bidding: true,
+        auction_result: true,
+        escrow: true,
+        listing_status: false,
+        reviews: false,
+      },
+    });
+  });
+
+  it("returns reviews=false by default", async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useNotificationPreferences(), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.slIm.reviews).toBe(false);
+  });
+});

--- a/frontend/src/hooks/notifications/useNotificationPreferences.ts
+++ b/frontend/src/hooks/notifications/useNotificationPreferences.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getNotificationPreferences } from "@/lib/notifications/preferencesApi";
+import { notificationKeys } from "@/lib/notifications/queryKeys";
+
+export function useNotificationPreferences() {
+  return useQuery({
+    queryKey: notificationKeys.preferences(),
+    queryFn: () => getNotificationPreferences(),
+    staleTime: 60_000,
+  });
+}

--- a/frontend/src/hooks/notifications/useUpdateNotificationPreferences.test.tsx
+++ b/frontend/src/hooks/notifications/useUpdateNotificationPreferences.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { http, HttpResponse } from "msw";
+import { ThemeProvider } from "next-themes";
+import type { ReactElement, ReactNode } from "react";
+import { ToastProvider } from "@/components/ui/Toast";
+import { server } from "@/test/msw/server";
+import {
+  preferencesHandlers,
+  resetPreferences,
+  seedPreferences,
+} from "@/test/msw/handlers";
+import { notificationKeys } from "@/lib/notifications/queryKeys";
+import type { PreferencesDto } from "@/lib/notifications/preferencesTypes";
+import { useNotificationPreferences } from "./useNotificationPreferences";
+import { useUpdateNotificationPreferences } from "./useUpdateNotificationPreferences";
+
+function makeWrapper(): {
+  client: QueryClient;
+  wrapper: (props: { children: ReactNode }) => ReactElement;
+} {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }): ReactElement => (
+    <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
+      <QueryClientProvider client={client}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    </ThemeProvider>
+  );
+
+  return { client, wrapper };
+}
+
+describe("useUpdateNotificationPreferences", () => {
+  beforeEach(() => {
+    resetPreferences();
+    server.use(...preferencesHandlers);
+  });
+
+  it("optimistically updates the cache before server confirms", async () => {
+    seedPreferences({
+      slImMuted: false,
+      slIm: {
+        bidding: true,
+        auction_result: true,
+        escrow: true,
+        listing_status: true,
+        reviews: false,
+      },
+    });
+
+    const { client, wrapper } = makeWrapper();
+
+    const { result: query } = renderHook(() => useNotificationPreferences(), {
+      wrapper,
+    });
+    await waitFor(() => expect(query.current.isSuccess).toBe(true));
+
+    const { result: mut } = renderHook(
+      () => useUpdateNotificationPreferences(),
+      { wrapper }
+    );
+
+    act(() => {
+      mut.current.mutate({
+        slImMuted: false,
+        slIm: {
+          bidding: false,
+          auction_result: true,
+          escrow: true,
+          listing_status: true,
+          reviews: false,
+        },
+      });
+    });
+
+    // Cache should reflect optimistic value immediately, before the request settles.
+    await waitFor(() => {
+      const cached = client.getQueryData<PreferencesDto>(
+        notificationKeys.preferences()
+      );
+      expect(cached?.slIm.bidding).toBe(false);
+    });
+  });
+
+  it("reverts cache + shows toast on server 4xx", async () => {
+    seedPreferences({
+      slImMuted: false,
+      slIm: {
+        bidding: true,
+        auction_result: true,
+        escrow: true,
+        listing_status: true,
+        reviews: false,
+      },
+    });
+
+    // Override PUT to 400 for this test
+    server.use(
+      http.put("*/api/v1/users/me/notification-preferences", () =>
+        new HttpResponse(null, { status: 400 })
+      )
+    );
+
+    const { client, wrapper } = makeWrapper();
+
+    const { result: query } = renderHook(() => useNotificationPreferences(), {
+      wrapper,
+    });
+    await waitFor(() => expect(query.current.isSuccess).toBe(true));
+
+    const { result: mut } = renderHook(
+      () => useUpdateNotificationPreferences(),
+      { wrapper }
+    );
+
+    act(() => {
+      mut.current.mutate({
+        slImMuted: false,
+        slIm: {
+          bidding: false,
+          auction_result: true,
+          escrow: true,
+          listing_status: true,
+          reviews: false,
+        },
+      });
+    });
+
+    await waitFor(() => expect(mut.current.isError).toBe(true));
+
+    // Cache reverted to prior value
+    const cached = client.getQueryData<PreferencesDto>(
+      notificationKeys.preferences()
+    );
+    expect(cached?.slIm.bidding).toBe(true);
+  });
+});

--- a/frontend/src/hooks/notifications/useUpdateNotificationPreferences.ts
+++ b/frontend/src/hooks/notifications/useUpdateNotificationPreferences.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { putNotificationPreferences } from "@/lib/notifications/preferencesApi";
+import { notificationKeys } from "@/lib/notifications/queryKeys";
+import type { PreferencesDto } from "@/lib/notifications/preferencesTypes";
+import { useToast } from "@/components/ui/Toast";
+
+export function useUpdateNotificationPreferences() {
+  const qc = useQueryClient();
+  const toast = useToast();
+  return useMutation({
+    mutationFn: (payload: PreferencesDto) => putNotificationPreferences(payload),
+    onMutate: async (payload) => {
+      await qc.cancelQueries({ queryKey: notificationKeys.preferences() });
+      const prev = qc.getQueryData<PreferencesDto>(notificationKeys.preferences());
+      qc.setQueryData(notificationKeys.preferences(), payload);
+      return { prev };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.prev) {
+        qc.setQueryData(notificationKeys.preferences(), ctx.prev);
+      }
+      toast.error("Couldn't save preferences");
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: notificationKeys.preferences() });
+      qc.invalidateQueries({ queryKey: ["currentUser"] });
+    },
+  });
+}

--- a/frontend/src/lib/notifications/preferencesApi.ts
+++ b/frontend/src/lib/notifications/preferencesApi.ts
@@ -1,0 +1,15 @@
+import { api } from "@/lib/api";
+import type { PreferencesDto } from "./preferencesTypes";
+
+export async function getNotificationPreferences(): Promise<PreferencesDto> {
+  return api.get<PreferencesDto>("/api/v1/users/me/notification-preferences");
+}
+
+export async function putNotificationPreferences(
+  body: PreferencesDto
+): Promise<PreferencesDto> {
+  return api.put<PreferencesDto>(
+    "/api/v1/users/me/notification-preferences",
+    body
+  );
+}

--- a/frontend/src/lib/notifications/preferencesTypes.ts
+++ b/frontend/src/lib/notifications/preferencesTypes.ts
@@ -1,0 +1,38 @@
+// Closed shape: exactly the user-mutable groups. SYSTEM/REALTY_GROUP/MARKETING
+// are excluded by server contract — sending them returns 400.
+export type EditableGroup =
+  | "bidding"
+  | "auction_result"
+  | "escrow"
+  | "listing_status"
+  | "reviews";
+
+export interface PreferencesDto {
+  slImMuted: boolean;
+  slIm: Record<EditableGroup, boolean>;
+}
+
+export const EDITABLE_GROUPS: EditableGroup[] = [
+  "bidding",
+  "auction_result",
+  "escrow",
+  "listing_status",
+  "reviews",
+];
+
+export const GROUP_LABELS: Record<EditableGroup, string> = {
+  bidding: "Bidding",
+  auction_result: "Auction Result",
+  escrow: "Escrow",
+  listing_status: "Listings",
+  reviews: "Reviews",
+};
+
+export const GROUP_SUBTEXT: Record<EditableGroup, string> = {
+  bidding: "Outbid, proxy exhausted",
+  auction_result: "Won, lost, ended (sold/reserve/no-bids/buy-now)",
+  escrow:
+    "Funded, transfer confirmed, payout, expired, disputed, frozen, payout stalled",
+  listing_status: "Verified, suspended, review required, cancelled by seller",
+  reviews: "New review received",
+};

--- a/frontend/src/lib/notifications/queryKeys.ts
+++ b/frontend/src/lib/notifications/queryKeys.ts
@@ -14,4 +14,5 @@ export const notificationKeys = {
   unreadCount: () => [...notificationKeys.all, "unreadCount"] as const,
   unreadCountBreakdown: () =>
     [...notificationKeys.all, "unreadCount", "breakdown"] as const,
+  preferences: () => [...notificationKeys.all, "preferences"] as const,
 };

--- a/frontend/src/test/msw/handlers.ts
+++ b/frontend/src/test/msw/handlers.ts
@@ -15,6 +15,7 @@ import {
 } from "./fixtures";
 import type { CurrentUser, PublicUserProfile, UpdateProfileRequest } from "@/lib/user/api";
 import type { NotificationDto } from "@/lib/notifications/types";
+import type { PreferencesDto, EditableGroup } from "@/lib/notifications/preferencesTypes";
 
 /**
  * Named handler factories for every auth endpoint, plus a `defaultHandlers`
@@ -330,6 +331,70 @@ export function seedNotification(partial: Partial<NotificationDto> = {}): Notifi
 export function clearNotifications(): void {
   _notifications.clear();
   _nextNotifId = 1;
+}
+
+// ---------------------------------------------------------------------------
+// Notification Preferences handlers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_PREFERENCES: PreferencesDto = {
+  slImMuted: false,
+  slIm: {
+    bidding: true,
+    auction_result: true,
+    escrow: true,
+    listing_status: true,
+    reviews: false,
+  },
+};
+
+let _currentPreferences: PreferencesDto = { ...DEFAULT_PREFERENCES, slIm: { ...DEFAULT_PREFERENCES.slIm } };
+const ALLOWED_PREFS_KEYS: Set<string> = new Set<EditableGroup>([
+  "bidding",
+  "auction_result",
+  "escrow",
+  "listing_status",
+  "reviews",
+]);
+
+export const preferencesHandlers = [
+  http.get("*/api/v1/users/me/notification-preferences", () => {
+    return HttpResponse.json(_currentPreferences);
+  }),
+  http.put(
+    "*/api/v1/users/me/notification-preferences",
+    async ({ request }) => {
+      const body = (await request.json()) as PreferencesDto;
+      if (!body.slIm) {
+        return new HttpResponse(null, { status: 400 });
+      }
+      const keys = new Set(Object.keys(body.slIm));
+      if (
+        keys.size !== ALLOWED_PREFS_KEYS.size ||
+        ![...keys].every((k) => ALLOWED_PREFS_KEYS.has(k))
+      ) {
+        return new HttpResponse(null, { status: 400 });
+      }
+      for (const v of Object.values(body.slIm)) {
+        if (typeof v !== "boolean") {
+          return new HttpResponse(null, { status: 400 });
+        }
+      }
+      if (typeof body.slImMuted !== "boolean") {
+        return new HttpResponse(null, { status: 400 });
+      }
+      _currentPreferences = body;
+      return HttpResponse.json(_currentPreferences);
+    }
+  ),
+];
+
+export function seedPreferences(p: PreferencesDto): void {
+  _currentPreferences = { ...p, slIm: { ...p.slIm } };
+}
+
+export function resetPreferences(): void {
+  _currentPreferences = { ...DEFAULT_PREFERENCES, slIm: { ...DEFAULT_PREFERENCES.slIm } };
 }
 
 /**

--- a/lsl-scripts/README.md
+++ b/lsl-scripts/README.md
@@ -1,0 +1,30 @@
+# LSL Scripts
+
+In-world Linden Scripting Language (LSL) code that consumes SLPA's backend APIs.
+Each script is the in-world half of an end-to-end integration; the matching
+backend code lives under `backend/src/main/java/com/slparcelauctions/backend/`.
+
+## Contributor rules
+
+**Each new script gets its own subdirectory with its own README.** Updates to
+any script's behavior, deployment, or configuration must be reflected in that
+script's README in the same commit. The top-level index below updates only on
+add / remove / rename.
+
+A script's README must cover:
+
+- **Purpose** — what the script does and what backend system it integrates with.
+- **Architecture summary** — high-level flow (events, timers, HTTP calls).
+- **Deployment** — step-by-step in-world deployment, prim setup, permissions.
+- **Configuration** — notecard format, where to obtain secrets, rotation procedure.
+- **Operations** — what owner-say / chat output to expect; how to verify health.
+- **Troubleshooting** — common failure modes and their signatures.
+- **Limits** — SL platform constraints the script depends on (HTTP throttles,
+  IM byte limits, etc.) and any known operational caveats.
+- **Security** — secret-handling expectations and access-control notes.
+
+## Scripts
+
+- [`sl-im-dispatcher/`](sl-im-dispatcher/) — Polls SLPA backend for pending
+  SL IM notifications and delivers them via `llInstantMessage`. SLPA-team-deployed
+  (one instance per environment); not user-deployed.

--- a/lsl-scripts/sl-im-dispatcher/README.md
+++ b/lsl-scripts/sl-im-dispatcher/README.md
@@ -1,0 +1,112 @@
+# SL IM Dispatcher
+
+In-world component of the SLPA SL IM notification channel. Polls the SLPA
+backend for pending IMs and delivers them via `llInstantMessage`.
+
+## Architecture summary
+
+- **Polling cadence:** 60 seconds when idle.
+- **Per-IM cadence:** 2 seconds (matches SL's `llInstantMessage` floor).
+- **Batch size:** up to 10 messages per poll, sized to fit comfortably within
+  SL's 20-second HTTP request window.
+- **Confirmation:** for each delivered IM, the script POSTs
+  `/api/v1/internal/sl-im/{id}/delivered` to mark the row DELIVERED.
+- **Authentication:** shared-secret bearer token, loaded from the `config`
+  notecard at script start.
+
+## Deployment
+
+This is a **SLPA-team-deployed object**, one per environment. Not user-deployed.
+
+1. Rez a generic prim somewhere with reliable land permissions (group land or
+   owner-controlled). Outbound HTTP must be permitted on that parcel.
+2. Drop `dispatcher.lsl` into the prim.
+3. Drop a copy of `config.notecard.example` renamed to **`config`** (no extension).
+   Edit the values to match the target environment.
+4. Reset the script (right-click → Edit → Reset Scripts in Selection).
+5. Watch local chat for the startup message: `SL IM dispatcher: ready (poll=...)`.
+
+Object ownership and modify permissions should be tightly scoped to SLPA-team
+avatars only. The shared secret is in the notecard, visible to anyone with
+edit-rights on the object.
+
+## Configuration
+
+The `config` notecard format is `key=value` pairs, one per line. Lines starting
+with `#` are comments. Whitespace is trimmed. Required keys:
+
+| Key | Description |
+| --- | --- |
+| `POLL_URL` | Full URL of the backend's pending-messages endpoint. |
+| `CONFIRM_URL_BASE` | URL prefix for delivery-confirmation posts. The script appends `{id}/delivered` to this base. |
+| `SHARED_SECRET` | The bearer-token secret. Obtain from the server's `slpa.notifications.sl-im.dispatcher.shared-secret` configuration property. |
+| `DEBUG_OWNER_SAY` | `true` to enable per-poll owner chat (default); `false` to silence. Recommended `true` in prod for observability. |
+
+### Rotating the shared secret
+
+1. Update the deployment's secrets store with the new value.
+2. Restart the SLPA backend so it picks up the new secret.
+3. Edit the `config` notecard with the new `SHARED_SECRET` value.
+4. Reset the script (the `changed(CHANGED_INVENTORY)` handler also auto-resets,
+   but a manual reset is faster).
+
+In-flight pending rows are unaffected; the next poll uses the new secret.
+
+## Operations
+
+In steady state, with `DEBUG_OWNER_SAY=true`, you'll see one of these every
+60 seconds:
+
+- `SL IM poll: 0 messages` — nothing pending; healthy.
+- `SL IM batch=N` — N messages found; per-IM cadence kicks in.
+- `SL IM confirm failed: status=N` — a confirmation HTTP call failed; the IM
+  was still sent, the row in the backend may end up EXPIRED via the cleanup
+  job. Investigate if these are frequent.
+- `SL IM poll failed: N` — the poll HTTP call failed. Common causes: 401
+  (secret mismatch), 500 (backend issue), 0 (network / permissions).
+
+If you go silent for >5 minutes (no startup ping, no poll output), something is
+wrong. Most common: notecard missing, notecard malformed, or the prim landed
+on a parcel without outbound HTTP permission.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| Startup says `incomplete config` | Notecard missing one of `POLL_URL`, `CONFIRM_URL_BASE`, `SHARED_SECRET`. |
+| Startup says `notecard 'config' missing or unreadable` | Notecard not in the prim, or named something other than exactly `config`. |
+| Periodic `SL IM poll failed: 401` | Shared secret in notecard doesn't match the backend's configured value. |
+| Periodic `SL IM poll failed: 500` | Backend issue. Check server logs. |
+| `SL IM poll failed: 0` (no HTTP response) | Land permissions blocking outbound HTTP, or no-script land. Move the object. |
+| Long silence in owner chat | Script may have wedged. Right-click → Edit → Reset Scripts. |
+| Backend shows growing PENDING count | Dispatcher is dark. Check that the object is rezzed, not on no-script land, has the right script + notecard. |
+
+## Limits
+
+Three load-bearing notes:
+
+- **Hard byte limit on IM text.** `llInstantMessage` truncates at 1024 BYTES
+  (not characters). The backend's `SlImMessageBuilder` enforces this; the
+  script trusts the messages it receives. **Operators should never modify
+  `messageText` in the script.**
+- **No `/failed` caller in this script.** `llInstantMessage` is fire-and-forget
+  — no return value, no error, no way to distinguish "delivered" from "UUID
+  doesn't exist." The script unconditionally calls `/{id}/delivered` after every
+  IM. So FAILED rows in the database only ever come from manual operator
+  intervention or a future revision of this script that adds UUID
+  pre-validation (e.g., `llRequestAgentData` against `DATA_ONLINE` before
+  sending). If `SELECT status, count(*) FROM sl_im_message GROUP BY status`
+  shows zero FAILED rows, that's correct behavior, not a missing pipeline.
+- **Batch size 10 with 2-second spacing fits the 20-second SL HTTP window.**
+  Increasing batch size beyond 10 risks the script's confirmation requests
+  racing the next poll cycle's request limits. Don't increase without verifying
+  the math.
+
+## Security
+
+The shared secret is a deployment artifact; treat it like a database password.
+Notecard contents are visible to anyone with object-edit rights, so the
+dispatcher prim's ownership and modify permissions should be SLPA-team-only.
+A leaked shared secret means an attacker can pull the entire pending IM queue
+and confirm-mark messages as DELIVERED, blocking real delivery — rotate
+immediately if compromise is suspected.

--- a/lsl-scripts/sl-im-dispatcher/config.notecard.example
+++ b/lsl-scripts/sl-im-dispatcher/config.notecard.example
@@ -1,0 +1,8 @@
+# SL IM Dispatcher configuration
+# Copy this file to a notecard named "config" in the same prim, then edit
+# values for your environment.
+
+POLL_URL=https://slpa.example.com/api/v1/internal/sl-im/pending
+CONFIRM_URL_BASE=https://slpa.example.com/api/v1/internal/sl-im/
+SHARED_SECRET=<obtain from server config: slpa.notifications.sl-im.dispatcher.shared-secret>
+DEBUG_OWNER_SAY=true

--- a/lsl-scripts/sl-im-dispatcher/dispatcher.lsl
+++ b/lsl-scripts/sl-im-dispatcher/dispatcher.lsl
@@ -1,0 +1,182 @@
+// SLPA SL IM Dispatcher
+//
+// Polls SLPA backend for pending notification IMs and delivers them via
+// llInstantMessage. Single state machine with two cadences:
+//   - 60-second poll interval when idle
+//   - 2-second per-IM tick when delivering a batch
+//
+// Configuration is loaded from a notecard named "config" in the same prim.
+// See README.md for deployment and operations details.
+
+// === Configuration loaded from notecard ===
+string POLL_URL = "";
+string CONFIRM_URL_BASE = "";
+string SHARED_SECRET = "";
+integer DEBUG_OWNER_SAY = TRUE;
+
+// === Cadences ===
+float POLL_INTERVAL = 60.0;
+float IM_INTERVAL = 2.0;
+
+// === Batch state during delivery ===
+list batchIds = [];
+list batchUuids = [];
+list batchTexts = [];
+integer batchIndex = 0;
+integer deliveringBatch = FALSE;
+
+// === HTTP request tracking ===
+key pollRequestId = NULL_KEY;
+
+// === Notecard reading state ===
+key notecardLineRequest = NULL_KEY;
+integer notecardLineNum = 0;
+
+readNotecardLine(integer n) {
+    notecardLineNum = n;
+    notecardLineRequest = llGetNotecardLine("config", n);
+}
+
+parseConfigLine(string line) {
+    if (llStringLength(line) == 0) return;
+    if (llSubStringIndex(line, "#") == 0) return;  // comment
+
+    integer eq = llSubStringIndex(line, "=");
+    if (eq < 1) return;
+
+    string key = llStringTrim(llGetSubString(line, 0, eq - 1), STRING_TRIM);
+    string val = llStringTrim(llGetSubString(line, eq + 1, -1), STRING_TRIM);
+
+    if (key == "POLL_URL") POLL_URL = val;
+    else if (key == "CONFIRM_URL_BASE") CONFIRM_URL_BASE = val;
+    else if (key == "SHARED_SECRET") SHARED_SECRET = val;
+    else if (key == "DEBUG_OWNER_SAY") DEBUG_OWNER_SAY = (val == "true" || val == "TRUE" || val == "1");
+}
+
+deliverNextInBatch() {
+    if (batchIndex >= llGetListLength(batchIds)) {
+        // Batch complete; reset state and return to slow cadence.
+        deliveringBatch = FALSE;
+        batchIds = [];
+        batchUuids = [];
+        batchTexts = [];
+        llSetTimerEvent(POLL_INTERVAL);
+        return;
+    }
+
+    string id = llList2String(batchIds, batchIndex);
+    string uuid = llList2String(batchUuids, batchIndex);
+    string text = llList2String(batchTexts, batchIndex);
+
+    llInstantMessage((key)uuid, text);
+    llHTTPRequest(
+        CONFIRM_URL_BASE + id + "/delivered",
+        [HTTP_METHOD, "POST",
+         HTTP_CUSTOM_HEADER, "Authorization", "Bearer " + SHARED_SECRET,
+         HTTP_BODY_MAXLENGTH, 4096],
+        ""
+    );
+    batchIndex += 1;
+}
+
+integer parseAndStoreBatch(string body) {
+    // body is JSON: { "messages": [ {id, avatarUuid, messageText}, ... ] }
+    string messagesJson = llJsonGetValue(body, ["messages"]);
+    if (messagesJson == JSON_INVALID || messagesJson == "") return 0;
+
+    list keys = llJson2List(messagesJson);
+    integer i;
+    integer n = llGetListLength(keys);
+    for (i = 0; i < n; ++i) {
+        string item = llList2String(keys, i);
+        string id = llJsonGetValue(item, ["id"]);
+        string uuid = llJsonGetValue(item, ["avatarUuid"]);
+        string text = llJsonGetValue(item, ["messageText"]);
+        if (id != JSON_INVALID && uuid != JSON_INVALID && text != JSON_INVALID) {
+            batchIds += [id];
+            batchUuids += [uuid];
+            batchTexts += [text];
+        }
+    }
+    return llGetListLength(batchIds);
+}
+
+default {
+    state_entry() {
+        POLL_URL = "";
+        CONFIRM_URL_BASE = "";
+        SHARED_SECRET = "";
+        readNotecardLine(0);
+    }
+
+    dataserver(key requested, string data) {
+        if (requested != notecardLineRequest) return;
+        if (data == NAK) {
+            llOwnerSay("SL IM dispatcher: notecard 'config' missing or unreadable");
+            return;
+        }
+        if (data == EOF) {
+            // Notecard fully read; validate config.
+            if (POLL_URL == "" || CONFIRM_URL_BASE == "" || SHARED_SECRET == "") {
+                llOwnerSay("SL IM dispatcher: incomplete config — POLL_URL / CONFIRM_URL_BASE / SHARED_SECRET required");
+                return;
+            }
+            if (DEBUG_OWNER_SAY) llOwnerSay("SL IM dispatcher: ready (poll=" + POLL_URL + ")");
+            llSetTimerEvent(POLL_INTERVAL);
+            return;
+        }
+        parseConfigLine(data);
+        readNotecardLine(notecardLineNum + 1);
+    }
+
+    timer() {
+        if (deliveringBatch) {
+            deliverNextInBatch();
+        } else {
+            // Slow-cadence poll cycle.
+            pollRequestId = llHTTPRequest(
+                POLL_URL + "?limit=10",
+                [HTTP_METHOD, "GET",
+                 HTTP_CUSTOM_HEADER, "Authorization", "Bearer " + SHARED_SECRET,
+                 HTTP_BODY_MAXLENGTH, 16384],
+                ""
+            );
+        }
+    }
+
+    http_response(key requestId, integer status, list meta, string body) {
+        if (requestId == pollRequestId) {
+            pollRequestId = NULL_KEY;
+            if (status != 200) {
+                if (DEBUG_OWNER_SAY) llOwnerSay("SL IM poll failed: " + (string)status);
+                return;
+            }
+            integer count = parseAndStoreBatch(body);
+            if (count > 0) {
+                if (DEBUG_OWNER_SAY) llOwnerSay("SL IM batch=" + (string)count);
+                deliveringBatch = TRUE;
+                batchIndex = 0;
+                llSetTimerEvent(IM_INTERVAL);
+                deliverNextInBatch();  // immediately fire the first IM
+            } else {
+                if (DEBUG_OWNER_SAY) llOwnerSay("SL IM poll: 0 messages");
+            }
+            return;
+        }
+        // Confirmation responses; log only on non-2xx.
+        if (status >= 400) {
+            llOwnerSay("SL IM confirm failed: status=" + (string)status);
+        }
+    }
+
+    on_rez(integer start_param) {
+        llResetScript();
+    }
+
+    changed(integer change) {
+        if (change & CHANGED_INVENTORY) {
+            // Notecard may have been re-edited; reload.
+            llResetScript();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ships the SL IM channel + notification preferences UI end-to-end:

- New `sl_im_message` queue with ON CONFLICT coalescing during pendency, partial unique index on `(user_id, coalesce_key) WHERE status = 'PENDING'`.
- `SlImChannelGate` discriminated decision logic (no-avatar floor, SYSTEM bypass, master mute, group prefs).
- Dispatch via afterCommit hook on `NotificationService.publish` (single-recipient) and sibling call inside `listingCancelledBySellerFanout`'s per-recipient REQUIRES_NEW lambda (fan-out).
- Internal endpoints `/api/v1/internal/sl-im/{pending, {id}/delivered, {id}/failed}` with shared-secret auth, symmetric state machines (PENDING → terminal, idempotent on match, 409 on other terminal statuses).
- 48h expiry job at 03:30 SLT with INFO canary log (`expired`, `deleted`, `top_users`).
- `/settings/notifications` UI: banner + master mute + 5 group toggles. Master mute disables group toggles visually but preserves their state. Closed-shape PUT validation (rejects SYSTEM/REALTY_GROUP/MARKETING).
- `lsl-scripts/sl-im-dispatcher/` LSL polling object (60s polls, 2s per-IM throttle, batch ≤10).
- Settings entry points from bell dropdown footer and `/notifications` feed page header.

Closes deferred-ledger entries:
- SL IM channel for notifications
- Notification preferences UI

Email channel: removed from the roadmap. SL's native offline-IM-to-email forwarding covers the email use case via the SL IM channel.

## Test plan

- [ ] Backend: `./mvnw test -pl backend` → green (≥ baseline + ~80 new tests)
- [ ] Frontend: `cd frontend && npm test -- --run` → green
- [ ] Frontend: `npm run lint` → clean
- [ ] Two browser sessions, two users; one with linked SL avatar, one without. Drive an OUTBID for each. Verify: linked user has a PENDING `sl_im_message` row; unlinked user has none. Both users still see in-app + WS push.
- [ ] In `/settings/notifications`, mute Bidding for the linked user. Drive another OUTBID. Verify in-app row created, no new IM row queued.
- [ ] Toggle master mute on. Verify group toggles render disabled with checked-states preserved. Toggle off. States return without API roundtrip.
- [ ] `curl -H "Authorization: Bearer ${SECRET}" GET /api/v1/internal/sl-im/pending?limit=10`. Verify assembled `messageText` matches template; multi-byte parcel name preserves the deeplink.
- [ ] `curl -H "Authorization: Bearer ${SECRET}" -X POST /api/v1/internal/sl-im/{id}/delivered`. Verify status transitions; second curl returns 204; manually mark a row FAILED then curl `/delivered` — expect 409.
- [ ] Deploy `sl-im-dispatcher` in beta sim with staging URL. Drive a notification for a test user with an avatar. Verify the alt account receives the IM with correct text and clickable deeplink. Watch owner-say for poll cadence.
- [ ] Stop the dispatcher object. Wait 49 hours. Verify the cleanup job's INFO log includes `expired > 0` and a `top_users` entry naming the test account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)