### PR TITLE
Epic 10 sub-spec 2 — Reports + Bans + Admin enforcement + User mgmt

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/admin/AdminAuctionController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/AdminAuctionController.java
@@ -1,0 +1,48 @@
+package com.slparcelauctions.backend.admin;
+
+import java.util.Optional;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.admin.AdminAuctionService.AdminAuctionReinstateResult;
+import com.slparcelauctions.backend.admin.audit.AdminActionService;
+import com.slparcelauctions.backend.admin.audit.AdminActionTargetType;
+import com.slparcelauctions.backend.admin.audit.AdminActionType;
+import com.slparcelauctions.backend.admin.dto.AdminAuctionReinstateResponse;
+import com.slparcelauctions.backend.admin.dto.ReinstateAuctionRequest;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/admin/auctions")
+@RequiredArgsConstructor
+public class AdminAuctionController {
+
+    private final AdminAuctionService adminAuctionService;
+    private final AdminActionService adminActionService;
+
+    @PostMapping("/{id}/reinstate")
+    public AdminAuctionReinstateResponse reinstate(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody ReinstateAuctionRequest body,
+            @AuthenticationPrincipal AuthPrincipal admin) {
+
+        AdminAuctionReinstateResult result = adminAuctionService.reinstate(id, Optional.empty());
+        adminActionService.record(admin.userId(),
+            AdminActionType.REINSTATE_LISTING, AdminActionTargetType.LISTING, id,
+            body.notes(), null);
+
+        return new AdminAuctionReinstateResponse(
+            result.auction().getId(),
+            result.auction().getStatus(),
+            result.newEndsAt(),
+            result.suspensionDuration().toSeconds());
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/AdminAuctionService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/AdminAuctionService.java
@@ -1,0 +1,76 @@
+package com.slparcelauctions.backend.admin;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.admin.exception.AuctionNotSuspendedException;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
+import com.slparcelauctions.backend.bot.BotMonitorLifecycleService;
+import com.slparcelauctions.backend.notification.NotificationPublisher;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Shared primitive for "flip SUSPENDED auction back to ACTIVE." Called
+ * from sub-spec 1's fraud-flag reinstate path AND from sub-spec 2's
+ * standalone /admin/auctions/{id}/reinstate endpoint. Auction-state-only
+ * — caller is responsible for any flag/report state changes and audit
+ * row writing (different callers want different audit semantics).
+ */
+@Service
+@RequiredArgsConstructor
+public class AdminAuctionService {
+
+    private final AuctionRepository auctionRepo;
+    private final BotMonitorLifecycleService botMonitorLifecycleService;
+    private final NotificationPublisher notificationPublisher;
+    private final Clock clock;
+
+    @Transactional
+    public AdminAuctionReinstateResult reinstate(
+            Long auctionId,
+            Optional<OffsetDateTime> fallbackSuspendedFrom) {
+
+        Auction auction = auctionRepo.findByIdForUpdate(auctionId)
+            .orElseThrow(() -> new AuctionNotFoundException(auctionId));
+        if (auction.getStatus() != AuctionStatus.SUSPENDED) {
+            throw new AuctionNotSuspendedException(auction.getStatus());
+        }
+
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        OffsetDateTime suspendedFrom = auction.getSuspendedAt() != null
+            ? auction.getSuspendedAt()
+            : fallbackSuspendedFrom.orElse(now); // 0-extension if no record
+
+        Duration suspensionDuration = Duration.between(suspendedFrom, now);
+        OffsetDateTime newEndsAt = auction.getEndsAt().plus(suspensionDuration);
+        if (newEndsAt.isBefore(now)) {
+            newEndsAt = now.plusHours(1);
+        }
+
+        auction.setStatus(AuctionStatus.ACTIVE);
+        auction.setSuspendedAt(null);
+        auction.setEndsAt(newEndsAt);
+        auctionRepo.save(auction);
+
+        botMonitorLifecycleService.onAuctionResumed(auction);
+
+        notificationPublisher.listingReinstated(
+            auction.getSeller().getId(), auction.getId(),
+            auction.getTitle(), newEndsAt);
+
+        return new AdminAuctionReinstateResult(auction, suspensionDuration, newEndsAt);
+    }
+
+    public record AdminAuctionReinstateResult(
+        Auction auction, Duration suspensionDuration, OffsetDateTime newEndsAt
+    ) {}
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/AdminFraudFlagService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/AdminFraudFlagService.java
@@ -1,12 +1,12 @@
 package com.slparcelauctions.backend.admin;
 
 import java.time.Clock;
-import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -24,14 +24,11 @@ import com.slparcelauctions.backend.admin.exception.AuctionNotSuspendedException
 import com.slparcelauctions.backend.admin.exception.FraudFlagAlreadyResolvedException;
 import com.slparcelauctions.backend.admin.exception.FraudFlagNotFoundException;
 import com.slparcelauctions.backend.auction.Auction;
-import com.slparcelauctions.backend.auction.AuctionRepository;
 import com.slparcelauctions.backend.auction.AuctionStatus;
 import com.slparcelauctions.backend.auction.fraud.FraudFlag;
 import com.slparcelauctions.backend.auction.fraud.FraudFlagReason;
 import com.slparcelauctions.backend.auction.fraud.FraudFlagRepository;
-import com.slparcelauctions.backend.bot.BotMonitorLifecycleService;
 import com.slparcelauctions.backend.common.PagedResponse;
-import com.slparcelauctions.backend.notification.NotificationPublisher;
 import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.user.UserRepository;
 
@@ -43,9 +40,7 @@ public class AdminFraudFlagService {
 
     private final FraudFlagRepository fraudFlagRepository;
     private final UserRepository userRepository;
-    private final AuctionRepository auctionRepository;
-    private final BotMonitorLifecycleService botMonitorLifecycleService;
-    private final NotificationPublisher notificationPublisher;
+    private final AdminAuctionService adminAuctionService;
     private final Clock clock;
 
     @Transactional(readOnly = true)
@@ -164,23 +159,12 @@ public class AdminFraudFlagService {
             throw new AuctionNotSuspendedException(auction == null ? null : auction.getStatus());
         }
 
+        // Delegate auction-state change + notification to the shared primitive.
+        adminAuctionService.reinstate(auction.getId(), Optional.of(flag.getDetectedAt()));
+
+        // Resolve the flag separately. Fraud flags continue to self-audit
+        // via FraudFlag.resolvedBy + adminNotes (no admin_actions row).
         OffsetDateTime now = OffsetDateTime.now(clock);
-        OffsetDateTime suspendedFrom = auction.getSuspendedAt() != null
-            ? auction.getSuspendedAt()
-            : flag.getDetectedAt();
-        Duration suspensionDuration = Duration.between(suspendedFrom, now);
-        OffsetDateTime newEndsAt = auction.getEndsAt().plus(suspensionDuration);
-        if (newEndsAt.isBefore(now)) {
-            newEndsAt = now.plusHours(1);
-        }
-
-        auction.setStatus(AuctionStatus.ACTIVE);
-        auction.setSuspendedAt(null);
-        auction.setEndsAt(newEndsAt);
-        auctionRepository.save(auction);
-
-        botMonitorLifecycleService.onAuctionResumed(auction);
-
         User admin = userRepository.findById(adminUserId)
             .orElseThrow(() -> new IllegalStateException("Admin user not found: " + adminUserId));
         flag.setResolved(true);
@@ -188,10 +172,6 @@ public class AdminFraudFlagService {
         flag.setResolvedBy(admin);
         flag.setAdminNotes(adminNotes);
         fraudFlagRepository.save(flag);
-
-        notificationPublisher.listingReinstated(
-            auction.getSeller().getId(), auction.getId(),
-            auction.getTitle(), newEndsAt);
 
         return detail(flagId);
     }

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/AdminStatsService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/AdminStatsService.java
@@ -8,6 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 import com.slparcelauctions.backend.admin.dto.AdminStatsResponse;
 import com.slparcelauctions.backend.admin.dto.AdminStatsResponse.PlatformStats;
 import com.slparcelauctions.backend.admin.dto.AdminStatsResponse.QueueStats;
+import com.slparcelauctions.backend.admin.reports.ListingReportRepository;
+import com.slparcelauctions.backend.admin.reports.ListingReportStatus;
 import com.slparcelauctions.backend.auction.AuctionRepository;
 import com.slparcelauctions.backend.auction.AuctionStatus;
 import com.slparcelauctions.backend.auction.fraud.FraudFlagRepository;
@@ -32,11 +34,13 @@ public class AdminStatsService {
     private final AuctionRepository auctionRepository;
     private final EscrowRepository escrowRepository;
     private final FraudFlagRepository fraudFlagRepository;
+    private final ListingReportRepository listingReportRepository;
 
     @Transactional(readOnly = true)
     public AdminStatsResponse compute() {
         QueueStats queues = new QueueStats(
             fraudFlagRepository.countByResolved(false),
+            listingReportRepository.countByStatus(ListingReportStatus.OPEN),
             escrowRepository.countByState(EscrowState.ESCROW_PENDING),
             escrowRepository.countByState(EscrowState.DISPUTED)
         );

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminAction.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminAction.java
@@ -1,0 +1,74 @@
+package com.slparcelauctions.backend.admin.audit;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.slparcelauctions.backend.user.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(
+    name = "admin_actions",
+    indexes = {
+        @Index(name = "idx_admin_actions_target", columnList = "target_type, target_id, created_at DESC"),
+        @Index(name = "idx_admin_actions_admin_user", columnList = "admin_user_id, created_at DESC")
+    }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdminAction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "admin_user_id", nullable = false)
+    private User adminUser;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "action_type", nullable = false, length = 40)
+    private AdminActionType actionType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false, length = 20)
+    private AdminActionTargetType targetType;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Column(columnDefinition = "text")
+    private String notes;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> details;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminActionRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminActionRepository.java
@@ -1,0 +1,13 @@
+package com.slparcelauctions.backend.admin.audit;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminActionRepository extends JpaRepository<AdminAction, Long> {
+
+    Page<AdminAction> findByTargetTypeAndTargetIdOrderByCreatedAtDesc(
+            AdminActionTargetType targetType, Long targetId, Pageable pageable);
+
+    Page<AdminAction> findByAdminUserIdOrderByCreatedAtDesc(Long adminUserId, Pageable pageable);
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminActionService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminActionService.java
@@ -1,0 +1,41 @@
+package com.slparcelauctions.backend.admin.audit;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminActionService {
+
+    private final AdminActionRepository repository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public AdminAction record(
+            Long adminUserId,
+            AdminActionType actionType,
+            AdminActionTargetType targetType,
+            Long targetId,
+            String notes,
+            Map<String, Object> details) {
+
+        User admin = userRepository.findById(adminUserId)
+            .orElseThrow(() -> new IllegalStateException("Admin user not found: " + adminUserId));
+
+        return repository.save(AdminAction.builder()
+            .adminUser(admin)
+            .actionType(actionType)
+            .targetType(targetType)
+            .targetId(targetId)
+            .notes(notes)
+            .details(details == null ? Map.of() : details)
+            .build());
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminActionTargetType.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminActionTargetType.java
@@ -1,0 +1,5 @@
+package com.slparcelauctions.backend.admin.audit;
+
+public enum AdminActionTargetType {
+    USER, LISTING, REPORT, FRAUD_FLAG, BAN
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminActionType.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminActionType.java
@@ -1,0 +1,14 @@
+package com.slparcelauctions.backend.admin.audit;
+
+public enum AdminActionType {
+    DISMISS_REPORT,
+    WARN_SELLER_FROM_REPORT,
+    SUSPEND_LISTING_FROM_REPORT,
+    CANCEL_LISTING_FROM_REPORT,
+    CREATE_BAN,
+    LIFT_BAN,
+    PROMOTE_USER,
+    DEMOTE_USER,
+    RESET_FRIVOLOUS_COUNTER,
+    REINSTATE_LISTING
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminAuditController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminAuditController.java
@@ -1,0 +1,50 @@
+package com.slparcelauctions.backend.admin.audit;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.admin.users.dto.AdminUserModerationRowDto;
+import com.slparcelauctions.backend.common.PagedResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/admin/audit")
+@RequiredArgsConstructor
+public class AdminAuditController {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final AdminActionRepository repo;
+
+    @GetMapping
+    public PagedResponse<AdminUserModerationRowDto> list(
+            @RequestParam(required = false) AdminActionTargetType targetType,
+            @RequestParam(required = false) Long targetId,
+            @RequestParam(required = false) Long adminUserId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "25") int size) {
+        Pageable pageable = PageRequest.of(page, Math.min(size, MAX_PAGE_SIZE));
+        Page<AdminAction> result;
+        if (targetType != null && targetId != null) {
+            result = repo.findByTargetTypeAndTargetIdOrderByCreatedAtDesc(targetType, targetId, pageable);
+        } else if (adminUserId != null) {
+            result = repo.findByAdminUserIdOrderByCreatedAtDesc(adminUserId, pageable);
+        } else {
+            result = repo.findAll(pageable);
+        }
+        return PagedResponse.from(result.map(this::toDto));
+    }
+
+    private AdminUserModerationRowDto toDto(AdminAction a) {
+        return new AdminUserModerationRowDto(
+            a.getId(), a.getActionType().name(),
+            a.getAdminUser().getDisplayName(),
+            a.getNotes(), a.getCreatedAt());
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ban/AdminBanController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ban/AdminBanController.java
@@ -1,0 +1,55 @@
+package com.slparcelauctions.backend.admin.ban;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.admin.ban.dto.AdminBanRowDto;
+import com.slparcelauctions.backend.admin.ban.dto.CreateBanRequest;
+import com.slparcelauctions.backend.admin.ban.dto.LiftBanRequest;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.common.PagedResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/admin/bans")
+@RequiredArgsConstructor
+public class AdminBanController {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final AdminBanService service;
+
+    @GetMapping
+    public PagedResponse<AdminBanRowDto> list(
+            @RequestParam(defaultValue = "active") String status,
+            @RequestParam(required = false) BanType type,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "25") int size) {
+        int clampedSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+        return service.list(status, type, PageRequest.of(page, clampedSize));
+    }
+
+    @PostMapping
+    public AdminBanRowDto create(
+            @Valid @RequestBody CreateBanRequest body,
+            @AuthenticationPrincipal AuthPrincipal admin) {
+        return service.create(body, admin.userId());
+    }
+
+    @PostMapping("/{id}/lift")
+    public AdminBanRowDto lift(
+            @PathVariable Long id,
+            @Valid @RequestBody LiftBanRequest body,
+            @AuthenticationPrincipal AuthPrincipal admin) {
+        return service.lift(id, admin.userId(), body.liftedReason());
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ban/AdminBanService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ban/AdminBanService.java
@@ -1,0 +1,170 @@
+package com.slparcelauctions.backend.admin.ban;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.admin.audit.AdminActionService;
+import com.slparcelauctions.backend.admin.audit.AdminActionTargetType;
+import com.slparcelauctions.backend.admin.audit.AdminActionType;
+import com.slparcelauctions.backend.admin.ban.dto.AdminBanRowDto;
+import com.slparcelauctions.backend.admin.ban.dto.CreateBanRequest;
+import com.slparcelauctions.backend.admin.ban.exception.BanAlreadyLiftedException;
+import com.slparcelauctions.backend.admin.ban.exception.BanNotFoundException;
+import com.slparcelauctions.backend.admin.ban.exception.BanTypeFieldMismatchException;
+import com.slparcelauctions.backend.admin.users.dto.UserIpProjection;
+import com.slparcelauctions.backend.auth.RefreshTokenRepository;
+import com.slparcelauctions.backend.common.PagedResponse;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminBanService {
+
+    private final BanRepository banRepository;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final BanCacheInvalidator cacheInvalidator;
+    private final AdminActionService adminActionService;
+    private final Clock clock;
+
+    @Transactional(readOnly = true)
+    public PagedResponse<AdminBanRowDto> list(String status, BanType type, Pageable pageable) {
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        Page<Ban> page;
+        if ("history".equalsIgnoreCase(status)) {
+            page = banRepository.findHistory(now, pageable);
+        } else {
+            page = banRepository.findActive(now, pageable);
+        }
+        return PagedResponse.from(page.map(this::toRow));
+    }
+
+    @Transactional
+    public AdminBanRowDto create(CreateBanRequest req, Long adminUserId) {
+        validateTypeMatchesFields(req);
+        User admin = userRepository.findById(adminUserId)
+            .orElseThrow(() -> new IllegalStateException("Admin user not found: " + adminUserId));
+
+        Ban ban = banRepository.save(Ban.builder()
+            .banType(req.banType())
+            .ipAddress(req.ipAddress())
+            .slAvatarUuid(req.slAvatarUuid())
+            .reasonCategory(req.reasonCategory())
+            .notes(req.reasonText())
+            .adminUser(admin)
+            .expiresAt(req.expiresAt())
+            .build());
+
+        // tv-bump only for AVATAR/BOTH bans where the avatar maps to a registered user.
+        if ((req.banType() == BanType.AVATAR || req.banType() == BanType.BOTH)
+                && req.slAvatarUuid() != null) {
+            userRepository.findBySlAvatarUuid(req.slAvatarUuid())
+                .ifPresent(u -> userRepository.bumpTokenVersion(u.getId()));
+        }
+
+        cacheInvalidator.invalidate(req.ipAddress(), req.slAvatarUuid());
+
+        adminActionService.record(adminUserId, AdminActionType.CREATE_BAN,
+            AdminActionTargetType.BAN, ban.getId(), req.reasonText(),
+            Map.of("banType", req.banType().name()));
+
+        return toRow(ban);
+    }
+
+    @Transactional
+    public AdminBanRowDto lift(Long banId, Long adminUserId, String liftedReason) {
+        Ban ban = banRepository.findById(banId)
+            .orElseThrow(() -> new BanNotFoundException(banId));
+        if (ban.getLiftedAt() != null) {
+            throw new BanAlreadyLiftedException(banId);
+        }
+        User admin = userRepository.findById(adminUserId)
+            .orElseThrow(() -> new IllegalStateException("Admin user not found: " + adminUserId));
+        OffsetDateTime now = OffsetDateTime.now(clock);
+
+        ban.setLiftedAt(now);
+        ban.setLiftedByUser(admin);
+        ban.setLiftedReason(liftedReason);
+        banRepository.save(ban);
+
+        cacheInvalidator.invalidate(ban.getIpAddress(), ban.getSlAvatarUuid());
+
+        adminActionService.record(adminUserId, AdminActionType.LIFT_BAN,
+            AdminActionTargetType.BAN, banId, liftedReason, null);
+
+        return toRow(ban);
+    }
+
+    private void validateTypeMatchesFields(CreateBanRequest req) {
+        switch (req.banType()) {
+            case IP -> {
+                if (req.ipAddress() == null || req.ipAddress().isBlank()
+                        || req.slAvatarUuid() != null) {
+                    throw new BanTypeFieldMismatchException(
+                        "IP ban requires ipAddress and no slAvatarUuid");
+                }
+            }
+            case AVATAR -> {
+                if (req.slAvatarUuid() == null
+                        || (req.ipAddress() != null && !req.ipAddress().isBlank())) {
+                    throw new BanTypeFieldMismatchException(
+                        "AVATAR ban requires slAvatarUuid and no ipAddress");
+                }
+            }
+            case BOTH -> {
+                if (req.ipAddress() == null || req.ipAddress().isBlank()
+                        || req.slAvatarUuid() == null) {
+                    throw new BanTypeFieldMismatchException(
+                        "BOTH ban requires both ipAddress and slAvatarUuid");
+                }
+            }
+        }
+    }
+
+    private AdminBanRowDto toRow(Ban ban) {
+        Long avatarLinkedUserId = null;
+        String avatarLinkedDisplayName = null;
+        String firstSeenIp = null;
+        if (ban.getSlAvatarUuid() != null) {
+            Optional<User> linkedOpt = userRepository.findBySlAvatarUuid(ban.getSlAvatarUuid());
+            if (linkedOpt.isPresent()) {
+                User linked = linkedOpt.get();
+                avatarLinkedUserId = linked.getId();
+                avatarLinkedDisplayName = linked.getDisplayName();
+                List<UserIpProjection> ips = refreshTokenRepository.findIpSummaryByUserId(linked.getId());
+                if (!ips.isEmpty()) {
+                    firstSeenIp = ips.get(0).ipAddress();
+                }
+            }
+        }
+        return new AdminBanRowDto(
+            ban.getId(),
+            ban.getBanType(),
+            ban.getIpAddress(),
+            ban.getSlAvatarUuid(),
+            avatarLinkedUserId,
+            avatarLinkedDisplayName,
+            firstSeenIp,
+            ban.getReasonCategory(),
+            ban.getNotes(),
+            ban.getAdminUser().getId(),
+            ban.getAdminUser().getDisplayName(),
+            ban.getExpiresAt(),
+            ban.getCreatedAt(),
+            ban.getLiftedAt(),
+            ban.getLiftedByUser() == null ? null : ban.getLiftedByUser().getId(),
+            ban.getLiftedByUser() == null ? null : ban.getLiftedByUser().getDisplayName(),
+            ban.getLiftedReason());
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ban/Ban.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ban/Ban.java
@@ -125,6 +125,13 @@ public class Ban {
     @JoinColumn(name = "lifted_by_user_id")
     private User liftedByUser;
 
+    /**
+     * Admin-provided reason for lifting the ban early.
+     * Only meaningful when {@code liftedAt} is non-null.
+     */
+    @Column(name = "lifted_reason", columnDefinition = "text")
+    private String liftedReason;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private OffsetDateTime createdAt;

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ban/Ban.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ban/Ban.java
@@ -1,0 +1,131 @@
+package com.slparcelauctions.backend.admin.ban;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import com.slparcelauctions.backend.user.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Represents an admin-issued ban record. A ban may target an IP address,
+ * an SL avatar UUID, or both (see {@link BanType}). The active-ban predicate
+ * is: {@code liftedAt IS NULL AND (expiresAt IS NULL OR expiresAt > now)}.
+ *
+ * <p>Validation that a given {@link BanType} has the required identifier
+ * fields populated is enforced at the service level in Task 9 — not via
+ * a {@code @Check} DB constraint (avoids Postgres INET-type complexity and
+ * keeps the constraint readable in Java).
+ *
+ * <p>Indexes:
+ * <ul>
+ *   <li>ip_address — fast lookup for {@code findActiveByIp}</li>
+ *   <li>sl_avatar_uuid — fast lookup for {@code findActiveByAvatar}</li>
+ *   <li>(lifted_at, expires_at) — supports the active-ban temporal predicate
+ *       in both list and check queries</li>
+ * </ul>
+ */
+@Entity
+@Table(
+    name = "bans",
+    indexes = {
+        @Index(name = "idx_bans_ip_address", columnList = "ip_address"),
+        @Index(name = "idx_bans_sl_avatar_uuid", columnList = "sl_avatar_uuid"),
+        @Index(name = "idx_bans_lifted_expires", columnList = "lifted_at, expires_at")
+    }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Ban {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * Who issued the ban. Lazy-loaded — only needed for admin-detail views.
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "admin_user_id", nullable = false)
+    private User adminUser;
+
+    /**
+     * Which identifier(s) the ban applies to.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ban_type", nullable = false, length = 10)
+    private BanType banType;
+
+    /**
+     * IPv4 or IPv6 address (max 45 chars). Populated when
+     * {@code banType = IP} or {@code banType = BOTH}.
+     */
+    @Column(name = "ip_address", length = 45)
+    private String ipAddress;
+
+    /**
+     * Second Life avatar UUID. Populated when
+     * {@code banType = AVATAR} or {@code banType = BOTH}.
+     */
+    @Column(name = "sl_avatar_uuid")
+    private UUID slAvatarUuid;
+
+    /**
+     * Structured reason category for admin reporting.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reason_category", nullable = false, length = 20)
+    private BanReasonCategory reasonCategory;
+
+    /**
+     * Free-text narrative from the admin. Optional.
+     */
+    @Column(columnDefinition = "text")
+    private String notes;
+
+    /**
+     * When the ban expires. {@code null} = permanent.
+     */
+    @Column(name = "expires_at")
+    private OffsetDateTime expiresAt;
+
+    /**
+     * Set by an admin to lift the ban early. {@code null} = still active
+     * (assuming not expired). Non-null = lifted (inactive regardless of
+     * {@code expiresAt}).
+     */
+    @Column(name = "lifted_at")
+    private OffsetDateTime liftedAt;
+
+    /**
+     * Who lifted the ban. Only meaningful when {@code liftedAt} is non-null.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lifted_by_user_id")
+    private User liftedByUser;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanCacheInvalidator.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanCacheInvalidator.java
@@ -1,0 +1,40 @@
+package com.slparcelauctions.backend.admin.ban;
+
+import java.util.UUID;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Clears {@link BanCheckService} Redis cache entries when a ban is created or
+ * lifted. Call {@link #invalidate} in the same transaction (or immediately
+ * after commit) as the ban-create or ban-lift operation so that the next
+ * request re-reads from the DB rather than serving a stale cached value.
+ */
+@Component
+@RequiredArgsConstructor
+public class BanCacheInvalidator {
+
+    private static final String IP_KEY = "bans:active:ip:";
+    private static final String AVATAR_KEY = "bans:active:avatar:";
+
+    private final StringRedisTemplate redis;
+
+    /**
+     * Deletes the cache keys for the given identifiers. Null arguments are
+     * silently skipped.
+     *
+     * @param ipAddress   the IP address key to evict (may be null)
+     * @param slAvatarUuid the avatar UUID key to evict (may be null)
+     */
+    public void invalidate(String ipAddress, UUID slAvatarUuid) {
+        if (ipAddress != null && !ipAddress.isBlank()) {
+            redis.delete(IP_KEY + ipAddress);
+        }
+        if (slAvatarUuid != null) {
+            redis.delete(AVATAR_KEY + slAvatarUuid);
+        }
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanCheckService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanCheckService.java
@@ -1,0 +1,107 @@
+package com.slparcelauctions.backend.admin.ban;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.admin.ban.exception.UserBannedException;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Redis-cached ban check service. Enforces that neither the requesting
+ * IP address nor the authenticated SL avatar UUID matches an active ban.
+ *
+ * <p>Cache strategy:
+ * <ul>
+ *   <li>Positive hit (ban found): stores the ban's {@code expiresAt} ISO-8601
+ *       string, or the sentinel {@code "perm"} for permanent bans.</li>
+ *   <li>Negative hit (no ban): stores the sentinel {@code "0"} to prevent
+ *       every unbanned user's request from hitting the DB.</li>
+ *   <li>TTL: 5 minutes for both positive and negative entries.</li>
+ * </ul>
+ *
+ * <p>Cache keys:
+ * <ul>
+ *   <li>{@code bans:active:ip:<ip>}</li>
+ *   <li>{@code bans:active:avatar:<uuid>}</li>
+ * </ul>
+ *
+ * <p>Cache invalidation on ban-create/lift is handled by
+ * {@link BanCacheInvalidator}.
+ */
+@Service
+@RequiredArgsConstructor
+public class BanCheckService {
+
+    private static final Duration CACHE_TTL = Duration.ofMinutes(5);
+    private static final String IP_KEY = "bans:active:ip:";
+    private static final String AVATAR_KEY = "bans:active:avatar:";
+    private static final String NEGATIVE = "0";
+
+    private final BanRepository banRepository;
+    private final StringRedisTemplate redis;
+    private final Clock clock;
+
+    /**
+     * Checks both IP and avatar identifiers. Throws {@link UserBannedException}
+     * on the first active ban found. A {@code null} argument skips that check.
+     *
+     * @param ipAddress   the caller's resolved IP address (may be null)
+     * @param slAvatarUuid the authenticated avatar UUID (may be null for unauthenticated requests)
+     */
+    @Transactional(readOnly = true)
+    public void assertNotBanned(String ipAddress, UUID slAvatarUuid) {
+        if (ipAddress != null && !ipAddress.isBlank()) {
+            checkIp(ipAddress);
+        }
+        if (slAvatarUuid != null) {
+            checkAvatar(slAvatarUuid);
+        }
+    }
+
+    private void checkIp(String ip) {
+        String cached = redis.opsForValue().get(IP_KEY + ip);
+        if (NEGATIVE.equals(cached)) return;
+        if (cached != null) {
+            throw new UserBannedException("perm".equals(cached) ? null
+                : OffsetDateTime.parse(cached));
+        }
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        List<Ban> hits = banRepository.findActiveByIp(ip, now);
+        if (hits.isEmpty()) {
+            redis.opsForValue().set(IP_KEY + ip, NEGATIVE, CACHE_TTL);
+            return;
+        }
+        Ban ban = hits.get(0);
+        String value = ban.getExpiresAt() == null ? "perm" : ban.getExpiresAt().toString();
+        redis.opsForValue().set(IP_KEY + ip, value, CACHE_TTL);
+        throw new UserBannedException(ban.getExpiresAt());
+    }
+
+    private void checkAvatar(UUID uuid) {
+        String key = AVATAR_KEY + uuid;
+        String cached = redis.opsForValue().get(key);
+        if (NEGATIVE.equals(cached)) return;
+        if (cached != null) {
+            throw new UserBannedException("perm".equals(cached) ? null
+                : OffsetDateTime.parse(cached));
+        }
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        List<Ban> hits = banRepository.findActiveByAvatar(uuid, now);
+        if (hits.isEmpty()) {
+            redis.opsForValue().set(key, NEGATIVE, CACHE_TTL);
+            return;
+        }
+        Ban ban = hits.get(0);
+        String value = ban.getExpiresAt() == null ? "perm" : ban.getExpiresAt().toString();
+        redis.opsForValue().set(key, value, CACHE_TTL);
+        throw new UserBannedException(ban.getExpiresAt());
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanReasonCategory.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanReasonCategory.java
@@ -1,0 +1,14 @@
+package com.slparcelauctions.backend.admin.ban;
+
+/**
+ * High-level reason category for the ban, recorded on the row for admin
+ * audit and reporting. Free-text {@code notes} on the {@link Ban} entity
+ * carries the narrative; this enum is the structured signal.
+ */
+public enum BanReasonCategory {
+    SHILL_BIDDING,
+    FRAUDULENT_SELLER,
+    TOS_ABUSE,
+    SPAM,
+    OTHER
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanRepository.java
@@ -1,0 +1,62 @@
+package com.slparcelauctions.backend.admin.ban;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BanRepository extends JpaRepository<Ban, Long> {
+
+    /**
+     * Returns active bans that cover the given IP address.
+     * Covers {@code BanType.IP} and {@code BanType.BOTH}.
+     */
+    @Query("""
+        SELECT b FROM Ban b
+        WHERE b.liftedAt IS NULL
+          AND (b.expiresAt IS NULL OR b.expiresAt > :now)
+          AND (b.banType = com.slparcelauctions.backend.admin.ban.BanType.IP
+               OR b.banType = com.slparcelauctions.backend.admin.ban.BanType.BOTH)
+          AND b.ipAddress = :ip
+        """)
+    List<Ban> findActiveByIp(@Param("ip") String ip, @Param("now") OffsetDateTime now);
+
+    /**
+     * Returns active bans that cover the given SL avatar UUID.
+     * Covers {@code BanType.AVATAR} and {@code BanType.BOTH}.
+     */
+    @Query("""
+        SELECT b FROM Ban b
+        WHERE b.liftedAt IS NULL
+          AND (b.expiresAt IS NULL OR b.expiresAt > :now)
+          AND (b.banType = com.slparcelauctions.backend.admin.ban.BanType.AVATAR
+               OR b.banType = com.slparcelauctions.backend.admin.ban.BanType.BOTH)
+          AND b.slAvatarUuid = :uuid
+        """)
+    List<Ban> findActiveByAvatar(@Param("uuid") UUID uuid, @Param("now") OffsetDateTime now);
+
+    /**
+     * Returns all currently-active bans (paged) for the admin list view.
+     */
+    @Query("""
+        SELECT b FROM Ban b
+        WHERE b.liftedAt IS NULL
+          AND (b.expiresAt IS NULL OR b.expiresAt > :now)
+        """)
+    Page<Ban> findActive(@Param("now") OffsetDateTime now, Pageable pageable);
+
+    /**
+     * Returns all historical (lifted or expired) bans (paged) for the admin history view.
+     */
+    @Query("""
+        SELECT b FROM Ban b
+        WHERE b.liftedAt IS NOT NULL
+           OR (b.expiresAt IS NOT NULL AND b.expiresAt <= :now)
+        """)
+    Page<Ban> findHistory(@Param("now") OffsetDateTime now, Pageable pageable);
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanType.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanType.java
@@ -1,0 +1,16 @@
+package com.slparcelauctions.backend.admin.ban;
+
+/**
+ * Determines which identifier(s) a ban applies to.
+ *
+ * <ul>
+ *   <li>{@code IP}     — matches on ip_address only</li>
+ *   <li>{@code AVATAR} — matches on sl_avatar_uuid only</li>
+ *   <li>{@code BOTH}   — matches on either; captured in both query paths</li>
+ * </ul>
+ */
+public enum BanType {
+    IP,
+    AVATAR,
+    BOTH
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ban/dto/AdminBanRowDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ban/dto/AdminBanRowDto.java
@@ -1,0 +1,27 @@
+package com.slparcelauctions.backend.admin.ban.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import com.slparcelauctions.backend.admin.ban.BanReasonCategory;
+import com.slparcelauctions.backend.admin.ban.BanType;
+
+public record AdminBanRowDto(
+    Long id,
+    BanType banType,
+    String ipAddress,
+    UUID slAvatarUuid,
+    Long avatarLinkedUserId,
+    String avatarLinkedDisplayName,
+    String firstSeenIp,
+    BanReasonCategory reasonCategory,
+    String reasonText,
+    Long bannedByUserId,
+    String bannedByDisplayName,
+    OffsetDateTime expiresAt,
+    OffsetDateTime createdAt,
+    OffsetDateTime liftedAt,
+    Long liftedByUserId,
+    String liftedByDisplayName,
+    String liftedReason
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ban/dto/CreateBanRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ban/dto/CreateBanRequest.java
@@ -1,0 +1,20 @@
+package com.slparcelauctions.backend.admin.ban.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import com.slparcelauctions.backend.admin.ban.BanReasonCategory;
+import com.slparcelauctions.backend.admin.ban.BanType;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateBanRequest(
+    @NotNull BanType banType,
+    String ipAddress,
+    UUID slAvatarUuid,
+    OffsetDateTime expiresAt,
+    @NotNull BanReasonCategory reasonCategory,
+    @NotBlank @Size(max = 1000) String reasonText
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ban/dto/LiftBanRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ban/dto/LiftBanRequest.java
@@ -1,0 +1,6 @@
+package com.slparcelauctions.backend.admin.ban.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record LiftBanRequest(@NotBlank @Size(max = 1000) String liftedReason) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ban/exception/BanAlreadyLiftedException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ban/exception/BanAlreadyLiftedException.java
@@ -1,0 +1,7 @@
+package com.slparcelauctions.backend.admin.ban.exception;
+
+public class BanAlreadyLiftedException extends RuntimeException {
+    public BanAlreadyLiftedException(Long id) {
+        super("Ban " + id + " already lifted");
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ban/exception/BanNotFoundException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ban/exception/BanNotFoundException.java
@@ -1,0 +1,7 @@
+package com.slparcelauctions.backend.admin.ban.exception;
+
+public class BanNotFoundException extends RuntimeException {
+    public BanNotFoundException(Long id) {
+        super("Ban not found: " + id);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ban/exception/BanTypeFieldMismatchException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ban/exception/BanTypeFieldMismatchException.java
@@ -1,0 +1,7 @@
+package com.slparcelauctions.backend.admin.ban.exception;
+
+public class BanTypeFieldMismatchException extends RuntimeException {
+    public BanTypeFieldMismatchException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ban/exception/UserBannedException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ban/exception/UserBannedException.java
@@ -1,0 +1,23 @@
+package com.slparcelauctions.backend.admin.ban.exception;
+
+import java.time.OffsetDateTime;
+
+import lombok.Getter;
+
+/**
+ * Thrown by {@link com.slparcelauctions.backend.admin.ban.BanCheckService} when
+ * an active ban is found for the requesting IP or avatar. Mapped to HTTP 403 by
+ * {@link UserBannedExceptionHandler} with {@code code: USER_BANNED}.
+ *
+ * <p>{@code expiresAt == null} means the ban is permanent.
+ */
+@Getter
+public class UserBannedException extends RuntimeException {
+
+    private final OffsetDateTime expiresAt;
+
+    public UserBannedException(OffsetDateTime expiresAt) {
+        super("Account is suspended");
+        this.expiresAt = expiresAt;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ban/exception/UserBannedExceptionHandler.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ban/exception/UserBannedExceptionHandler.java
@@ -1,0 +1,30 @@
+package com.slparcelauctions.backend.admin.ban.exception;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Maps {@link UserBannedException} to an HTTP 403 response with
+ * {@code code: USER_BANNED} and an optional {@code expiresAt} timestamp.
+ *
+ * <p>Intentionally NOT scoped to the admin package — this exception is thrown
+ * from user-facing enforcement paths (Task 8). {@code @Order(HIGHEST_PRECEDENCE)}
+ * ensures it beats any other global handler that might claim the same exception.
+ */
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class UserBannedExceptionHandler {
+
+    @ExceptionHandler(UserBannedException.class)
+    public ProblemDetail handleBanned(UserBannedException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.FORBIDDEN);
+        pd.setTitle("Account suspended");
+        pd.setProperty("code", "USER_BANNED");
+        pd.setProperty("expiresAt", ex.getExpiresAt() == null ? null : ex.getExpiresAt().toString());
+        return pd;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/dto/AdminAuctionReinstateResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/dto/AdminAuctionReinstateResponse.java
@@ -1,0 +1,12 @@
+package com.slparcelauctions.backend.admin.dto;
+
+import java.time.OffsetDateTime;
+
+import com.slparcelauctions.backend.auction.AuctionStatus;
+
+public record AdminAuctionReinstateResponse(
+    Long auctionId,
+    AuctionStatus status,
+    OffsetDateTime newEndsAt,
+    long suspensionDurationSeconds
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/dto/AdminStatsResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/dto/AdminStatsResponse.java
@@ -6,6 +6,7 @@ public record AdminStatsResponse(
 ) {
     public record QueueStats(
         long openFraudFlags,
+        long openReports,
         long pendingPayments,
         long activeDisputes
     ) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/dto/ReinstateAuctionRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/dto/ReinstateAuctionRequest.java
@@ -1,0 +1,8 @@
+package com.slparcelauctions.backend.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ReinstateAuctionRequest(
+    @NotBlank @Size(max = 1000) String notes
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/exception/AdminExceptionHandler.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/exception/AdminExceptionHandler.java
@@ -10,6 +10,10 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.slparcelauctions.backend.admin.ban.exception.BanAlreadyLiftedException;
+import com.slparcelauctions.backend.admin.ban.exception.BanNotFoundException;
+import com.slparcelauctions.backend.admin.ban.exception.BanTypeFieldMismatchException;
+
 @RestControllerAdvice(basePackages = "com.slparcelauctions.backend.admin")
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class AdminExceptionHandler {
@@ -40,6 +44,24 @@ public class AdminExceptionHandler {
             com.slparcelauctions.backend.admin.reports.exception.ReportNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
             .body(AdminApiError.of("REPORT_NOT_FOUND", ex.getMessage()));
+    }
+
+    @ExceptionHandler(BanNotFoundException.class)
+    public ResponseEntity<AdminApiError> handleBanNotFound(BanNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(AdminApiError.of("BAN_NOT_FOUND", ex.getMessage()));
+    }
+
+    @ExceptionHandler(BanAlreadyLiftedException.class)
+    public ResponseEntity<AdminApiError> handleBanAlreadyLifted(BanAlreadyLiftedException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+            .body(AdminApiError.of("BAN_ALREADY_LIFTED", ex.getMessage()));
+    }
+
+    @ExceptionHandler(BanTypeFieldMismatchException.class)
+    public ResponseEntity<AdminApiError> handleBanTypeMismatch(BanTypeFieldMismatchException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(AdminApiError.of("BAN_TYPE_FIELD_MISMATCH", ex.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/exception/AdminExceptionHandler.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/exception/AdminExceptionHandler.java
@@ -13,6 +13,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.slparcelauctions.backend.admin.ban.exception.BanAlreadyLiftedException;
 import com.slparcelauctions.backend.admin.ban.exception.BanNotFoundException;
 import com.slparcelauctions.backend.admin.ban.exception.BanTypeFieldMismatchException;
+import com.slparcelauctions.backend.admin.users.exception.SelfDemoteException;
+import com.slparcelauctions.backend.admin.users.exception.UserAlreadyAdminException;
+import com.slparcelauctions.backend.admin.users.exception.UserNotAdminException;
 
 @RestControllerAdvice(basePackages = "com.slparcelauctions.backend.admin")
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -62,6 +65,24 @@ public class AdminExceptionHandler {
     public ResponseEntity<AdminApiError> handleBanTypeMismatch(BanTypeFieldMismatchException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(AdminApiError.of("BAN_TYPE_FIELD_MISMATCH", ex.getMessage()));
+    }
+
+    @ExceptionHandler(SelfDemoteException.class)
+    public ResponseEntity<AdminApiError> handleSelfDemote(SelfDemoteException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+            .body(AdminApiError.of("SELF_DEMOTE_FORBIDDEN", ex.getMessage()));
+    }
+
+    @ExceptionHandler(UserAlreadyAdminException.class)
+    public ResponseEntity<AdminApiError> handleAlreadyAdmin(UserAlreadyAdminException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+            .body(AdminApiError.of("ALREADY_ADMIN", ex.getMessage()));
+    }
+
+    @ExceptionHandler(UserNotAdminException.class)
+    public ResponseEntity<AdminApiError> handleNotAdmin(UserNotAdminException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+            .body(AdminApiError.of("NOT_ADMIN", ex.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/exception/AdminExceptionHandler.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/exception/AdminExceptionHandler.java
@@ -35,6 +35,13 @@ public class AdminExceptionHandler {
                     ex.getCurrentStatus() == null ? "null" : ex.getCurrentStatus().name())));
     }
 
+    @ExceptionHandler(com.slparcelauctions.backend.admin.reports.exception.ReportNotFoundException.class)
+    public ResponseEntity<AdminApiError> handleReportNotFound(
+            com.slparcelauctions.backend.admin.reports.exception.ReportNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(AdminApiError.of("REPORT_NOT_FOUND", ex.getMessage()));
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<AdminApiError> handleValidation(MethodArgumentNotValidException ex) {
         String message = ex.getBindingResult().getFieldErrors().stream()

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/AdminReportController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/AdminReportController.java
@@ -1,0 +1,89 @@
+package com.slparcelauctions.backend.admin.reports;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.admin.reports.dto.AdminReportActionRequest;
+import com.slparcelauctions.backend.admin.reports.dto.AdminReportDetailDto;
+import com.slparcelauctions.backend.admin.reports.dto.AdminReportListingRowDto;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.common.PagedResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/admin/reports")
+@RequiredArgsConstructor
+public class AdminReportController {
+
+    private final AdminReportService service;
+
+    @GetMapping
+    public PagedResponse<AdminReportListingRowDto> list(
+            @RequestParam(defaultValue = "open") String status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "25") int size) {
+        int clampedSize = Math.min(Math.max(size, 1), 100);
+        Pageable pageable = PageRequest.of(page, clampedSize);
+        if ("all".equalsIgnoreCase(status)) {
+            return service.listAllGrouped(pageable);
+        }
+        ListingReportStatus filter = "reviewed".equalsIgnoreCase(status)
+            ? ListingReportStatus.REVIEWED
+            : ListingReportStatus.OPEN;
+        return service.listGrouped(filter, pageable);
+    }
+
+    @GetMapping("/listing/{auctionId}")
+    public List<AdminReportDetailDto> findByListing(@PathVariable Long auctionId) {
+        return service.findByListing(auctionId);
+    }
+
+    @GetMapping("/{id}")
+    public AdminReportDetailDto findOne(@PathVariable Long id) {
+        return service.findOne(id);
+    }
+
+    @PostMapping("/{id}/dismiss")
+    public AdminReportDetailDto dismiss(
+            @PathVariable Long id,
+            @Valid @RequestBody AdminReportActionRequest body,
+            @AuthenticationPrincipal AuthPrincipal admin) {
+        return service.dismiss(id, admin.userId(), body.notes());
+    }
+
+    @PostMapping("/listing/{auctionId}/warn-seller")
+    public void warnSeller(
+            @PathVariable Long auctionId,
+            @Valid @RequestBody AdminReportActionRequest body,
+            @AuthenticationPrincipal AuthPrincipal admin) {
+        service.warnSeller(auctionId, admin.userId(), body.notes());
+    }
+
+    @PostMapping("/listing/{auctionId}/suspend")
+    public void suspend(
+            @PathVariable Long auctionId,
+            @Valid @RequestBody AdminReportActionRequest body,
+            @AuthenticationPrincipal AuthPrincipal admin) {
+        service.suspend(auctionId, admin.userId(), body.notes());
+    }
+
+    @PostMapping("/listing/{auctionId}/cancel")
+    public void cancel(
+            @PathVariable Long auctionId,
+            @Valid @RequestBody AdminReportActionRequest body,
+            @AuthenticationPrincipal AuthPrincipal admin) {
+        service.cancel(auctionId, admin.userId(), body.notes());
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/AdminReportService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/AdminReportService.java
@@ -1,0 +1,226 @@
+package com.slparcelauctions.backend.admin.reports;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.admin.audit.AdminActionService;
+import com.slparcelauctions.backend.admin.audit.AdminActionTargetType;
+import com.slparcelauctions.backend.admin.audit.AdminActionType;
+import com.slparcelauctions.backend.admin.reports.dto.AdminReportDetailDto;
+import com.slparcelauctions.backend.admin.reports.dto.AdminReportListingRowDto;
+import com.slparcelauctions.backend.admin.reports.exception.ReportNotFoundException;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.CancellationService;
+import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
+import com.slparcelauctions.backend.auction.monitoring.SuspensionService;
+import com.slparcelauctions.backend.common.PagedResponse;
+import com.slparcelauctions.backend.notification.NotificationPublisher;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminReportService {
+
+    private final ListingReportRepository reportRepo;
+    private final AuctionRepository auctionRepo;
+    private final UserRepository userRepo;
+    private final AdminActionService adminActionService;
+    private final NotificationPublisher notificationPublisher;
+    private final SuspensionService suspensionService;
+    private final CancellationService cancellationService;
+    private final Clock clock;
+
+    @Transactional(readOnly = true)
+    public PagedResponse<AdminReportListingRowDto> listGrouped(ListingReportStatus status, Pageable pageable) {
+        Page<AdminReportListingRowDto> page = reportRepo.findListingsGroupedByStatus(status, pageable);
+        return PagedResponse.from(page);
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResponse<AdminReportListingRowDto> listAllGrouped(Pageable pageable) {
+        Page<AdminReportListingRowDto> page = reportRepo.findAllListingsGrouped(pageable);
+        return PagedResponse.from(page);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminReportDetailDto> findByListing(Long auctionId) {
+        List<ListingReport> reports = reportRepo.findByAuctionIdOrderByCreatedAtDesc(auctionId);
+        return reports.stream().map(this::toDetailDto).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public AdminReportDetailDto findOne(Long reportId) {
+        ListingReport report = reportRepo.findById(reportId)
+            .orElseThrow(() -> new ReportNotFoundException(reportId));
+        return toDetailDto(report);
+    }
+
+    @Transactional
+    public AdminReportDetailDto dismiss(Long reportId, Long adminUserId, String notes) {
+        ListingReport report = reportRepo.findById(reportId)
+            .orElseThrow(() -> new ReportNotFoundException(reportId));
+
+        User reporter = report.getReporter();
+        reporter.setDismissedReportsCount(reporter.getDismissedReportsCount() + 1);
+        userRepo.save(reporter);
+
+        User admin = userRepo.findById(adminUserId)
+            .orElseThrow(() -> new IllegalStateException("Admin user not found: " + adminUserId));
+
+        report.setStatus(ListingReportStatus.DISMISSED);
+        report.setAdminNotes(notes);
+        report.setReviewedBy(admin);
+        report.setReviewedAt(OffsetDateTime.now(clock));
+        reportRepo.save(report);
+
+        adminActionService.record(
+            adminUserId,
+            AdminActionType.DISMISS_REPORT,
+            AdminActionTargetType.REPORT,
+            reportId,
+            notes,
+            Map.of("auctionId", report.getAuction().getId())
+        );
+
+        return toDetailDto(report);
+    }
+
+    @Transactional
+    public void warnSeller(Long auctionId, Long adminUserId, String notes) {
+        Auction auction = auctionRepo.findById(auctionId)
+            .orElseThrow(() -> new AuctionNotFoundException(auctionId));
+
+        List<ListingReport> reports = reportRepo.findByAuctionIdOrderByCreatedAtDesc(auctionId);
+
+        User admin = userRepo.findById(adminUserId)
+            .orElseThrow(() -> new IllegalStateException("Admin user not found: " + adminUserId));
+
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        List<ListingReport> openReports = reports.stream()
+            .filter(r -> r.getStatus() == ListingReportStatus.OPEN)
+            .toList();
+
+        for (ListingReport r : openReports) {
+            r.setStatus(ListingReportStatus.REVIEWED);
+            r.setAdminNotes(notes);
+            r.setReviewedBy(admin);
+            r.setReviewedAt(now);
+            reportRepo.save(r);
+        }
+
+        notificationPublisher.listingWarned(
+            auction.getSeller().getId(),
+            auctionId,
+            auction.getParcel().getRegionName(),
+            notes
+        );
+
+        adminActionService.record(
+            adminUserId,
+            AdminActionType.WARN_SELLER_FROM_REPORT,
+            AdminActionTargetType.LISTING,
+            auctionId,
+            notes,
+            Map.of("openReportsMarkedReviewed", openReports.size())
+        );
+    }
+
+    @Transactional
+    public void suspend(Long auctionId, Long adminUserId, String notes) {
+        Auction auction = auctionRepo.findById(auctionId)
+            .orElseThrow(() -> new AuctionNotFoundException(auctionId));
+
+        List<ListingReport> reports = reportRepo.findByAuctionIdOrderByCreatedAtDesc(auctionId);
+
+        User admin = userRepo.findById(adminUserId)
+            .orElseThrow(() -> new IllegalStateException("Admin user not found: " + adminUserId));
+
+        suspensionService.suspendByAdmin(auction, adminUserId, notes);
+
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        List<ListingReport> openReports = reports.stream()
+            .filter(r -> r.getStatus() == ListingReportStatus.OPEN)
+            .toList();
+
+        for (ListingReport r : openReports) {
+            r.setStatus(ListingReportStatus.ACTION_TAKEN);
+            r.setAdminNotes(notes);
+            r.setReviewedBy(admin);
+            r.setReviewedAt(now);
+            reportRepo.save(r);
+        }
+
+        adminActionService.record(
+            adminUserId,
+            AdminActionType.SUSPEND_LISTING_FROM_REPORT,
+            AdminActionTargetType.LISTING,
+            auctionId,
+            notes,
+            Map.of("openReportsMarkedActionTaken", openReports.size())
+        );
+    }
+
+    @Transactional
+    public void cancel(Long auctionId, Long adminUserId, String notes) {
+        List<ListingReport> reports = reportRepo.findByAuctionIdOrderByCreatedAtDesc(auctionId);
+
+        User admin = userRepo.findById(adminUserId)
+            .orElseThrow(() -> new IllegalStateException("Admin user not found: " + adminUserId));
+
+        cancellationService.cancelByAdmin(auctionId, adminUserId, notes);
+
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        List<ListingReport> openReports = reports.stream()
+            .filter(r -> r.getStatus() == ListingReportStatus.OPEN)
+            .toList();
+
+        for (ListingReport r : openReports) {
+            r.setStatus(ListingReportStatus.ACTION_TAKEN);
+            r.setAdminNotes(notes);
+            r.setReviewedBy(admin);
+            r.setReviewedAt(now);
+            reportRepo.save(r);
+        }
+
+        adminActionService.record(
+            adminUserId,
+            AdminActionType.CANCEL_LISTING_FROM_REPORT,
+            AdminActionTargetType.LISTING,
+            auctionId,
+            notes,
+            Map.of("openReportsMarkedActionTaken", openReports.size())
+        );
+    }
+
+    private AdminReportDetailDto toDetailDto(ListingReport r) {
+        User reporter = r.getReporter();
+        User reviewedBy = r.getReviewedBy();
+        return new AdminReportDetailDto(
+            r.getId(),
+            r.getReason(),
+            r.getSubject(),
+            r.getDetails(),
+            r.getStatus(),
+            r.getAdminNotes(),
+            r.getCreatedAt(),
+            r.getUpdatedAt(),
+            r.getReviewedAt(),
+            reporter != null ? reporter.getId() : null,
+            reporter != null ? reporter.getDisplayName() : null,
+            reporter != null && reporter.getDismissedReportsCount() != null
+                ? reporter.getDismissedReportsCount() : 0L,
+            reviewedBy != null ? reviewedBy.getDisplayName() : null
+        );
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReport.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReport.java
@@ -1,0 +1,85 @@
+package com.slparcelauctions.backend.admin.reports;
+
+import java.time.OffsetDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.user.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "listing_reports",
+    uniqueConstraints = @UniqueConstraint(name = "uk_listing_reports_auction_reporter",
+        columnNames = {"auction_id", "reporter_id"}),
+    indexes = {
+        @Index(name = "idx_listing_reports_status", columnList = "status, auction_id"),
+        @Index(name = "idx_listing_reports_auction", columnList = "auction_id, updated_at DESC")
+    })
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class ListingReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "auction_id", nullable = false)
+    private Auction auction;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
+
+    @Column(length = 100, nullable = false)
+    private String subject;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30, nullable = false)
+    private ListingReportReason reason;
+
+    @Column(columnDefinition = "text", nullable = false)
+    private String details;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    @Builder.Default
+    private ListingReportStatus status = ListingReportStatus.OPEN;
+
+    @Column(name = "admin_notes", columnDefinition = "text")
+    private String adminNotes;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewed_by")
+    private User reviewedBy;
+
+    @Column(name = "reviewed_at")
+    private OffsetDateTime reviewedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReportReason.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReportReason.java
@@ -1,0 +1,12 @@
+package com.slparcelauctions.backend.admin.reports;
+
+public enum ListingReportReason {
+    INACCURATE_DESCRIPTION,
+    WRONG_TAGS,
+    SHILL_BIDDING,
+    FRAUDULENT_SELLER,
+    DUPLICATE_LISTING,
+    NOT_ACTUALLY_FOR_SALE,
+    TOS_VIOLATION,
+    OTHER
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReportRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReportRepository.java
@@ -3,7 +3,13 @@ package com.slparcelauctions.backend.admin.reports;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.slparcelauctions.backend.admin.reports.dto.AdminReportListingRowDto;
 
 public interface ListingReportRepository extends JpaRepository<ListingReport, Long> {
 
@@ -12,4 +18,33 @@ public interface ListingReportRepository extends JpaRepository<ListingReport, Lo
     List<ListingReport> findByAuctionIdOrderByCreatedAtDesc(Long auctionId);
 
     long countByStatus(ListingReportStatus status);
+
+    @Query("""
+        SELECT new com.slparcelauctions.backend.admin.reports.dto.AdminReportListingRowDto(
+            r.auction.id, r.auction.title, r.auction.status,
+            r.auction.parcel.regionName, r.auction.seller.id, r.auction.seller.displayName,
+            COUNT(r), MAX(r.updatedAt))
+        FROM ListingReport r
+        WHERE r.status = :status
+        GROUP BY r.auction.id, r.auction.title, r.auction.status,
+                 r.auction.parcel.regionName, r.auction.seller.id, r.auction.seller.displayName
+        ORDER BY COUNT(r) DESC, MAX(r.updatedAt) DESC
+    """)
+    Page<AdminReportListingRowDto> findListingsGroupedByStatus(
+        @Param("status") ListingReportStatus status, Pageable pageable);
+
+    @Query("""
+        SELECT new com.slparcelauctions.backend.admin.reports.dto.AdminReportListingRowDto(
+            r.auction.id, r.auction.title, r.auction.status,
+            r.auction.parcel.regionName, r.auction.seller.id, r.auction.seller.displayName,
+            COUNT(r), MAX(r.updatedAt))
+        FROM ListingReport r
+        GROUP BY r.auction.id, r.auction.title, r.auction.status,
+                 r.auction.parcel.regionName, r.auction.seller.id, r.auction.seller.displayName
+        ORDER BY COUNT(r) DESC, MAX(r.updatedAt) DESC
+    """)
+    Page<AdminReportListingRowDto> findAllListingsGrouped(Pageable pageable);
+
+    @Query("SELECT count(r) FROM ListingReport r WHERE r.auction.id = :auctionId AND r.status = 'OPEN'")
+    long countOpenByAuctionId(@Param("auctionId") Long auctionId);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReportRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReportRepository.java
@@ -47,4 +47,11 @@ public interface ListingReportRepository extends JpaRepository<ListingReport, Lo
 
     @Query("SELECT count(r) FROM ListingReport r WHERE r.auction.id = :auctionId AND r.status = 'OPEN'")
     long countOpenByAuctionId(@Param("auctionId") Long auctionId);
+
+    @Query("""
+        SELECT r FROM ListingReport r
+        WHERE r.reporter.id = :userId OR r.auction.seller.id = :userId
+        ORDER BY r.updatedAt DESC
+        """)
+    Page<ListingReport> findByUserAsReporterOrSeller(@Param("userId") Long userId, Pageable pageable);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReportRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReportRepository.java
@@ -1,0 +1,15 @@
+package com.slparcelauctions.backend.admin.reports;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ListingReportRepository extends JpaRepository<ListingReport, Long> {
+
+    Optional<ListingReport> findByAuctionIdAndReporterId(Long auctionId, Long reporterId);
+
+    List<ListingReport> findByAuctionIdOrderByCreatedAtDesc(Long auctionId);
+
+    long countByStatus(ListingReportStatus status);
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReportStatus.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReportStatus.java
@@ -1,0 +1,5 @@
+package com.slparcelauctions.backend.admin.reports;
+
+public enum ListingReportStatus {
+    OPEN, REVIEWED, DISMISSED, ACTION_TAKEN
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/UserReportController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/UserReportController.java
@@ -1,0 +1,42 @@
+package com.slparcelauctions.backend.admin.reports;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.admin.reports.dto.MyReportResponse;
+import com.slparcelauctions.backend.admin.reports.dto.ReportRequest;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/auctions/{auctionId}")
+@RequiredArgsConstructor
+public class UserReportController {
+
+    private final UserReportService service;
+
+    @PostMapping("/report")
+    public MyReportResponse report(
+            @PathVariable Long auctionId,
+            @Valid @RequestBody ReportRequest body,
+            @AuthenticationPrincipal AuthPrincipal principal) {
+        return service.upsertReport(auctionId, principal.userId(), body);
+    }
+
+    @GetMapping("/my-report")
+    public ResponseEntity<MyReportResponse> myReport(
+            @PathVariable Long auctionId,
+            @AuthenticationPrincipal AuthPrincipal principal) {
+        return service.findMyReport(auctionId, principal.userId())
+            .map(ResponseEntity::ok)
+            .orElse(ResponseEntity.noContent().build());
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/UserReportService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/UserReportService.java
@@ -1,0 +1,72 @@
+package com.slparcelauctions.backend.admin.reports;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.admin.reports.dto.MyReportResponse;
+import com.slparcelauctions.backend.admin.reports.dto.ReportRequest;
+import com.slparcelauctions.backend.admin.reports.exception.AuctionNotReportableException;
+import com.slparcelauctions.backend.admin.reports.exception.CannotReportOwnListingException;
+import com.slparcelauctions.backend.admin.reports.exception.MustBeVerifiedToReportException;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserReportService {
+
+    private final ListingReportRepository repo;
+    private final AuctionRepository auctionRepo;
+    private final UserRepository userRepo;
+
+    @Transactional
+    public MyReportResponse upsertReport(Long auctionId, Long reporterId, ReportRequest req) {
+        Auction auction = auctionRepo.findById(auctionId)
+            .orElseThrow(() -> new AuctionNotFoundException(auctionId));
+        User reporter = userRepo.findById(reporterId)
+            .orElseThrow(() -> new IllegalStateException("Reporter not found: " + reporterId));
+
+        if (!Boolean.TRUE.equals(reporter.getVerified())) {
+            throw new MustBeVerifiedToReportException();
+        }
+        if (auction.getSeller().getId().equals(reporterId)) {
+            throw new CannotReportOwnListingException();
+        }
+        if (auction.getStatus() != AuctionStatus.ACTIVE) {
+            throw new AuctionNotReportableException(auction.getStatus());
+        }
+
+        ListingReport report = repo.findByAuctionIdAndReporterId(auctionId, reporterId)
+            .orElseGet(() -> ListingReport.builder()
+                .auction(auction).reporter(reporter)
+                .build());
+        report.setSubject(req.subject());
+        report.setReason(req.reason());
+        report.setDetails(req.details());
+        report.setStatus(ListingReportStatus.OPEN);
+        report.setReviewedBy(null);
+        report.setReviewedAt(null);
+        report.setAdminNotes(null);
+        ListingReport saved = repo.save(report);
+        return toMyReport(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<MyReportResponse> findMyReport(Long auctionId, Long reporterId) {
+        return repo.findByAuctionIdAndReporterId(auctionId, reporterId)
+            .map(this::toMyReport);
+    }
+
+    private MyReportResponse toMyReport(ListingReport r) {
+        return new MyReportResponse(r.getId(), r.getSubject(), r.getReason(), r.getDetails(),
+            r.getStatus(), r.getCreatedAt(), r.getUpdatedAt());
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/dto/AdminReportActionRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/dto/AdminReportActionRequest.java
@@ -1,0 +1,6 @@
+package com.slparcelauctions.backend.admin.reports.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminReportActionRequest(@NotBlank @Size(max = 1000) String notes) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/dto/AdminReportDetailDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/dto/AdminReportDetailDto.java
@@ -1,0 +1,14 @@
+package com.slparcelauctions.backend.admin.reports.dto;
+
+import java.time.OffsetDateTime;
+
+import com.slparcelauctions.backend.admin.reports.ListingReportReason;
+import com.slparcelauctions.backend.admin.reports.ListingReportStatus;
+
+public record AdminReportDetailDto(
+    Long id, ListingReportReason reason, String subject, String details,
+    ListingReportStatus status, String adminNotes,
+    OffsetDateTime createdAt, OffsetDateTime updatedAt, OffsetDateTime reviewedAt,
+    Long reporterUserId, String reporterDisplayName, long reporterDismissedReportsCount,
+    String reviewedByDisplayName
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/dto/AdminReportListingRowDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/dto/AdminReportListingRowDto.java
@@ -1,0 +1,11 @@
+package com.slparcelauctions.backend.admin.reports.dto;
+
+import java.time.OffsetDateTime;
+
+import com.slparcelauctions.backend.auction.AuctionStatus;
+
+public record AdminReportListingRowDto(
+    Long auctionId, String auctionTitle, AuctionStatus auctionStatus,
+    String parcelRegionName, Long sellerUserId, String sellerDisplayName,
+    Long openReportCount, OffsetDateTime latestReportAt
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/dto/MyReportResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/dto/MyReportResponse.java
@@ -1,0 +1,16 @@
+package com.slparcelauctions.backend.admin.reports.dto;
+
+import java.time.OffsetDateTime;
+
+import com.slparcelauctions.backend.admin.reports.ListingReportReason;
+import com.slparcelauctions.backend.admin.reports.ListingReportStatus;
+
+public record MyReportResponse(
+    Long id,
+    String subject,
+    ListingReportReason reason,
+    String details,
+    ListingReportStatus status,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/dto/ReportRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/dto/ReportRequest.java
@@ -1,0 +1,13 @@
+package com.slparcelauctions.backend.admin.reports.dto;
+
+import com.slparcelauctions.backend.admin.reports.ListingReportReason;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ReportRequest(
+    @NotBlank @Size(max = 100) String subject,
+    @NotNull ListingReportReason reason,
+    @NotBlank @Size(max = 2000) String details
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/exception/AuctionNotReportableException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/exception/AuctionNotReportableException.java
@@ -1,0 +1,15 @@
+package com.slparcelauctions.backend.admin.reports.exception;
+
+import com.slparcelauctions.backend.auction.AuctionStatus;
+
+import lombok.Getter;
+
+@Getter
+public class AuctionNotReportableException extends RuntimeException {
+    private final AuctionStatus currentStatus;
+
+    public AuctionNotReportableException(AuctionStatus s) {
+        super("Auction is " + s + ", not reportable");
+        this.currentStatus = s;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/exception/CannotReportOwnListingException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/exception/CannotReportOwnListingException.java
@@ -1,0 +1,7 @@
+package com.slparcelauctions.backend.admin.reports.exception;
+
+public class CannotReportOwnListingException extends RuntimeException {
+    public CannotReportOwnListingException() {
+        super("Cannot report your own listing");
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/exception/MustBeVerifiedToReportException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/exception/MustBeVerifiedToReportException.java
@@ -1,0 +1,7 @@
+package com.slparcelauctions.backend.admin.reports.exception;
+
+public class MustBeVerifiedToReportException extends RuntimeException {
+    public MustBeVerifiedToReportException() {
+        super("Verify your SL avatar to report listings");
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/exception/ReportNotFoundException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/exception/ReportNotFoundException.java
@@ -1,0 +1,5 @@
+package com.slparcelauctions.backend.admin.reports.exception;
+
+public class ReportNotFoundException extends RuntimeException {
+    public ReportNotFoundException(Long id) { super("Report not found: " + id); }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/reports/exception/UserReportExceptionHandler.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/reports/exception/UserReportExceptionHandler.java
@@ -1,0 +1,50 @@
+package com.slparcelauctions.backend.admin.reports.exception;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Slice-scoped exception handler for the user-facing report endpoints in
+ * {@code com.slparcelauctions.backend.admin.reports}. Returns RFC 9457
+ * {@link ProblemDetail} for the three user-facing report exceptions.
+ *
+ * <p><strong>Ordering:</strong> {@code @Order(Ordered.HIGHEST_PRECEDENCE)} guarantees
+ * this handler wins over {@code AdminExceptionHandler} (which is scoped to
+ * {@code com.slparcelauctions.backend.admin} and therefore technically covers
+ * {@code admin.reports} too). The higher precedence ensures the user-facing
+ * ProblemDetail shape is returned for requests handled by controllers in this
+ * package.
+ */
+@RestControllerAdvice(basePackages = "com.slparcelauctions.backend.admin.reports")
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class UserReportExceptionHandler {
+
+    @ExceptionHandler(CannotReportOwnListingException.class)
+    public ProblemDetail handleOwnListing(CannotReportOwnListingException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.CONFLICT);
+        pd.setTitle(ex.getMessage());
+        pd.setProperty("code", "CANNOT_REPORT_OWN_LISTING");
+        return pd;
+    }
+
+    @ExceptionHandler(MustBeVerifiedToReportException.class)
+    public ProblemDetail handleNotVerified(MustBeVerifiedToReportException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.FORBIDDEN);
+        pd.setTitle(ex.getMessage());
+        pd.setProperty("code", "VERIFICATION_REQUIRED");
+        return pd;
+    }
+
+    @ExceptionHandler(AuctionNotReportableException.class)
+    public ProblemDetail handleNotActive(AuctionNotReportableException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.CONFLICT);
+        pd.setTitle(ex.getMessage());
+        pd.setProperty("code", "AUCTION_NOT_REPORTABLE");
+        pd.setProperty("currentStatus", ex.getCurrentStatus().name());
+        return pd;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/AdminRoleService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/AdminRoleService.java
@@ -1,0 +1,65 @@
+package com.slparcelauctions.backend.admin.users;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.admin.audit.AdminActionService;
+import com.slparcelauctions.backend.admin.audit.AdminActionTargetType;
+import com.slparcelauctions.backend.admin.audit.AdminActionType;
+import com.slparcelauctions.backend.admin.users.exception.SelfDemoteException;
+import com.slparcelauctions.backend.admin.users.exception.UserAlreadyAdminException;
+import com.slparcelauctions.backend.admin.users.exception.UserNotAdminException;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminRoleService {
+
+    private final UserRepository userRepo;
+    private final AdminActionService adminActionService;
+
+    @Transactional
+    public void promote(Long targetUserId, Long callingAdminId, String notes) {
+        User target = userRepo.findById(targetUserId)
+            .orElseThrow(() -> new IllegalStateException("User not found: " + targetUserId));
+        if (target.getRole() == Role.ADMIN) {
+            throw new UserAlreadyAdminException(targetUserId);
+        }
+        target.setRole(Role.ADMIN);
+        userRepo.save(target);
+        userRepo.bumpTokenVersion(targetUserId);
+        adminActionService.record(callingAdminId, AdminActionType.PROMOTE_USER,
+            AdminActionTargetType.USER, targetUserId, notes, null);
+    }
+
+    @Transactional
+    public void demote(Long targetUserId, Long callingAdminId, String notes) {
+        if (targetUserId.equals(callingAdminId)) {
+            throw new SelfDemoteException();
+        }
+        User target = userRepo.findById(targetUserId)
+            .orElseThrow(() -> new IllegalStateException("User not found: " + targetUserId));
+        if (target.getRole() != Role.ADMIN) {
+            throw new UserNotAdminException(targetUserId);
+        }
+        target.setRole(Role.USER);
+        userRepo.save(target);
+        userRepo.bumpTokenVersion(targetUserId);
+        adminActionService.record(callingAdminId, AdminActionType.DEMOTE_USER,
+            AdminActionTargetType.USER, targetUserId, notes, null);
+    }
+
+    @Transactional
+    public void resetFrivolousCounter(Long targetUserId, Long callingAdminId, String notes) {
+        User target = userRepo.findById(targetUserId)
+            .orElseThrow(() -> new IllegalStateException("User not found: " + targetUserId));
+        target.setDismissedReportsCount(0L);
+        userRepo.save(target);
+        adminActionService.record(callingAdminId, AdminActionType.RESET_FRIVOLOUS_COUNTER,
+            AdminActionTargetType.USER, targetUserId, notes, null);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/AdminUserController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/AdminUserController.java
@@ -1,0 +1,130 @@
+package com.slparcelauctions.backend.admin.users;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.admin.users.dto.AdminUserActionRequest;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserBidRowDto;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserCancellationRowDto;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserDetailDto;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserFraudFlagRowDto;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserListingRowDto;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserModerationRowDto;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserReportRowDto;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserSummaryDto;
+import com.slparcelauctions.backend.admin.users.dto.UserIpProjection;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.common.PagedResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/admin/users")
+@RequiredArgsConstructor
+public class AdminUserController {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final AdminUserService userService;
+    private final AdminRoleService roleService;
+
+    @GetMapping
+    public PagedResponse<AdminUserSummaryDto> search(
+            @RequestParam(required = false) String search,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "25") int size) {
+        return userService.search(search, PageRequest.of(page, Math.min(size, MAX_PAGE_SIZE)));
+    }
+
+    @GetMapping("/{id}")
+    public AdminUserDetailDto detail(@PathVariable Long id) {
+        return userService.detail(id);
+    }
+
+    @GetMapping("/{id}/listings")
+    public PagedResponse<AdminUserListingRowDto> listings(
+            @PathVariable Long id,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "25") int size) {
+        return userService.listings(id, PageRequest.of(page, Math.min(size, MAX_PAGE_SIZE)));
+    }
+
+    @GetMapping("/{id}/bids")
+    public PagedResponse<AdminUserBidRowDto> bids(
+            @PathVariable Long id,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "25") int size) {
+        return userService.bids(id, PageRequest.of(page, Math.min(size, MAX_PAGE_SIZE)));
+    }
+
+    @GetMapping("/{id}/cancellations")
+    public PagedResponse<AdminUserCancellationRowDto> cancellations(
+            @PathVariable Long id,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "25") int size) {
+        return userService.cancellations(id, PageRequest.of(page, Math.min(size, MAX_PAGE_SIZE)));
+    }
+
+    @GetMapping("/{id}/reports")
+    public PagedResponse<AdminUserReportRowDto> reports(
+            @PathVariable Long id,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "25") int size) {
+        return userService.reports(id, PageRequest.of(page, Math.min(size, MAX_PAGE_SIZE)));
+    }
+
+    @GetMapping("/{id}/fraud-flags")
+    public PagedResponse<AdminUserFraudFlagRowDto> fraudFlags(
+            @PathVariable Long id,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "25") int size) {
+        return userService.fraudFlags(id, PageRequest.of(page, Math.min(size, MAX_PAGE_SIZE)));
+    }
+
+    @GetMapping("/{id}/moderation")
+    public PagedResponse<AdminUserModerationRowDto> moderation(
+            @PathVariable Long id,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "25") int size) {
+        return userService.moderation(id, PageRequest.of(page, Math.min(size, MAX_PAGE_SIZE)));
+    }
+
+    @GetMapping("/{id}/ips")
+    public List<UserIpProjection> ips(@PathVariable Long id) {
+        return userService.ips(id);
+    }
+
+    @PostMapping("/{id}/promote")
+    public void promote(
+            @PathVariable Long id,
+            @Valid @RequestBody AdminUserActionRequest body,
+            @AuthenticationPrincipal AuthPrincipal admin) {
+        roleService.promote(id, admin.userId(), body.notes());
+    }
+
+    @PostMapping("/{id}/demote")
+    public void demote(
+            @PathVariable Long id,
+            @Valid @RequestBody AdminUserActionRequest body,
+            @AuthenticationPrincipal AuthPrincipal admin) {
+        roleService.demote(id, admin.userId(), body.notes());
+    }
+
+    @PostMapping("/{id}/reset-frivolous-counter")
+    public void resetCounter(
+            @PathVariable Long id,
+            @Valid @RequestBody AdminUserActionRequest body,
+            @AuthenticationPrincipal AuthPrincipal admin) {
+        roleService.resetFrivolousCounter(id, admin.userId(), body.notes());
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/AdminUserService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/AdminUserService.java
@@ -1,0 +1,178 @@
+package com.slparcelauctions.backend.admin.users;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.admin.audit.AdminAction;
+import com.slparcelauctions.backend.admin.audit.AdminActionRepository;
+import com.slparcelauctions.backend.admin.ban.Ban;
+import com.slparcelauctions.backend.admin.ban.BanRepository;
+import com.slparcelauctions.backend.admin.reports.ListingReport;
+import com.slparcelauctions.backend.admin.reports.ListingReportRepository;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserBidRowDto;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserCancellationRowDto;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserDetailDto;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserFraudFlagRowDto;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserListingRowDto;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserModerationRowDto;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserReportRowDto;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserSummaryDto;
+import com.slparcelauctions.backend.admin.users.dto.UserIpProjection;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.Bid;
+import com.slparcelauctions.backend.auction.BidRepository;
+import com.slparcelauctions.backend.auction.CancellationLog;
+import com.slparcelauctions.backend.auction.CancellationLogRepository;
+import com.slparcelauctions.backend.auction.fraud.FraudFlag;
+import com.slparcelauctions.backend.auction.fraud.FraudFlagRepository;
+import com.slparcelauctions.backend.auth.RefreshTokenRepository;
+import com.slparcelauctions.backend.common.PagedResponse;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminUserService {
+
+    private final UserRepository userRepo;
+    private final BanRepository banRepo;
+    private final AuctionRepository auctionRepo;
+    private final BidRepository bidRepo;
+    private final CancellationLogRepository cancellationLogRepo;
+    private final ListingReportRepository listingReportRepo;
+    private final FraudFlagRepository fraudFlagRepo;
+    private final AdminActionRepository adminActionRepo;
+    private final RefreshTokenRepository refreshTokenRepo;
+    private final Clock clock;
+
+    @Transactional(readOnly = true)
+    public PagedResponse<AdminUserSummaryDto> search(String input, Pageable pageable) {
+        UUID uuid = tryParseUuid(input);
+        String search = uuid != null ? null
+            : (input == null || input.isBlank() ? null : input.trim());
+        Page<User> page = userRepo.searchAdmin(search, uuid, pageable);
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        return PagedResponse.from(page.map(u -> toSummary(u, now)));
+    }
+
+    @Transactional(readOnly = true)
+    public AdminUserDetailDto detail(Long userId) {
+        User u = userRepo.findById(userId)
+            .orElseThrow(() -> new IllegalStateException("User not found: " + userId));
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        AdminUserDetailDto.ActiveBanSummary activeBan = null;
+        if (u.getSlAvatarUuid() != null) {
+            List<Ban> hits = banRepo.findActiveByAvatar(u.getSlAvatarUuid(), now);
+            if (!hits.isEmpty()) {
+                Ban b = hits.get(0);
+                activeBan = new AdminUserDetailDto.ActiveBanSummary(
+                    b.getId(), b.getBanType(), b.getNotes(), b.getExpiresAt());
+            }
+        }
+        return new AdminUserDetailDto(
+            u.getId(), u.getEmail(), u.getDisplayName(),
+            u.getSlAvatarUuid(), u.getSlDisplayName(),
+            u.getRole(), Boolean.TRUE.equals(u.getVerified()), u.getVerifiedAt(),
+            u.getCreatedAt(),
+            u.getCompletedSales(), u.getCancelledWithBids(),
+            u.getEscrowExpiredUnfulfilled(), u.getDismissedReportsCount(),
+            u.getPenaltyBalanceOwed(), u.getListingSuspensionUntil(),
+            Boolean.TRUE.equals(u.getBannedFromListing()),
+            activeBan);
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResponse<AdminUserListingRowDto> listings(Long userId, Pageable pageable) {
+        Page<Auction> page = auctionRepo.findBySellerIdOrderByCreatedAtDesc(userId, pageable);
+        return PagedResponse.from(page.map(a -> new AdminUserListingRowDto(
+            a.getId(), a.getTitle(),
+            a.getParcel() != null ? a.getParcel().getRegionName() : null,
+            a.getStatus(), a.getEndsAt(), a.getFinalBidAmount())));
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResponse<AdminUserBidRowDto> bids(Long userId, Pageable pageable) {
+        Page<Bid> page = bidRepo.findByBidderIdOrderByCreatedAtDesc(userId, pageable);
+        return PagedResponse.from(page.map(b -> new AdminUserBidRowDto(
+            b.getId(), b.getAuction().getId(), b.getAuction().getTitle(),
+            b.getAmount(), b.getCreatedAt(), b.getAuction().getStatus())));
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResponse<AdminUserCancellationRowDto> cancellations(Long userId, Pageable pageable) {
+        Page<CancellationLog> page = cancellationLogRepo.findBySellerIdOrderByCancelledAtDesc(userId, pageable);
+        return PagedResponse.from(page.map(c -> new AdminUserCancellationRowDto(
+            c.getId(), c.getAuction().getId(), c.getAuction().getTitle(),
+            c.getCancelledFromStatus(), Boolean.TRUE.equals(c.getHadBids()),
+            c.getReason(),
+            c.getPenaltyKind() != null ? c.getPenaltyKind().name() : null,
+            c.getPenaltyAmountL(), c.getCancelledByAdminId(), c.getCancelledAt())));
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResponse<AdminUserReportRowDto> reports(Long userId, Pageable pageable) {
+        Page<ListingReport> page = listingReportRepo.findByUserAsReporterOrSeller(userId, pageable);
+        return PagedResponse.from(page.map(r -> {
+            String direction = r.getReporter().getId().equals(userId) ? "FILED_BY" : "AGAINST_LISTING";
+            return new AdminUserReportRowDto(
+                r.getId(), r.getAuction().getId(), r.getAuction().getTitle(),
+                r.getReason().name(), r.getStatus().name(),
+                direction, r.getCreatedAt(), r.getUpdatedAt());
+        }));
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResponse<AdminUserFraudFlagRowDto> fraudFlags(Long userId, Pageable pageable) {
+        Page<FraudFlag> page = fraudFlagRepo.findByAuctionSellerId(userId, pageable);
+        return PagedResponse.from(page.map(f -> new AdminUserFraudFlagRowDto(
+            f.getId(),
+            f.getAuction() != null ? f.getAuction().getId() : null,
+            f.getAuction() != null ? f.getAuction().getTitle() : null,
+            f.getReason().name(), f.isResolved(), f.getDetectedAt())));
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResponse<AdminUserModerationRowDto> moderation(Long userId, Pageable pageable) {
+        Page<AdminAction> page = adminActionRepo.findByTargetTypeAndTargetIdOrderByCreatedAtDesc(
+            com.slparcelauctions.backend.admin.audit.AdminActionTargetType.USER, userId, pageable);
+        return PagedResponse.from(page.map(a -> new AdminUserModerationRowDto(
+            a.getId(), a.getActionType().name(),
+            a.getAdminUser().getDisplayName(),
+            a.getNotes(), a.getCreatedAt())));
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserIpProjection> ips(Long userId) {
+        return refreshTokenRepo.findIpSummaryByUserId(userId);
+    }
+
+    private AdminUserSummaryDto toSummary(User u, OffsetDateTime now) {
+        boolean banned = u.getSlAvatarUuid() != null
+            && !banRepo.findActiveByAvatar(u.getSlAvatarUuid(), now).isEmpty();
+        return new AdminUserSummaryDto(
+            u.getId(), u.getEmail(), u.getDisplayName(),
+            u.getSlAvatarUuid(), u.getSlDisplayName(),
+            u.getRole(), Boolean.TRUE.equals(u.getVerified()), banned,
+            u.getCompletedSales(), u.getCancelledWithBids(),
+            u.getCreatedAt());
+    }
+
+    private UUID tryParseUuid(String input) {
+        if (input == null || input.isBlank()) return null;
+        try {
+            return UUID.fromString(input.trim());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserActionRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserActionRequest.java
@@ -1,0 +1,8 @@
+package com.slparcelauctions.backend.admin.users.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminUserActionRequest(
+    @NotBlank @Size(max = 1000) String notes
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserBidRowDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserBidRowDto.java
@@ -1,0 +1,14 @@
+package com.slparcelauctions.backend.admin.users.dto;
+
+import java.time.OffsetDateTime;
+
+import com.slparcelauctions.backend.auction.AuctionStatus;
+
+public record AdminUserBidRowDto(
+    Long bidId,
+    Long auctionId,
+    String auctionTitle,
+    long amount,
+    OffsetDateTime placedAt,
+    AuctionStatus auctionStatus
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserCancellationRowDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserCancellationRowDto.java
@@ -1,0 +1,16 @@
+package com.slparcelauctions.backend.admin.users.dto;
+
+import java.time.OffsetDateTime;
+
+public record AdminUserCancellationRowDto(
+    Long logId,
+    Long auctionId,
+    String auctionTitle,
+    String cancelledFromStatus,
+    boolean hadBids,
+    String reason,
+    String penaltyKind,
+    Long penaltyAmountL,
+    Long cancelledByAdminId,
+    OffsetDateTime cancelledAt
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserDetailDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserDetailDto.java
@@ -1,0 +1,34 @@
+package com.slparcelauctions.backend.admin.users.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import com.slparcelauctions.backend.admin.ban.BanType;
+import com.slparcelauctions.backend.user.Role;
+
+public record AdminUserDetailDto(
+    Long id,
+    String email,
+    String displayName,
+    UUID slAvatarUuid,
+    String slDisplayName,
+    Role role,
+    boolean verified,
+    OffsetDateTime verifiedAt,
+    OffsetDateTime createdAt,
+    long completedSales,
+    long cancelledWithBids,
+    long escrowExpiredUnfulfilled,
+    long dismissedReportsCount,
+    long penaltyBalanceOwed,
+    OffsetDateTime listingSuspensionUntil,
+    boolean bannedFromListing,
+    ActiveBanSummary activeBan
+) {
+    public record ActiveBanSummary(
+        Long id,
+        BanType banType,
+        String reasonText,
+        OffsetDateTime expiresAt
+    ) {}
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserFraudFlagRowDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserFraudFlagRowDto.java
@@ -1,0 +1,12 @@
+package com.slparcelauctions.backend.admin.users.dto;
+
+import java.time.OffsetDateTime;
+
+public record AdminUserFraudFlagRowDto(
+    Long flagId,
+    Long auctionId,
+    String auctionTitle,
+    String reason,
+    boolean resolved,
+    OffsetDateTime detectedAt
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserListingRowDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserListingRowDto.java
@@ -1,0 +1,14 @@
+package com.slparcelauctions.backend.admin.users.dto;
+
+import java.time.OffsetDateTime;
+
+import com.slparcelauctions.backend.auction.AuctionStatus;
+
+public record AdminUserListingRowDto(
+    Long auctionId,
+    String title,
+    String regionName,
+    AuctionStatus status,
+    OffsetDateTime endsAt,
+    Long finalBidAmount
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserModerationRowDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserModerationRowDto.java
@@ -1,0 +1,11 @@
+package com.slparcelauctions.backend.admin.users.dto;
+
+import java.time.OffsetDateTime;
+
+public record AdminUserModerationRowDto(
+    Long actionId,
+    String actionType,
+    String adminDisplayName,
+    String notes,
+    OffsetDateTime createdAt
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserReportRowDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserReportRowDto.java
@@ -1,0 +1,14 @@
+package com.slparcelauctions.backend.admin.users.dto;
+
+import java.time.OffsetDateTime;
+
+public record AdminUserReportRowDto(
+    Long reportId,
+    Long auctionId,
+    String auctionTitle,
+    String reason,
+    String status,
+    String direction,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserSummaryDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserSummaryDto.java
@@ -1,0 +1,20 @@
+package com.slparcelauctions.backend.admin.users.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import com.slparcelauctions.backend.user.Role;
+
+public record AdminUserSummaryDto(
+    Long id,
+    String email,
+    String displayName,
+    UUID slAvatarUuid,
+    String slDisplayName,
+    Role role,
+    boolean verified,
+    boolean hasActiveBan,
+    long completedSales,
+    long cancelledWithBids,
+    OffsetDateTime createdAt
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/UserIpProjection.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/UserIpProjection.java
@@ -1,0 +1,20 @@
+package com.slparcelauctions.backend.admin.users.dto;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Projection of IP activity for a user, derived from their refresh token rows.
+ * Used by the admin user-detail "Recent IPs" modal and by {@code BanRepository}
+ * for IP-history lookups.
+ *
+ * @param ipAddress    the resolved IP address seen on the token
+ * @param firstSeenAt  earliest {@code created_at} across all tokens from this IP
+ * @param lastSeenAt   latest {@code last_used_at} across all tokens from this IP
+ * @param sessionCount count of distinct refresh token rows from this IP
+ */
+public record UserIpProjection(
+    String ipAddress,
+    OffsetDateTime firstSeenAt,
+    OffsetDateTime lastSeenAt,
+    long sessionCount
+) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/exception/SelfDemoteException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/exception/SelfDemoteException.java
@@ -1,0 +1,7 @@
+package com.slparcelauctions.backend.admin.users.exception;
+
+public class SelfDemoteException extends RuntimeException {
+    public SelfDemoteException() {
+        super("Cannot demote yourself.");
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/exception/UserAlreadyAdminException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/exception/UserAlreadyAdminException.java
@@ -1,0 +1,7 @@
+package com.slparcelauctions.backend.admin.users.exception;
+
+public class UserAlreadyAdminException extends RuntimeException {
+    public UserAlreadyAdminException(Long userId) {
+        super("User " + userId + " is already an admin");
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/exception/UserNotAdminException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/exception/UserNotAdminException.java
@@ -1,0 +1,7 @@
+package com.slparcelauctions.backend.admin.users.exception;
+
+public class UserNotAdminException extends RuntimeException {
+    public UserNotAdminException(Long userId) {
+        super("User " + userId + " is not an admin");
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionController.java
@@ -35,6 +35,7 @@ import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.user.UserNotFoundException;
 import com.slparcelauctions.backend.user.UserRepository;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -62,9 +63,11 @@ public class AuctionController {
     @ResponseStatus(HttpStatus.CREATED)
     public SellerAuctionResponse create(
             @AuthenticationPrincipal AuthPrincipal principal,
-            @Valid @RequestBody AuctionCreateRequest req) {
+            @Valid @RequestBody AuctionCreateRequest req,
+            HttpServletRequest httpRequest) {
         requireVerified(principal.userId());
-        Auction created = auctionService.create(principal.userId(), req);
+        String ip = httpRequest.getRemoteAddr();
+        Auction created = auctionService.create(principal.userId(), req, ip);
         return mapper.toSellerResponse(created, null);
     }
 
@@ -124,13 +127,15 @@ public class AuctionController {
     public SellerAuctionResponse cancel(
             @PathVariable Long id,
             @AuthenticationPrincipal AuthPrincipal principal,
-            @Valid @RequestBody AuctionCancelRequest req) {
+            @Valid @RequestBody AuctionCancelRequest req,
+            HttpServletRequest httpRequest) {
         requireVerified(principal.userId());
         // Non-locking load authorises the seller; the service re-fetches under
         // a pessimistic write lock for the state transition so cancellation
         // races with bid placement / auction end serialise on the row lock.
         auctionService.loadForSeller(id, principal.userId());
-        Auction cancelled = cancellationService.cancel(id, req.reason());
+        String ip = httpRequest.getRemoteAddr();
+        Auction cancelled = cancellationService.cancel(id, req.reason(), ip);
         return mapper.toSellerResponse(cancelled, null);
     }
 

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionRepository.java
@@ -184,4 +184,6 @@ public interface AuctionRepository extends JpaRepository<Auction, Long>, JpaSpec
     List<Auction> findAllByIdWithParcelAndSeller(@Param("ids") Collection<Long> ids);
 
     long countByStatus(AuctionStatus status);
+
+    Page<Auction> findBySellerIdOrderByCreatedAtDesc(Long sellerId, Pageable pageable);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionService.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.slparcelauctions.backend.admin.ban.BanCheckService;
 import com.slparcelauctions.backend.auction.dto.AuctionCreateRequest;
 import com.slparcelauctions.backend.auction.dto.AuctionUpdateRequest;
 import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
@@ -45,13 +46,14 @@ public class AuctionService {
     private final ParcelRepository parcelRepo;
     private final UserRepository userRepo;
     private final ParcelTagRepository tagRepo;
+    private final BanCheckService banCheckService;
     private final Clock clock;
 
     @Value("${slpa.commission.default-rate:0.05}")
     private BigDecimal defaultCommissionRate;
 
     @Transactional
-    public Auction create(Long sellerId, AuctionCreateRequest req) {
+    public Auction create(Long sellerId, AuctionCreateRequest req, String ipAddress) {
         validateTitle(req.title());
         validatePricing(req.startingBid(), req.reservePrice(), req.buyNowPrice());
         validateDuration(req.durationHours());
@@ -59,6 +61,8 @@ public class AuctionService {
 
         User seller = userRepo.findById(sellerId)
                 .orElseThrow(() -> new IllegalStateException("Authenticated user not found: " + sellerId));
+
+        banCheckService.assertNotBanned(ipAddress, seller.getSlAvatarUuid());
 
         // Listing-creation suspension gate (Epic 08 sub-spec 2 §7.7). Order is
         // most-restrictive-first: a permanent ban shadows a timed suspension,

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/BidRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/BidRepository.java
@@ -142,4 +142,6 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
     @Modifying
     @Transactional
     int deleteAllByAuctionId(Long auctionId);
+
+    Page<Bid> findByBidderIdOrderByCreatedAtDesc(Long bidderId, Pageable pageable);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/BidService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/BidService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import com.slparcelauctions.backend.admin.ban.BanCheckService;
 import com.slparcelauctions.backend.auction.broadcast.AuctionBroadcastPublisher;
 import com.slparcelauctions.backend.auction.broadcast.AuctionEndedEnvelope;
 import com.slparcelauctions.backend.auction.broadcast.BidSettlementEnvelope;
@@ -80,6 +81,7 @@ public class BidService {
     private final AuctionBroadcastPublisher publisher;
     private final EscrowService escrowService;
     private final NotificationPublisher notificationPublisher;
+    private final BanCheckService banCheckService;
 
     /**
      * Places a manual bid on an auction. See class javadoc for the
@@ -120,6 +122,7 @@ public class BidService {
         // remediable (go verify the SL avatar); SELLER_CANNOT_BID is not.
         User bidder = userRepo.findById(bidderId)
                 .orElseThrow(() -> new UserNotFoundException(bidderId));
+        banCheckService.assertNotBanned(ipAddress, bidder.getSlAvatarUuid());
         if (!Boolean.TRUE.equals(bidder.getVerified())) {
             throw new NotVerifiedException();
         }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLog.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLog.java
@@ -72,6 +72,15 @@ public class CancellationLog {
     @Column(name = "penalty_amount_l")
     private Long penaltyAmountL;
 
+    /**
+     * Non-null when the cancellation was initiated by a staff admin rather than
+     * the seller. Admin-cancel rows are excluded from
+     * {@code countPriorOffensesWithBids} so they do not advance the seller's
+     * penalty ladder. Null for all seller-initiated cancellations.
+     */
+    @Column(name = "cancelled_by_admin_id")
+    private Long cancelledByAdminId;
+
     @CreationTimestamp
     @Column(name = "cancelled_at", nullable = false, updatable = false)
     private OffsetDateTime cancelledAt;

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLogRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLogRepository.java
@@ -53,4 +53,6 @@ public interface CancellationLogRepository extends JpaRepository<CancellationLog
             + "ORDER BY c.cancelledAt DESC")
     List<CancellationLog> findLatestByAuctionId(
             @Param("auctionId") Long auctionId, Pageable pageable);
+
+    Page<CancellationLog> findBySellerIdOrderByCancelledAtDesc(Long sellerId, Pageable pageable);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLogRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLogRepository.java
@@ -21,7 +21,9 @@ public interface CancellationLogRepository extends JpaRepository<CancellationLog
      * count.
      */
     @Query("SELECT count(c) FROM CancellationLog c "
-            + "WHERE c.seller.id = :sellerId AND c.hadBids = true")
+            + "WHERE c.seller.id = :sellerId "
+            + "AND c.hadBids = true "
+            + "AND c.cancelledByAdminId IS NULL")
     long countPriorOffensesWithBids(@Param("sellerId") Long sellerId);
 
     /**

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationService.java
@@ -207,4 +207,73 @@ public class CancellationService {
 
         return saved;
     }
+
+    /**
+     * Admin-initiated cancellation. Skips the penalty ladder entirely —
+     * staff removal is not a seller offense. The {@link CancellationLog} row
+     * is written with {@code cancelledByAdminId} set so that
+     * {@code countPriorOffensesWithBids} (which filters {@code IS NULL}) does
+     * not count it against the seller's ladder.
+     *
+     * <p>The seller receives a distinct {@code LISTING_REMOVED_BY_ADMIN}
+     * notification. Bidders receive the existing
+     * {@code listingCancelledBySellerFanout} (whose body copy is cause-neutral
+     * as of sub-spec 2 Task 3). {@code seller.cancelledWithBids} is NOT
+     * incremented.
+     */
+    @Transactional
+    public Auction cancelByAdmin(Long auctionId, Long adminUserId, String notes) {
+        Auction a = auctionRepo.findByIdForUpdate(auctionId)
+                .orElseThrow(() -> new AuctionNotFoundException(auctionId));
+        if (!CANCELLABLE.contains(a.getStatus())) {
+            throw new InvalidAuctionStateException(a.getId(), a.getStatus(), "ADMIN_CANCEL");
+        }
+
+        boolean hadBids = a.getBidCount() != null && a.getBidCount() > 0;
+        AuctionStatus from = a.getStatus();
+
+        // No penalty ladder. No seller-row lock — no seller-side state changes.
+        logRepo.save(CancellationLog.builder()
+                .auction(a)
+                .seller(a.getSeller())
+                .cancelledFromStatus(from.name())
+                .hadBids(hadBids)
+                .reason(notes)
+                .penaltyKind(CancellationOffenseKind.NONE)
+                .penaltyAmountL(null)
+                .cancelledByAdminId(adminUserId)
+                .build());
+
+        a.setStatus(AuctionStatus.CANCELLED);
+        Auction saved = auctionRepo.save(a);
+        monitorLifecycle.onAuctionClosed(saved);
+
+        notificationPublisher.listingRemovedByAdmin(
+                a.getSeller().getId(), a.getId(), a.getTitle(), notes);
+
+        if (hadBids) {
+            List<Long> bidderIds = bidRepo.findDistinctBidderUserIdsByAuctionId(a.getId());
+            notificationPublisher.listingCancelledBySellerFanout(
+                    a.getId(), bidderIds, a.getTitle(), notes);
+        }
+
+        log.info("Auction {} admin-cancelled from {} by adminUserId={} (hadBids={})",
+                a.getId(), from, adminUserId, hadBids);
+
+        AuctionCancelledEnvelope envelope = AuctionCancelledEnvelope.of(
+                saved, hadBids, OffsetDateTime.now(clock));
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            broadcastPublisher.publishCancelled(envelope);
+                        }
+                    });
+        } else {
+            broadcastPublisher.publishCancelled(envelope);
+        }
+
+        return saved;
+    }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import com.slparcelauctions.backend.admin.ban.BanCheckService;
 import com.slparcelauctions.backend.auction.broadcast.AuctionBroadcastPublisher;
 import com.slparcelauctions.backend.auction.dto.AuctionCancelledEnvelope;
 import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
@@ -66,10 +67,11 @@ public class CancellationService {
     private final AuctionBroadcastPublisher broadcastPublisher;
     private final NotificationPublisher notificationPublisher;
     private final CancellationPenaltyProperties penaltyProps;
+    private final BanCheckService banCheckService;
     private final Clock clock;
 
     @Transactional
-    public Auction cancel(Long auctionId, String reason) {
+    public Auction cancel(Long auctionId, String reason, String ipAddress) {
         Auction a = auctionRepo.findByIdForUpdate(auctionId)
                 .orElseThrow(() -> new AuctionNotFoundException(auctionId));
         if (!CANCELLABLE.contains(a.getStatus())) {
@@ -93,6 +95,8 @@ public class CancellationService {
         // the cold path.
         User seller = userRepo.findByIdForUpdate(a.getSeller().getId())
                 .orElseThrow(); // FK guarantees existence
+
+        banCheckService.assertNotBanned(ipAddress, seller.getSlAvatarUuid());
 
         // Pre-INSERT count → ladder index → consequence snapshot. Indices are
         // clamped at 3 so the 4th-and-beyond offenses all snapshot

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/fraud/FraudFlagRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/fraud/FraudFlagRepository.java
@@ -2,8 +2,12 @@ package com.slparcelauctions.backend.auction.fraud;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FraudFlagRepository extends
         JpaRepository<FraudFlag, Long>,
@@ -14,4 +18,11 @@ public interface FraudFlagRepository extends
     long countByResolved(boolean resolved);
 
     long countByAuctionIdAndResolvedFalseAndIdNot(Long auctionId, Long flagId);
+
+    @Query("""
+        SELECT f FROM FraudFlag f
+        WHERE f.auction.seller.id = :sellerId
+        ORDER BY f.detectedAt DESC
+        """)
+    Page<FraudFlag> findByAuctionSellerId(@Param("sellerId") Long sellerId, Pageable pageable);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/SuspensionService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/SuspensionService.java
@@ -225,4 +225,25 @@ public class SuspensionService {
         log.warn("Auction {} SUSPENDED by bot monitor: reason={}, evidence={}",
                 auction.getId(), reason, evidence);
     }
+
+    /**
+     * Admin-driven suspension. No FraudFlag created — admin reason is captured
+     * in the admin_actions audit row written by the caller. Sets suspendedAt
+     * if currently null, mirroring suspendForOwnershipChange.
+     */
+    @Transactional
+    public void suspendByAdmin(Auction auction, Long adminUserId, String notes) {
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        auction.setStatus(AuctionStatus.SUSPENDED);
+        if (auction.getSuspendedAt() == null) {
+            auction.setSuspendedAt(now);
+        }
+        auctionRepo.save(auction);
+
+        monitorLifecycle.onAuctionClosed(auction);
+
+        notificationPublisher.listingSuspended(
+            auction.getSeller().getId(), auction.getId(),
+            auction.getTitle(), "Suspended by SLPA staff");
+    }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/auth/AuthService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auth/AuthService.java
@@ -1,5 +1,6 @@
 package com.slparcelauctions.backend.auth;
 
+import com.slparcelauctions.backend.admin.ban.BanCheckService;
 import com.slparcelauctions.backend.auth.dto.AuthResult;
 import com.slparcelauctions.backend.auth.dto.LoginRequest;
 import com.slparcelauctions.backend.auth.dto.RegisterRequest;
@@ -39,6 +40,7 @@ public class AuthService {
     private final RefreshTokenService refreshTokenService;
     private final JwtService jwtService;
     private final PasswordEncoder passwordEncoder;
+    private final BanCheckService banCheckService;
 
     // -------------------------------------------------------------------------
     // Register
@@ -57,6 +59,8 @@ public class AuthService {
      * @throws EmailAlreadyExistsException if the email is already in use
      */
     public AuthResult register(RegisterRequest request, HttpServletRequest httpReq) {
+        String ip = httpReq.getRemoteAddr();
+        banCheckService.assertNotBanned(ip, null);
         UserResponse created;
         try {
             created = userService.createUser(
@@ -90,6 +94,8 @@ public class AuthService {
      * @throws InvalidCredentialsException if the email is unknown or the password does not match
      */
     public AuthResult login(LoginRequest request, HttpServletRequest httpReq) {
+        String ip = httpReq.getRemoteAddr();
+        banCheckService.assertNotBanned(ip, null);
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(InvalidCredentialsException::new);
 

--- a/backend/src/main/java/com/slparcelauctions/backend/auth/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auth/RefreshTokenRepository.java
@@ -8,6 +8,8 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import com.slparcelauctions.backend.admin.users.dto.UserIpProjection;
+
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByTokenHash(String tokenHash);
@@ -35,4 +37,22 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
          + "(rt.revokedAt IS NOT NULL AND rt.revokedAt < :cutoff) OR "
          + "(rt.expiresAt < :cutoff)")
     int deleteOldRows(@Param("cutoff") OffsetDateTime cutoff);
+
+    /**
+     * Returns one row per distinct IP address seen in this user's refresh token
+     * history, with first/last seen timestamps and a session count. Used by the
+     * admin user-detail "Recent IPs" modal.
+     *
+     * <p>Rows with a null {@code ip_address} are excluded (recorded before the
+     * column was added, or from clients that don't send an IP).
+     */
+    @Query("""
+        SELECT new com.slparcelauctions.backend.admin.users.dto.UserIpProjection(
+            rt.ipAddress, MIN(rt.createdAt), MAX(rt.lastUsedAt), COUNT(rt.id))
+        FROM RefreshToken rt
+        WHERE rt.userId = :userId AND rt.ipAddress IS NOT NULL
+        GROUP BY rt.ipAddress
+        ORDER BY MIN(rt.createdAt) ASC
+        """)
+    List<UserIpProjection> findIpSummaryByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationCategory.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationCategory.java
@@ -23,6 +23,7 @@ public enum NotificationCategory {
     LISTING_REVIEW_REQUIRED(NotificationGroup.LISTING_STATUS),
     LISTING_CANCELLED_BY_SELLER(NotificationGroup.LISTING_STATUS),
     LISTING_REMOVED_BY_ADMIN(NotificationGroup.LISTING_STATUS),
+    LISTING_WARNED(NotificationGroup.LISTING_STATUS),
     REVIEW_RECEIVED(NotificationGroup.REVIEWS),
     SYSTEM_ANNOUNCEMENT(NotificationGroup.SYSTEM);
 

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationCategory.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationCategory.java
@@ -22,6 +22,7 @@ public enum NotificationCategory {
     LISTING_REINSTATED(NotificationGroup.LISTING_STATUS),
     LISTING_REVIEW_REQUIRED(NotificationGroup.LISTING_STATUS),
     LISTING_CANCELLED_BY_SELLER(NotificationGroup.LISTING_STATUS),
+    LISTING_REMOVED_BY_ADMIN(NotificationGroup.LISTING_STATUS),
     REVIEW_RECEIVED(NotificationGroup.REVIEWS),
     SYSTEM_ANNOUNCEMENT(NotificationGroup.SYSTEM);
 

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationDataBuilder.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationDataBuilder.java
@@ -147,6 +147,12 @@ public final class NotificationDataBuilder {
         return m;
     }
 
+    public static Map<String, Object> listingWarned(long auctionId, String parcelName, String notes) {
+        Map<String, Object> m = base(auctionId, parcelName);
+        m.put("notes", notes);
+        return m;
+    }
+
     private static Map<String, Object> base(long auctionId, String parcelName) {
         Map<String, Object> m = new LinkedHashMap<>();
         m.put("auctionId", auctionId);

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationDataBuilder.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationDataBuilder.java
@@ -141,6 +141,12 @@ public final class NotificationDataBuilder {
         return m;
     }
 
+    public static Map<String, Object> listingRemovedByAdmin(long auctionId, String parcelName, String reason) {
+        Map<String, Object> m = base(auctionId, parcelName);
+        m.put("reason", reason);
+        return m;
+    }
+
     private static Map<String, Object> base(long auctionId, String parcelName) {
         Map<String, Object> m = new LinkedHashMap<>();
         m.put("auctionId", auctionId);

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisher.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisher.java
@@ -42,6 +42,9 @@ public interface NotificationPublisher {
     void listingReinstated(long sellerUserId, long auctionId, String parcelName, OffsetDateTime newEndsAt);
     void listingReviewRequired(long sellerUserId, long auctionId, String parcelName, String reason);
 
+    // Listing status — admin-facing actions
+    void listingRemovedByAdmin(long sellerUserId, long auctionId, String parcelName, String reason);
+
     // Reviews
     void reviewReceived(long revieweeUserId, long reviewId, long auctionId,
                         String parcelName, int rating);

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisher.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisher.java
@@ -44,6 +44,7 @@ public interface NotificationPublisher {
 
     // Listing status — admin-facing actions
     void listingRemovedByAdmin(long sellerUserId, long auctionId, String parcelName, String reason);
+    void listingWarned(long sellerUserId, long auctionId, String parcelName, String notes);
 
     // Reviews
     void reviewReceived(long revieweeUserId, long reviewId, long auctionId,

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java
@@ -261,6 +261,17 @@ public class NotificationPublisherImpl implements NotificationPublisher {
     }
 
     @Override
+    public void listingRemovedByAdmin(long sellerUserId, long auctionId, String parcelName, String reason) {
+        String title = "Listing removed: " + parcelName;
+        String body = "Your listing has been removed by SLPA staff. Reason: " + reason + ".";
+        notificationService.publish(new NotificationEvent(
+            sellerUserId, NotificationCategory.LISTING_REMOVED_BY_ADMIN, title, body,
+            NotificationDataBuilder.listingRemovedByAdmin(auctionId, parcelName, reason),
+            null
+        ));
+    }
+
+    @Override
     public void listingReinstated(long sellerUserId, long auctionId, String parcelName, OffsetDateTime newEndsAt) {
         String title = "Listing reinstated: " + parcelName;
         String body = "Your auction has been reinstated. All existing bids and proxy maxes are preserved. "
@@ -298,9 +309,10 @@ public class NotificationPublisherImpl implements NotificationPublisher {
     @Override
     public void listingCancelledBySellerFanout(long auctionId, List<Long> bidderUserIds,
                                                 String parcelName, String reason) {
+        // Cause-neutral copy — applies to both seller-driven cancel and admin-driven cancel.
         Map<String, Object> data = NotificationDataBuilder.listingCancelledBySeller(auctionId, parcelName, reason);
-        String title = "Listing cancelled: " + parcelName;
-        String body = "The seller cancelled this listing. Reason: " + reason + ".";
+        String title = "Auction cancelled: " + parcelName;
+        String body = "This auction has been cancelled. Your active proxy bid is no longer in effect. Reason: " + reason + ".";
 
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java
@@ -272,6 +272,17 @@ public class NotificationPublisherImpl implements NotificationPublisher {
     }
 
     @Override
+    public void listingWarned(long sellerUserId, long auctionId, String parcelName, String notes) {
+        String title = "Warning on your listing: " + parcelName;
+        String body = "An admin has reviewed reports on this listing and issued a warning. Notes: " + notes;
+        notificationService.publish(new NotificationEvent(
+            sellerUserId, NotificationCategory.LISTING_WARNED, title, body,
+            NotificationDataBuilder.listingWarned(auctionId, parcelName, notes),
+            null
+        ));
+    }
+
+    @Override
     public void listingReinstated(long sellerUserId, long auctionId, String parcelName, OffsetDateTime newEndsAt) {
         String title = "Listing reinstated: " + parcelName;
         String body = "Your auction has been reinstated. All existing bids and proxy maxes are preserved. "

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImLinkResolver.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImLinkResolver.java
@@ -26,6 +26,7 @@ public class SlImLinkResolver {
                  AUCTION_ENDED_RESERVE_NOT_MET, AUCTION_ENDED_NO_BIDS,
                  AUCTION_ENDED_BOUGHT_NOW, AUCTION_ENDED_SOLD,
                  LISTING_VERIFIED, LISTING_CANCELLED_BY_SELLER,
+                 LISTING_REMOVED_BY_ADMIN,
                  REVIEW_RECEIVED ->
                 base + "/auction/" + data.get("auctionId");
             case AUCTION_WON ->

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImLinkResolver.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImLinkResolver.java
@@ -26,7 +26,7 @@ public class SlImLinkResolver {
                  AUCTION_ENDED_RESERVE_NOT_MET, AUCTION_ENDED_NO_BIDS,
                  AUCTION_ENDED_BOUGHT_NOW, AUCTION_ENDED_SOLD,
                  LISTING_VERIFIED, LISTING_CANCELLED_BY_SELLER,
-                 LISTING_REMOVED_BY_ADMIN,
+                 LISTING_REMOVED_BY_ADMIN, LISTING_WARNED,
                  REVIEW_RECEIVED ->
                 base + "/auction/" + data.get("auctionId");
             case AUCTION_WON ->

--- a/backend/src/main/java/com/slparcelauctions/backend/sl/SlVerificationService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/sl/SlVerificationService.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.slparcelauctions.backend.admin.ban.BanCheckService;
 import com.slparcelauctions.backend.sl.dto.SlVerifyRequest;
 import com.slparcelauctions.backend.sl.dto.SlVerifyResponse;
 import com.slparcelauctions.backend.sl.exception.AvatarAlreadyLinkedException;
@@ -49,12 +50,14 @@ public class SlVerificationService {
     private final VerificationCodeService verificationCodeService;
     private final UserRepository userRepository;
     private final SlHeaderValidator headerValidator;
+    private final BanCheckService banCheckService;
     private final Clock clock;
 
     @Transactional(noRollbackFor = CodeCollisionException.class)
     public SlVerifyResponse verify(
             String shardHeader, String ownerKeyHeader, SlVerifyRequest body) {
         headerValidator.validate(shardHeader, ownerKeyHeader);
+        banCheckService.assertNotBanned(null, body.avatarUuid());
 
         Optional<User> existingLinked = userRepository.findBySlAvatarUuid(body.avatarUuid());
         if (existingLinked.isPresent()) {

--- a/backend/src/main/java/com/slparcelauctions/backend/user/User.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/User.java
@@ -170,6 +170,25 @@ public class User {
             columnDefinition = "boolean not null default false")
     private Boolean bannedFromListing = false;
 
+    /**
+     * Count of listing reports submitted by this user that were dismissed by
+     * admins (Epic 10 sub-spec 2 §5). Used as a frivolous-reporter signal:
+     * high dismissed counts may be surfaced in the admin queue to flag repeat
+     * low-quality reporters. Incremented inside
+     * {@code AdminReportService.dismissReport} when a report transitions to
+     * {@code DISMISSED}. Never decremented.
+     *
+     * <p>The {@code columnDefinition} supplies a SQL-side default so
+     * Hibernate's {@code ddl-auto: update} can add this NOT NULL column to
+     * existing rows on local dev databases without failing. The
+     * {@code @Builder.Default} handles the Java-side default for newly-
+     * constructed entities.
+     */
+    @Builder.Default
+    @Column(name = "dismissed_reports_count", nullable = false,
+            columnDefinition = "bigint not null default 0")
+    private Long dismissedReportsCount = 0L;
+
     @Builder.Default
     @Column(name = "email_verified", nullable = false)
     private Boolean emailVerified = false;

--- a/backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java
@@ -60,4 +60,14 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("UPDATE User u SET u.role = com.slparcelauctions.backend.user.Role.ADMIN " +
            "WHERE u.email IN :emails AND u.role = com.slparcelauctions.backend.user.Role.USER")
     int bulkPromoteByEmailIfUser(@Param("emails") List<String> emails);
+
+    /**
+     * Atomically increments {@code tokenVersion} for the given user, invalidating
+     * all live access tokens within their 15-minute window. Called on AVATAR/BOTH
+     * ban creation to force re-authentication of the banned user's active sessions.
+     */
+    @Modifying
+    @Transactional
+    @Query("UPDATE User u SET u.tokenVersion = u.tokenVersion + 1 WHERE u.id = :userId")
+    int bumpTokenVersion(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
@@ -70,4 +72,16 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Transactional
     @Query("UPDATE User u SET u.tokenVersion = u.tokenVersion + 1 WHERE u.id = :userId")
     int bumpTokenVersion(@Param("userId") Long userId);
+
+    @Query("""
+        SELECT u FROM User u
+        WHERE (:uuid IS NOT NULL AND u.slAvatarUuid = :uuid)
+           OR (:uuid IS NULL AND :search IS NOT NULL AND
+               (LOWER(u.email) LIKE LOWER(CONCAT('%', :search, '%'))
+                OR LOWER(COALESCE(u.displayName, '')) LIKE LOWER(CONCAT('%', :search, '%'))
+                OR LOWER(COALESCE(u.slDisplayName, '')) LIKE LOWER(CONCAT('%', :search, '%'))))
+           OR (:search IS NULL AND :uuid IS NULL)
+        ORDER BY u.createdAt DESC
+        """)
+    Page<User> searchAdmin(@Param("search") String search, @Param("uuid") UUID uuidOrNull, Pageable pageable);
 }

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/AdminAuctionControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/AdminAuctionControllerSliceTest.java
@@ -1,0 +1,144 @@
+package com.slparcelauctions.backend.admin;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.slparcelauctions.backend.admin.AdminAuctionService.AdminAuctionReinstateResult;
+import com.slparcelauctions.backend.admin.audit.AdminActionService;
+import com.slparcelauctions.backend.admin.audit.AdminActionTargetType;
+import com.slparcelauctions.backend.admin.audit.AdminActionType;
+import com.slparcelauctions.backend.admin.exception.AuctionNotSuspendedException;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class AdminAuctionControllerSliceTest {
+
+    @Autowired MockMvc mvc;
+    @Autowired JwtService jwtService;
+
+    @MockitoBean AdminAuctionService adminAuctionService;
+    @MockitoBean AdminActionService adminActionService;
+
+    private String adminToken() {
+        return jwtService.issueAccessToken(new AuthPrincipal(99L, "admin@x.com", 1L, Role.ADMIN));
+    }
+
+    private String userToken() {
+        return jwtService.issueAccessToken(new AuthPrincipal(5L, "user@x.com", 1L, Role.USER));
+    }
+
+    @Test
+    void reinstate_anonymous_returns401() throws Exception {
+        mvc.perform(post("/api/v1/admin/auctions/100/reinstate")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"notes\":\"some notes\"}"))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void reinstate_userRole_returns403() throws Exception {
+        mvc.perform(post("/api/v1/admin/auctions/100/reinstate")
+            .header("Authorization", "Bearer " + userToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"notes\":\"some notes\"}"))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void reinstate_emptyNotes_returns400() throws Exception {
+        mvc.perform(post("/api/v1/admin/auctions/100/reinstate")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"notes\":\"\"}"))
+           .andExpect(status().isBadRequest())
+           .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"));
+    }
+
+    @Test
+    void reinstate_notSuspended_returns409() throws Exception {
+        when(adminAuctionService.reinstate(eq(100L), any()))
+            .thenThrow(new AuctionNotSuspendedException(AuctionStatus.CANCELLED));
+
+        mvc.perform(post("/api/v1/admin/auctions/100/reinstate")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"notes\":\"verified\"}"))
+           .andExpect(status().isConflict())
+           .andExpect(jsonPath("$.code").value("AUCTION_NOT_SUSPENDED"))
+           .andExpect(jsonPath("$.details.currentStatus").value("CANCELLED"));
+    }
+
+    @Test
+    void reinstate_admin_returns200_writesAudit() throws Exception {
+        OffsetDateTime newEndsAt = OffsetDateTime.now().plusHours(8);
+        User seller = User.builder().id(7L).email("seller@x.com").passwordHash("x").displayName("Seller").build();
+        Auction auction = Auction.builder()
+            .id(100L)
+            .status(AuctionStatus.ACTIVE)
+            .endsAt(newEndsAt)
+            .title("Test Auction")
+            .seller(seller)
+            .consecutiveWorldApiFailures(0)
+            .build();
+        AdminAuctionReinstateResult mockResult =
+            new AdminAuctionReinstateResult(auction, Duration.ofHours(6), newEndsAt);
+
+        when(adminAuctionService.reinstate(eq(100L), eq(Optional.empty()))).thenReturn(mockResult);
+
+        mvc.perform(post("/api/v1/admin/auctions/100/reinstate")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"notes\":\"verified\"}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.auctionId").value(100))
+           .andExpect(jsonPath("$.status").value("ACTIVE"))
+           .andExpect(jsonPath("$.suspensionDurationSeconds").value(21600));
+
+        verify(adminActionService).record(
+            eq(99L),
+            eq(AdminActionType.REINSTATE_LISTING),
+            eq(AdminActionTargetType.LISTING),
+            eq(100L),
+            eq("verified"),
+            isNull());
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/AdminAuctionReinstateIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/AdminAuctionReinstateIntegrationTest.java
@@ -1,0 +1,209 @@
+package com.slparcelauctions.backend.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.slparcelauctions.backend.admin.audit.AdminActionRepository;
+import com.slparcelauctions.backend.admin.audit.AdminActionService;
+import com.slparcelauctions.backend.admin.audit.AdminActionTargetType;
+import com.slparcelauctions.backend.admin.audit.AdminActionType;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.VerificationMethod;
+import com.slparcelauctions.backend.auction.VerificationTier;
+import com.slparcelauctions.backend.notification.Notification;
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationRepository;
+import com.slparcelauctions.backend.notification.NotificationWsBroadcasterPort;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.parcel.ParcelRepository;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class AdminAuctionReinstateIntegrationTest {
+
+    @Autowired AdminAuctionService adminAuctionService;
+    @Autowired AdminActionService adminActionService;
+    @Autowired AuctionRepository auctionRepo;
+    @Autowired ParcelRepository parcelRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired NotificationRepository notificationRepo;
+    @Autowired AdminActionRepository adminActionRepo;
+    @Autowired PlatformTransactionManager txManager;
+    @Autowired DataSource dataSource;
+
+    @MockitoBean NotificationWsBroadcasterPort wsBroadcaster;
+
+    private Long sellerId;
+    private Long adminId;
+    private Long parcelId;
+    private Long auctionId;
+
+    @BeforeEach
+    void seed() {
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            User seller = userRepo.save(User.builder()
+                .email("reinstate-auction-int-seller-" + UUID.randomUUID() + "@x.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("Reinstate Auction Int Seller")
+                .build());
+            sellerId = seller.getId();
+
+            User admin = userRepo.save(User.builder()
+                .email("reinstate-auction-int-admin-" + UUID.randomUUID() + "@x.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("Reinstate Auction Int Admin")
+                .role(Role.ADMIN)
+                .build());
+            adminId = admin.getId();
+
+            Parcel parcel = parcelRepo.save(Parcel.builder()
+                .slParcelUuid(UUID.randomUUID())
+                .regionName("ReinstateAuctionIntRegion")
+                .ownerUuid(seller.getSlAvatarUuid())
+                .ownerType("agent")
+                .areaSqm(1024)
+                .maturityRating("MODERATE")
+                .positionX(128.0)
+                .positionY(64.0)
+                .positionZ(22.0)
+                .continentName("Sansara")
+                .verified(true)
+                .verifiedAt(OffsetDateTime.now())
+                .build());
+            parcelId = parcel.getId();
+
+            OffsetDateTime now = OffsetDateTime.now();
+            Auction auction = auctionRepo.save(Auction.builder()
+                .seller(seller)
+                .parcel(parcel)
+                .title("Admin Reinstate Integration Auction")
+                .status(AuctionStatus.SUSPENDED)
+                .verificationTier(VerificationTier.BOT)
+                .verificationMethod(VerificationMethod.SALE_TO_BOT)
+                .verifiedAt(now)
+                .startingBid(1_000L)
+                .durationHours(168)
+                .snipeProtect(false)
+                .listingFeePaid(true)
+                .listingFeeAmt(100L)
+                .currentBid(0L)
+                .bidCount(0)
+                .consecutiveWorldApiFailures(0)
+                .commissionRate(new BigDecimal("0.05"))
+                .agentFeeRate(BigDecimal.ZERO)
+                .startsAt(now.minusHours(2))
+                .endsAt(now.plusHours(2))
+                .originalEndsAt(now.plusHours(2))
+                .suspendedAt(now.minusHours(3))
+                .createdAt(now)
+                .updatedAt(now)
+                .build());
+            auctionId = auction.getId();
+        });
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var st = conn.createStatement()) {
+                if (auctionId != null) {
+                    st.execute("DELETE FROM bot_tasks WHERE auction_id = " + auctionId);
+                    st.execute("DELETE FROM admin_actions WHERE target_type = 'LISTING' AND target_id = " + auctionId);
+                    st.execute("DELETE FROM auction_tags WHERE auction_id = " + auctionId);
+                    st.execute("DELETE FROM auctions WHERE id = " + auctionId);
+                }
+                if (parcelId != null) {
+                    st.execute("DELETE FROM parcels WHERE id = " + parcelId);
+                }
+                if (sellerId != null) {
+                    st.execute("DELETE FROM notification WHERE user_id = " + sellerId);
+                    st.execute("DELETE FROM sl_im_message WHERE user_id = " + sellerId);
+                    st.execute("DELETE FROM refresh_tokens WHERE user_id = " + sellerId);
+                    st.execute("DELETE FROM users WHERE id = " + sellerId);
+                }
+                if (adminId != null) {
+                    st.execute("DELETE FROM admin_actions WHERE admin_user_id = " + adminId);
+                    st.execute("DELETE FROM notification WHERE user_id = " + adminId);
+                    st.execute("DELETE FROM refresh_tokens WHERE user_id = " + adminId);
+                    st.execute("DELETE FROM users WHERE id = " + adminId);
+                }
+            }
+        }
+        sellerId = null;
+        adminId = null;
+        parcelId = null;
+        auctionId = null;
+    }
+
+    @Test
+    void reinstate_fullFlow_flipsActive_clearsSuspendedAt_publishesNotification_writesAdminAction() {
+        // Call service.reinstate (the shared primitive) then adminActionService.record (as controller does)
+        adminAuctionService.reinstate(auctionId, Optional.empty());
+        adminActionService.record(adminId,
+            AdminActionType.REINSTATE_LISTING,
+            AdminActionTargetType.LISTING,
+            auctionId,
+            "Admin reinstated from user-detail page",
+            null);
+
+        // Auction: status = ACTIVE, suspendedAt = null
+        Auction auction = auctionRepo.findById(auctionId).orElseThrow();
+        assertThat(auction.getStatus()).isEqualTo(AuctionStatus.ACTIVE);
+        assertThat(auction.getSuspendedAt()).isNull();
+
+        // Notification: LISTING_REINSTATED for seller
+        List<Notification> notifications = notificationRepo.findAll().stream()
+            .filter(n -> n.getUser().getId().equals(sellerId))
+            .filter(n -> n.getCategory() == NotificationCategory.LISTING_REINSTATED)
+            .toList();
+        assertThat(notifications).hasSize(1);
+        assertThat(notifications.get(0).getTitle()).contains("Admin Reinstate Integration Auction");
+
+        // AdminAction row: REINSTATE_LISTING + LISTING + auctionId
+        var actions = adminActionRepo.findByTargetTypeAndTargetIdOrderByCreatedAtDesc(
+            AdminActionTargetType.LISTING, auctionId, org.springframework.data.domain.Pageable.unpaged());
+        assertThat(actions.getContent()).hasSize(1);
+        var action = actions.getContent().get(0);
+        assertThat(action.getActionType()).isEqualTo(AdminActionType.REINSTATE_LISTING);
+        assertThat(action.getTargetType()).isEqualTo(AdminActionTargetType.LISTING);
+        assertThat(action.getTargetId()).isEqualTo(auctionId);
+        assertThat(action.getAdminUser().getId()).isEqualTo(adminId);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/AdminAuctionServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/AdminAuctionServiceTest.java
@@ -1,0 +1,181 @@
+package com.slparcelauctions.backend.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.slparcelauctions.backend.admin.AdminAuctionService.AdminAuctionReinstateResult;
+import com.slparcelauctions.backend.admin.exception.AuctionNotSuspendedException;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.bot.BotMonitorLifecycleService;
+import com.slparcelauctions.backend.notification.NotificationPublisher;
+import com.slparcelauctions.backend.user.User;
+
+@ExtendWith(MockitoExtension.class)
+class AdminAuctionServiceTest {
+
+    @Mock AuctionRepository auctionRepo;
+    @Mock BotMonitorLifecycleService botMonitorLifecycleService;
+    @Mock NotificationPublisher notificationPublisher;
+
+    // Fixed clock: "now" = 2025-01-01T12:00:00Z
+    private static final Instant NOW_INSTANT = Instant.parse("2025-01-01T12:00:00Z");
+    private static final OffsetDateTime NOW = OffsetDateTime.ofInstant(NOW_INSTANT, ZoneOffset.UTC);
+
+    private AdminAuctionService service;
+
+    @BeforeEach
+    void setUp() {
+        Clock fixed = Clock.fixed(NOW_INSTANT, ZoneOffset.UTC);
+        service = new AdminAuctionService(auctionRepo, botMonitorLifecycleService, notificationPublisher, fixed);
+    }
+
+    private User seller() {
+        return User.builder().id(7L).email("seller@x.com").passwordHash("x").displayName("Seller").build();
+    }
+
+    @Test
+    void reinstate_happyPath_extendsEndsAt_withSuspendedAt() {
+        // suspendedAt = now - 6h, endsAt = now + 2h → new endsAt = now + 8h
+        OffsetDateTime suspendedAt = NOW.minusHours(6);
+        OffsetDateTime originalEndsAt = NOW.plusHours(2);
+        Auction auction = Auction.builder()
+            .id(100L)
+            .status(AuctionStatus.SUSPENDED)
+            .suspendedAt(suspendedAt)
+            .endsAt(originalEndsAt)
+            .title("Test Auction")
+            .seller(seller())
+            .consecutiveWorldApiFailures(0)
+            .build();
+
+        when(auctionRepo.findByIdForUpdate(100L)).thenReturn(Optional.of(auction));
+        when(auctionRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        AdminAuctionReinstateResult result = service.reinstate(100L, Optional.empty());
+
+        assertThat(result.auction().getStatus()).isEqualTo(AuctionStatus.ACTIVE);
+        assertThat(result.auction().getSuspendedAt()).isNull();
+        // suspension was 6h, so endsAt extends by 6h: now+2h + 6h = now+8h
+        assertThat(result.newEndsAt()).isEqualTo(NOW.plusHours(8));
+        assertThat(result.suspensionDuration().toHours()).isEqualTo(6L);
+
+        verify(botMonitorLifecycleService).onAuctionResumed(auction);
+        verify(notificationPublisher).listingReinstated(eq(7L), eq(100L), eq("Test Auction"), eq(NOW.plusHours(8)));
+    }
+
+    @Test
+    void reinstate_fallbackUsedWhenSuspendedAtNull() {
+        // suspendedAt = null, fallback = now - 3h, endsAt = now + 4h → new endsAt = now + 7h
+        OffsetDateTime fallback = NOW.minusHours(3);
+        OffsetDateTime originalEndsAt = NOW.plusHours(4);
+        Auction auction = Auction.builder()
+            .id(101L)
+            .status(AuctionStatus.SUSPENDED)
+            .suspendedAt(null)
+            .endsAt(originalEndsAt)
+            .title("Fallback Auction")
+            .seller(seller())
+            .consecutiveWorldApiFailures(0)
+            .build();
+
+        when(auctionRepo.findByIdForUpdate(101L)).thenReturn(Optional.of(auction));
+        when(auctionRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        AdminAuctionReinstateResult result = service.reinstate(101L, Optional.of(fallback));
+
+        // suspensionDuration = 3h, endsAt = now+4h + 3h = now+7h
+        assertThat(result.newEndsAt()).isEqualTo(NOW.plusHours(7));
+        assertThat(result.suspensionDuration().toHours()).isEqualTo(3L);
+        assertThat(result.auction().getStatus()).isEqualTo(AuctionStatus.ACTIVE);
+    }
+
+    @Test
+    void reinstate_zeroExtensionWhenBothNull() {
+        // suspendedAt = null, fallback = empty → suspendedFrom = now → duration = 0 → endsAt unchanged
+        OffsetDateTime originalEndsAt = NOW.plusHours(10);
+        Auction auction = Auction.builder()
+            .id(102L)
+            .status(AuctionStatus.SUSPENDED)
+            .suspendedAt(null)
+            .endsAt(originalEndsAt)
+            .title("Zero Extension Auction")
+            .seller(seller())
+            .consecutiveWorldApiFailures(0)
+            .build();
+
+        when(auctionRepo.findByIdForUpdate(102L)).thenReturn(Optional.of(auction));
+        when(auctionRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        AdminAuctionReinstateResult result = service.reinstate(102L, Optional.empty());
+
+        // duration = 0, newEndsAt = originalEndsAt (not before now, so no clamp)
+        assertThat(result.suspensionDuration().toSeconds()).isEqualTo(0L);
+        assertThat(result.newEndsAt()).isEqualTo(originalEndsAt);
+    }
+
+    @Test
+    void reinstate_clampsPastEndsAt_toNowPlus1h() {
+        // suspendedAt = now - 6h, endsAt = now - 8h → newEndsAt = now-8h+6h = now-2h (past) → clamp to now+1h
+        OffsetDateTime suspendedAt = NOW.minusHours(6);
+        OffsetDateTime originalEndsAt = NOW.minusHours(8);
+        Auction auction = Auction.builder()
+            .id(103L)
+            .status(AuctionStatus.SUSPENDED)
+            .suspendedAt(suspendedAt)
+            .endsAt(originalEndsAt)
+            .title("Clamp Auction")
+            .seller(seller())
+            .consecutiveWorldApiFailures(0)
+            .build();
+
+        when(auctionRepo.findByIdForUpdate(103L)).thenReturn(Optional.of(auction));
+        when(auctionRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        AdminAuctionReinstateResult result = service.reinstate(103L, Optional.empty());
+
+        // newEndsAt = now-8h + 6h = now-2h → before now → clamp to now+1h
+        assertThat(result.newEndsAt()).isEqualTo(NOW.plusHours(1));
+    }
+
+    @Test
+    void reinstate_throwsWhenNotSuspended() {
+        Auction auction = Auction.builder()
+            .id(104L)
+            .status(AuctionStatus.CANCELLED)
+            .endsAt(NOW.plusHours(1))
+            .title("Cancelled Auction")
+            .seller(seller())
+            .consecutiveWorldApiFailures(0)
+            .build();
+
+        when(auctionRepo.findByIdForUpdate(104L)).thenReturn(Optional.of(auction));
+
+        assertThatThrownBy(() -> service.reinstate(104L, Optional.empty()))
+            .isInstanceOf(AuctionNotSuspendedException.class)
+            .hasMessageContaining("CANCELLED");
+
+        verify(auctionRepo, never()).save(any());
+        verify(botMonitorLifecycleService, never()).onAuctionResumed(any());
+        verify(notificationPublisher, never()).listingReinstated(anyLong(), anyLong(), any(), any());
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/AdminStatsControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/AdminStatsControllerSliceTest.java
@@ -60,7 +60,7 @@ class AdminStatsControllerSliceTest {
     @Test
     void stats_adminRole_returns200_withPayload() throws Exception {
         AdminStatsResponse fixture = new AdminStatsResponse(
-            new QueueStats(7L, 3L, 1L),
+            new QueueStats(7L, 5L, 3L, 1L),
             new PlatformStats(42L, 381L, 12L, 156L, 4_827_500L, 241_375L)
         );
         when(statsService.compute()).thenReturn(fixture);
@@ -71,6 +71,7 @@ class AdminStatsControllerSliceTest {
             .header("Authorization", "Bearer " + token))
            .andExpect(status().isOk())
            .andExpect(jsonPath("$.queues.openFraudFlags").value(7))
+           .andExpect(jsonPath("$.queues.openReports").value(5))
            .andExpect(jsonPath("$.queues.pendingPayments").value(3))
            .andExpect(jsonPath("$.queues.activeDisputes").value(1))
            .andExpect(jsonPath("$.platform.activeListings").value(42))

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/AdminStatsIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/AdminStatsIntegrationTest.java
@@ -205,9 +205,10 @@ class AdminStatsIntegrationTest {
     void compute_returnsCorrectQueueAndPlatformCounts() {
         AdminStatsResponse stats = statsService.compute();
 
-        // Queue: 1 ESCROW_PENDING, 0 DISPUTED, 0 open fraud flags (none seeded)
+        // Queue: 1 ESCROW_PENDING, 0 DISPUTED, 0 open fraud flags, 0 open reports (none seeded)
         assertThat(stats.queues().pendingPayments()).isGreaterThanOrEqualTo(1L);
         assertThat(stats.queues().activeDisputes()).isGreaterThanOrEqualTo(0L);
+        assertThat(stats.queues().openReports()).isGreaterThanOrEqualTo(0L);
 
         // Platform: exactly 2 ACTIVE auctions seeded
         assertThat(stats.platform().activeListings()).isGreaterThanOrEqualTo(2L);

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/AdminStatsServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/AdminStatsServiceTest.java
@@ -13,6 +13,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.slparcelauctions.backend.admin.dto.AdminStatsResponse;
+import com.slparcelauctions.backend.admin.reports.ListingReportRepository;
+import com.slparcelauctions.backend.admin.reports.ListingReportStatus;
 import com.slparcelauctions.backend.auction.AuctionRepository;
 import com.slparcelauctions.backend.auction.AuctionStatus;
 import com.slparcelauctions.backend.auction.fraud.FraudFlagRepository;
@@ -27,12 +29,14 @@ class AdminStatsServiceTest {
     @Mock AuctionRepository auctionRepository;
     @Mock EscrowRepository escrowRepository;
     @Mock FraudFlagRepository fraudFlagRepository;
+    @Mock ListingReportRepository listingReportRepository;
 
     @InjectMocks AdminStatsService service;
 
     @Test
-    void compute_assemblesAllNineNumbers() {
+    void compute_assemblesAllTenNumbers() {
         when(fraudFlagRepository.countByResolved(false)).thenReturn(7L);
+        when(listingReportRepository.countByStatus(ListingReportStatus.OPEN)).thenReturn(5L);
         when(escrowRepository.countByState(EscrowState.ESCROW_PENDING)).thenReturn(3L);
         when(escrowRepository.countByState(EscrowState.DISPUTED)).thenReturn(1L);
         when(auctionRepository.countByStatus(AuctionStatus.ACTIVE)).thenReturn(42L);
@@ -45,6 +49,7 @@ class AdminStatsServiceTest {
         AdminStatsResponse result = service.compute();
 
         assertThat(result.queues().openFraudFlags()).isEqualTo(7L);
+        assertThat(result.queues().openReports()).isEqualTo(5L);
         assertThat(result.queues().pendingPayments()).isEqualTo(3L);
         assertThat(result.queues().activeDisputes()).isEqualTo(1L);
         assertThat(result.platform().activeListings()).isEqualTo(42L);
@@ -61,6 +66,7 @@ class AdminStatsServiceTest {
             EscrowState.COMPLETED, EscrowState.EXPIRED,
             EscrowState.DISPUTED, EscrowState.FROZEN);
         when(fraudFlagRepository.countByResolved(false)).thenReturn(0L);
+        when(listingReportRepository.countByStatus(any())).thenReturn(0L);
         when(escrowRepository.countByState(any())).thenReturn(0L);
         when(auctionRepository.countByStatus(any())).thenReturn(0L);
         when(userRepository.count()).thenReturn(0L);

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/audit/AdminActionRepositoryTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/audit/AdminActionRepositoryTest.java
@@ -1,0 +1,136 @@
+package com.slparcelauctions.backend.admin.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class AdminActionRepositoryTest {
+
+    @Autowired AdminActionService adminActionService;
+    @Autowired AdminActionRepository adminActionRepository;
+    @Autowired UserRepository userRepository;
+
+    private Long adminId;
+    private List<Long> actionIds;
+
+    @BeforeEach
+    void seed() {
+        String suffix = UUID.randomUUID().toString();
+        User admin = userRepository.save(User.builder()
+            .email("audit-admin-" + suffix + "@x.com")
+            .passwordHash("x")
+            .role(Role.ADMIN)
+            .tokenVersion(1L)
+            .build());
+        adminId = admin.getId();
+
+        AdminAction a1 = adminActionService.record(
+            adminId,
+            AdminActionType.CREATE_BAN,
+            AdminActionTargetType.USER,
+            101L,
+            "first action",
+            null
+        );
+        AdminAction a2 = adminActionService.record(
+            adminId,
+            AdminActionType.LIFT_BAN,
+            AdminActionTargetType.USER,
+            101L,
+            "second action",
+            null
+        );
+        AdminAction a3 = adminActionService.record(
+            adminId,
+            AdminActionType.PROMOTE_USER,
+            AdminActionTargetType.USER,
+            202L,
+            "different target",
+            null
+        );
+
+        actionIds = List.of(a1.getId(), a2.getId(), a3.getId());
+    }
+
+    @AfterEach
+    void cleanup() {
+        if (actionIds != null) {
+            actionIds.forEach(id -> adminActionRepository.findById(id).ifPresent(adminActionRepository::delete));
+        }
+        if (adminId != null) {
+            userRepository.findById(adminId).ifPresent(userRepository::delete);
+        }
+    }
+
+    @Test
+    void findByTargetTypeAndTargetId_returnsOnlyMatchingRows_newestFirst() {
+        Page<AdminAction> page = adminActionRepository.findByTargetTypeAndTargetIdOrderByCreatedAtDesc(
+            AdminActionTargetType.USER,
+            101L,
+            PageRequest.of(0, 10)
+        );
+
+        assertThat(page.getTotalElements()).isEqualTo(2);
+        List<AdminAction> content = page.getContent();
+        assertThat(content).hasSize(2);
+        assertThat(content.get(0).getCreatedAt()).isAfterOrEqualTo(content.get(1).getCreatedAt());
+        assertThat(content).allMatch(a -> a.getTargetId().equals(101L));
+        assertThat(content).allMatch(a -> a.getTargetType() == AdminActionTargetType.USER);
+    }
+
+    @Test
+    void findByAdminUserId_returnsAllActionsForAdmin_newestFirst() {
+        Page<AdminAction> page = adminActionRepository.findByAdminUserIdOrderByCreatedAtDesc(
+            adminId,
+            PageRequest.of(0, 10)
+        );
+
+        assertThat(page.getTotalElements()).isGreaterThanOrEqualTo(3);
+        List<AdminAction> content = page.getContent();
+        for (int i = 0; i < content.size() - 1; i++) {
+            assertThat(content.get(i).getCreatedAt())
+                .isAfterOrEqualTo(content.get(i + 1).getCreatedAt());
+        }
+        assertThat(content).allMatch(a -> a.getAdminUser().getId().equals(adminId));
+    }
+
+    @Test
+    void record_withNullDetails_storesEmptyMap() {
+        Page<AdminAction> page = adminActionRepository.findByTargetTypeAndTargetIdOrderByCreatedAtDesc(
+            AdminActionTargetType.USER,
+            101L,
+            PageRequest.of(0, 10)
+        );
+
+        assertThat(page.getContent())
+            .allMatch(a -> a.getDetails() != null && a.getDetails().isEmpty());
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/audit/AdminActionServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/audit/AdminActionServiceTest.java
@@ -1,0 +1,94 @@
+package com.slparcelauctions.backend.admin.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AdminActionServiceTest {
+
+    @Mock AdminActionRepository repository;
+    @Mock UserRepository userRepository;
+
+    @InjectMocks AdminActionService service;
+
+    @Test
+    void record_buildsRowAndSaves() {
+        User admin = User.builder().id(42L).email("admin@x.com").passwordHash("x").build();
+        when(userRepository.findById(42L)).thenReturn(Optional.of(admin));
+
+        AdminAction saved = AdminAction.builder()
+            .id(1L)
+            .adminUser(admin)
+            .actionType(AdminActionType.CREATE_BAN)
+            .targetType(AdminActionTargetType.USER)
+            .targetId(99L)
+            .notes("banned for abuse")
+            .details(Map.of("reason", "spam"))
+            .build();
+        when(repository.save(any())).thenReturn(saved);
+
+        ArgumentCaptor<AdminAction> captor = ArgumentCaptor.forClass(AdminAction.class);
+
+        AdminAction result = service.record(
+            42L,
+            AdminActionType.CREATE_BAN,
+            AdminActionTargetType.USER,
+            99L,
+            "banned for abuse",
+            Map.of("reason", "spam")
+        );
+
+        verify(repository).save(captor.capture());
+        AdminAction captured = captor.getValue();
+
+        assertThat(captured.getAdminUser()).isEqualTo(admin);
+        assertThat(captured.getActionType()).isEqualTo(AdminActionType.CREATE_BAN);
+        assertThat(captured.getTargetType()).isEqualTo(AdminActionTargetType.USER);
+        assertThat(captured.getTargetId()).isEqualTo(99L);
+        assertThat(captured.getNotes()).isEqualTo("banned for abuse");
+        assertThat(captured.getDetails()).containsEntry("reason", "spam");
+
+        assertThat(result.getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void record_nullDetails_storedAsEmptyMap() {
+        User admin = User.builder().id(7L).email("admin2@x.com").passwordHash("x").build();
+        when(userRepository.findById(7L)).thenReturn(Optional.of(admin));
+        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        ArgumentCaptor<AdminAction> captor = ArgumentCaptor.forClass(AdminAction.class);
+
+        service.record(7L, AdminActionType.LIFT_BAN, AdminActionTargetType.BAN, 5L, null, null);
+
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getDetails()).isEmpty();
+    }
+
+    @Test
+    void record_adminUserNotFound_throwsIllegalState() {
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+            service.record(999L, AdminActionType.PROMOTE_USER, AdminActionTargetType.USER, 1L, null, null)
+        )
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("999");
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/audit/AdminAuditControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/audit/AdminAuditControllerSliceTest.java
@@ -1,0 +1,135 @@
+package com.slparcelauctions.backend.admin.audit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class AdminAuditControllerSliceTest {
+
+    @Autowired MockMvc mvc;
+    @Autowired JwtService jwtService;
+
+    @MockitoBean AdminActionRepository adminActionRepo;
+
+    private String adminToken() {
+        return jwtService.issueAccessToken(new AuthPrincipal(1L, "admin@x.com", 1L, Role.ADMIN));
+    }
+
+    private String userToken() {
+        return jwtService.issueAccessToken(new AuthPrincipal(2L, "user@x.com", 1L, Role.USER));
+    }
+
+    private AdminAction buildAction() {
+        User admin = User.builder()
+            .email("admin@x.com")
+            .passwordHash("x")
+            .displayName("Admin")
+            .build();
+        return AdminAction.builder()
+            .id(1L)
+            .adminUser(admin)
+            .actionType(AdminActionType.PROMOTE_USER)
+            .targetType(AdminActionTargetType.USER)
+            .targetId(99L)
+            .notes("promoted")
+            .createdAt(OffsetDateTime.now())
+            .build();
+    }
+
+    // -------------------------------------------------------------------------
+    // Auth gates
+    // -------------------------------------------------------------------------
+
+    @Test
+    void list_anon_returns401() throws Exception {
+        mvc.perform(get("/api/v1/admin/audit"))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void list_userRole_returns403() throws Exception {
+        mvc.perform(get("/api/v1/admin/audit")
+            .header("Authorization", "Bearer " + userToken()))
+           .andExpect(status().isForbidden());
+    }
+
+    // -------------------------------------------------------------------------
+    // Response shape
+    // -------------------------------------------------------------------------
+
+    @Test
+    void list_noFilter_admin_returns200_withPagedShape() throws Exception {
+        when(adminActionRepo.findAll(any(org.springframework.data.domain.Pageable.class)))
+            .thenReturn(new PageImpl<>(Collections.emptyList()));
+
+        mvc.perform(get("/api/v1/admin/audit")
+            .header("Authorization", "Bearer " + adminToken()))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.totalElements").value(0))
+           .andExpect(jsonPath("$.content").isArray());
+    }
+
+    @Test
+    void list_filterByTargetTypeAndId_returns200() throws Exception {
+        AdminAction action = buildAction();
+        when(adminActionRepo.findByTargetTypeAndTargetIdOrderByCreatedAtDesc(
+            eq(AdminActionTargetType.USER), eq(99L), any()))
+            .thenReturn(new PageImpl<>(List.of(action)));
+
+        mvc.perform(get("/api/v1/admin/audit?targetType=USER&targetId=99")
+            .header("Authorization", "Bearer " + adminToken()))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.totalElements").value(1))
+           .andExpect(jsonPath("$.content[0].actionType").value("PROMOTE_USER"))
+           .andExpect(jsonPath("$.content[0].adminDisplayName").value("Admin"))
+           .andExpect(jsonPath("$.content[0].notes").value("promoted"));
+    }
+
+    @Test
+    void list_filterByAdminUserId_returns200() throws Exception {
+        AdminAction action = buildAction();
+        when(adminActionRepo.findByAdminUserIdOrderByCreatedAtDesc(eq(1L), any()))
+            .thenReturn(new PageImpl<>(List.of(action)));
+
+        mvc.perform(get("/api/v1/admin/audit?adminUserId=1")
+            .header("Authorization", "Bearer " + adminToken()))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.totalElements").value(1));
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/ban/AdminBanControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/ban/AdminBanControllerSliceTest.java
@@ -1,0 +1,241 @@
+package com.slparcelauctions.backend.admin.ban;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.slparcelauctions.backend.admin.ban.dto.AdminBanRowDto;
+import com.slparcelauctions.backend.admin.ban.exception.BanAlreadyLiftedException;
+import com.slparcelauctions.backend.admin.ban.exception.BanNotFoundException;
+import com.slparcelauctions.backend.admin.ban.exception.BanTypeFieldMismatchException;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.common.PagedResponse;
+import com.slparcelauctions.backend.user.Role;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class AdminBanControllerSliceTest {
+
+    @Autowired MockMvc mvc;
+    @Autowired JwtService jwtService;
+
+    @MockitoBean AdminBanService adminBanService;
+
+    private String adminToken() {
+        return jwtService.issueAccessToken(new AuthPrincipal(1L, "admin@x.com", 1L, Role.ADMIN));
+    }
+
+    private String userToken() {
+        return jwtService.issueAccessToken(new AuthPrincipal(2L, "user@x.com", 1L, Role.USER));
+    }
+
+    private AdminBanRowDto sampleRow() {
+        return new AdminBanRowDto(
+            1L, BanType.IP, "10.0.0.1", null,
+            null, null, null,
+            BanReasonCategory.SPAM, "spam ban",
+            1L, "Admin",
+            null, OffsetDateTime.now(),
+            null, null, null, null);
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /api/v1/admin/bans — auth gate
+    // -------------------------------------------------------------------------
+
+    @Test
+    void list_anon_returns401() throws Exception {
+        mvc.perform(get("/api/v1/admin/bans"))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void list_userRole_returns403() throws Exception {
+        mvc.perform(get("/api/v1/admin/bans")
+            .header("Authorization", "Bearer " + userToken()))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void list_admin_returns200() throws Exception {
+        PagedResponse<AdminBanRowDto> response =
+            new PagedResponse<>(List.of(sampleRow()), 1L, 1, 0, 25);
+        when(adminBanService.list(anyString(), any(), any())).thenReturn(response);
+
+        mvc.perform(get("/api/v1/admin/bans")
+            .header("Authorization", "Bearer " + adminToken()))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/v1/admin/bans — auth gate + validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    void create_anon_returns401() throws Exception {
+        mvc.perform(post("/api/v1/admin/bans")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"banType\":\"IP\",\"ipAddress\":\"10.0.0.1\","
+                + "\"reasonCategory\":\"SPAM\",\"reasonText\":\"test\"}"))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void create_userRole_returns403() throws Exception {
+        mvc.perform(post("/api/v1/admin/bans")
+            .header("Authorization", "Bearer " + userToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"banType\":\"IP\",\"ipAddress\":\"10.0.0.1\","
+                + "\"reasonCategory\":\"SPAM\",\"reasonText\":\"test\"}"))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void create_emptyReasonText_returns400_VALIDATION_FAILED() throws Exception {
+        mvc.perform(post("/api/v1/admin/bans")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"banType\":\"IP\",\"ipAddress\":\"10.0.0.1\","
+                + "\"reasonCategory\":\"SPAM\",\"reasonText\":\"\"}"))
+           .andExpect(status().isBadRequest())
+           .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"));
+    }
+
+    @Test
+    void create_banTypeMismatch_returns400_BAN_TYPE_FIELD_MISMATCH() throws Exception {
+        when(adminBanService.create(any(), anyLong()))
+            .thenThrow(new BanTypeFieldMismatchException("IP ban requires ipAddress and no slAvatarUuid"));
+
+        mvc.perform(post("/api/v1/admin/bans")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"banType\":\"IP\",\"ipAddress\":\"10.0.0.1\","
+                + "\"slAvatarUuid\":\"" + UUID.randomUUID() + "\","
+                + "\"reasonCategory\":\"SPAM\",\"reasonText\":\"test\"}"))
+           .andExpect(status().isBadRequest())
+           .andExpect(jsonPath("$.code").value("BAN_TYPE_FIELD_MISMATCH"));
+    }
+
+    @Test
+    void create_admin_returns200() throws Exception {
+        when(adminBanService.create(any(), anyLong())).thenReturn(sampleRow());
+
+        mvc.perform(post("/api/v1/admin/bans")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"banType\":\"IP\",\"ipAddress\":\"10.0.0.1\","
+                + "\"reasonCategory\":\"SPAM\",\"reasonText\":\"spam ban\"}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.id").value(1));
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/v1/admin/bans/{id}/lift — auth gate + validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    void lift_anon_returns401() throws Exception {
+        mvc.perform(post("/api/v1/admin/bans/42/lift")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"liftedReason\":\"lifting\"}"))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void lift_userRole_returns403() throws Exception {
+        mvc.perform(post("/api/v1/admin/bans/42/lift")
+            .header("Authorization", "Bearer " + userToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"liftedReason\":\"lifting\"}"))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void lift_emptyLiftedReason_returns400_VALIDATION_FAILED() throws Exception {
+        mvc.perform(post("/api/v1/admin/bans/42/lift")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"liftedReason\":\"\"}"))
+           .andExpect(status().isBadRequest())
+           .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"));
+    }
+
+    @Test
+    void lift_banNotFound_returns404_BAN_NOT_FOUND() throws Exception {
+        when(adminBanService.lift(anyLong(), anyLong(), anyString()))
+            .thenThrow(new BanNotFoundException(42L));
+
+        mvc.perform(post("/api/v1/admin/bans/42/lift")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"liftedReason\":\"lifting ban\"}"))
+           .andExpect(status().isNotFound())
+           .andExpect(jsonPath("$.code").value("BAN_NOT_FOUND"));
+    }
+
+    @Test
+    void lift_alreadyLifted_returns409_BAN_ALREADY_LIFTED() throws Exception {
+        when(adminBanService.lift(anyLong(), anyLong(), anyString()))
+            .thenThrow(new BanAlreadyLiftedException(42L));
+
+        mvc.perform(post("/api/v1/admin/bans/42/lift")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"liftedReason\":\"lifting ban\"}"))
+           .andExpect(status().isConflict())
+           .andExpect(jsonPath("$.code").value("BAN_ALREADY_LIFTED"));
+    }
+
+    @Test
+    void lift_admin_returns200() throws Exception {
+        AdminBanRowDto liftedRow = new AdminBanRowDto(
+            42L, BanType.IP, "10.0.0.1", null,
+            null, null, null,
+            BanReasonCategory.SPAM, "spam ban",
+            1L, "Admin",
+            null, OffsetDateTime.now(),
+            OffsetDateTime.now(), 1L, "Admin", "lifting ban");
+        when(adminBanService.lift(anyLong(), anyLong(), anyString())).thenReturn(liftedRow);
+
+        mvc.perform(post("/api/v1/admin/bans/42/lift")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"liftedReason\":\"lifting ban\"}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.id").value(42))
+           .andExpect(jsonPath("$.liftedReason").value("lifting ban"));
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/ban/AdminBanServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/ban/AdminBanServiceTest.java
@@ -1,0 +1,297 @@
+package com.slparcelauctions.backend.admin.ban;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.slparcelauctions.backend.admin.audit.AdminActionService;
+import com.slparcelauctions.backend.admin.ban.dto.CreateBanRequest;
+import com.slparcelauctions.backend.admin.ban.exception.BanAlreadyLiftedException;
+import com.slparcelauctions.backend.admin.ban.exception.BanTypeFieldMismatchException;
+import com.slparcelauctions.backend.auth.RefreshTokenRepository;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AdminBanServiceTest {
+
+    @Mock BanRepository banRepository;
+    @Mock UserRepository userRepository;
+    @Mock RefreshTokenRepository refreshTokenRepository;
+    @Mock BanCacheInvalidator cacheInvalidator;
+    @Mock AdminActionService adminActionService;
+
+    private static final Clock FIXED_CLOCK =
+        Clock.fixed(Instant.parse("2026-01-01T12:00:00Z"), ZoneOffset.UTC);
+
+    private AdminBanService service;
+
+    private static final Long ADMIN_ID = 1L;
+    private static final Long LINKED_USER_ID = 99L;
+    private static final UUID AVATAR_UUID = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    private static final String IP = "10.0.0.1";
+
+    private User adminUser;
+    private User linkedUser;
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminBanService(banRepository, userRepository, refreshTokenRepository,
+            cacheInvalidator, adminActionService, FIXED_CLOCK);
+
+        adminUser = User.builder()
+            .email("admin@x.com")
+            .passwordHash("x")
+            .displayName("Admin")
+            .build();
+        setId(adminUser, ADMIN_ID);
+
+        linkedUser = User.builder()
+            .email("user@x.com")
+            .passwordHash("x")
+            .slAvatarUuid(AVATAR_UUID)
+            .displayName("Linked User")
+            .build();
+        setId(linkedUser, LINKED_USER_ID);
+    }
+
+    // -------------------------------------------------------------------------
+    // validateTypeMatchesFields
+    // -------------------------------------------------------------------------
+
+    @Test
+    void create_ipBan_withAvatarUuid_throwsMismatch() {
+        CreateBanRequest req = new CreateBanRequest(
+            BanType.IP, IP, AVATAR_UUID, null, BanReasonCategory.SPAM, "reason");
+
+        assertThatThrownBy(() -> service.create(req, ADMIN_ID))
+            .isInstanceOf(BanTypeFieldMismatchException.class)
+            .hasMessageContaining("IP ban");
+    }
+
+    @Test
+    void create_ipBan_withNoIpAddress_throwsMismatch() {
+        CreateBanRequest req = new CreateBanRequest(
+            BanType.IP, null, null, null, BanReasonCategory.SPAM, "reason");
+
+        assertThatThrownBy(() -> service.create(req, ADMIN_ID))
+            .isInstanceOf(BanTypeFieldMismatchException.class)
+            .hasMessageContaining("IP ban");
+    }
+
+    @Test
+    void create_avatarBan_withIpAddress_throwsMismatch() {
+        CreateBanRequest req = new CreateBanRequest(
+            BanType.AVATAR, IP, AVATAR_UUID, null, BanReasonCategory.SPAM, "reason");
+
+        assertThatThrownBy(() -> service.create(req, ADMIN_ID))
+            .isInstanceOf(BanTypeFieldMismatchException.class)
+            .hasMessageContaining("AVATAR ban");
+    }
+
+    @Test
+    void create_avatarBan_withNoAvatarUuid_throwsMismatch() {
+        CreateBanRequest req = new CreateBanRequest(
+            BanType.AVATAR, null, null, null, BanReasonCategory.SPAM, "reason");
+
+        assertThatThrownBy(() -> service.create(req, ADMIN_ID))
+            .isInstanceOf(BanTypeFieldMismatchException.class)
+            .hasMessageContaining("AVATAR ban");
+    }
+
+    @Test
+    void create_bothBan_withMissingIp_throwsMismatch() {
+        CreateBanRequest req = new CreateBanRequest(
+            BanType.BOTH, null, AVATAR_UUID, null, BanReasonCategory.SPAM, "reason");
+
+        assertThatThrownBy(() -> service.create(req, ADMIN_ID))
+            .isInstanceOf(BanTypeFieldMismatchException.class)
+            .hasMessageContaining("BOTH ban");
+    }
+
+    @Test
+    void create_bothBan_withMissingAvatar_throwsMismatch() {
+        CreateBanRequest req = new CreateBanRequest(
+            BanType.BOTH, IP, null, null, BanReasonCategory.SPAM, "reason");
+
+        assertThatThrownBy(() -> service.create(req, ADMIN_ID))
+            .isInstanceOf(BanTypeFieldMismatchException.class)
+            .hasMessageContaining("BOTH ban");
+    }
+
+    // -------------------------------------------------------------------------
+    // tv-bump behavior
+    // -------------------------------------------------------------------------
+
+    @Test
+    void create_avatarBan_bumpsMatchingUserTokenVersion() {
+        CreateBanRequest req = new CreateBanRequest(
+            BanType.AVATAR, null, AVATAR_UUID, null, BanReasonCategory.TOS_ABUSE, "reason");
+
+        when(userRepository.findById(ADMIN_ID)).thenReturn(Optional.of(adminUser));
+        Ban savedBan = buildBan(BanType.AVATAR, null, AVATAR_UUID, adminUser);
+        when(banRepository.save(any())).thenReturn(savedBan);
+        when(userRepository.findBySlAvatarUuid(AVATAR_UUID)).thenReturn(Optional.of(linkedUser));
+        when(userRepository.bumpTokenVersion(LINKED_USER_ID)).thenReturn(1);
+        when(refreshTokenRepository.findIpSummaryByUserId(anyLong())).thenReturn(Collections.emptyList());
+
+        service.create(req, ADMIN_ID);
+
+        verify(userRepository).bumpTokenVersion(LINKED_USER_ID);
+    }
+
+    @Test
+    void create_avatarBan_noMatchingUser_skipsTvBump() {
+        CreateBanRequest req = new CreateBanRequest(
+            BanType.AVATAR, null, AVATAR_UUID, null, BanReasonCategory.TOS_ABUSE, "reason");
+
+        when(userRepository.findById(ADMIN_ID)).thenReturn(Optional.of(adminUser));
+        Ban savedBan = buildBan(BanType.AVATAR, null, AVATAR_UUID, adminUser);
+        when(banRepository.save(any())).thenReturn(savedBan);
+        when(userRepository.findBySlAvatarUuid(AVATAR_UUID)).thenReturn(Optional.empty());
+
+        service.create(req, ADMIN_ID);
+
+        verify(userRepository, never()).bumpTokenVersion(anyLong());
+    }
+
+    @Test
+    void create_ipOnlyBan_doesNotBumpAnyTokenVersion() {
+        CreateBanRequest req = new CreateBanRequest(
+            BanType.IP, IP, null, null, BanReasonCategory.SPAM, "reason");
+
+        when(userRepository.findById(ADMIN_ID)).thenReturn(Optional.of(adminUser));
+        Ban savedBan = buildBan(BanType.IP, IP, null, adminUser);
+        when(banRepository.save(any())).thenReturn(savedBan);
+
+        service.create(req, ADMIN_ID);
+
+        verify(userRepository, never()).bumpTokenVersion(anyLong());
+    }
+
+    @Test
+    void create_bothBan_bumpsMatchingUserTokenVersion() {
+        CreateBanRequest req = new CreateBanRequest(
+            BanType.BOTH, IP, AVATAR_UUID, null, BanReasonCategory.SHILL_BIDDING, "reason");
+
+        when(userRepository.findById(ADMIN_ID)).thenReturn(Optional.of(adminUser));
+        Ban savedBan = buildBan(BanType.BOTH, IP, AVATAR_UUID, adminUser);
+        when(banRepository.save(any())).thenReturn(savedBan);
+        when(userRepository.findBySlAvatarUuid(AVATAR_UUID)).thenReturn(Optional.of(linkedUser));
+        when(userRepository.bumpTokenVersion(LINKED_USER_ID)).thenReturn(1);
+        when(refreshTokenRepository.findIpSummaryByUserId(anyLong())).thenReturn(Collections.emptyList());
+
+        service.create(req, ADMIN_ID);
+
+        verify(userRepository).bumpTokenVersion(LINKED_USER_ID);
+    }
+
+    // -------------------------------------------------------------------------
+    // Cache invalidation and admin action recording
+    // -------------------------------------------------------------------------
+
+    @Test
+    void create_invalidatesCache_andWritesAdminAction() {
+        CreateBanRequest req = new CreateBanRequest(
+            BanType.IP, IP, null, null, BanReasonCategory.SPAM, "reason text");
+
+        when(userRepository.findById(ADMIN_ID)).thenReturn(Optional.of(adminUser));
+        Ban savedBan = buildBan(BanType.IP, IP, null, adminUser);
+        when(banRepository.save(any())).thenReturn(savedBan);
+
+        service.create(req, ADMIN_ID);
+
+        verify(cacheInvalidator).invalidate(eq(IP), eq(null));
+        verify(adminActionService).record(
+            eq(ADMIN_ID),
+            eq(com.slparcelauctions.backend.admin.audit.AdminActionType.CREATE_BAN),
+            eq(com.slparcelauctions.backend.admin.audit.AdminActionTargetType.BAN),
+            any(),
+            eq("reason text"),
+            any());
+    }
+
+    // -------------------------------------------------------------------------
+    // lift
+    // -------------------------------------------------------------------------
+
+    @Test
+    void lift_alreadyLifted_throws() {
+        Ban alreadyLifted = buildBan(BanType.IP, IP, null, adminUser);
+        alreadyLifted.setLiftedAt(OffsetDateTime.now(FIXED_CLOCK).minusHours(1));
+
+        when(banRepository.findById(42L)).thenReturn(Optional.of(alreadyLifted));
+
+        assertThatThrownBy(() -> service.lift(42L, ADMIN_ID, "some reason"))
+            .isInstanceOf(BanAlreadyLiftedException.class)
+            .hasMessageContaining("42");
+    }
+
+    @Test
+    void lift_invalidatesCache_andWritesAdminAction() {
+        Ban ban = buildBan(BanType.IP, IP, null, adminUser);
+
+        when(banRepository.findById(42L)).thenReturn(Optional.of(ban));
+        when(userRepository.findById(ADMIN_ID)).thenReturn(Optional.of(adminUser));
+        when(banRepository.save(any())).thenReturn(ban);
+
+        service.lift(42L, ADMIN_ID, "lift reason");
+
+        verify(cacheInvalidator).invalidate(eq(IP), eq(null));
+        verify(adminActionService).record(
+            eq(ADMIN_ID),
+            eq(com.slparcelauctions.backend.admin.audit.AdminActionType.LIFT_BAN),
+            eq(com.slparcelauctions.backend.admin.audit.AdminActionTargetType.BAN),
+            eq(42L),
+            eq("lift reason"),
+            eq(null));
+        assertThat(ban.getLiftedAt()).isNotNull();
+        assertThat(ban.getLiftedByUser()).isEqualTo(adminUser);
+        assertThat(ban.getLiftedReason()).isEqualTo("lift reason");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private Ban buildBan(BanType type, String ip, UUID avatarUuid, User admin) {
+        return Ban.builder()
+            .banType(type)
+            .ipAddress(ip)
+            .slAvatarUuid(avatarUuid)
+            .reasonCategory(BanReasonCategory.SPAM)
+            .notes("reason")
+            .adminUser(admin)
+            .build();
+    }
+
+    /** Reflectively set the id field (Lombok @Builder doesn't expose it normally for transient entities). */
+    private void setId(User user, Long id) {
+        try {
+            java.lang.reflect.Field f = User.class.getDeclaredField("id");
+            f.setAccessible(true);
+            f.set(user, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/ban/BanCheckServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/ban/BanCheckServiceTest.java
@@ -1,0 +1,232 @@
+package com.slparcelauctions.backend.admin.ban;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import com.slparcelauctions.backend.admin.ban.exception.UserBannedException;
+
+@ExtendWith(MockitoExtension.class)
+class BanCheckServiceTest {
+
+    @Mock BanRepository banRepository;
+    @Mock StringRedisTemplate redis;
+    @Mock ValueOperations<String, String> valueOps;
+
+    private Clock fixedClock;
+    private BanCheckService service;
+
+    private static final String TEST_IP = "192.168.1.1";
+    private static final UUID TEST_UUID = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    private static final String IP_KEY = "bans:active:ip:" + TEST_IP;
+    private static final String AVATAR_KEY = "bans:active:avatar:" + TEST_UUID;
+
+    @BeforeEach
+    void setUp() {
+        fixedClock = Clock.fixed(Instant.parse("2026-01-01T12:00:00Z"), ZoneOffset.UTC);
+        // lenient: the noop test (both args null) never calls opsForValue()
+        lenient().when(redis.opsForValue()).thenReturn(valueOps);
+        service = new BanCheckService(banRepository, redis, fixedClock);
+    }
+
+    // -------------------------------------------------------------------------
+    // Cache hit — NEGATIVE sentinel ("0")
+    // -------------------------------------------------------------------------
+
+    @Test
+    void cacheHitNegative_ip_noDbQueryNoThrow() {
+        when(valueOps.get(IP_KEY)).thenReturn("0");
+
+        service.assertNotBanned(TEST_IP, null);
+
+        verify(banRepository, never()).findActiveByIp(any(), any());
+    }
+
+    @Test
+    void cacheHitNegative_avatar_noDbQueryNoThrow() {
+        when(valueOps.get(AVATAR_KEY)).thenReturn("0");
+
+        service.assertNotBanned(null, TEST_UUID);
+
+        verify(banRepository, never()).findActiveByAvatar(any(), any());
+    }
+
+    // -------------------------------------------------------------------------
+    // Cache hit — "perm" sentinel
+    // -------------------------------------------------------------------------
+
+    @Test
+    void cacheHitPerm_ip_throwsWithNullExpiresAt() {
+        when(valueOps.get(IP_KEY)).thenReturn("perm");
+
+        assertThatThrownBy(() -> service.assertNotBanned(TEST_IP, null))
+            .isInstanceOf(UserBannedException.class)
+            .satisfies(ex -> assertThat(((UserBannedException) ex).getExpiresAt()).isNull());
+
+        verify(banRepository, never()).findActiveByIp(any(), any());
+    }
+
+    @Test
+    void cacheHitPerm_avatar_throwsWithNullExpiresAt() {
+        when(valueOps.get(AVATAR_KEY)).thenReturn("perm");
+
+        assertThatThrownBy(() -> service.assertNotBanned(null, TEST_UUID))
+            .isInstanceOf(UserBannedException.class)
+            .satisfies(ex -> assertThat(((UserBannedException) ex).getExpiresAt()).isNull());
+
+        verify(banRepository, never()).findActiveByAvatar(any(), any());
+    }
+
+    // -------------------------------------------------------------------------
+    // Cache hit — ISO-8601 date string
+    // -------------------------------------------------------------------------
+
+    @Test
+    void cacheHitIsoDate_ip_throwsWithParsedExpiresAt() {
+        String isoDate = "2026-06-01T00:00:00Z";
+        when(valueOps.get(IP_KEY)).thenReturn(isoDate);
+
+        assertThatThrownBy(() -> service.assertNotBanned(TEST_IP, null))
+            .isInstanceOf(UserBannedException.class)
+            .satisfies(ex -> assertThat(((UserBannedException) ex).getExpiresAt())
+                .isEqualTo(OffsetDateTime.parse(isoDate)));
+    }
+
+    @Test
+    void cacheHitIsoDate_avatar_throwsWithParsedExpiresAt() {
+        String isoDate = "2026-06-01T00:00:00Z";
+        when(valueOps.get(AVATAR_KEY)).thenReturn(isoDate);
+
+        assertThatThrownBy(() -> service.assertNotBanned(null, TEST_UUID))
+            .isInstanceOf(UserBannedException.class)
+            .satisfies(ex -> assertThat(((UserBannedException) ex).getExpiresAt())
+                .isEqualTo(OffsetDateTime.parse(isoDate)));
+    }
+
+    // -------------------------------------------------------------------------
+    // Cache miss → DB hit positive
+    // -------------------------------------------------------------------------
+
+    @Test
+    void cacheMissDbHitPositive_ip_cachesAndThrows() {
+        when(valueOps.get(IP_KEY)).thenReturn(null);
+        OffsetDateTime expiresAt = OffsetDateTime.parse("2027-01-01T00:00:00Z");
+        Ban ban = Ban.builder()
+            .banType(BanType.IP)
+            .ipAddress(TEST_IP)
+            .reasonCategory(BanReasonCategory.SPAM)
+            .expiresAt(expiresAt)
+            .build();
+        when(banRepository.findActiveByIp(eq(TEST_IP), any())).thenReturn(List.of(ban));
+
+        assertThatThrownBy(() -> service.assertNotBanned(TEST_IP, null))
+            .isInstanceOf(UserBannedException.class)
+            .satisfies(ex -> assertThat(((UserBannedException) ex).getExpiresAt())
+                .isEqualTo(expiresAt));
+
+        verify(valueOps).set(eq(IP_KEY), eq(expiresAt.toString()), any());
+    }
+
+    @Test
+    void cacheMissDbHitPositivePerm_ip_cachesPermSentinelAndThrows() {
+        when(valueOps.get(IP_KEY)).thenReturn(null);
+        Ban ban = Ban.builder()
+            .banType(BanType.IP)
+            .ipAddress(TEST_IP)
+            .reasonCategory(BanReasonCategory.SPAM)
+            .expiresAt(null)   // permanent
+            .build();
+        when(banRepository.findActiveByIp(eq(TEST_IP), any())).thenReturn(List.of(ban));
+
+        assertThatThrownBy(() -> service.assertNotBanned(TEST_IP, null))
+            .isInstanceOf(UserBannedException.class)
+            .satisfies(ex -> assertThat(((UserBannedException) ex).getExpiresAt()).isNull());
+
+        verify(valueOps).set(eq(IP_KEY), eq("perm"), any());
+    }
+
+    // -------------------------------------------------------------------------
+    // Cache miss → DB miss (negative)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void cacheMissDbEmpty_ip_cachesNegativeSentinel() {
+        when(valueOps.get(IP_KEY)).thenReturn(null);
+        when(banRepository.findActiveByIp(eq(TEST_IP), any())).thenReturn(List.of());
+
+        service.assertNotBanned(TEST_IP, null);   // no throw
+
+        verify(valueOps).set(eq(IP_KEY), eq("0"), any());
+    }
+
+    @Test
+    void cacheMissDbEmpty_avatar_cachesNegativeSentinel() {
+        when(valueOps.get(AVATAR_KEY)).thenReturn(null);
+        when(banRepository.findActiveByAvatar(eq(TEST_UUID), any())).thenReturn(List.of());
+
+        service.assertNotBanned(null, TEST_UUID);   // no throw
+
+        verify(valueOps).set(eq(AVATAR_KEY), eq("0"), any());
+    }
+
+    // -------------------------------------------------------------------------
+    // Null / blank argument handling
+    // -------------------------------------------------------------------------
+
+    @Test
+    void assertNotBanned_bothNull_isNoop() {
+        service.assertNotBanned(null, null);
+
+        verify(redis, never()).opsForValue();
+        verify(banRepository, never()).findActiveByIp(anyString(), any());
+        verify(banRepository, never()).findActiveByAvatar(any(), any());
+    }
+
+    @Test
+    void assertNotBanned_nullUuid_onlyIpCheckFires() {
+        when(valueOps.get(IP_KEY)).thenReturn("0");
+
+        service.assertNotBanned(TEST_IP, null);
+
+        verify(banRepository, never()).findActiveByAvatar(any(), any());
+    }
+
+    @Test
+    void assertNotBanned_nullIp_onlyAvatarCheckFires() {
+        when(valueOps.get(AVATAR_KEY)).thenReturn("0");
+
+        service.assertNotBanned(null, TEST_UUID);
+
+        verify(banRepository, never()).findActiveByIp(anyString(), any());
+    }
+
+    @Test
+    void assertNotBanned_blankIp_skipsIpCheck() {
+        when(valueOps.get(AVATAR_KEY)).thenReturn("0");
+
+        service.assertNotBanned("   ", TEST_UUID);
+
+        verify(banRepository, never()).findActiveByIp(anyString(), any());
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/ban/BanEnforcementIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/ban/BanEnforcementIntegrationTest.java
@@ -1,0 +1,445 @@
+package com.slparcelauctions.backend.admin.ban;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.VerificationMethod;
+import com.slparcelauctions.backend.auction.VerificationTier;
+import com.slparcelauctions.backend.auction.broadcast.AuctionBroadcastPublisher;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.parcel.ParcelRepository;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Integration tests verifying {@link BanCheckService#assertNotBanned} is wired
+ * into all 6 enforcement paths. A real {@link BanRepository} seeds active
+ * {@link Ban} rows; {@code StringRedisTemplate} is mocked so every check is a
+ * cache-miss → DB query.
+ *
+ * <p>{@code @Transactional} at the class level rolls back all DB changes after
+ * each test so ban rows, users, parcels, and auctions never leak between cases.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.auction-end.enabled=false",
+        "slpa.ownership-monitor.enabled=false",
+        "slpa.escrow.ownership-monitor-job.enabled=false",
+        "slpa.escrow.timeout-job.enabled=false",
+        "slpa.escrow.command-dispatcher-job.enabled=false",
+        "slpa.review.scheduler.enabled=false",
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+@Transactional
+class BanEnforcementIntegrationTest {
+
+    private static final String TRUSTED_OWNER = "00000000-0000-0000-0000-000000000001";
+
+    @Autowired MockMvc mockMvc;
+    @Autowired BanRepository banRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired ParcelRepository parcelRepo;
+    @Autowired AuctionRepository auctionRepo;
+
+    @MockitoBean StringRedisTemplate redis;
+    @MockitoBean AuctionBroadcastPublisher broadcastPublisher;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // Shared admin user for seeding bans (FK requirement)
+    private User adminUser;
+
+    @BeforeEach
+    void setUpRedisNoOp() {
+        // Stub redis to always cache-miss so BanCheckService goes to the DB.
+        @SuppressWarnings("unchecked")
+        ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+        lenient().when(redis.opsForValue()).thenReturn(valueOps);
+        lenient().when(valueOps.get(anyString())).thenReturn(null);
+        lenient().doNothing().when(valueOps).set(anyString(), anyString(), any());
+
+        adminUser = userRepo.save(User.builder()
+                .email("ban-admin-" + UUID.randomUUID() + "@x.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .build());
+    }
+
+    // -------------------------------------------------------------------------
+    // 1. Bid endpoint — AVATAR ban → 403 USER_BANNED
+    // -------------------------------------------------------------------------
+
+    @Test
+    void bidEndpoint_avatarBan_returns403_USER_BANNED() throws Exception {
+        UUID avatarUuid = UUID.randomUUID();
+        String bidderToken = registerAndVerifyUser(
+                "bid-avatar-banned-" + UUID.randomUUID() + "@x.com", "BidAvatarBanned",
+                avatarUuid.toString());
+        String sellerToken = registerAndVerifyUser(
+                "bid-avatar-seller-" + UUID.randomUUID() + "@x.com", "BidAvatarSeller",
+                UUID.randomUUID().toString());
+        Auction auction = seedActiveAuction(findUserByToken(sellerToken));
+
+        banRepo.save(Ban.builder()
+                .adminUser(adminUser)
+                .banType(BanType.AVATAR)
+                .slAvatarUuid(avatarUuid)
+                .reasonCategory(BanReasonCategory.SHILL_BIDDING)
+                .build());
+
+        mockMvc.perform(post("/api/v1/auctions/" + auction.getId() + "/bids")
+                        .header("Authorization", "Bearer " + bidderToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"amount\":1000}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("USER_BANNED"));
+    }
+
+    // -------------------------------------------------------------------------
+    // 2. Bid endpoint — IP ban → 403
+    // -------------------------------------------------------------------------
+
+    @Test
+    void bidEndpoint_ipBan_returns403() throws Exception {
+        String bidderToken = registerAndVerifyUser(
+                "bid-ip-banned-" + UUID.randomUUID() + "@x.com", "BidIpBanned",
+                UUID.randomUUID().toString());
+        String sellerToken = registerAndVerifyUser(
+                "bid-ip-seller-" + UUID.randomUUID() + "@x.com", "BidIpSeller",
+                UUID.randomUUID().toString());
+        Auction auction = seedActiveAuction(findUserByToken(sellerToken));
+
+        // MockMvc uses 127.0.0.1 as the remote address
+        banRepo.save(Ban.builder()
+                .adminUser(adminUser)
+                .banType(BanType.IP)
+                .ipAddress("127.0.0.1")
+                .reasonCategory(BanReasonCategory.SPAM)
+                .build());
+
+        mockMvc.perform(post("/api/v1/auctions/" + auction.getId() + "/bids")
+                        .header("Authorization", "Bearer " + bidderToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"amount\":1000}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("USER_BANNED"));
+    }
+
+    // -------------------------------------------------------------------------
+    // 3. Register endpoint — IP ban → 403
+    // -------------------------------------------------------------------------
+
+    @Test
+    void registerEndpoint_ipBan_returns403() throws Exception {
+        banRepo.save(Ban.builder()
+                .adminUser(adminUser)
+                .banType(BanType.IP)
+                .ipAddress("127.0.0.1")
+                .reasonCategory(BanReasonCategory.SPAM)
+                .build());
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"reg-banned-" + UUID.randomUUID()
+                                + "@x.com\",\"password\":\"hunter22abc\",\"displayName\":\"RegBanned\"}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("USER_BANNED"));
+    }
+
+    // -------------------------------------------------------------------------
+    // 4. Login endpoint — IP ban → 403
+    // -------------------------------------------------------------------------
+
+    @Test
+    void loginEndpoint_ipBan_returns403() throws Exception {
+        // Register first (no ban yet), then add ban, then attempt login
+        String email = "login-banned-" + UUID.randomUUID() + "@x.com";
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + email
+                                + "\",\"password\":\"hunter22abc\",\"displayName\":\"LoginBanned\"}"))
+                .andExpect(status().isCreated());
+
+        banRepo.save(Ban.builder()
+                .adminUser(adminUser)
+                .banType(BanType.IP)
+                .ipAddress("127.0.0.1")
+                .reasonCategory(BanReasonCategory.SPAM)
+                .build());
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + email + "\",\"password\":\"hunter22abc\"}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("USER_BANNED"));
+    }
+
+    // -------------------------------------------------------------------------
+    // 5. Cancel endpoint — AVATAR ban on seller → 403
+    // -------------------------------------------------------------------------
+
+    @Test
+    void cancelEndpoint_avatarBan_returns403() throws Exception {
+        UUID sellerAvatarUuid = UUID.randomUUID();
+        String sellerToken = registerAndVerifyUser(
+                "cancel-seller-" + UUID.randomUUID() + "@x.com", "CancelSeller",
+                sellerAvatarUuid.toString());
+        User seller = findUserByToken(sellerToken);
+        Auction auction = seedDraftAuction(seller);
+
+        banRepo.save(Ban.builder()
+                .adminUser(adminUser)
+                .banType(BanType.AVATAR)
+                .slAvatarUuid(sellerAvatarUuid)
+                .reasonCategory(BanReasonCategory.FRAUDULENT_SELLER)
+                .build());
+
+        mockMvc.perform(put("/api/v1/auctions/" + auction.getId() + "/cancel")
+                        .header("Authorization", "Bearer " + sellerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\":\"change of mind\"}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("USER_BANNED"));
+    }
+
+    // -------------------------------------------------------------------------
+    // 6. BOTH ban — blocks bid AND login
+    // -------------------------------------------------------------------------
+
+    @Test
+    void bothBan_blocksBidAndLogin() throws Exception {
+        UUID avatarUuid = UUID.randomUUID();
+        String bidderToken = registerAndVerifyUser(
+                "both-bidder-" + UUID.randomUUID() + "@x.com", "BothBidder",
+                avatarUuid.toString());
+        String sellerToken = registerAndVerifyUser(
+                "both-seller-" + UUID.randomUUID() + "@x.com", "BothSeller",
+                UUID.randomUUID().toString());
+        Auction auction = seedActiveAuction(findUserByToken(sellerToken));
+
+        String email = "both-login-" + UUID.randomUUID() + "@x.com";
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + email
+                                + "\",\"password\":\"hunter22abc\",\"displayName\":\"BothLogin\"}"))
+                .andExpect(status().isCreated());
+
+        banRepo.save(Ban.builder()
+                .adminUser(adminUser)
+                .banType(BanType.BOTH)
+                .ipAddress("127.0.0.1")
+                .slAvatarUuid(avatarUuid)
+                .reasonCategory(BanReasonCategory.FRAUDULENT_SELLER)
+                .build());
+
+        // Bid is blocked by avatar
+        mockMvc.perform(post("/api/v1/auctions/" + auction.getId() + "/bids")
+                        .header("Authorization", "Bearer " + bidderToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"amount\":1000}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("USER_BANNED"));
+
+        // Login is blocked by IP
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + email + "\",\"password\":\"hunter22abc\"}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("USER_BANNED"));
+    }
+
+    // -------------------------------------------------------------------------
+    // 7. Lifted ban — action succeeds
+    // -------------------------------------------------------------------------
+
+    @Test
+    void liftedBan_allowsAction() throws Exception {
+        Ban ban = banRepo.save(Ban.builder()
+                .adminUser(adminUser)
+                .banType(BanType.IP)
+                .ipAddress("127.0.0.1")
+                .reasonCategory(BanReasonCategory.SPAM)
+                .liftedAt(OffsetDateTime.now().minusMinutes(5))
+                .build());
+
+        // With lifted ban, register should succeed
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"lifted-" + UUID.randomUUID()
+                                + "@x.com\",\"password\":\"hunter22abc\",\"displayName\":\"Lifted\"}"))
+                .andExpect(status().isCreated());
+    }
+
+    // -------------------------------------------------------------------------
+    // 8. Expired ban — action succeeds
+    // -------------------------------------------------------------------------
+
+    @Test
+    void expiredBan_allowsAction() throws Exception {
+        banRepo.save(Ban.builder()
+                .adminUser(adminUser)
+                .banType(BanType.IP)
+                .ipAddress("127.0.0.1")
+                .reasonCategory(BanReasonCategory.SPAM)
+                .expiresAt(OffsetDateTime.now().minusHours(1))
+                .build());
+
+        // With expired ban, register should succeed
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"expired-" + UUID.randomUUID()
+                                + "@x.com\",\"password\":\"hunter22abc\",\"displayName\":\"Expired\"}"))
+                .andExpect(status().isCreated());
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private String registerUser(String email, String displayName) throws Exception {
+        String body = String.format(
+                "{\"email\":\"%s\",\"password\":\"hunter22abc\",\"displayName\":\"%s\"}",
+                email, displayName);
+        MvcResult reg = mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated()).andReturn();
+        JsonNode json = objectMapper.readTree(reg.getResponse().getContentAsString());
+        return json.get("accessToken").asText();
+    }
+
+    private String registerAndVerifyUser(String email, String displayName, String avatarUuid)
+            throws Exception {
+        String token = registerUser(email, displayName);
+        MvcResult gen = mockMvc.perform(post("/api/v1/verification/generate")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk()).andReturn();
+        String code = objectMapper.readTree(gen.getResponse().getContentAsString())
+                .get("code").asText();
+        String slVerifyBody = String.format("""
+            {
+              "verificationCode":"%s",
+              "avatarUuid":"%s",
+              "avatarName":"%s",
+              "displayName":"%s",
+              "username":"test.resident",
+              "bornDate":"2012-05-15",
+              "payInfo":3
+            }
+            """, code, avatarUuid, displayName, displayName);
+        mockMvc.perform(post("/api/v1/sl/verify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(slVerifyBody)
+                        .header("X-SecondLife-Shard", "Production")
+                        .header("X-SecondLife-Owner-Key", TRUSTED_OWNER))
+                .andExpect(status().isOk());
+        return token;
+    }
+
+    /**
+     * Resolves a user entity by decoding the user ID from the access token returned
+     * by registerAndVerifyUser. Since the JWT is opaque here, we load the most recently
+     * saved verified user with a matching avatar UUID — or just fetch the last-saved user.
+     * Simpler: we look up by email encoded in the setup helpers.
+     *
+     * <p>This helper is only called for users whose email was passed in to the register
+     * helpers above, so we search by verified=true and pick the latest.
+     */
+    private User findUserByToken(String token) throws Exception {
+        // Decode JWT payload to extract sub (userId)
+        String[] parts = token.split("\\.");
+        String payload = new String(java.util.Base64.getUrlDecoder().decode(parts[1]));
+        JsonNode payloadJson = objectMapper.readTree(payload);
+        long userId = payloadJson.get("sub").asLong();
+        return userRepo.findById(userId).orElseThrow();
+    }
+
+    private Auction seedActiveAuction(User seller) {
+        Parcel parcel = parcelRepo.save(Parcel.builder()
+                .slParcelUuid(UUID.randomUUID())
+                .regionName("BanTestRegion")
+                .ownerUuid(seller.getSlAvatarUuid())
+                .areaSqm(512)
+                .build());
+        OffsetDateTime now = OffsetDateTime.now();
+        return auctionRepo.save(Auction.builder()
+                .title("Ban test auction")
+                .parcel(parcel)
+                .seller(seller)
+                .status(AuctionStatus.ACTIVE)
+                .verificationMethod(VerificationMethod.UUID_ENTRY)
+                .verificationTier(VerificationTier.SCRIPT)
+                .startingBid(1000L)
+                .durationHours(24)
+                .snipeProtect(false)
+                .listingFeePaid(false)
+                .currentBid(0L)
+                .bidCount(0)
+                .consecutiveWorldApiFailures(0)
+                .commissionRate(new BigDecimal("0.05"))
+                .agentFeeRate(BigDecimal.ZERO)
+                .startsAt(now.minusHours(1))
+                .endsAt(now.plusDays(1))
+                .originalEndsAt(now.plusDays(1))
+                .build());
+    }
+
+    private Auction seedDraftAuction(User seller) {
+        Parcel parcel = parcelRepo.save(Parcel.builder()
+                .slParcelUuid(UUID.randomUUID())
+                .regionName("BanCancelRegion")
+                .ownerUuid(seller.getSlAvatarUuid())
+                .areaSqm(512)
+                .build());
+        return auctionRepo.save(Auction.builder()
+                .title("Ban cancel test auction")
+                .parcel(parcel)
+                .seller(seller)
+                .status(AuctionStatus.DRAFT)
+                .startingBid(1000L)
+                .durationHours(24)
+                .snipeProtect(false)
+                .listingFeePaid(false)
+                .currentBid(0L)
+                .bidCount(0)
+                .consecutiveWorldApiFailures(0)
+                .commissionRate(new BigDecimal("0.05"))
+                .agentFeeRate(BigDecimal.ZERO)
+                .build());
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/ban/BanRepositoryTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/ban/BanRepositoryTest.java
@@ -1,0 +1,219 @@
+package com.slparcelauctions.backend.admin.ban;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.slparcelauctions.backend.notification.NotificationWsBroadcasterPort;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class BanRepositoryTest {
+
+    @Autowired BanRepository banRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired PlatformTransactionManager txManager;
+    @Autowired DataSource dataSource;
+
+    @MockitoBean NotificationWsBroadcasterPort wsBroadcaster;
+
+    private Long adminUserId;
+    private Long savedBanId;
+
+    @BeforeEach
+    void seedAdmin() {
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            User admin = userRepo.save(User.builder()
+                .email("ban-repo-admin-" + UUID.randomUUID() + "@x.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .build());
+            adminUserId = admin.getId();
+        });
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            if (savedBanId != null) {
+                banRepo.findById(savedBanId).ifPresent(banRepo::delete);
+                savedBanId = null;
+            }
+        });
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var st = conn.createStatement()) {
+                if (adminUserId != null) {
+                    st.execute("DELETE FROM notification WHERE user_id = " + adminUserId);
+                    st.execute("DELETE FROM refresh_tokens WHERE user_id = " + adminUserId);
+                    st.execute("DELETE FROM users WHERE id = " + adminUserId);
+                }
+            }
+        }
+        adminUserId = null;
+    }
+
+    // -------------------------------------------------------------------------
+    // findActiveByIp
+    // -------------------------------------------------------------------------
+
+    @Test
+    void findActiveByIp_activePermanentBan_isFound() {
+        OffsetDateTime now = OffsetDateTime.now();
+        String ip = "10.0.0.1";
+
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            User admin = userRepo.findById(adminUserId).orElseThrow();
+            Ban ban = banRepo.save(Ban.builder()
+                .adminUser(admin)
+                .banType(BanType.IP)
+                .ipAddress(ip)
+                .reasonCategory(BanReasonCategory.SPAM)
+                .build());
+            savedBanId = ban.getId();
+        });
+
+        List<Ban> results = banRepo.findActiveByIp(ip, now);
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getIpAddress()).isEqualTo(ip);
+    }
+
+    @Test
+    void findActiveByAvatar_activePermanentBan_isFound() {
+        OffsetDateTime now = OffsetDateTime.now();
+        UUID avatarUuid = UUID.randomUUID();
+
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            User admin = userRepo.findById(adminUserId).orElseThrow();
+            Ban ban = banRepo.save(Ban.builder()
+                .adminUser(admin)
+                .banType(BanType.AVATAR)
+                .slAvatarUuid(avatarUuid)
+                .reasonCategory(BanReasonCategory.SHILL_BIDDING)
+                .build());
+            savedBanId = ban.getId();
+        });
+
+        List<Ban> results = banRepo.findActiveByAvatar(avatarUuid, now);
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getSlAvatarUuid()).isEqualTo(avatarUuid);
+    }
+
+    @Test
+    void findActiveByIp_expiredBan_notReturned() {
+        OffsetDateTime now = OffsetDateTime.now();
+        String ip = "10.0.0.2";
+
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            User admin = userRepo.findById(adminUserId).orElseThrow();
+            Ban ban = banRepo.save(Ban.builder()
+                .adminUser(admin)
+                .banType(BanType.IP)
+                .ipAddress(ip)
+                .reasonCategory(BanReasonCategory.SPAM)
+                .expiresAt(now.minusHours(1))   // already expired
+                .build());
+            savedBanId = ban.getId();
+        });
+
+        List<Ban> results = banRepo.findActiveByIp(ip, now);
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void findActiveByIp_liftedBan_notReturned() {
+        OffsetDateTime now = OffsetDateTime.now();
+        String ip = "10.0.0.3";
+
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            User admin = userRepo.findById(adminUserId).orElseThrow();
+            Ban ban = banRepo.save(Ban.builder()
+                .adminUser(admin)
+                .banType(BanType.IP)
+                .ipAddress(ip)
+                .reasonCategory(BanReasonCategory.TOS_ABUSE)
+                .liftedAt(now.minusMinutes(5))   // already lifted
+                .build());
+            savedBanId = ban.getId();
+        });
+
+        List<Ban> results = banRepo.findActiveByIp(ip, now);
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void bothTypeBan_returnedByBothQueries() {
+        OffsetDateTime now = OffsetDateTime.now();
+        String ip = "10.0.0.4";
+        UUID avatarUuid = UUID.randomUUID();
+
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            User admin = userRepo.findById(adminUserId).orElseThrow();
+            Ban ban = banRepo.save(Ban.builder()
+                .adminUser(admin)
+                .banType(BanType.BOTH)
+                .ipAddress(ip)
+                .slAvatarUuid(avatarUuid)
+                .reasonCategory(BanReasonCategory.FRAUDULENT_SELLER)
+                .build());
+            savedBanId = ban.getId();
+        });
+
+        List<Ban> byIp = banRepo.findActiveByIp(ip, now);
+        List<Ban> byAvatar = banRepo.findActiveByAvatar(avatarUuid, now);
+
+        assertThat(byIp).hasSize(1);
+        assertThat(byAvatar).hasSize(1);
+        assertThat(byIp.get(0).getId()).isEqualTo(byAvatar.get(0).getId());
+    }
+
+    @Test
+    void ipOnlyBan_notReturnedByAvatarQuery() {
+        OffsetDateTime now = OffsetDateTime.now();
+        String ip = "10.0.0.5";
+        UUID someOtherUuid = UUID.randomUUID();
+
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            User admin = userRepo.findById(adminUserId).orElseThrow();
+            Ban ban = banRepo.save(Ban.builder()
+                .adminUser(admin)
+                .banType(BanType.IP)
+                .ipAddress(ip)
+                .reasonCategory(BanReasonCategory.OTHER)
+                .build());
+            savedBanId = ban.getId();
+        });
+
+        // The avatar UUID used in the query has nothing to do with this ban
+        List<Ban> byAvatar = banRepo.findActiveByAvatar(someOtherUuid, now);
+        assertThat(byAvatar).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/reports/AdminReportControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/reports/AdminReportControllerSliceTest.java
@@ -1,0 +1,290 @@
+package com.slparcelauctions.backend.admin.reports;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.slparcelauctions.backend.admin.reports.dto.AdminReportActionRequest;
+import com.slparcelauctions.backend.admin.reports.dto.AdminReportDetailDto;
+import com.slparcelauctions.backend.admin.reports.dto.AdminReportListingRowDto;
+import com.slparcelauctions.backend.admin.reports.exception.ReportNotFoundException;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.common.PagedResponse;
+import com.slparcelauctions.backend.user.Role;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class AdminReportControllerSliceTest {
+
+    @Autowired MockMvc mvc;
+    @Autowired JwtService jwtService;
+
+    @MockitoBean AdminReportService service;
+
+    private String adminToken() {
+        return jwtService.issueAccessToken(new AuthPrincipal(1L, "a@x.com", 1L, Role.ADMIN));
+    }
+
+    private String userToken() {
+        return jwtService.issueAccessToken(new AuthPrincipal(2L, "u@x.com", 2L, Role.USER));
+    }
+
+    private static final String VALID_NOTES = "{\"notes\":\"Some admin notes\"}";
+
+    // -------------------------------------------------------------------------
+    // Auth gate — GET /api/v1/admin/reports
+    // -------------------------------------------------------------------------
+
+    @Test
+    void list_anonymous_returns401() throws Exception {
+        mvc.perform(get("/api/v1/admin/reports"))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void list_userRole_returns403() throws Exception {
+        mvc.perform(get("/api/v1/admin/reports")
+            .header("Authorization", "Bearer " + userToken()))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void list_admin_returns200_withPagedShape() throws Exception {
+        OffsetDateTime now = OffsetDateTime.now();
+        AdminReportListingRowDto row = new AdminReportListingRowDto(
+            10L, "Test Auction", AuctionStatus.ACTIVE, "RegionOne",
+            5L, "SellerName", 3L, now);
+        PagedResponse<AdminReportListingRowDto> response =
+            new PagedResponse<>(List.of(row), 1L, 1, 0, 25);
+        when(service.listGrouped(any(), any())).thenReturn(response);
+
+        mvc.perform(get("/api/v1/admin/reports")
+            .header("Authorization", "Bearer " + adminToken()))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.content[0].auctionId").value(10))
+           .andExpect(jsonPath("$.content[0].auctionTitle").value("Test Auction"))
+           .andExpect(jsonPath("$.content[0].openReportCount").value(3))
+           .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    // -------------------------------------------------------------------------
+    // Auth gate — GET /api/v1/admin/reports/{id}
+    // -------------------------------------------------------------------------
+
+    @Test
+    void findOne_anonymous_returns401() throws Exception {
+        mvc.perform(get("/api/v1/admin/reports/1"))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void findOne_userRole_returns403() throws Exception {
+        mvc.perform(get("/api/v1/admin/reports/1")
+            .header("Authorization", "Bearer " + userToken()))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void findOne_notFound_returns404_REPORT_NOT_FOUND() throws Exception {
+        when(service.findOne(anyLong())).thenThrow(new ReportNotFoundException(999L));
+
+        mvc.perform(get("/api/v1/admin/reports/999")
+            .header("Authorization", "Bearer " + adminToken()))
+           .andExpect(status().isNotFound())
+           .andExpect(jsonPath("$.code").value("REPORT_NOT_FOUND"));
+    }
+
+    @Test
+    void findOne_admin_returns200() throws Exception {
+        OffsetDateTime now = OffsetDateTime.now();
+        AdminReportDetailDto detail = new AdminReportDetailDto(
+            42L, ListingReportReason.SHILL_BIDDING, "Subject", "Details",
+            ListingReportStatus.OPEN, null, now, now, null,
+            7L, "ReporterName", 0L, null);
+        when(service.findOne(42L)).thenReturn(detail);
+
+        mvc.perform(get("/api/v1/admin/reports/42")
+            .header("Authorization", "Bearer " + adminToken()))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.id").value(42))
+           .andExpect(jsonPath("$.reason").value("SHILL_BIDDING"))
+           .andExpect(jsonPath("$.status").value("OPEN"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Auth gate — GET /api/v1/admin/reports/listing/{auctionId}
+    // -------------------------------------------------------------------------
+
+    @Test
+    void findByListing_anonymous_returns401() throws Exception {
+        mvc.perform(get("/api/v1/admin/reports/listing/1"))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void findByListing_userRole_returns403() throws Exception {
+        mvc.perform(get("/api/v1/admin/reports/listing/1")
+            .header("Authorization", "Bearer " + userToken()))
+           .andExpect(status().isForbidden());
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /{id}/dismiss — auth gate + validation + not found
+    // -------------------------------------------------------------------------
+
+    @Test
+    void dismiss_anonymous_returns401() throws Exception {
+        mvc.perform(post("/api/v1/admin/reports/1/dismiss")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(VALID_NOTES))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void dismiss_userRole_returns403() throws Exception {
+        mvc.perform(post("/api/v1/admin/reports/1/dismiss")
+            .header("Authorization", "Bearer " + userToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(VALID_NOTES))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void dismiss_emptyNotes_returns400_VALIDATION_FAILED() throws Exception {
+        mvc.perform(post("/api/v1/admin/reports/1/dismiss")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"notes\":\"\"}"))
+           .andExpect(status().isBadRequest())
+           .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"));
+    }
+
+    @Test
+    void dismiss_reportNotFound_returns404_REPORT_NOT_FOUND() throws Exception {
+        when(service.dismiss(anyLong(), anyLong(), anyString()))
+            .thenThrow(new ReportNotFoundException(999L));
+
+        mvc.perform(post("/api/v1/admin/reports/999/dismiss")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(VALID_NOTES))
+           .andExpect(status().isNotFound())
+           .andExpect(jsonPath("$.code").value("REPORT_NOT_FOUND"));
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /listing/{auctionId}/warn-seller — auth gate + validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    void warnSeller_anonymous_returns401() throws Exception {
+        mvc.perform(post("/api/v1/admin/reports/listing/1/warn-seller")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(VALID_NOTES))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void warnSeller_userRole_returns403() throws Exception {
+        mvc.perform(post("/api/v1/admin/reports/listing/1/warn-seller")
+            .header("Authorization", "Bearer " + userToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(VALID_NOTES))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void warnSeller_emptyNotes_returns400() throws Exception {
+        mvc.perform(post("/api/v1/admin/reports/listing/1/warn-seller")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"notes\":\"\"}"))
+           .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void warnSeller_admin_returns200() throws Exception {
+        doNothing().when(service).warnSeller(anyLong(), anyLong(), anyString());
+
+        mvc.perform(post("/api/v1/admin/reports/listing/1/warn-seller")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(VALID_NOTES))
+           .andExpect(status().isOk());
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /listing/{auctionId}/suspend — auth gate
+    // -------------------------------------------------------------------------
+
+    @Test
+    void suspend_anonymous_returns401() throws Exception {
+        mvc.perform(post("/api/v1/admin/reports/listing/1/suspend")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(VALID_NOTES))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void suspend_userRole_returns403() throws Exception {
+        mvc.perform(post("/api/v1/admin/reports/listing/1/suspend")
+            .header("Authorization", "Bearer " + userToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(VALID_NOTES))
+           .andExpect(status().isForbidden());
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /listing/{auctionId}/cancel — auth gate
+    // -------------------------------------------------------------------------
+
+    @Test
+    void cancel_anonymous_returns401() throws Exception {
+        mvc.perform(post("/api/v1/admin/reports/listing/1/cancel")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(VALID_NOTES))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void cancel_userRole_returns403() throws Exception {
+        mvc.perform(post("/api/v1/admin/reports/listing/1/cancel")
+            .header("Authorization", "Bearer " + userToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(VALID_NOTES))
+           .andExpect(status().isForbidden());
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/reports/AdminReportServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/reports/AdminReportServiceTest.java
@@ -1,0 +1,338 @@
+package com.slparcelauctions.backend.admin.reports;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.slparcelauctions.backend.admin.audit.AdminActionRepository;
+import com.slparcelauctions.backend.admin.reports.dto.AdminReportDetailDto;
+import com.slparcelauctions.backend.admin.reports.dto.AdminReportListingRowDto;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.VerificationMethod;
+import com.slparcelauctions.backend.auction.VerificationTier;
+import com.slparcelauctions.backend.common.PagedResponse;
+import com.slparcelauctions.backend.notification.NotificationWsBroadcasterPort;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.parcel.ParcelRepository;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class AdminReportServiceTest {
+
+    @Autowired AdminReportService service;
+    @Autowired ListingReportRepository reportRepo;
+    @Autowired AuctionRepository auctionRepo;
+    @Autowired ParcelRepository parcelRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired AdminActionRepository adminActionRepo;
+    @Autowired PlatformTransactionManager txManager;
+    @Autowired DataSource dataSource;
+
+    @MockitoBean NotificationWsBroadcasterPort wsBroadcaster;
+
+    private Long sellerId;
+    private Long adminId;
+    private Long reporter1Id;
+    private Long reporter2Id;
+    private Long reporter3Id;
+    private Long reporter4Id;
+    private Long parcelId;
+    private Long auctionId;
+    private Long openReport1Id;
+    private Long openReport2Id;
+    private Long openReport3Id;
+    private Long dismissedReportId;
+
+    @BeforeEach
+    void seed() {
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            User seller = userRepo.save(User.builder()
+                .email("rptadmin-seller-" + UUID.randomUUID() + "@x.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("Report Test Seller")
+                .verified(true)
+                .build());
+            sellerId = seller.getId();
+
+            User admin = userRepo.save(User.builder()
+                .email("rptadmin-admin-" + UUID.randomUUID() + "@x.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("Report Test Admin")
+                .role(Role.ADMIN)
+                .build());
+            adminId = admin.getId();
+
+            User reporter1 = userRepo.save(User.builder()
+                .email("rptadmin-r1-" + UUID.randomUUID() + "@x.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("Reporter One")
+                .verified(true)
+                .build());
+            reporter1Id = reporter1.getId();
+
+            User reporter2 = userRepo.save(User.builder()
+                .email("rptadmin-r2-" + UUID.randomUUID() + "@x.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("Reporter Two")
+                .verified(true)
+                .build());
+            reporter2Id = reporter2.getId();
+
+            User reporter3 = userRepo.save(User.builder()
+                .email("rptadmin-r3-" + UUID.randomUUID() + "@x.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("Reporter Three")
+                .verified(true)
+                .build());
+            reporter3Id = reporter3.getId();
+
+            User reporter4 = userRepo.save(User.builder()
+                .email("rptadmin-r4-" + UUID.randomUUID() + "@x.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("Reporter Four")
+                .verified(true)
+                .build());
+            reporter4Id = reporter4.getId();
+
+            Parcel parcel = parcelRepo.save(Parcel.builder()
+                .slParcelUuid(UUID.randomUUID())
+                .regionName("ReportAdminRegion")
+                .ownerUuid(seller.getSlAvatarUuid())
+                .areaSqm(1024)
+                .build());
+            parcelId = parcel.getId();
+
+            Auction auction = auctionRepo.save(Auction.builder()
+                .seller(seller)
+                .parcel(parcel)
+                .title("Admin Report Test Auction")
+                .status(AuctionStatus.ACTIVE)
+                .verificationTier(VerificationTier.SCRIPT)
+                .verificationMethod(VerificationMethod.UUID_ENTRY)
+                .startingBid(100L)
+                .durationHours(24)
+                .endsAt(OffsetDateTime.now().plusHours(24))
+                .build());
+            auctionId = auction.getId();
+
+            ListingReport r1 = reportRepo.save(ListingReport.builder()
+                .auction(auction)
+                .reporter(reporter1)
+                .subject("Open Report 1")
+                .reason(ListingReportReason.SHILL_BIDDING)
+                .details("Details 1")
+                .status(ListingReportStatus.OPEN)
+                .build());
+            openReport1Id = r1.getId();
+
+            ListingReport r2 = reportRepo.save(ListingReport.builder()
+                .auction(auction)
+                .reporter(reporter2)
+                .subject("Open Report 2")
+                .reason(ListingReportReason.FRAUDULENT_SELLER)
+                .details("Details 2")
+                .status(ListingReportStatus.OPEN)
+                .build());
+            openReport2Id = r2.getId();
+
+            ListingReport r3 = reportRepo.save(ListingReport.builder()
+                .auction(auction)
+                .reporter(reporter3)
+                .subject("Open Report 3")
+                .reason(ListingReportReason.INACCURATE_DESCRIPTION)
+                .details("Details 3")
+                .status(ListingReportStatus.OPEN)
+                .build());
+            openReport3Id = r3.getId();
+
+            ListingReport dismissed = reportRepo.save(ListingReport.builder()
+                .auction(auction)
+                .reporter(reporter4)
+                .subject("Dismissed Report")
+                .reason(ListingReportReason.OTHER)
+                .details("Already dismissed")
+                .status(ListingReportStatus.DISMISSED)
+                .build());
+            dismissedReportId = dismissed.getId();
+        });
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var st = conn.createStatement()) {
+                if (auctionId != null) {
+                    st.execute("DELETE FROM listing_reports WHERE auction_id = " + auctionId);
+                    st.execute("DELETE FROM cancellation_logs WHERE auction_id = " + auctionId);
+                    st.execute("DELETE FROM bot_tasks WHERE auction_id = " + auctionId);
+                    st.execute("DELETE FROM admin_actions WHERE target_type = 'LISTING' AND target_id = " + auctionId);
+                    st.execute("DELETE FROM auctions WHERE id = " + auctionId);
+                }
+                if (parcelId != null) {
+                    st.execute("DELETE FROM parcels WHERE id = " + parcelId);
+                }
+                if (adminId != null) {
+                    st.execute("DELETE FROM admin_actions WHERE admin_user_id = " + adminId);
+                    st.execute("DELETE FROM notification WHERE user_id = " + adminId);
+                    st.execute("DELETE FROM refresh_tokens WHERE user_id = " + adminId);
+                    st.execute("DELETE FROM users WHERE id = " + adminId);
+                }
+                for (Long id : List.of(sellerId, reporter1Id, reporter2Id, reporter3Id, reporter4Id)) {
+                    if (id != null) {
+                        st.execute("DELETE FROM notification WHERE user_id = " + id);
+                        st.execute("DELETE FROM sl_im_message WHERE user_id = " + id);
+                        st.execute("DELETE FROM refresh_tokens WHERE user_id = " + id);
+                        st.execute("DELETE FROM users WHERE id = " + id);
+                    }
+                }
+            }
+        }
+        sellerId = adminId = reporter1Id = reporter2Id = reporter3Id = reporter4Id = null;
+        parcelId = auctionId = null;
+        openReport1Id = openReport2Id = openReport3Id = dismissedReportId = null;
+    }
+
+    @Test
+    void listGrouped_openOnly_returnsOneRowPerAuction_sortedByReportCount() {
+        PagedResponse<AdminReportListingRowDto> resp =
+            service.listGrouped(ListingReportStatus.OPEN, PageRequest.of(0, 25));
+
+        List<AdminReportListingRowDto> rows = resp.content().stream()
+            .filter(r -> r.auctionId().equals(auctionId))
+            .toList();
+
+        assertThat(rows).hasSize(1);
+        AdminReportListingRowDto row = rows.get(0);
+        assertThat(row.auctionId()).isEqualTo(auctionId);
+        assertThat(row.openReportCount()).isEqualTo(3L);
+        assertThat(row.auctionTitle()).isEqualTo("Admin Report Test Auction");
+        assertThat(row.auctionStatus()).isEqualTo(AuctionStatus.ACTIVE);
+        assertThat(row.sellerUserId()).isEqualTo(sellerId);
+    }
+
+    @Test
+    void findByListing_returnsAllReports_orderedNewestFirst() {
+        List<AdminReportDetailDto> reports = service.findByListing(auctionId);
+
+        assertThat(reports).hasSize(4);
+        assertThat(reports.get(0).createdAt()).isAfterOrEqualTo(reports.get(1).createdAt());
+    }
+
+    @Test
+    void dismiss_marksDismissed_incrementsReporterFrivolousCounter() {
+        service.dismiss(openReport1Id, adminId, "Frivolous report");
+
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            ListingReport report = reportRepo.findById(openReport1Id).orElseThrow();
+            assertThat(report.getStatus()).isEqualTo(ListingReportStatus.DISMISSED);
+            assertThat(report.getAdminNotes()).isEqualTo("Frivolous report");
+            assertThat(report.getReviewedAt()).isNotNull();
+            assertThat(report.getReviewedBy()).isNotNull();
+
+            User reporter = userRepo.findById(reporter1Id).orElseThrow();
+            assertThat(reporter.getDismissedReportsCount()).isEqualTo(1L);
+        });
+
+        long actionCount = adminActionRepo.findAll().stream()
+            .filter(a -> a.getTargetId().equals(openReport1Id)
+                && a.getTargetType().name().equals("REPORT"))
+            .count();
+        assertThat(actionCount).isGreaterThanOrEqualTo(1L);
+    }
+
+    @Test
+    void warnSeller_marksOnlyOpenAsReviewed_dismissedPreserved() {
+        service.warnSeller(auctionId, adminId, "Final warning");
+
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            ListingReport r1 = reportRepo.findById(openReport1Id).orElseThrow();
+            ListingReport r2 = reportRepo.findById(openReport2Id).orElseThrow();
+            ListingReport r3 = reportRepo.findById(openReport3Id).orElseThrow();
+            ListingReport dismissed = reportRepo.findById(dismissedReportId).orElseThrow();
+
+            assertThat(r1.getStatus()).isEqualTo(ListingReportStatus.REVIEWED);
+            assertThat(r2.getStatus()).isEqualTo(ListingReportStatus.REVIEWED);
+            assertThat(r3.getStatus()).isEqualTo(ListingReportStatus.REVIEWED);
+            assertThat(dismissed.getStatus()).isEqualTo(ListingReportStatus.DISMISSED);
+        });
+    }
+
+    @Test
+    void suspend_callsSuspendByAdmin_marksOpenAsActionTaken_dismissedPreserved() {
+        service.suspend(auctionId, adminId, "Policy violation");
+
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            Auction auction = auctionRepo.findById(auctionId).orElseThrow();
+            assertThat(auction.getStatus()).isEqualTo(AuctionStatus.SUSPENDED);
+
+            ListingReport r1 = reportRepo.findById(openReport1Id).orElseThrow();
+            ListingReport r2 = reportRepo.findById(openReport2Id).orElseThrow();
+            ListingReport r3 = reportRepo.findById(openReport3Id).orElseThrow();
+            ListingReport dismissed = reportRepo.findById(dismissedReportId).orElseThrow();
+
+            assertThat(r1.getStatus()).isEqualTo(ListingReportStatus.ACTION_TAKEN);
+            assertThat(r2.getStatus()).isEqualTo(ListingReportStatus.ACTION_TAKEN);
+            assertThat(r3.getStatus()).isEqualTo(ListingReportStatus.ACTION_TAKEN);
+            assertThat(dismissed.getStatus()).isEqualTo(ListingReportStatus.DISMISSED);
+        });
+    }
+
+    @Test
+    void cancel_callsCancelByAdmin_marksOpenAsActionTaken_dismissedPreserved() {
+        service.cancel(auctionId, adminId, "Removed for violations");
+
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            Auction auction = auctionRepo.findById(auctionId).orElseThrow();
+            assertThat(auction.getStatus()).isEqualTo(AuctionStatus.CANCELLED);
+
+            ListingReport r1 = reportRepo.findById(openReport1Id).orElseThrow();
+            ListingReport r2 = reportRepo.findById(openReport2Id).orElseThrow();
+            ListingReport r3 = reportRepo.findById(openReport3Id).orElseThrow();
+            ListingReport dismissed = reportRepo.findById(dismissedReportId).orElseThrow();
+
+            assertThat(r1.getStatus()).isEqualTo(ListingReportStatus.ACTION_TAKEN);
+            assertThat(r2.getStatus()).isEqualTo(ListingReportStatus.ACTION_TAKEN);
+            assertThat(r3.getStatus()).isEqualTo(ListingReportStatus.ACTION_TAKEN);
+            assertThat(dismissed.getStatus()).isEqualTo(ListingReportStatus.DISMISSED);
+        });
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/reports/ListingReportRepositoryTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/reports/ListingReportRepositoryTest.java
@@ -1,0 +1,197 @@
+package com.slparcelauctions.backend.admin.reports;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.VerificationMethod;
+import com.slparcelauctions.backend.auction.VerificationTier;
+import com.slparcelauctions.backend.notification.NotificationWsBroadcasterPort;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.parcel.ParcelRepository;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class ListingReportRepositoryTest {
+
+    @Autowired ListingReportRepository reportRepo;
+    @Autowired AuctionRepository auctionRepo;
+    @Autowired ParcelRepository parcelRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired PlatformTransactionManager txManager;
+    @Autowired DataSource dataSource;
+
+    @MockitoBean NotificationWsBroadcasterPort wsBroadcaster;
+
+    private Long sellerId;
+    private Long reporterId;
+    private Long parcelId;
+    private Long auctionId;
+
+    @BeforeEach
+    void seed() {
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            User seller = userRepo.save(User.builder()
+                .email("lrr-seller-" + UUID.randomUUID() + "@x.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .build());
+            sellerId = seller.getId();
+
+            User reporter = userRepo.save(User.builder()
+                .email("lrr-reporter-" + UUID.randomUUID() + "@x.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .build());
+            reporterId = reporter.getId();
+
+            Parcel parcel = parcelRepo.save(Parcel.builder()
+                .slParcelUuid(UUID.randomUUID())
+                .regionName("LrrRegion")
+                .ownerUuid(seller.getSlAvatarUuid())
+                .areaSqm(512)
+                .build());
+            parcelId = parcel.getId();
+
+            Auction auction = auctionRepo.save(Auction.builder()
+                .seller(seller)
+                .parcel(parcel)
+                .title("LRR Test Auction")
+                .status(AuctionStatus.ACTIVE)
+                .verificationTier(VerificationTier.SCRIPT)
+                .verificationMethod(VerificationMethod.UUID_ENTRY)
+                .startingBid(100L)
+                .durationHours(24)
+                .endsAt(OffsetDateTime.now().plusHours(24))
+                .build());
+            auctionId = auction.getId();
+        });
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            if (auctionId != null) {
+                reportRepo.deleteAll(reportRepo.findByAuctionIdOrderByCreatedAtDesc(auctionId));
+                auctionRepo.findById(auctionId).ifPresent(auctionRepo::delete);
+            }
+            if (parcelId != null) {
+                parcelRepo.findById(parcelId).ifPresent(parcelRepo::delete);
+            }
+        });
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var st = conn.createStatement()) {
+                if (reporterId != null) {
+                    st.execute("DELETE FROM notification WHERE user_id = " + reporterId);
+                    st.execute("DELETE FROM refresh_tokens WHERE user_id = " + reporterId);
+                    st.execute("DELETE FROM users WHERE id = " + reporterId);
+                }
+                if (sellerId != null) {
+                    st.execute("DELETE FROM notification WHERE user_id = " + sellerId);
+                    st.execute("DELETE FROM refresh_tokens WHERE user_id = " + sellerId);
+                    st.execute("DELETE FROM users WHERE id = " + sellerId);
+                }
+            }
+        }
+        sellerId = reporterId = parcelId = auctionId = null;
+    }
+
+    @Test
+    void findByAuctionIdAndReporterId_noRow_returnsEmpty() {
+        Optional<ListingReport> result = reportRepo.findByAuctionIdAndReporterId(auctionId, reporterId);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void findByAuctionIdAndReporterId_withRow_returnsReport() {
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            Auction auction = auctionRepo.findById(auctionId).orElseThrow();
+            User reporter = userRepo.findById(reporterId).orElseThrow();
+            reportRepo.save(ListingReport.builder()
+                .auction(auction)
+                .reporter(reporter)
+                .subject("Test subject")
+                .reason(ListingReportReason.WRONG_TAGS)
+                .details("Some details")
+                .build());
+        });
+
+        Optional<ListingReport> result = reportRepo.findByAuctionIdAndReporterId(auctionId, reporterId);
+        assertThat(result).isPresent();
+        assertThat(result.get().getSubject()).isEqualTo("Test subject");
+        assertThat(result.get().getReason()).isEqualTo(ListingReportReason.WRONG_TAGS);
+        assertThat(result.get().getStatus()).isEqualTo(ListingReportStatus.OPEN);
+    }
+
+    @Test
+    void findByAuctionIdOrderByCreatedAtDesc_returnsOnlyForThatAuction() {
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            Auction auction = auctionRepo.findById(auctionId).orElseThrow();
+            User reporter = userRepo.findById(reporterId).orElseThrow();
+            reportRepo.save(ListingReport.builder()
+                .auction(auction)
+                .reporter(reporter)
+                .subject("Subject A")
+                .reason(ListingReportReason.SHILL_BIDDING)
+                .details("Details A")
+                .build());
+        });
+
+        List<ListingReport> reports = reportRepo.findByAuctionIdOrderByCreatedAtDesc(auctionId);
+        assertThat(reports).hasSize(1);
+        assertThat(reports.get(0).getSubject()).isEqualTo("Subject A");
+    }
+
+    @Test
+    void countByStatus_countsOpenReports() {
+        long openBefore = reportRepo.countByStatus(ListingReportStatus.OPEN);
+
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            Auction auction = auctionRepo.findById(auctionId).orElseThrow();
+            User reporter = userRepo.findById(reporterId).orElseThrow();
+            reportRepo.save(ListingReport.builder()
+                .auction(auction)
+                .reporter(reporter)
+                .subject("Count test")
+                .reason(ListingReportReason.OTHER)
+                .details("Details")
+                .build());
+        });
+
+        long openAfter = reportRepo.countByStatus(ListingReportStatus.OPEN);
+        assertThat(openAfter).isEqualTo(openBefore + 1);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/reports/UserReportControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/reports/UserReportControllerSliceTest.java
@@ -1,0 +1,191 @@
+package com.slparcelauctions.backend.admin.reports;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.slparcelauctions.backend.admin.reports.dto.MyReportResponse;
+import com.slparcelauctions.backend.admin.reports.exception.AuctionNotReportableException;
+import com.slparcelauctions.backend.admin.reports.exception.CannotReportOwnListingException;
+import com.slparcelauctions.backend.admin.reports.exception.MustBeVerifiedToReportException;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.user.Role;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class UserReportControllerSliceTest {
+
+    @Autowired MockMvc mvc;
+    @Autowired JwtService jwtService;
+
+    @MockitoBean UserReportService service;
+
+    private String userToken() {
+        return jwtService.issueAccessToken(new AuthPrincipal(42L, "u@x.com", 1L, Role.USER));
+    }
+
+    private static final String VALID_BODY = """
+            {"subject":"Bad listing","reason":"INACCURATE_DESCRIPTION","details":"Details here."}
+            """;
+
+    // -------------------------------------------------------------------------
+    // Auth gate
+    // -------------------------------------------------------------------------
+
+    @Test
+    void report_anonymous_returns401() throws Exception {
+        mvc.perform(post("/api/v1/auctions/1/report")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(VALID_BODY))
+           .andExpect(status().isUnauthorized());
+    }
+
+    // -------------------------------------------------------------------------
+    // Bean Validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    void report_emptySubject_returns400() throws Exception {
+        mvc.perform(post("/api/v1/auctions/1/report")
+            .header("Authorization", "Bearer " + userToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"subject\":\"\",\"reason\":\"OTHER\",\"details\":\"some details\"}"))
+           .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void report_blankDetails_returns400() throws Exception {
+        mvc.perform(post("/api/v1/auctions/1/report")
+            .header("Authorization", "Bearer " + userToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"subject\":\"A subject\",\"reason\":\"OTHER\",\"details\":\"   \"}"))
+           .andExpect(status().isBadRequest());
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path
+    // -------------------------------------------------------------------------
+
+    @Test
+    void report_validInput_returns200_withMyReportResponse() throws Exception {
+        OffsetDateTime now = OffsetDateTime.now();
+        MyReportResponse resp = new MyReportResponse(
+            99L, "Bad listing", ListingReportReason.INACCURATE_DESCRIPTION,
+            "Details here.", ListingReportStatus.OPEN, now, now);
+        when(service.upsertReport(eq(1L), eq(42L), any())).thenReturn(resp);
+
+        mvc.perform(post("/api/v1/auctions/1/report")
+            .header("Authorization", "Bearer " + userToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(VALID_BODY))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.id").value(99))
+           .andExpect(jsonPath("$.subject").value("Bad listing"))
+           .andExpect(jsonPath("$.reason").value("INACCURATE_DESCRIPTION"))
+           .andExpect(jsonPath("$.status").value("OPEN"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Exception handler wiring
+    // -------------------------------------------------------------------------
+
+    @Test
+    void report_unverifiedReporter_returns403_VERIFICATION_REQUIRED() throws Exception {
+        when(service.upsertReport(any(), any(), any()))
+            .thenThrow(new MustBeVerifiedToReportException());
+
+        mvc.perform(post("/api/v1/auctions/1/report")
+            .header("Authorization", "Bearer " + userToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(VALID_BODY))
+           .andExpect(status().isForbidden())
+           .andExpect(jsonPath("$.code").value("VERIFICATION_REQUIRED"));
+    }
+
+    @Test
+    void report_ownListing_returns409_CANNOT_REPORT_OWN_LISTING() throws Exception {
+        when(service.upsertReport(any(), any(), any()))
+            .thenThrow(new CannotReportOwnListingException());
+
+        mvc.perform(post("/api/v1/auctions/1/report")
+            .header("Authorization", "Bearer " + userToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(VALID_BODY))
+           .andExpect(status().isConflict())
+           .andExpect(jsonPath("$.code").value("CANNOT_REPORT_OWN_LISTING"));
+    }
+
+    @Test
+    void report_nonActiveAuction_returns409_AUCTION_NOT_REPORTABLE() throws Exception {
+        when(service.upsertReport(any(), any(), any()))
+            .thenThrow(new AuctionNotReportableException(AuctionStatus.CANCELLED));
+
+        mvc.perform(post("/api/v1/auctions/1/report")
+            .header("Authorization", "Bearer " + userToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(VALID_BODY))
+           .andExpect(status().isConflict())
+           .andExpect(jsonPath("$.code").value("AUCTION_NOT_REPORTABLE"))
+           .andExpect(jsonPath("$.currentStatus").value("CANCELLED"));
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /my-report
+    // -------------------------------------------------------------------------
+
+    @Test
+    void myReport_noRow_returns204() throws Exception {
+        when(service.findMyReport(eq(1L), eq(42L))).thenReturn(Optional.empty());
+
+        mvc.perform(get("/api/v1/auctions/1/my-report")
+            .header("Authorization", "Bearer " + userToken()))
+           .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void myReport_withRow_returns200() throws Exception {
+        OffsetDateTime now = OffsetDateTime.now();
+        MyReportResponse resp = new MyReportResponse(
+            7L, "Subject", ListingReportReason.TOS_VIOLATION,
+            "Details.", ListingReportStatus.REVIEWED, now, now);
+        when(service.findMyReport(eq(1L), eq(42L))).thenReturn(Optional.of(resp));
+
+        mvc.perform(get("/api/v1/auctions/1/my-report")
+            .header("Authorization", "Bearer " + userToken()))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.id").value(7))
+           .andExpect(jsonPath("$.reason").value("TOS_VIOLATION"))
+           .andExpect(jsonPath("$.status").value("REVIEWED"));
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/reports/UserReportServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/reports/UserReportServiceTest.java
@@ -1,0 +1,243 @@
+package com.slparcelauctions.backend.admin.reports;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.slparcelauctions.backend.admin.reports.dto.MyReportResponse;
+import com.slparcelauctions.backend.admin.reports.dto.ReportRequest;
+import com.slparcelauctions.backend.admin.reports.exception.AuctionNotReportableException;
+import com.slparcelauctions.backend.admin.reports.exception.CannotReportOwnListingException;
+import com.slparcelauctions.backend.admin.reports.exception.MustBeVerifiedToReportException;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.VerificationMethod;
+import com.slparcelauctions.backend.auction.VerificationTier;
+import com.slparcelauctions.backend.notification.NotificationWsBroadcasterPort;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.parcel.ParcelRepository;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class UserReportServiceTest {
+
+    @Autowired UserReportService service;
+    @Autowired ListingReportRepository reportRepo;
+    @Autowired AuctionRepository auctionRepo;
+    @Autowired ParcelRepository parcelRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired PlatformTransactionManager txManager;
+    @Autowired DataSource dataSource;
+
+    @MockitoBean NotificationWsBroadcasterPort wsBroadcaster;
+
+    private Long sellerId;
+    private Long reporterId;
+    private Long parcelId;
+    private Long auctionId;
+
+    @BeforeEach
+    void seed() {
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            User seller = userRepo.save(User.builder()
+                .email("rpt-seller-" + UUID.randomUUID() + "@x.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .verified(true)
+                .build());
+            sellerId = seller.getId();
+
+            User reporter = userRepo.save(User.builder()
+                .email("rpt-reporter-" + UUID.randomUUID() + "@x.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .verified(true)
+                .build());
+            reporterId = reporter.getId();
+
+            Parcel parcel = parcelRepo.save(Parcel.builder()
+                .slParcelUuid(UUID.randomUUID())
+                .regionName("ReportRegion")
+                .ownerUuid(seller.getSlAvatarUuid())
+                .areaSqm(1024)
+                .build());
+            parcelId = parcel.getId();
+
+            Auction auction = auctionRepo.save(Auction.builder()
+                .seller(seller)
+                .parcel(parcel)
+                .title("Reportable Auction")
+                .status(AuctionStatus.ACTIVE)
+                .verificationTier(VerificationTier.SCRIPT)
+                .verificationMethod(VerificationMethod.UUID_ENTRY)
+                .startingBid(100L)
+                .durationHours(24)
+                .endsAt(OffsetDateTime.now().plusHours(24))
+                .build());
+            auctionId = auction.getId();
+        });
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            if (auctionId != null) {
+                reportRepo.deleteAll(reportRepo.findByAuctionIdOrderByCreatedAtDesc(auctionId));
+                auctionRepo.findById(auctionId).ifPresent(auctionRepo::delete);
+            }
+            if (parcelId != null) {
+                parcelRepo.findById(parcelId).ifPresent(parcelRepo::delete);
+            }
+        });
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var st = conn.createStatement()) {
+                if (reporterId != null) {
+                    st.execute("DELETE FROM notification WHERE user_id = " + reporterId);
+                    st.execute("DELETE FROM refresh_tokens WHERE user_id = " + reporterId);
+                    st.execute("DELETE FROM users WHERE id = " + reporterId);
+                }
+                if (sellerId != null) {
+                    st.execute("DELETE FROM notification WHERE user_id = " + sellerId);
+                    st.execute("DELETE FROM refresh_tokens WHERE user_id = " + sellerId);
+                    st.execute("DELETE FROM users WHERE id = " + sellerId);
+                }
+            }
+        }
+        sellerId = reporterId = parcelId = auctionId = null;
+    }
+
+    // -------------------------------------------------------------------------
+    // upsertReport — happy path
+    // -------------------------------------------------------------------------
+
+    @Test
+    void upsertReport_firstSubmit_createsReportWithStatusOpen() {
+        ReportRequest req = new ReportRequest("Bad listing", ListingReportReason.INACCURATE_DESCRIPTION, "The details are wrong.");
+
+        MyReportResponse resp = service.upsertReport(auctionId, reporterId, req);
+
+        assertThat(resp.id()).isNotNull();
+        assertThat(resp.subject()).isEqualTo("Bad listing");
+        assertThat(resp.reason()).isEqualTo(ListingReportReason.INACCURATE_DESCRIPTION);
+        assertThat(resp.details()).isEqualTo("The details are wrong.");
+        assertThat(resp.status()).isEqualTo(ListingReportStatus.OPEN);
+        assertThat(resp.createdAt()).isNotNull();
+        assertThat(resp.updatedAt()).isNotNull();
+    }
+
+    @Test
+    void upsertReport_resubmit_replacesExistingRow_resetsToOpen() {
+        ReportRequest req1 = new ReportRequest("First subject", ListingReportReason.WRONG_TAGS, "First details.");
+        MyReportResponse first = service.upsertReport(auctionId, reporterId, req1);
+
+        // Manually set status to DISMISSED
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            ListingReport r = reportRepo.findById(first.id()).orElseThrow();
+            r.setStatus(ListingReportStatus.DISMISSED);
+            reportRepo.save(r);
+        });
+
+        // Resubmit
+        ReportRequest req2 = new ReportRequest("Updated subject", ListingReportReason.SHILL_BIDDING, "New details.");
+        MyReportResponse second = service.upsertReport(auctionId, reporterId, req2);
+
+        assertThat(second.id()).isEqualTo(first.id()); // same row
+        assertThat(second.subject()).isEqualTo("Updated subject");
+        assertThat(second.reason()).isEqualTo(ListingReportReason.SHILL_BIDDING);
+        assertThat(second.details()).isEqualTo("New details.");
+        assertThat(second.status()).isEqualTo(ListingReportStatus.OPEN);
+    }
+
+    // -------------------------------------------------------------------------
+    // upsertReport — gate failures
+    // -------------------------------------------------------------------------
+
+    @Test
+    void upsertReport_unverifiedReporter_throwsMustBeVerified() {
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            User r = userRepo.findById(reporterId).orElseThrow();
+            r.setVerified(false);
+            userRepo.save(r);
+        });
+
+        ReportRequest req = new ReportRequest("x", ListingReportReason.OTHER, "y");
+        assertThatThrownBy(() -> service.upsertReport(auctionId, reporterId, req))
+            .isInstanceOf(MustBeVerifiedToReportException.class);
+    }
+
+    @Test
+    void upsertReport_ownListing_throwsCannotReportOwn() {
+        ReportRequest req = new ReportRequest("x", ListingReportReason.OTHER, "y");
+        assertThatThrownBy(() -> service.upsertReport(auctionId, sellerId, req))
+            .isInstanceOf(CannotReportOwnListingException.class);
+    }
+
+    @Test
+    void upsertReport_nonActiveAuction_throwsAuctionNotReportable() {
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            Auction a = auctionRepo.findById(auctionId).orElseThrow();
+            a.setStatus(AuctionStatus.CANCELLED);
+            auctionRepo.save(a);
+        });
+
+        ReportRequest req = new ReportRequest("x", ListingReportReason.OTHER, "y");
+        assertThatThrownBy(() -> service.upsertReport(auctionId, reporterId, req))
+            .isInstanceOf(AuctionNotReportableException.class)
+            .satisfies(ex -> assertThat(((AuctionNotReportableException) ex).getCurrentStatus())
+                .isEqualTo(AuctionStatus.CANCELLED));
+    }
+
+    // -------------------------------------------------------------------------
+    // findMyReport
+    // -------------------------------------------------------------------------
+
+    @Test
+    void findMyReport_noRow_returnsEmpty() {
+        Optional<MyReportResponse> result = service.findMyReport(auctionId, reporterId);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void findMyReport_withRow_returnsPopulated() {
+        ReportRequest req = new ReportRequest("My subject", ListingReportReason.DUPLICATE_LISTING, "Details here.");
+        service.upsertReport(auctionId, reporterId, req);
+
+        Optional<MyReportResponse> result = service.findMyReport(auctionId, reporterId);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().subject()).isEqualTo("My subject");
+        assertThat(result.get().reason()).isEqualTo(ListingReportReason.DUPLICATE_LISTING);
+        assertThat(result.get().status()).isEqualTo(ListingReportStatus.OPEN);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/users/AdminRoleServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/users/AdminRoleServiceTest.java
@@ -1,0 +1,148 @@
+package com.slparcelauctions.backend.admin.users;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.slparcelauctions.backend.admin.audit.AdminActionService;
+import com.slparcelauctions.backend.admin.audit.AdminActionTargetType;
+import com.slparcelauctions.backend.admin.audit.AdminActionType;
+import com.slparcelauctions.backend.admin.users.exception.SelfDemoteException;
+import com.slparcelauctions.backend.admin.users.exception.UserAlreadyAdminException;
+import com.slparcelauctions.backend.admin.users.exception.UserNotAdminException;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AdminRoleServiceTest {
+
+    @Mock UserRepository userRepo;
+    @Mock AdminActionService adminActionService;
+
+    private AdminRoleService service;
+
+    private static final Long ADMIN_ID = 1L;
+    private static final Long TARGET_ID = 2L;
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminRoleService(userRepo, adminActionService);
+    }
+
+    private User buildUser(Long id, Role role) {
+        User u = User.builder()
+            .email("user" + id + "@x.com")
+            .passwordHash("x")
+            .displayName("User" + id)
+            .build();
+        try {
+            java.lang.reflect.Field f = User.class.getDeclaredField("id");
+            f.setAccessible(true);
+            f.set(u, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        u.setRole(role);
+        return u;
+    }
+
+    // -------------------------------------------------------------------------
+    // promote
+    // -------------------------------------------------------------------------
+
+    @Test
+    void promote_alreadyAdmin_throws() {
+        User target = buildUser(TARGET_ID, Role.ADMIN);
+        when(userRepo.findById(TARGET_ID)).thenReturn(Optional.of(target));
+
+        assertThatThrownBy(() -> service.promote(TARGET_ID, ADMIN_ID, "notes"))
+            .isInstanceOf(UserAlreadyAdminException.class)
+            .hasMessageContaining(TARGET_ID.toString());
+    }
+
+    @Test
+    void promote_happyPath_flipsRoleAndBumpsTv_writesAuditRow() {
+        User target = buildUser(TARGET_ID, Role.USER);
+        when(userRepo.findById(TARGET_ID)).thenReturn(Optional.of(target));
+        when(userRepo.save(any())).thenReturn(target);
+        when(userRepo.bumpTokenVersion(TARGET_ID)).thenReturn(1);
+
+        service.promote(TARGET_ID, ADMIN_ID, "promoting user");
+
+        assertThat(target.getRole()).isEqualTo(Role.ADMIN);
+        verify(userRepo).bumpTokenVersion(TARGET_ID);
+        verify(adminActionService).record(
+            eq(ADMIN_ID), eq(AdminActionType.PROMOTE_USER),
+            eq(AdminActionTargetType.USER), eq(TARGET_ID),
+            eq("promoting user"), eq(null));
+    }
+
+    // -------------------------------------------------------------------------
+    // demote
+    // -------------------------------------------------------------------------
+
+    @Test
+    void demote_selfDemote_throws() {
+        assertThatThrownBy(() -> service.demote(ADMIN_ID, ADMIN_ID, "notes"))
+            .isInstanceOf(SelfDemoteException.class);
+    }
+
+    @Test
+    void demote_notAdmin_throws() {
+        User target = buildUser(TARGET_ID, Role.USER);
+        when(userRepo.findById(TARGET_ID)).thenReturn(Optional.of(target));
+
+        assertThatThrownBy(() -> service.demote(TARGET_ID, ADMIN_ID, "notes"))
+            .isInstanceOf(UserNotAdminException.class)
+            .hasMessageContaining(TARGET_ID.toString());
+    }
+
+    @Test
+    void demote_happyPath_flipsRoleAndBumpsTv_writesAuditRow() {
+        User target = buildUser(TARGET_ID, Role.ADMIN);
+        when(userRepo.findById(TARGET_ID)).thenReturn(Optional.of(target));
+        when(userRepo.save(any())).thenReturn(target);
+        when(userRepo.bumpTokenVersion(TARGET_ID)).thenReturn(1);
+
+        service.demote(TARGET_ID, ADMIN_ID, "demoting user");
+
+        assertThat(target.getRole()).isEqualTo(Role.USER);
+        verify(userRepo).bumpTokenVersion(TARGET_ID);
+        verify(adminActionService).record(
+            eq(ADMIN_ID), eq(AdminActionType.DEMOTE_USER),
+            eq(AdminActionTargetType.USER), eq(TARGET_ID),
+            eq("demoting user"), eq(null));
+    }
+
+    // -------------------------------------------------------------------------
+    // resetFrivolousCounter
+    // -------------------------------------------------------------------------
+
+    @Test
+    void resetFrivolousCounter_zeroes_writesAuditRow() {
+        User target = buildUser(TARGET_ID, Role.USER);
+        target.setDismissedReportsCount(5L);
+        when(userRepo.findById(TARGET_ID)).thenReturn(Optional.of(target));
+        when(userRepo.save(any())).thenReturn(target);
+
+        service.resetFrivolousCounter(TARGET_ID, ADMIN_ID, "reset counter");
+
+        assertThat(target.getDismissedReportsCount()).isEqualTo(0L);
+        verify(adminActionService).record(
+            eq(ADMIN_ID), eq(AdminActionType.RESET_FRIVOLOUS_COUNTER),
+            eq(AdminActionTargetType.USER), eq(TARGET_ID),
+            eq("reset counter"), eq(null));
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/users/AdminUserControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/users/AdminUserControllerSliceTest.java
@@ -1,0 +1,308 @@
+package com.slparcelauctions.backend.admin.users;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.slparcelauctions.backend.admin.users.dto.AdminUserDetailDto;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserSummaryDto;
+import com.slparcelauctions.backend.admin.users.exception.SelfDemoteException;
+import com.slparcelauctions.backend.admin.users.exception.UserAlreadyAdminException;
+import com.slparcelauctions.backend.admin.users.exception.UserNotAdminException;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.common.PagedResponse;
+import com.slparcelauctions.backend.user.Role;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class AdminUserControllerSliceTest {
+
+    @Autowired MockMvc mvc;
+    @Autowired JwtService jwtService;
+
+    @MockitoBean AdminUserService adminUserService;
+    @MockitoBean AdminRoleService adminRoleService;
+
+    private String adminToken() {
+        return jwtService.issueAccessToken(new AuthPrincipal(1L, "admin@x.com", 1L, Role.ADMIN));
+    }
+
+    private String userToken() {
+        return jwtService.issueAccessToken(new AuthPrincipal(2L, "user@x.com", 1L, Role.USER));
+    }
+
+    private static final String NOTES_BODY = "{\"notes\":\"some reason\"}";
+
+    // -------------------------------------------------------------------------
+    // GET /api/v1/admin/users — auth gate
+    // -------------------------------------------------------------------------
+
+    @Test
+    void search_anon_returns401() throws Exception {
+        mvc.perform(get("/api/v1/admin/users"))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void search_userRole_returns403() throws Exception {
+        mvc.perform(get("/api/v1/admin/users")
+            .header("Authorization", "Bearer " + userToken()))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void search_admin_returns200() throws Exception {
+        PagedResponse<AdminUserSummaryDto> empty =
+            new PagedResponse<>(Collections.emptyList(), 0L, 0, 0, 25);
+        when(adminUserService.search(any(), any())).thenReturn(empty);
+
+        mvc.perform(get("/api/v1/admin/users")
+            .header("Authorization", "Bearer " + adminToken()))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.totalElements").value(0));
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /api/v1/admin/users/{id} — auth gate
+    // -------------------------------------------------------------------------
+
+    @Test
+    void detail_anon_returns401() throws Exception {
+        mvc.perform(get("/api/v1/admin/users/1"))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void detail_userRole_returns403() throws Exception {
+        mvc.perform(get("/api/v1/admin/users/1")
+            .header("Authorization", "Bearer " + userToken()))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void detail_admin_returns200() throws Exception {
+        AdminUserDetailDto dto = new AdminUserDetailDto(
+            1L, "u@x.com", "User", null, null,
+            Role.USER, false, null, null,
+            0L, 0L, 0L, 0L, 0L, null, false, null);
+        when(adminUserService.detail(1L)).thenReturn(dto);
+
+        mvc.perform(get("/api/v1/admin/users/1")
+            .header("Authorization", "Bearer " + adminToken()))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.id").value(1));
+    }
+
+    // -------------------------------------------------------------------------
+    // Tab endpoints — auth gates (spot-check listings and bids)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void listings_anon_returns401() throws Exception {
+        mvc.perform(get("/api/v1/admin/users/1/listings"))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void listings_userRole_returns403() throws Exception {
+        mvc.perform(get("/api/v1/admin/users/1/listings")
+            .header("Authorization", "Bearer " + userToken()))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void listings_admin_returns200() throws Exception {
+        PagedResponse<com.slparcelauctions.backend.admin.users.dto.AdminUserListingRowDto> empty =
+            new PagedResponse<>(Collections.emptyList(), 0L, 0, 0, 25);
+        when(adminUserService.listings(anyLong(), any())).thenReturn(empty);
+
+        mvc.perform(get("/api/v1/admin/users/1/listings")
+            .header("Authorization", "Bearer " + adminToken()))
+           .andExpect(status().isOk());
+    }
+
+    @Test
+    void bids_anon_returns401() throws Exception {
+        mvc.perform(get("/api/v1/admin/users/1/bids"))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void ips_anon_returns401() throws Exception {
+        mvc.perform(get("/api/v1/admin/users/1/ips"))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void ips_admin_returns200() throws Exception {
+        when(adminUserService.ips(anyLong())).thenReturn(Collections.emptyList());
+
+        mvc.perform(get("/api/v1/admin/users/1/ips")
+            .header("Authorization", "Bearer " + adminToken()))
+           .andExpect(status().isOk());
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/v1/admin/users/{id}/promote — auth + conflict paths
+    // -------------------------------------------------------------------------
+
+    @Test
+    void promote_anon_returns401() throws Exception {
+        mvc.perform(post("/api/v1/admin/users/2/promote")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(NOTES_BODY))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void promote_userRole_returns403() throws Exception {
+        mvc.perform(post("/api/v1/admin/users/2/promote")
+            .header("Authorization", "Bearer " + userToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(NOTES_BODY))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void promote_alreadyAdmin_returns409_ALREADY_ADMIN() throws Exception {
+        doThrow(new UserAlreadyAdminException(2L))
+            .when(adminRoleService).promote(anyLong(), anyLong(), anyString());
+
+        mvc.perform(post("/api/v1/admin/users/2/promote")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(NOTES_BODY))
+           .andExpect(status().isConflict())
+           .andExpect(jsonPath("$.code").value("ALREADY_ADMIN"));
+    }
+
+    @Test
+    void promote_admin_returns200() throws Exception {
+        doNothing().when(adminRoleService).promote(anyLong(), anyLong(), anyString());
+
+        mvc.perform(post("/api/v1/admin/users/2/promote")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(NOTES_BODY))
+           .andExpect(status().isOk());
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/v1/admin/users/{id}/demote — auth + conflict paths
+    // -------------------------------------------------------------------------
+
+    @Test
+    void demote_anon_returns401() throws Exception {
+        mvc.perform(post("/api/v1/admin/users/2/demote")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(NOTES_BODY))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void demote_selfDemote_returns409_SELF_DEMOTE_FORBIDDEN() throws Exception {
+        doThrow(new SelfDemoteException())
+            .when(adminRoleService).demote(anyLong(), anyLong(), anyString());
+
+        mvc.perform(post("/api/v1/admin/users/1/demote")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(NOTES_BODY))
+           .andExpect(status().isConflict())
+           .andExpect(jsonPath("$.code").value("SELF_DEMOTE_FORBIDDEN"));
+    }
+
+    @Test
+    void demote_notAdmin_returns409_NOT_ADMIN() throws Exception {
+        doThrow(new UserNotAdminException(2L))
+            .when(adminRoleService).demote(anyLong(), anyLong(), anyString());
+
+        mvc.perform(post("/api/v1/admin/users/2/demote")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(NOTES_BODY))
+           .andExpect(status().isConflict())
+           .andExpect(jsonPath("$.code").value("NOT_ADMIN"));
+    }
+
+    @Test
+    void demote_admin_returns200() throws Exception {
+        doNothing().when(adminRoleService).demote(anyLong(), anyLong(), anyString());
+
+        mvc.perform(post("/api/v1/admin/users/2/demote")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(NOTES_BODY))
+           .andExpect(status().isOk());
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/v1/admin/users/{id}/reset-frivolous-counter
+    // -------------------------------------------------------------------------
+
+    @Test
+    void resetCounter_anon_returns401() throws Exception {
+        mvc.perform(post("/api/v1/admin/users/2/reset-frivolous-counter")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(NOTES_BODY))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void resetCounter_admin_returns200() throws Exception {
+        doNothing().when(adminRoleService).resetFrivolousCounter(anyLong(), anyLong(), anyString());
+
+        mvc.perform(post("/api/v1/admin/users/2/reset-frivolous-counter")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(NOTES_BODY))
+           .andExpect(status().isOk());
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation: blank notes returns 400
+    // -------------------------------------------------------------------------
+
+    @Test
+    void promote_blankNotes_returns400_VALIDATION_FAILED() throws Exception {
+        mvc.perform(post("/api/v1/admin/users/2/promote")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"notes\":\"\"}"))
+           .andExpect(status().isBadRequest())
+           .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"));
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/users/AdminUserServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/users/AdminUserServiceTest.java
@@ -1,0 +1,197 @@
+package com.slparcelauctions.backend.admin.users;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.slparcelauctions.backend.admin.audit.AdminActionRepository;
+import com.slparcelauctions.backend.admin.ban.BanRepository;
+import com.slparcelauctions.backend.admin.reports.ListingReportRepository;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserDetailDto;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserListingRowDto;
+import com.slparcelauctions.backend.admin.users.dto.AdminUserSummaryDto;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.BidRepository;
+import com.slparcelauctions.backend.auction.CancellationLogRepository;
+import com.slparcelauctions.backend.auction.fraud.FraudFlagRepository;
+import com.slparcelauctions.backend.auth.RefreshTokenRepository;
+import com.slparcelauctions.backend.common.PagedResponse;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AdminUserServiceTest {
+
+    @Mock UserRepository userRepo;
+    @Mock BanRepository banRepo;
+    @Mock AuctionRepository auctionRepo;
+    @Mock BidRepository bidRepo;
+    @Mock CancellationLogRepository cancellationLogRepo;
+    @Mock ListingReportRepository listingReportRepo;
+    @Mock FraudFlagRepository fraudFlagRepo;
+    @Mock AdminActionRepository adminActionRepo;
+    @Mock RefreshTokenRepository refreshTokenRepo;
+
+    private static final Clock FIXED_CLOCK =
+        Clock.fixed(Instant.parse("2026-01-01T12:00:00Z"), ZoneOffset.UTC);
+
+    private AdminUserService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminUserService(userRepo, banRepo, auctionRepo, bidRepo,
+            cancellationLogRepo, listingReportRepo, fraudFlagRepo, adminActionRepo,
+            refreshTokenRepo, FIXED_CLOCK);
+    }
+
+    private User buildUser(Long id) {
+        User u = User.builder()
+            .email("user" + id + "@x.com")
+            .passwordHash("x")
+            .displayName("User" + id)
+            .build();
+        try {
+            java.lang.reflect.Field f = User.class.getDeclaredField("id");
+            f.setAccessible(true);
+            f.set(u, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return u;
+    }
+
+    // -------------------------------------------------------------------------
+    // search routing
+    // -------------------------------------------------------------------------
+
+    @Test
+    void search_uuidInput_parsesAsUuid_passesUuidParam() {
+        UUID uuid = UUID.randomUUID();
+        User user = buildUser(1L);
+        Page<User> page = new PageImpl<>(List.of(user));
+        Pageable pageable = PageRequest.of(0, 25);
+
+        when(userRepo.searchAdmin(isNull(), eq(uuid), eq(pageable))).thenReturn(page);
+
+        PagedResponse<AdminUserSummaryDto> result = service.search(uuid.toString(), pageable);
+
+        assertThat(result.totalElements()).isEqualTo(1);
+        verify(userRepo).searchAdmin(isNull(), eq(uuid), eq(pageable));
+    }
+
+    @Test
+    void search_substringInput_passesSearchParam_nullUuid() {
+        String input = "testuser";
+        User user = buildUser(2L);
+        Page<User> page = new PageImpl<>(List.of(user));
+        Pageable pageable = PageRequest.of(0, 25);
+
+        when(userRepo.searchAdmin(eq(input), isNull(), eq(pageable))).thenReturn(page);
+
+        PagedResponse<AdminUserSummaryDto> result = service.search(input, pageable);
+
+        assertThat(result.totalElements()).isEqualTo(1);
+        verify(userRepo).searchAdmin(eq(input), isNull(), eq(pageable));
+    }
+
+    @Test
+    void search_emptyInput_passesNullBoth() {
+        Page<User> page = new PageImpl<>(Collections.emptyList());
+        Pageable pageable = PageRequest.of(0, 25);
+
+        when(userRepo.searchAdmin(isNull(), isNull(), eq(pageable))).thenReturn(page);
+
+        PagedResponse<AdminUserSummaryDto> result = service.search("", pageable);
+
+        assertThat(result.totalElements()).isEqualTo(0);
+        verify(userRepo).searchAdmin(isNull(), isNull(), eq(pageable));
+    }
+
+    @Test
+    void search_nullInput_passesNullBoth() {
+        Page<User> page = new PageImpl<>(Collections.emptyList());
+        Pageable pageable = PageRequest.of(0, 25);
+
+        when(userRepo.searchAdmin(isNull(), isNull(), eq(pageable))).thenReturn(page);
+
+        service.search(null, pageable);
+
+        verify(userRepo).searchAdmin(isNull(), isNull(), eq(pageable));
+    }
+
+    // -------------------------------------------------------------------------
+    // detail
+    // -------------------------------------------------------------------------
+
+    @Test
+    void detail_returnsDto_withNullActiveBan_whenNoSlUuid() {
+        User user = buildUser(5L);
+        when(userRepo.findById(5L)).thenReturn(Optional.of(user));
+
+        AdminUserDetailDto dto = service.detail(5L);
+
+        assertThat(dto.id()).isEqualTo(5L);
+        assertThat(dto.activeBan()).isNull();
+    }
+
+    // -------------------------------------------------------------------------
+    // listings tab
+    // -------------------------------------------------------------------------
+
+    @Test
+    void listings_mapsAuctionToDto() {
+        Parcel parcel = Parcel.builder().regionName("Test Region").build();
+        Auction auction = Auction.builder()
+            .title("My Auction")
+            .status(AuctionStatus.ACTIVE)
+            .endsAt(OffsetDateTime.now(FIXED_CLOCK).plusHours(24))
+            .parcel(parcel)
+            .build();
+        try {
+            java.lang.reflect.Field f = Auction.class.getDeclaredField("id");
+            f.setAccessible(true);
+            f.set(auction, 10L);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        Pageable pageable = PageRequest.of(0, 25);
+        when(auctionRepo.findBySellerIdOrderByCreatedAtDesc(eq(5L), eq(pageable)))
+            .thenReturn(new PageImpl<>(List.of(auction)));
+
+        PagedResponse<AdminUserListingRowDto> result = service.listings(5L, pageable);
+
+        assertThat(result.totalElements()).isEqualTo(1);
+        AdminUserListingRowDto row = result.content().get(0);
+        assertThat(row.auctionId()).isEqualTo(10L);
+        assertThat(row.title()).isEqualTo("My Auction");
+        assertThat(row.regionName()).isEqualTo("Test Region");
+        assertThat(row.status()).isEqualTo(AuctionStatus.ACTIVE);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionServiceTest.java
@@ -26,6 +26,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.slparcelauctions.backend.admin.ban.BanCheckService;
 import com.slparcelauctions.backend.auction.exception.SellerSuspendedException;
 import com.slparcelauctions.backend.auction.exception.SuspensionReason;
 
@@ -47,6 +48,7 @@ class AuctionServiceTest {
     @Mock ParcelRepository parcelRepo;
     @Mock UserRepository userRepo;
     @Mock ParcelTagRepository tagRepo;
+    @Mock BanCheckService banCheckService;
     @Spy Clock clock = Clock.fixed(Instant.parse("2026-04-24T10:00:00Z"), ZoneOffset.UTC);
 
     @InjectMocks AuctionService service;
@@ -79,7 +81,7 @@ class AuctionServiceTest {
                 100L, "Test listing", 1000L, null, null,
                 168, false, null, "Nice parcel", Set.of());
 
-        Auction a = service.create(42L, req);
+        Auction a = service.create(42L, req, null);
 
         assertThat(a.getStatus()).isEqualTo(AuctionStatus.DRAFT);
         assertThat(a.getSeller().getId()).isEqualTo(42L);
@@ -96,7 +98,7 @@ class AuctionServiceTest {
     void create_persistsTitle() {
         AuctionCreateRequest req = minimalCreateRequest("Premium Waterfront — Must Sell!");
 
-        Auction created = service.create(42L, req);
+        Auction created = service.create(42L, req, null);
 
         assertThat(created.getTitle()).isEqualTo("Premium Waterfront — Must Sell!");
     }
@@ -107,7 +109,7 @@ class AuctionServiceTest {
         // callers that bypass MockMvc validation still hit a hard failure.
         AuctionCreateRequest req = minimalCreateRequest("   ");
 
-        assertThatThrownBy(() -> service.create(42L, req))
+        assertThatThrownBy(() -> service.create(42L, req, null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -118,7 +120,7 @@ class AuctionServiceTest {
         // the invariant holds for every entry point.
         AuctionCreateRequest req = minimalCreateRequest(null);
 
-        assertThatThrownBy(() -> service.create(42L, req))
+        assertThatThrownBy(() -> service.create(42L, req, null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -129,7 +131,7 @@ class AuctionServiceTest {
         String over120 = "x".repeat(121);
         AuctionCreateRequest req = minimalCreateRequest(over120);
 
-        assertThatThrownBy(() -> service.create(42L, req))
+        assertThatThrownBy(() -> service.create(42L, req, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("at most 120 characters");
     }
@@ -207,7 +209,7 @@ class AuctionServiceTest {
 
         SellerSuspendedException ex = org.junit.jupiter.api.Assertions.assertThrows(
                 SellerSuspendedException.class,
-                () -> service.create(42L, req));
+                () -> service.create(42L, req, null));
 
         assertThat(ex.getReason()).isEqualTo(SuspensionReason.PENALTY_OWED);
     }
@@ -219,7 +221,7 @@ class AuctionServiceTest {
 
         SellerSuspendedException ex = org.junit.jupiter.api.Assertions.assertThrows(
                 SellerSuspendedException.class,
-                () -> service.create(42L, req));
+                () -> service.create(42L, req, null));
 
         assertThat(ex.getReason()).isEqualTo(SuspensionReason.TIMED_SUSPENSION);
     }
@@ -230,7 +232,7 @@ class AuctionServiceTest {
         seller.setListingSuspensionUntil(OffsetDateTime.now(clock).minusSeconds(1));
         AuctionCreateRequest req = minimalCreateRequest("Test listing");
 
-        Auction created = service.create(42L, req);
+        Auction created = service.create(42L, req, null);
 
         assertThat(created.getStatus()).isEqualTo(AuctionStatus.DRAFT);
     }
@@ -242,7 +244,7 @@ class AuctionServiceTest {
 
         SellerSuspendedException ex = org.junit.jupiter.api.Assertions.assertThrows(
                 SellerSuspendedException.class,
-                () -> service.create(42L, req));
+                () -> service.create(42L, req, null));
 
         assertThat(ex.getReason()).isEqualTo(SuspensionReason.PERMANENT_BAN);
     }
@@ -257,7 +259,7 @@ class AuctionServiceTest {
 
         SellerSuspendedException ex = org.junit.jupiter.api.Assertions.assertThrows(
                 SellerSuspendedException.class,
-                () -> service.create(42L, req));
+                () -> service.create(42L, req, null));
 
         assertThat(ex.getReason()).isEqualTo(SuspensionReason.PERMANENT_BAN);
     }
@@ -271,7 +273,7 @@ class AuctionServiceTest {
 
         SellerSuspendedException ex = org.junit.jupiter.api.Assertions.assertThrows(
                 SellerSuspendedException.class,
-                () -> service.create(42L, req));
+                () -> service.create(42L, req, null));
 
         assertThat(ex.getReason()).isEqualTo(SuspensionReason.TIMED_SUSPENSION);
     }
@@ -291,7 +293,7 @@ class AuctionServiceTest {
                 100L, "Test listing", 500L, null, null,
                 72, true, 10, "Test", Set.of());
 
-        Auction created = service.create(42L, req);
+        Auction created = service.create(42L, req, null);
 
         assertThat(created.getStatus()).isEqualTo(AuctionStatus.DRAFT);
         assertThat(created.getVerificationMethod()).isNull();
@@ -303,7 +305,7 @@ class AuctionServiceTest {
                 100L, "Test listing", 1000L, null, null,
                 168, true, 10, null, Set.of());
 
-        Auction a = service.create(42L, req);
+        Auction a = service.create(42L, req, null);
 
         assertThat(a.getSnipeProtect()).isTrue();
         assertThat(a.getSnipeWindowMin()).isEqualTo(10);
@@ -319,7 +321,7 @@ class AuctionServiceTest {
                 100L, "Test listing", 1000L, 500L, null,
                 168, false, null, null, Set.of());
 
-        assertThatThrownBy(() -> service.create(42L, req))
+        assertThatThrownBy(() -> service.create(42L, req, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("reservePrice must be >= startingBid");
     }
@@ -330,7 +332,7 @@ class AuctionServiceTest {
                 100L, "Test listing", 1000L, 5000L, 4000L,
                 168, false, null, null, Set.of());
 
-        assertThatThrownBy(() -> service.create(42L, req))
+        assertThatThrownBy(() -> service.create(42L, req, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("buyNowPrice must be >= max");
     }
@@ -341,7 +343,7 @@ class AuctionServiceTest {
                 100L, "Test listing", 1000L, null, 500L,
                 168, false, null, null, Set.of());
 
-        assertThatThrownBy(() -> service.create(42L, req))
+        assertThatThrownBy(() -> service.create(42L, req, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("buyNowPrice must be >= max");
     }
@@ -356,7 +358,7 @@ class AuctionServiceTest {
                 100L, "Test listing", 1000L, null, null,
                 100, false, null, null, Set.of());
 
-        assertThatThrownBy(() -> service.create(42L, req))
+        assertThatThrownBy(() -> service.create(42L, req, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("durationHours");
     }
@@ -371,7 +373,7 @@ class AuctionServiceTest {
                 100L, "Test listing", 1000L, null, null,
                 168, true, null, null, Set.of());
 
-        assertThatThrownBy(() -> service.create(42L, req))
+        assertThatThrownBy(() -> service.create(42L, req, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("snipeWindowMin");
     }
@@ -382,7 +384,7 @@ class AuctionServiceTest {
                 100L, "Test listing", 1000L, null, null,
                 168, false, 10, null, Set.of());
 
-        assertThatThrownBy(() -> service.create(42L, req))
+        assertThatThrownBy(() -> service.create(42L, req, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("snipeWindowMin must be null");
     }
@@ -393,7 +395,7 @@ class AuctionServiceTest {
                 100L, "Test listing", 1000L, null, null,
                 168, true, 7, null, Set.of());
 
-        assertThatThrownBy(() -> service.create(42L, req))
+        assertThatThrownBy(() -> service.create(42L, req, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("snipeWindowMin");
     }
@@ -413,7 +415,7 @@ class AuctionServiceTest {
                 100L, "Test listing", 1000L, null, null,
                 168, false, null, null, codes);
 
-        assertThatThrownBy(() -> service.create(42L, req))
+        assertThatThrownBy(() -> service.create(42L, req, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Unknown parcel tag codes")
                 .hasMessageContaining("unknown_tag");
@@ -426,7 +428,7 @@ class AuctionServiceTest {
                 999L, "Test listing", 1000L, null, null,
                 168, false, null, null, Set.of());
 
-        assertThatThrownBy(() -> service.create(42L, req))
+        assertThatThrownBy(() -> service.create(42L, req, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Parcel not found");
     }

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/BidServiceBuyNowTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/BidServiceBuyNowTest.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.support.SimpleTransactionStatus;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import com.slparcelauctions.backend.admin.ban.BanCheckService;
 import com.slparcelauctions.backend.auction.broadcast.AuctionBroadcastPublisher;
 import com.slparcelauctions.backend.auction.broadcast.AuctionEndedEnvelope;
 import com.slparcelauctions.backend.auction.dto.BidResponse;
@@ -63,7 +64,7 @@ class BidServiceBuyNowTest {
     @BeforeEach
     void setUp() {
         Clock clock = Clock.fixed(NOW.toInstant(), ZoneOffset.UTC);
-        service = new BidService(auctionRepo, bidRepo, proxyBidRepo, userRepo, clock, publisher, escrowService, mock(com.slparcelauctions.backend.notification.NotificationPublisher.class));
+        service = new BidService(auctionRepo, bidRepo, proxyBidRepo, userRepo, clock, publisher, escrowService, mock(com.slparcelauctions.backend.notification.NotificationPublisher.class), mock(BanCheckService.class));
 
         seller = User.builder().id(10L).email("seller@example.com")
                 .displayName("Seller").verified(true).build();

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/BidServiceSnipeTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/BidServiceSnipeTest.java
@@ -23,6 +23,7 @@ import org.springframework.transaction.support.SimpleTransactionStatus;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import com.slparcelauctions.backend.admin.ban.BanCheckService;
 import com.slparcelauctions.backend.auction.broadcast.AuctionBroadcastPublisher;
 import com.slparcelauctions.backend.escrow.EscrowService;
 import com.slparcelauctions.backend.user.User;
@@ -64,7 +65,7 @@ class BidServiceSnipeTest {
     @BeforeEach
     void setUp() {
         Clock clock = Clock.fixed(NOW.toInstant(), ZoneOffset.UTC);
-        service = new BidService(auctionRepo, bidRepo, proxyBidRepo, userRepo, clock, publisher, escrowService, mock(com.slparcelauctions.backend.notification.NotificationPublisher.class));
+        service = new BidService(auctionRepo, bidRepo, proxyBidRepo, userRepo, clock, publisher, escrowService, mock(com.slparcelauctions.backend.notification.NotificationPublisher.class), mock(BanCheckService.class));
 
         seller = User.builder().id(10L).email("seller@example.com")
                 .displayName("Seller").verified(true).build();

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/BidServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/BidServiceTest.java
@@ -32,6 +32,7 @@ import com.slparcelauctions.backend.auction.broadcast.AuctionBroadcastPublisher;
 import com.slparcelauctions.backend.auction.broadcast.BidSettlementEnvelope;
 import com.slparcelauctions.backend.auction.dto.BidResponse;
 import com.slparcelauctions.backend.auction.exception.AuctionAlreadyEndedException;
+import com.slparcelauctions.backend.admin.ban.BanCheckService;
 import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
 import com.slparcelauctions.backend.auction.exception.BidTooLowException;
 import com.slparcelauctions.backend.auction.exception.InvalidAuctionStateException;
@@ -73,7 +74,7 @@ class BidServiceTest {
     @BeforeEach
     void setUp() {
         Clock clock = Clock.fixed(NOW.toInstant(), ZoneOffset.UTC);
-        service = new BidService(auctionRepo, bidRepo, proxyBidRepo, userRepo, clock, publisher, escrowService, mock(com.slparcelauctions.backend.notification.NotificationPublisher.class));
+        service = new BidService(auctionRepo, bidRepo, proxyBidRepo, userRepo, clock, publisher, escrowService, mock(com.slparcelauctions.backend.notification.NotificationPublisher.class), mock(BanCheckService.class));
 
         seller = User.builder().id(10L).email("seller@example.com")
                 .displayName("Seller").verified(true).build();

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationServiceCancelByAdminTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationServiceCancelByAdminTest.java
@@ -1,0 +1,222 @@
+package com.slparcelauctions.backend.auction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationRepository;
+import com.slparcelauctions.backend.notification.NotificationWsBroadcasterPort;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.parcel.ParcelRepository;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Integration tests for {@link CancellationService#cancelByAdmin}.
+ *
+ * <p>Verifies:
+ * <ul>
+ *   <li>Auction flips to CANCELLED with a log row that records cancelledByAdminId.</li>
+ *   <li>seller.cancelledWithBids is NOT incremented (no penalty ladder).</li>
+ *   <li>{@code countPriorOffensesWithBids} excludes admin-cancel rows.</li>
+ *   <li>Seller receives a LISTING_REMOVED_BY_ADMIN notification.</li>
+ * </ul>
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.auction-end.enabled=false",
+        "slpa.ownership-monitor.enabled=false",
+        "slpa.escrow.ownership-monitor-job.enabled=false",
+        "slpa.escrow.timeout-job.enabled=false",
+        "slpa.escrow.command-dispatcher-job.enabled=false",
+        "slpa.review.scheduler.enabled=false",
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class CancellationServiceCancelByAdminTest {
+
+    @Autowired CancellationService cancellationService;
+    @Autowired AuctionRepository auctionRepo;
+    @Autowired CancellationLogRepository cancellationLogRepo;
+    @Autowired ParcelRepository parcelRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired NotificationRepository notifRepo;
+    @Autowired PlatformTransactionManager txManager;
+    @Autowired DataSource dataSource;
+
+    @MockitoBean NotificationWsBroadcasterPort wsBroadcaster;
+
+    private Long sellerId, adminId, auctionId, parcelId;
+
+    @AfterEach
+    void cleanup() throws Exception {
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var st = conn.createStatement()) {
+                if (auctionId != null) {
+                    st.execute("DELETE FROM cancellation_logs WHERE auction_id = " + auctionId);
+                    st.execute("DELETE FROM bids WHERE auction_id = " + auctionId);
+                    st.execute("DELETE FROM auctions WHERE id = " + auctionId);
+                }
+                if (parcelId != null) {
+                    st.execute("DELETE FROM parcels WHERE id = " + parcelId);
+                }
+            }
+        } catch (Exception ignored) {
+            // best-effort
+        }
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var st = conn.createStatement()) {
+                for (Long id : new Long[]{sellerId, adminId}) {
+                    if (id != null) {
+                        st.execute("DELETE FROM notification WHERE user_id = " + id);
+                        st.execute("DELETE FROM cancellation_logs WHERE seller_id = " + id);
+                        st.execute("DELETE FROM refresh_tokens WHERE user_id = " + id);
+                        st.execute("DELETE FROM users WHERE id = " + id);
+                    }
+                }
+            }
+        }
+        sellerId = adminId = auctionId = parcelId = null;
+    }
+
+    private User newUser(String prefix, Role role) {
+        return new TransactionTemplate(txManager).execute(s -> userRepo.save(User.builder()
+                .email(prefix + "-" + UUID.randomUUID() + "@test.com")
+                .passwordHash("h")
+                .displayName(prefix)
+                .slAvatarUuid(UUID.randomUUID())
+                .verified(true)
+                .role(role)
+                .cancelledWithBids(0)
+                .penaltyBalanceOwed(0L)
+                .build()));
+    }
+
+    private Auction buildActiveAuction(User seller, int bidCount) {
+        return new TransactionTemplate(txManager).execute(s -> {
+            Parcel p = parcelRepo.save(Parcel.builder()
+                    .slParcelUuid(UUID.randomUUID())
+                    .ownerUuid(seller.getSlAvatarUuid())
+                    .ownerType("agent")
+                    .regionName("AdminCancelRegion")
+                    .continentName("Sansara")
+                    .areaSqm(512)
+                    .maturityRating("GENERAL")
+                    .verified(true)
+                    .verifiedAt(OffsetDateTime.now())
+                    .build());
+            parcelId = p.getId();
+            Auction a = auctionRepo.save(Auction.builder()
+                    .title("Admin Cancel Test Lot")
+                    .parcel(p)
+                    .seller(seller)
+                    .status(AuctionStatus.ACTIVE)
+                    .verificationMethod(VerificationMethod.UUID_ENTRY)
+                    .verificationTier(VerificationTier.SCRIPT)
+                    .startingBid(1000L)
+                    .currentBid(bidCount > 0 ? 1500L : 0L)
+                    .bidCount(bidCount)
+                    .durationHours(168)
+                    .snipeProtect(false)
+                    .listingFeePaid(true)
+                    .consecutiveWorldApiFailures(0)
+                    .commissionRate(new BigDecimal("0.05"))
+                    .agentFeeRate(BigDecimal.ZERO)
+                    .startsAt(OffsetDateTime.now().minusHours(1))
+                    .endsAt(OffsetDateTime.now().plusHours(24))
+                    .originalEndsAt(OffsetDateTime.now().plusHours(24))
+                    .build());
+            auctionId = a.getId();
+            return a;
+        });
+    }
+
+    @Test
+    void cancelByAdmin_flipsCancelled_writesLogWithCancelledByAdminId() {
+        User seller = newUser("admin-cancel-seller", Role.USER); sellerId = seller.getId();
+        User admin  = newUser("admin-cancel-admin",  Role.ADMIN); adminId  = admin.getId();
+        buildActiveAuction(seller, 0);
+
+        cancellationService.cancelByAdmin(auctionId, adminId, "TOS violation");
+
+        // Auction must be CANCELLED
+        Auction saved = new TransactionTemplate(txManager).execute(
+                s -> auctionRepo.findById(auctionId).orElseThrow());
+        assertThat(saved.getStatus()).isEqualTo(AuctionStatus.CANCELLED);
+
+        // Log row must exist with cancelledByAdminId = adminId and penaltyKind = NONE
+        var logs = cancellationLogRepo.findLatestByAuctionId(
+                auctionId, org.springframework.data.domain.PageRequest.of(0, 1));
+        assertThat(logs).hasSize(1);
+        CancellationLog log = logs.get(0);
+        assertThat(log.getCancelledByAdminId()).isEqualTo(adminId);
+        assertThat(log.getPenaltyKind()).isEqualTo(CancellationOffenseKind.NONE);
+        assertThat(log.getPenaltyAmountL()).isNull();
+    }
+
+    @Test
+    void cancelByAdmin_doesNotIncrementSellerCancelledWithBidsCounter() {
+        User seller = newUser("admin-cancel-nobump-seller", Role.USER); sellerId = seller.getId();
+        User admin  = newUser("admin-cancel-nobump-admin",  Role.ADMIN); adminId  = admin.getId();
+        buildActiveAuction(seller, 0);
+
+        cancellationService.cancelByAdmin(auctionId, adminId, "No penalty");
+
+        User reloaded = new TransactionTemplate(txManager).execute(
+                s -> userRepo.findById(sellerId).orElseThrow());
+        assertThat(reloaded.getCancelledWithBids()).isZero();
+    }
+
+    @Test
+    void cancelByAdmin_priorOffensesQueryExcludesAdminCancel() {
+        User seller = newUser("admin-cancel-ladder-seller", Role.USER); sellerId = seller.getId();
+        User admin  = newUser("admin-cancel-ladder-admin",  Role.ADMIN); adminId  = admin.getId();
+        // Auction with bidCount=0 so hadBids=false — still creates the log row.
+        // Use bidCount=1 to ensure hadBids=true on the admin-cancel log row,
+        // which is the condition that countPriorOffensesWithBids filters on.
+        buildActiveAuction(seller, 1);
+
+        cancellationService.cancelByAdmin(auctionId, adminId, "Staff removal");
+
+        // Admin-cancel rows have cancelledByAdminId IS NOT NULL, so they must be
+        // excluded from countPriorOffensesWithBids. Result must be 0.
+        long count = new TransactionTemplate(txManager).execute(
+                s -> cancellationLogRepo.countPriorOffensesWithBids(sellerId));
+        assertThat(count).isZero();
+    }
+
+    @Test
+    void cancelByAdmin_publishesListingRemovedByAdminToSeller() {
+        User seller = newUser("admin-cancel-notif-seller", Role.USER); sellerId = seller.getId();
+        User admin  = newUser("admin-cancel-notif-admin",  Role.ADMIN); adminId  = admin.getId();
+        buildActiveAuction(seller, 0);
+
+        cancellationService.cancelByAdmin(auctionId, adminId, "Policy breach");
+
+        // Seller must receive LISTING_REMOVED_BY_ADMIN
+        var sellerNotifs = notifRepo.findAllByUserId(sellerId);
+        assertThat(sellerNotifs)
+                .filteredOn(n -> n.getCategory() == NotificationCategory.LISTING_REMOVED_BY_ADMIN)
+                .hasSize(1);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationServiceLadderTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationServiceLadderTest.java
@@ -24,6 +24,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.slparcelauctions.backend.admin.ban.BanCheckService;
 import com.slparcelauctions.backend.auction.broadcast.AuctionBroadcastPublisher;
 import com.slparcelauctions.backend.auction.dto.AuctionCancelledEnvelope;
 import com.slparcelauctions.backend.notification.NotificationPublisher;
@@ -52,6 +53,7 @@ class CancellationServiceLadderTest {
     @Mock com.slparcelauctions.backend.bot.BotMonitorLifecycleService monitorLifecycle;
     @Mock AuctionBroadcastPublisher broadcastPublisher;
     @Mock NotificationPublisher notificationPublisher;
+    @Mock BanCheckService banCheckService;
 
     CancellationService service;
 
@@ -70,7 +72,7 @@ class CancellationServiceLadderTest {
                 48);
         service = new CancellationService(
                 auctionRepo, bidRepo, logRepo, refundRepo, userRepo, monitorLifecycle,
-                broadcastPublisher, notificationPublisher, penaltyProps, fixed);
+                broadcastPublisher, notificationPublisher, penaltyProps, banCheckService, fixed);
         seller = User.builder().id(42L).email("s@example.com")
                 .cancelledWithBids(0)
                 .penaltyBalanceOwed(0L)
@@ -83,7 +85,7 @@ class CancellationServiceLadderTest {
 
     private Auction cancel(Auction a, String reason) {
         lenient().when(auctionRepo.findByIdForUpdate(anyLong())).thenReturn(Optional.of(a));
-        return service.cancel(a.getId(), reason);
+        return service.cancel(a.getId(), reason, null);
     }
 
     private CancellationLog capturedLog() {

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationServiceTest.java
@@ -23,6 +23,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.slparcelauctions.backend.admin.ban.BanCheckService;
 import com.slparcelauctions.backend.auction.broadcast.AuctionBroadcastPublisher;
 import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
 import com.slparcelauctions.backend.auction.exception.InvalidAuctionStateException;
@@ -42,6 +43,7 @@ class CancellationServiceTest {
     @Mock com.slparcelauctions.backend.bot.BotMonitorLifecycleService monitorLifecycle;
     @Mock AuctionBroadcastPublisher broadcastPublisher;
     @Mock NotificationPublisher notificationPublisher;
+    @Mock BanCheckService banCheckService;
 
     CancellationService service;
 
@@ -58,7 +60,7 @@ class CancellationServiceTest {
                 48);
         service = new CancellationService(
                 auctionRepo, bidRepo, logRepo, refundRepo, userRepo, monitorLifecycle,
-                broadcastPublisher, notificationPublisher, penaltyProps, fixed);
+                broadcastPublisher, notificationPublisher, penaltyProps, banCheckService, fixed);
         seller = User.builder().id(42L).email("s@example.com")
                 .cancelledWithBids(0)
                 .penaltyBalanceOwed(0L)
@@ -77,7 +79,7 @@ class CancellationServiceTest {
      */
     private Auction cancel(Auction a, String reason) {
         lenient().when(auctionRepo.findByIdForUpdate(anyLong())).thenReturn(Optional.of(a));
-        return service.cancel(a.getId(), reason);
+        return service.cancel(a.getId(), reason, null);
     }
 
     // -------------------------------------------------------------------------
@@ -225,7 +227,7 @@ class CancellationServiceTest {
     void cancel_missingAuction_throwsNotFound() {
         lenient().when(auctionRepo.findByIdForUpdate(999L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.cancel(999L, "gone"))
+        assertThatThrownBy(() -> service.cancel(999L, "gone", null))
                 .isInstanceOf(AuctionNotFoundException.class);
     }
 

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/ParcelLockingRaceIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/ParcelLockingRaceIntegrationTest.java
@@ -187,7 +187,7 @@ class ParcelLockingRaceIntegrationTest {
         // this task; the lock-release semantics we care about are owned by the service.
         TransactionTemplate tx = new TransactionTemplate(txManager);
         tx.executeWithoutResult(ts -> {
-            cancellationService.cancel(a1Id, "switching");
+            cancellationService.cancel(a1Id, "switching", null);
         });
 
         // After the failed verify above, @Transactional rolled back the VERIFICATION_PENDING

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/concurrency/BidCancelRaceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/concurrency/BidCancelRaceTest.java
@@ -167,7 +167,7 @@ class BidCancelRaceTest {
                 go.await();
                 // CancellationService uses its own @Transactional; the test
                 // drives it directly so both threads contend on the row lock.
-                cancellationService.cancel(auctionId, "race-test");
+                cancellationService.cancel(auctionId, "race-test", null);
                 cancelSucceeded.set(true);
             } catch (Throwable t) {
                 cancelError.set(unwrap(t));

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/concurrency/CancelLadderRaceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/concurrency/CancelLadderRaceTest.java
@@ -136,7 +136,7 @@ class CancelLadderRaceTest {
             ready.countDown();
             try {
                 go.await();
-                cancellationService.cancel(auctionId1, "race-1");
+                cancellationService.cancel(auctionId1, "race-1", null);
             } catch (Throwable t) {
                 err1.set(t);
             }
@@ -145,7 +145,7 @@ class CancelLadderRaceTest {
             ready.countDown();
             try {
                 go.await();
-                cancellationService.cancel(auctionId2, "race-2");
+                cancellationService.cancel(auctionId2, "race-2", null);
             } catch (Throwable t) {
                 err2.set(t);
             }

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/monitoring/SuspensionServiceSuspendByAdminTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/monitoring/SuspensionServiceSuspendByAdminTest.java
@@ -1,0 +1,145 @@
+package com.slparcelauctions.backend.auction.monitoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.VerificationMethod;
+import com.slparcelauctions.backend.auction.VerificationTier;
+import com.slparcelauctions.backend.auction.fraud.FraudFlag;
+import com.slparcelauctions.backend.auction.fraud.FraudFlagRepository;
+import com.slparcelauctions.backend.notification.Notification;
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationRepository;
+import com.slparcelauctions.backend.notification.NotificationWsBroadcasterPort;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.parcel.ParcelRepository;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class SuspensionServiceSuspendByAdminTest {
+
+    @Autowired SuspensionService suspensionService;
+    @Autowired AuctionRepository auctionRepo;
+    @Autowired ParcelRepository parcelRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired FraudFlagRepository fraudFlagRepo;
+    @Autowired NotificationRepository notificationRepo;
+    @Autowired PlatformTransactionManager txManager;
+    @Autowired DataSource dataSource;
+
+    @MockitoBean NotificationWsBroadcasterPort wsBroadcaster;
+
+    private Long sellerId;
+    private Long parcelId;
+    private Long auctionId;
+    private Auction savedAuction;
+
+    @BeforeEach
+    void seed() {
+        savedAuction = new TransactionTemplate(txManager).execute(s -> {
+            User seller = userRepo.save(User.builder()
+                .email("seller-" + UUID.randomUUID() + "@x.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .build());
+            sellerId = seller.getId();
+
+            Parcel parcel = parcelRepo.save(Parcel.builder()
+                .slParcelUuid(UUID.randomUUID())
+                .regionName("TestRegion")
+                .ownerUuid(seller.getSlAvatarUuid())
+                .areaSqm(1024)
+                .build());
+            parcelId = parcel.getId();
+
+            Auction auction = auctionRepo.save(Auction.builder()
+                .seller(seller)
+                .parcel(parcel)
+                .title("Test parcel auction")
+                .status(AuctionStatus.ACTIVE)
+                .verificationTier(VerificationTier.SCRIPT)
+                .verificationMethod(VerificationMethod.UUID_ENTRY)
+                .startingBid(100L)
+                .durationHours(24)
+                .endsAt(OffsetDateTime.now().plusHours(24))
+                .build());
+            auctionId = auction.getId();
+            return auction;
+        });
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        new TransactionTemplate(txManager).executeWithoutResult(s -> {
+            if (auctionId != null) {
+                fraudFlagRepo.findByAuctionId(auctionId).forEach(fraudFlagRepo::delete);
+                auctionRepo.findById(auctionId).ifPresent(auctionRepo::delete);
+            }
+            if (parcelId != null) parcelRepo.findById(parcelId).ifPresent(parcelRepo::delete);
+        });
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var st = conn.createStatement()) {
+                if (sellerId != null) {
+                    st.execute("DELETE FROM notification WHERE user_id = " + sellerId);
+                    st.execute("DELETE FROM refresh_tokens WHERE user_id = " + sellerId);
+                    st.execute("DELETE FROM users WHERE id = " + sellerId);
+                }
+            }
+        }
+        sellerId = auctionId = parcelId = null;
+    }
+
+    @Test
+    void suspendByAdmin_flipsSuspended_setsSuspendedAt_noFraudFlag() {
+        suspensionService.suspendByAdmin(savedAuction, 999L, "Violates ToS");
+
+        Auction reloaded = auctionRepo.findById(auctionId).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(AuctionStatus.SUSPENDED);
+        assertThat(reloaded.getSuspendedAt()).isNotNull();
+
+        List<FraudFlag> flags = fraudFlagRepo.findByAuctionId(auctionId);
+        assertThat(flags).isEmpty();
+    }
+
+    @Test
+    void suspendByAdmin_publishesListingSuspendedToSeller() {
+        suspensionService.suspendByAdmin(savedAuction, 999L, "Admin action");
+
+        List<Notification> notifications = notificationRepo.findAllByUserId(sellerId);
+        assertThat(notifications)
+            .anyMatch(n -> n.getCategory() == NotificationCategory.LISTING_SUSPENDED);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auth/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.slparcelauctions.backend.auth;
 
+import com.slparcelauctions.backend.admin.ban.BanCheckService;
 import com.slparcelauctions.backend.auth.dto.AuthResult;
 import com.slparcelauctions.backend.auth.dto.LoginRequest;
 import com.slparcelauctions.backend.auth.dto.RegisterRequest;
@@ -52,6 +53,9 @@ class AuthServiceTest {
     PasswordEncoder passwordEncoder;
 
     @Mock
+    BanCheckService banCheckService;
+
+    @Mock
     HttpServletRequest httpRequest;
 
     AuthService authService;
@@ -59,7 +63,7 @@ class AuthServiceTest {
     @BeforeEach
     void setUp() {
         authService = new AuthService(userService, userRepository, refreshTokenService,
-                jwtService, passwordEncoder);
+                jwtService, passwordEncoder, banCheckService);
         // lenient: these stubs are only consumed by tests that exercise HTTP paths
         lenient().when(httpRequest.getHeader("User-Agent")).thenReturn("TestAgent/1.0");
         lenient().when(httpRequest.getRemoteAddr()).thenReturn("127.0.0.1");

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/integration/CancellationFanoutIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/integration/CancellationFanoutIntegrationTest.java
@@ -172,7 +172,7 @@ class CancellationFanoutIntegrationTest {
                     .amount(1500L).bidType(BidType.MANUAL).build());
         });
 
-        cancellationService.cancel(auctionId, "changed mind");
+        cancellationService.cancel(auctionId, "changed mind", null);
 
         // Both bidders should have LISTING_CANCELLED_BY_SELLER
         assertThat(notifRepo.findAll().stream()
@@ -195,7 +195,7 @@ class CancellationFanoutIntegrationTest {
         User seller = newUser("nobid-cancel-seller"); sellerId = seller.getId();
         buildActiveAuction(seller, 0, null, 0L);
 
-        cancellationService.cancel(auctionId, "testing");
+        cancellationService.cancel(auctionId, "testing", null);
 
         // No bidders → no LISTING_CANCELLED_BY_SELLER notifications for anyone.
         // Check specifically: no notification for the seller and no other recipients

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/CancellationFanoutImIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/CancellationFanoutImIntegrationTest.java
@@ -138,7 +138,7 @@ class CancellationFanoutImIntegrationTest {
             auctionRepo.save(fresh);
         });
 
-        cancellationService.cancel(auctionId, "ownership lost");
+        cancellationService.cancel(auctionId, "ownership lost", null);
 
         // 3 IM rows, one per active bidder, all LISTING_CANCELLED_BY_SELLER.
         var rows = slImRepo.findAll();
@@ -177,7 +177,7 @@ class CancellationFanoutImIntegrationTest {
             auctionRepo.save(fresh);
         });
 
-        cancellationService.cancel(auctionId, "ownership lost");
+        cancellationService.cancel(auctionId, "ownership lost", null);
 
         var rows = slImRepo.findAll();
         assertThat(rows).hasSize(1);
@@ -189,7 +189,7 @@ class CancellationFanoutImIntegrationTest {
         User seller = saveUser(false);
         saveAuction(seller, 1000L);
 
-        cancellationService.cancel(auctionId, "no bidders");
+        cancellationService.cancel(auctionId, "no bidders", null);
 
         assertThat(slImRepo.findAll()).isEmpty();
     }

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/CancellationFanoutImIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/slim/integration/CancellationFanoutImIntegrationTest.java
@@ -145,7 +145,7 @@ class CancellationFanoutImIntegrationTest {
         assertThat(rows).hasSize(3);
         assertThat(rows.stream().map(SlImMessage::getUserId).toList())
             .containsExactlyInAnyOrder(a.getId(), b.getId(), c.getId());
-        assertThat(rows).allMatch(m -> m.getMessageText().contains("[SLPA] Listing cancelled"));
+        assertThat(rows).allMatch(m -> m.getMessageText().contains("[SLPA] Auction cancelled"));
         assertThat(rows).allMatch(m -> m.getMessageText().contains("ownership lost"));
     }
 

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/SlVerificationServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/SlVerificationServiceTest.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.slparcelauctions.backend.admin.ban.BanCheckService;
 import com.slparcelauctions.backend.sl.dto.SlVerifyRequest;
 import com.slparcelauctions.backend.sl.dto.SlVerifyResponse;
 import com.slparcelauctions.backend.sl.exception.AvatarAlreadyLinkedException;
@@ -47,7 +48,7 @@ class SlVerificationServiceTest {
         userRepository = mock(UserRepository.class);
         headerValidator = new SlHeaderValidator(
                 new SlConfigProperties("Production", Set.of(TRUSTED)));
-        service = new SlVerificationService(codeService, userRepository, headerValidator, FIXED);
+        service = new SlVerificationService(codeService, userRepository, headerValidator, mock(BanCheckService.class), FIXED);
     }
 
     private SlVerifyRequest body() {

--- a/docs/implementation/DEFERRED_WORK.md
+++ b/docs/implementation/DEFERRED_WORK.md
@@ -47,9 +47,9 @@ When finishing a sub-spec that completes a deferred item, remove the entry.
 
 ### Account deletion UI
 - **From:** Epic 02 sub-spec 2a (Task 02-03 user profile backend)
-- **Why:** Backend `DELETE /me` returns 501 Not Implemented. Needs a GDPR-compliant deletion flow (cascade rules, data retention, soft-delete vs hard-delete decisions) that was out of scope for 2a. Not a browse/discovery concern — does not belong in Epic 07.
-- **When:** Epic 10 sub-spec 4 (account deletion + audit log). Admin foundation (sub-spec 1) ships `User.role` enum and JWT gate — deletion plumbing does not depend on the role system but can share cascade-matrix design with the ban system.
-- **Notes:** Dashboard has no delete button. Backend endpoint returns 501. Design the cascade matrix (active auctions, open escrows, review history) alongside the ban system (sub-spec 2), not before. `User.role` enum is now available (Epic 10 sub-spec 1) — the deletion endpoint can set `role = 'USER'` as a pre-step if needed, but the main cascade work is still outstanding.
+- **Why:** Backend `DELETE /me` returns 501 Not Implemented. Needs a GDPR-compliant deletion flow (cascade rules, data retention, soft-delete vs hard-delete decisions) that was out of scope for 2a. Not a browse/discovery concern — does not belong in Epic 07. Admin foundation (sub-spec 1) ships `User.role` enum + JWT gate; ban system (sub-spec 2) ships the cascade primitives (active-auction check, bidder fan-out, ban-path guards). The cascade-matrix design for deletion can now be built on these foundations.
+- **When:** Epic 10 sub-spec 4 (account deletion + audit log viewer). Sub-spec 4 is the canonical home — all admin cascade infrastructure now exists to support the design.
+- **Notes:** Dashboard has no delete button. Backend endpoint returns 501. Design the cascade matrix (active auctions, open escrows, review history, ban records) in sub-spec 4 — `User.role` enum (sub-spec 1) + ban primitives (sub-spec 2) are both available.
 
 ### Notification preferences editor
 - **From:** Epic 02 sub-spec 2b (Task 02-04 dashboard)
@@ -96,8 +96,8 @@ When finishing a sub-spec that completes a deferred item, remove the entry.
 ### Non-dev admin endpoint for ownership-monitor trigger
 - **From:** Epic 03 sub-spec 2 (DevOwnershipMonitorController)
 - **Why:** `POST /api/v1/dev/ownership-monitor/run` is `@Profile("dev")` — the only way to force an ownership sweep in prod is to wait for the next scheduled tick (default 15 minutes). Admins triaging a suspected fraud report need a "re-check this listing now" button that runs a single-auction check and returns the result synchronously.
-- **When:** Epic 10 sub-spec 3 — admin role + auth gate now exists (sub-spec 1). Remaining work: the `POST /api/v1/admin/auctions/{id}/recheck-ownership` endpoint itself, delegating to `OwnershipCheckTask`, plus a one-off trigger button in the fraud-flag slide-over or a dedicated parcel-detail admin panel.
-- **Notes:** Keep the dev endpoint unchanged — it's useful for test suites and local verification. The admin endpoint is a separate surface with different auth and a different response shape. The admin role + Spring Security gate shipped in Epic 10 sub-spec 1 unblocks this endpoint.
+- **When:** Epic 10 sub-spec 3 — admin role + auth gate exists (sub-spec 1); ban/report/user-mgmt foundation exists (sub-spec 2). Remaining work is just the endpoint itself (`POST /api/v1/admin/auctions/{id}/recheck-ownership`, delegating to `OwnershipCheckTask`) plus a one-off trigger button in the fraud-flag slide-over or a dedicated parcel-detail admin panel.
+- **Notes:** Keep the dev endpoint unchanged — it's useful for test suites and local verification. The admin endpoint is a separate surface with different auth and a different response shape.
 
 ### Destructive-variant copy polish
 - **From:** Epic 03 sub-spec 2 (Task 9 review follow-up + Task 10 Button variant)
@@ -339,6 +339,36 @@ When finishing a sub-spec that completes a deferred item, remove the entry.
   poll, with an alarm scheduler that pages on `now - last_polled_at > 5 min`.
 - **When:** No committed phase. Out of scope until operational data shows the
   48 h canary is insufficient.
+
+### `REPORT_THRESHOLD_REACHED` admin-targeted notification
+- **From:** Epic 10 sub-spec 2 brainstorm
+- **Why:** Sub-spec 2 ships the admin reports queue sorted by `reportCount DESC`, which surfaces high-report listings passively. If admins miss a listing that crosses 3+ open reports between queue refreshes, there's no proactive signal. A fan-out notification when a listing crosses the threshold would close that gap.
+- **When:** Indefinite — pull in once operational data shows admins are missing high-report listings. Gate on a configurable threshold property (e.g. `slpa.reports.alert-threshold=3`).
+- **Notes:** Implementation sketch: `AdminReportService.submitReport` increments `openReportCount`; if it crosses the threshold and no prior threshold notification exists for this listing, call `NotificationPublisher.reportThresholdReached(listing, adminIds)`. Needs a new `REPORT_THRESHOLD_REACHED` notification category.
+
+### Admin "Send notification to user" surface
+- **From:** Epic 10 sub-spec 2 (admin user-detail page design)
+- **Why:** Admins sometimes need to send a custom SL IM to a user outside of the automated notification categories (e.g., "your account was flagged for review"). No freeform message surface exists.
+- **When:** Indefinite — no committed phase. Add when a real operational need is demonstrated.
+- **Notes:** Implementation would be a new `POST /api/v1/admin/users/{id}/notify` endpoint + modal on the user-detail page. Requires rate limiting per target user to prevent admin harassment.
+
+### Frivolous-reporter automatic privilege revocation
+- **From:** Epic 10 sub-spec 2 brainstorm
+- **Why:** Sub-spec 2 ships `User.dismissedReportsCount` — the counter increments each time an admin dismisses one of a user's reports as frivolous. The counter is visible on the user-detail Moderation tab but no automatic threshold revocation is wired.
+- **When:** Indefinite — pull in once operational data shows a threshold is justified.
+- **Notes:** Counter is in place. Automatic revoke would be a flag (`User.reportingPrivilegeRevoked`) set when `dismissedReportsCount` crosses a configurable threshold, checked in `ListingReportService.submit`. Until then, admin can revoke manually via a future "ban from reporting" action.
+
+### Realtime ban broadcast / forced-logout WebSocket
+- **From:** Epic 10 sub-spec 2 design
+- **Why:** Sub-spec 2 ships ban enforcement on the next API call — a banned user is blocked on their next bid/list/etc. request after the Redis cache (5-min TTL) flushes. There's no forced-logout WebSocket push that immediately disconnects the user's session.
+- **When:** Indefinite — revisit if forced-logout latency becomes a user complaint (e.g., banned users continue to bid-spam within the 5-min cache window).
+- **Notes:** Implementation shape: `BanCacheInvalidator` publishes a `BAN_IMPOSED` event on create; a new `BanBroadcastService` sends a `tv-bump` to `/topic/user/{userId}/account-status`; the frontend's `AccountStatusWatcher` hook redirects on receipt. See FOOTGUNS §F.106 for the current TTL reasoning.
+
+### ProxyBid bidder fan-out from admin-cancel
+- **From:** Epic 10 sub-spec 2 brainstorm
+- **Why:** Sub-spec 2 ships admin-cancel with cause-neutral bidder fan-out via `listingCancelledBySellerFanout` for regular (manual) bidders. If proxy bidders exist, the current fan-out path also notifies them via the same `LISTING_CANCELLED_BY_SELLER` category reused for admin-cancel. If proxy-bid semantics are added in a future sub-spec, confirm the fan-out covers proxy-bidder edge cases (e.g., multiple proxy bids from the same user at different max amounts).
+- **When:** Indefinite — pull in when proxy bidding ships and operational data shows proxy-bidder notification gaps.
+- **Notes:** `NotificationPublisher.listingCancelledBySellerFanout` is the current fan-out method. Body strings are cause-neutral per FOOTGUNS §F.104.
 
 ---
 

--- a/docs/implementation/FOOTGUNS.md
+++ b/docs/implementation/FOOTGUNS.md
@@ -1720,3 +1720,56 @@ read-only transaction, no Redis cache. Acceptable today (admin traffic
 is low). If pre-launch volume makes the dashboard noticeably slow, the
 fix is a 30-second Redis cache, NOT N+1 fixes — there are no joins to
 optimize.
+
+### F.103 — Admin-cancel must NOT bump the seller's penalty ladder
+
+`CancellationLog.cancelledByAdminId IS NULL` is the load-bearing predicate
+in `countPriorOffensesWithBids`. Without it, every admin-removed listing
+counts as a seller offense — a seller who's been wrongly reported but
+exonerated would still climb the ladder. Test
+`CancellationServiceCancelByAdminTest.priorOffensesQueryExcludesAdminCancel`
+is the canary.
+
+### F.104 — Cause-neutral fanout body string
+
+`NotificationPublisher.listingCancelledBySellerFanout` body strings
+("This auction has been cancelled. Your active proxy bid is no longer
+in effect.") are deliberately cause-neutral so admin-cancel can call the
+same method. If anyone reverts the body to seller-attributed copy ("The
+seller cancelled..."), bidders on admin-cancelled auctions get a
+misleading message. Existing seller-cancel tests assert against the
+new copy — they're the canary.
+
+### F.105 — Listing-level report actions touch ONLY OPEN reports
+
+`AdminReportService.warnSeller / suspend / cancel` filter to OPEN status
+when batching the report-state-change. DISMISSED reports stay DISMISSED
+because each represents a deliberate per-report decision (with the
+reporter's frivolous counter already incremented). Reclassifying them
+on a listing-level action would undo that decision.
+
+### F.106 — Ban cache TTL = 5 min; create/lift flushes immediately
+
+`BanCheckService` caches both positive AND negative results with 5-min
+TTL. `BanCacheInvalidator.invalidate(ip, uuid)` is called on ban-create
+and ban-lift to clear the keys immediately. The 5-min cap limits the
+worst-case stale window to 5 min — acceptable because admin actions are
+infrequent and a banned user being one bid late to be blocked is a
+non-event.
+
+### F.107 — Listing-creation IP capture didn't exist before
+
+`AuctionController.create` and `AuctionService.create` gained
+`HttpServletRequest` / `String ipAddress` parameters in sub-spec 2. Any
+test calling `auctionService.create(sellerId, req)` directly fails with
+a method-not-found compile error — pass `null` or `""` as the new third
+arg. The integration tests in this sub-spec already do this; older tests
+that haven't been touched in a while may need a sweep.
+
+### F.108 — Self-demote returns 409, NOT 403
+
+A current admin trying to demote themselves gets `409 SELF_DEMOTE_FORBIDDEN`
+from `AdminRoleService.demote`. The 409 is intentional — they have
+permission to call the endpoint (they're an admin), but the operation
+is forbidden by business rule. The frontend toast surfaces "You cannot
+demote yourself."

--- a/docs/initial-design/DESIGN.md
+++ b/docs/initial-design/DESIGN.md
@@ -1695,6 +1695,38 @@ Users can report any ACTIVE listing they believe is suspicious, fraudulent, or i
   post-cancel watcher (teal/primary). Token mapping in
   `frontend/src/lib/admin/reasonStyle.ts`.
 
+### Notes (Epic 10 sub-spec 2 — Reports + Bans + Admin enforcement + User mgmt, 2026-04-26)
+
+- Listing reports: users flag with subject + reason + details. Upsert by
+  (auction, reporter) — resubmit replaces and resets status to OPEN
+  (issue-still-happening escape valve). Reports are ALWAYS informational
+  — admin acts manually.
+- Admin queue is listing-grouped, sorted reportCount DESC. Listing-level
+  actions (warn/suspend/cancel) only touch OPEN reports — DISMISSED
+  reports preserve the admin's prior per-report decision (and the
+  reporter's frivolous counter increment).
+- Bans block at 6 paths: register, login, SL-verify, bid, listing
+  creation, listing cancellation. The cancel-path check prevents banned
+  sellers from circumventing via cancel-and-sell. Cached in Redis with
+  5-min TTL.
+- Multi-ban stacking: one user can have AVATAR + IP bans concurrently as
+  separate rows. Active = liftedAt IS NULL AND (expiresAt IS NULL OR > now).
+- Admin-cancel skips the seller penalty ladder. `CancellationLog.
+  cancelledByAdminId` excludes the row from `countPriorOffensesWithBids`.
+  Distinct seller notification (LISTING_REMOVED_BY_ADMIN) plus
+  cause-neutral bidder fan-out (LISTING_CANCELLED_BY_SELLER reused).
+- Admin reinstate is a shared primitive (`AdminAuctionService.reinstate`)
+  used by both fraud-flag-resolution (sub-spec 1) and the standalone
+  `/admin/auctions/{id}/reinstate` endpoint (called from the user-detail
+  Listings tab Reinstate button when status=SUSPENDED).
+- `admin_actions` audit table writes from sub-spec 2 forward. Sub-spec 1
+  fraud-flag actions continue to self-audit on FraudFlag.resolvedBy +
+  adminNotes — no backfill.
+- Frivolous reporter tracking: counter only this sub-spec
+  (`User.dismissedReportsCount`). Automatic privilege revocation deferred.
+- Self-demote returns 409 SELF_DEMOTE_FORBIDDEN. Promote doesn't need
+  the guard (you're already admin to reach the page).
+
 ---
 
 ## 9. LSL Script Communication Protocol

--- a/docs/superpowers/plans/2026-04-26-epic-10-sub-2-reports-bans-admin-enforcement.md
+++ b/docs/superpowers/plans/2026-04-26-epic-10-sub-2-reports-bans-admin-enforcement.md
@@ -1,0 +1,4054 @@
+# Epic 10 Sub-spec 2 — Reports + Bans + Admin Enforcement + Admin User Mgmt Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the moderation loop — `ListingReport` entity + report POST endpoint + admin queue/actions, `Ban` entity + Redis cache + 6-path enforcement, admin user search + user-detail page (6 tabs + 280px right rail + actions), `admin_actions` audit table, plus refactor sub-spec 1's reinstate logic into a shared `AdminAuctionService` primitive.
+
+**Architecture:** Three new sub-packages under `com.slparcelauctions.backend.admin` (`reports`, `ban`, `users`), one new shared service (`AdminAuctionService`), one audit-table sub-package (`audit`). JPA `ddl-auto: update` adds three new tables (`listing_reports`, `bans`, `admin_actions`) and two columns (`User.dismissedReportsCount`, `CancellationLog.cancelledByAdminId`). Two new notification categories (`LISTING_WARNED`, `LISTING_REMOVED_BY_ADMIN`).
+
+**Tech Stack:** Spring Boot 4 / Java 26 / Spring Security / Spring Data JPA / Postgres / Redis (spring-data-redis) · Next.js 16 / React 19 / TanStack Query v5 / MSW v2 / Vitest
+
+**Spec:** [`docs/superpowers/specs/2026-04-26-epic-10-sub-2-reports-bans-admin-enforcement.md`](../specs/2026-04-26-epic-10-sub-2-reports-bans-admin-enforcement.md) (commit `4e586d1`)
+
+**Branch:** `task/10-sub-2-reports-bans-admin-enforcement` (already created on the spec commit; subsequent commits go on this branch).
+
+---
+
+## Pre-implementation findings (read once, refer back as needed)
+
+### Reference patterns and exact-shape signatures
+
+#### Cancellation + bidder fan-out (existing)
+
+- **`CancellationService.cancel`** — `backend/src/main/java/com/slparcelauctions/backend/auction/CancellationService.java:71+`. Bidder-fan-out call is at lines 183-185:
+  ```java
+  List<Long> allBidderIds = bidRepo.findDistinctBidderUserIdsByAuctionId(a.getId());
+  notificationPublisher.listingCancelledBySellerFanout(
+          a.getId(), allBidderIds, a.getTitle(), reason);
+  ```
+- **`NotificationPublisher.listingCancelledBySellerFanout`** — `notification/NotificationPublisher.java:49-51`:
+  ```java
+  void listingCancelledBySellerFanout(long auctionId, List<Long> activeBidderUserIds,
+                                       String parcelName, String reason);
+  ```
+- **`NotificationPublisherImpl.listingCancelledBySellerFanout`** — `notification/NotificationPublisherImpl.java:299-327`. Body strings are CURRENTLY seller-attributed: `title = "Listing cancelled: " + parcelName; body = "The seller cancelled this listing. Reason: " + reason + ".";`. **Sub-spec 2 makes these cause-neutral so admin-cancel can call the same method.**
+- **`NotificationDataBuilder.listingCancelledBySeller`** — `notification/NotificationDataBuilder.java:138-142`.
+- **`BidRepository.findDistinctBidderUserIdsByAuctionId`** — `auction/BidRepository.java:134-135`. Reused for admin-cancel fan-out.
+- **`CancellationLog`** entity — `auction/CancellationLog.java:26-78`. Fields: `id`, `auction`, `seller`, `cancelledFromStatus`, `hadBids`, `reason`, `penaltyKind`, `penaltyAmountL`, `cancelledAt` (`@CreationTimestamp`). Sub-spec 2 adds `cancelledByAdminId` (nullable).
+- **`countPriorOffensesWithBids`** — `auction/CancellationLogRepository.java:23-25`:
+  ```java
+  @Query("SELECT count(c) FROM CancellationLog c WHERE c.seller.id = :sellerId AND c.hadBids = true")
+  long countPriorOffensesWithBids(@Param("sellerId") Long sellerId);
+  ```
+  Sub-spec 2 adds `AND c.cancelledByAdminId IS NULL` to exclude admin cancels.
+
+#### Auction listing creation (capture IP for ban enforcement)
+
+- **`AuctionController.create`** — `auction/AuctionController.java:61-69`. Currently does NOT accept `HttpServletRequest`. Sub-spec 2 adds it.
+- **`AuctionService.create`** — `auction/AuctionService.java:54`. Currently `Auction create(Long sellerId, AuctionCreateRequest req)`. Sub-spec 2 adds `String ipAddress`.
+- **`BidController` IP-capture pattern** — `auction/BidController.java:52-68`. Mirror exactly: inject `HttpServletRequest httpRequest`, call `httpRequest.getRemoteAddr()`, pass to service.
+
+#### Sub-spec 1 admin code (refactor targets)
+
+- **`AdminFraudFlagService.reinstate`** — `admin/AdminFraudFlagService.java:155-197`. Sub-spec 2 refactors this to delegate to new `AdminAuctionService.reinstate`. Net behavior unchanged.
+- **`AdminFraudFlagService` constructor deps** (`@RequiredArgsConstructor`) — `FraudFlagRepository`, `UserRepository`, `AuctionRepository`, `BotMonitorLifecycleService`, `NotificationPublisher`, `Clock`. The auction-related deps move to `AdminAuctionService`; the fraud-flag service keeps `FraudFlagRepository`, `UserRepository`, `AdminAuctionService`, `Clock`.
+- **`AdminFraudFlagController.reinstate`** — `admin/AdminFraudFlagController.java:62-68`. Endpoint signature stays the same.
+- **`AdminExceptionHandler`** — `admin/exception/AdminExceptionHandler.java:13-46`. New handlers append at the bottom.
+- **`AdminApiError`** record — `admin/exception/AdminApiError.java:1-14`. Reuse as-is.
+- **`BotMonitorLifecycleService.onAuctionResumed`** — `bot/BotMonitorLifecycleService.java:83-86`. Confirmed delegating to `onAuctionActivatedBot`.
+- **`NotificationCategoryCheckConstraintInitializer`** — exists from sub-spec 1. Sub-spec 2 just adds new enum values to its set; the initializer auto-syncs the DB CHECK constraint on each app start.
+
+#### Notifications
+
+- **`NotificationCategory`** enum — `notification/NotificationCategory.java:20-24` (LISTING_STATUS group entries). Sub-spec 2 adds two new values after `LISTING_CANCELLED_BY_SELLER`:
+  ```java
+  LISTING_WARNED(NotificationGroup.LISTING_STATUS),
+  LISTING_REMOVED_BY_ADMIN(NotificationGroup.LISTING_STATUS),
+  ```
+- **`NotificationPublisherImpl.listingReinstated`** — `notification/NotificationPublisherImpl.java:264+`. Mirror for the two new methods.
+- **Group-keyed user prefs**: `User.notifyEmail` and `User.notifySlIm` are JSON keyed by group (`listing_status`, etc.). New categories in LISTING_STATUS group automatically inherit the existing user preference — **no User entity changes for preference routing**.
+
+#### User entity + repository
+
+- **`User`** entity — `user/User.java:30-224`. Sub-spec 2 adds `dismissedReportsCount` field next to `cancelledWithBids` (line 109). Already has `role` (sub-spec 1).
+- **`UserRepository`** — `user/UserRepository.java:18-63`. Existing methods: `findByEmail`, `findBySlAvatarUuid`, `findAllBySlAvatarUuidIn`, `existsByEmail`, `findByIdForUpdate`, `findIdBySlAvatarUuid`, `bulkPromoteByEmailIfUser`. Sub-spec 2 adds `bumpTokenVersion(Long userId)` (`@Modifying @Query` UPDATE), the user-search query (`searchAdmin`), and new derived counters as needed.
+
+#### RefreshToken (IP history source for admin user-detail)
+
+- **`RefreshToken`** entity — `auth/RefreshToken.java:31-73`. Has `userId` (Long), `ipAddress` (String, length 45), `createdAt`, `lastUsedAt`. No new entity changes needed.
+- **`RefreshTokenRepository`** — `auth/RefreshTokenRepository.java:11+`. Sub-spec 2 adds:
+  ```java
+  @Query("SELECT new com.slparcelauctions.backend.admin.users.dto.UserIpProjection(" +
+      "rt.ipAddress, MIN(rt.createdAt), MAX(rt.lastUsedAt), COUNT(rt.id)) " +
+      "FROM RefreshToken rt WHERE rt.userId = :userId AND rt.ipAddress IS NOT NULL " +
+      "GROUP BY rt.ipAddress ORDER BY MIN(rt.createdAt) ASC")
+  List<UserIpProjection> findIpSummaryByUserId(@Param("userId") Long userId);
+  ```
+
+#### Reports / Bans / AdminActions (new — confirmed not present)
+
+No existing entities. Sub-spec 2 introduces all three.
+
+#### Bid + ProxyBid bidder-fanout
+
+- **`BidRepository.findDistinctBidderUserIdsByAuctionId`** — `auction/BidRepository.java:134-135`. Reuse for admin-cancel.
+- **`ProxyBidRepository`** — no existing distinct-bidder-by-auction query. **Sub-spec 2 does NOT add proxy-bid coverage to admin-cancel fan-out.** Manual-bid fan-out is sufficient (matches existing seller-cancel behavior).
+
+#### SecurityConfig
+
+- **Admin matcher** — `config/SecurityConfig.java:216` already has `.requestMatchers("/api/v1/admin/**").hasRole("ADMIN")`. **No SecurityConfig change needed for sub-spec 2.** New admin endpoints inherit the gate.
+
+#### SuspensionService
+
+- Constructor deps — `auction/monitoring/SuspensionService.java:47-53`: `AuctionRepository`, `FraudFlagRepository`, `BotMonitorLifecycleService`, `NotificationPublisher`, `Clock`. Sub-spec 2 adds `suspendByAdmin(Auction auction, Long adminUserId, String notes)` mirroring the existing `suspendForXxx` shape.
+
+#### FOOTGUNS index
+
+- Last entry **F.102** (sub-spec 1's last). Sub-spec 2 appends F.103 onwards.
+
+### Footguns to actively respect
+
+1. **Admin-cancel must NOT count as a seller offense.** The `countPriorOffensesWithBids` query update is load-bearing. If the WHERE clause forgets `cancelledByAdminId IS NULL`, every admin-cancel bumps the seller's penalty ladder by one. Test covers it.
+2. **Bidder fanout body becomes cause-neutral.** Updating `listingCancelledBySellerFanout` body strings affects existing seller-cancel notifications too. Confirm copy reads OK for both.
+3. **`listing_reports` UNIQUE (auction_id, reporter_id)** is the upsert key. Concurrent POSTs from the same user → DataIntegrityViolation; catch + retry as update.
+4. **Ban-create tv-bump only fires for AVATAR/BOTH bans where avatar maps to a registered user.** IP-only bans don't have a user account to invalidate.
+5. **Redis cache for bans is 5-min TTL.** Cache invalidation on create/lift caps the stale window. Acceptable.
+6. **Listing-creation IP capture didn't exist before.** `AuctionController.create` gains `HttpServletRequest`. Existing tests that invoke `auctionService.create(sellerId, req)` directly need an empty IP fixture (`""` or `null`) — the service signature changes too.
+7. **`@TestPropertySource` propagation** — every new `@SpringBootTest` integration test must include the full 9-line scheduler-disable property block. Same as sub-spec 1.
+8. **Self-demote 409** — `POST /admin/users/{id}/demote` on the calling admin returns 409 `SELF_DEMOTE_FORBIDDEN`. Test guards.
+9. **Listing-level report actions only touch OPEN reports** (spec §4.4 fix). Suspend/Cancel/Warn must NOT reclassify DISMISSED reports — those represent deliberate per-report decisions.
+
+### Conventions reminders
+
+- **No new Flyway migrations.** All schema via JPA `ddl-auto: update`.
+- **Lombok required** on backend classes. Records preferred for DTOs.
+- **Vertical slices** — every task ships entity + repo + service + controller + tests where applicable.
+- **Feature-based packages** — admin code lives in `com.slparcelauctions.backend.admin.{reports,ban,users,audit}` plus shared `AdminAuctionService` at `com.slparcelauctions.backend.admin`.
+- **`PagedResponse<T>`** for paginated endpoints. Never raw `Page<T>`.
+- **Frontend AGENTS.md** — Next.js 16 has breaking changes. Read `frontend/node_modules/next/dist/docs/` before writing new frontend code.
+- **No emojis** unless the user explicitly asked.
+- **No new comments** unless they explain non-obvious WHY.
+
+### Test Property Source — disable all schedulers (paste into every new @SpringBootTest)
+
+```java
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+```
+
+---
+
+## Task index
+
+| # | Title | Tests |
+|---|---|---|
+| 1 | `AdminAction` audit table + `AdminActionService` helper | unit + integration |
+| 2 | `AdminAuctionService.reinstate` shared primitive + sub-spec 1 refactor + standalone endpoint | unit + slice + integration |
+| 3 | `CancellationLog.cancelledByAdminId` + `cancelByAdmin` + `LISTING_REMOVED_BY_ADMIN` + cause-neutral fanout copy | unit + integration |
+| 4 | `SuspensionService.suspendByAdmin` + `LISTING_WARNED` notification category | unit + integration |
+| 5 | `ListingReport` entity + user-facing endpoints + `User.dismissedReportsCount` | unit + slice + integration |
+| 6 | `AdminReportService` + `AdminReportController` + stats `openReports` extension | unit + slice + integration |
+| 7 | `Ban` entity + `BanCheckService` + Redis cache + `RefreshToken` IPs query | unit + integration |
+| 8 | Ban enforcement at 6 paths (register/login/SL-verify/bid/listing-create/listing-cancel) | integration |
+| 9 | `AdminBanController` + `AdminBanService` + tv-bump + cache invalidation | unit + slice + integration |
+| 10 | `AdminUserController` + `AdminUserService` + role mgmt + `AdminAudit` read endpoint | unit + slice + integration |
+| 11 | Frontend foundations (`lib/admin` types/api/queryKeys/MSW) + dashboard 4-up | unit |
+| 12 | Frontend reports UI (button + modal + admin queue + slide-over) | unit |
+| 13 | Frontend bans UI (page + create modal) | unit |
+| 14 | Frontend users UI (search + detail page with 6 tabs + right rail + recent IPs modal) | unit |
+| 15 | Cross-cutting docs + manual test + push branch + open PR | manual |
+
+---
+
+## Task 1: `AdminAction` audit table + `AdminActionService` helper
+
+**Goal:** Establish the audit-trail table and a thin helper service that every later admin write action calls. Foundation for tasks 3-10.
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminAction.java` (entity)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminActionType.java` (enum)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminActionTargetType.java` (enum)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminActionRepository.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminActionService.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/admin/audit/AdminActionServiceTest.java` (unit, Mockito)
+- Test: `backend/src/test/java/com/slparcelauctions/backend/admin/audit/AdminActionRepositoryTest.java` (`@SpringBootTest`)
+
+- [ ] **Step 1: Create `AdminActionType` enum**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminActionType.java
+package com.slparcelauctions.backend.admin.audit;
+
+public enum AdminActionType {
+    DISMISS_REPORT,
+    WARN_SELLER_FROM_REPORT,
+    SUSPEND_LISTING_FROM_REPORT,
+    CANCEL_LISTING_FROM_REPORT,
+    CREATE_BAN,
+    LIFT_BAN,
+    PROMOTE_USER,
+    DEMOTE_USER,
+    RESET_FRIVOLOUS_COUNTER,
+    REINSTATE_LISTING
+}
+```
+
+- [ ] **Step 2: Create `AdminActionTargetType` enum**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminActionTargetType.java
+package com.slparcelauctions.backend.admin.audit;
+
+public enum AdminActionTargetType {
+    USER, LISTING, REPORT, FRAUD_FLAG, BAN
+}
+```
+
+- [ ] **Step 3: Create `AdminAction` entity**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminAction.java
+package com.slparcelauctions.backend.admin.audit;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.slparcelauctions.backend.user.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "admin_actions", indexes = {
+    @Index(name = "idx_admin_actions_target",
+           columnList = "target_type, target_id, created_at DESC"),
+    @Index(name = "idx_admin_actions_admin",
+           columnList = "admin_user_id, created_at DESC")
+})
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class AdminAction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "admin_user_id", nullable = false)
+    private User adminUser;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "action_type", nullable = false, length = 40)
+    private AdminActionType actionType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false, length = 20)
+    private AdminActionTargetType targetType;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Column(columnDefinition = "text")
+    private String notes;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> details;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+}
+```
+
+- [ ] **Step 4: Create `AdminActionRepository`**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminActionRepository.java
+package com.slparcelauctions.backend.admin.audit;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminActionRepository extends JpaRepository<AdminAction, Long> {
+
+    Page<AdminAction> findByTargetTypeAndTargetIdOrderByCreatedAtDesc(
+        AdminActionTargetType targetType, Long targetId, Pageable pageable);
+
+    Page<AdminAction> findByAdminUserIdOrderByCreatedAtDesc(
+        Long adminUserId, Pageable pageable);
+}
+```
+
+- [ ] **Step 5: Create `AdminActionService` helper**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminActionService.java
+package com.slparcelauctions.backend.admin.audit;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Helper for writing admin_actions audit rows. All admin write paths in
+ * sub-specs 2+ call this. Sub-spec 1's fraud-flag actions self-audit on
+ * FraudFlag.resolvedBy + adminNotes and do NOT write here.
+ */
+@Service
+@RequiredArgsConstructor
+public class AdminActionService {
+
+    private final AdminActionRepository repository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public AdminAction record(
+            Long adminUserId,
+            AdminActionType actionType,
+            AdminActionTargetType targetType,
+            Long targetId,
+            String notes,
+            Map<String, Object> details) {
+
+        User admin = userRepository.findById(adminUserId)
+            .orElseThrow(() -> new IllegalStateException("Admin user not found: " + adminUserId));
+
+        return repository.save(AdminAction.builder()
+            .adminUser(admin)
+            .actionType(actionType)
+            .targetType(targetType)
+            .targetId(targetId)
+            .notes(notes)
+            .details(details == null ? Map.of() : details)
+            .build());
+    }
+}
+```
+
+- [ ] **Step 6: Write unit test for `AdminActionService`**
+
+```java
+// backend/src/test/java/com/slparcelauctions/backend/admin/audit/AdminActionServiceTest.java
+package com.slparcelauctions.backend.admin.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AdminActionServiceTest {
+
+    @Mock AdminActionRepository repository;
+    @Mock UserRepository userRepository;
+
+    @InjectMocks AdminActionService service;
+
+    @Test
+    void record_buildsRowAndSaves() {
+        User admin = User.builder().id(7L).build();
+        when(userRepository.findById(7L)).thenReturn(Optional.of(admin));
+        when(repository.save(any(AdminAction.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service.record(7L, AdminActionType.DISMISS_REPORT,
+            AdminActionTargetType.REPORT, 42L, "frivolous claim", Map.of("k", "v"));
+
+        ArgumentCaptor<AdminAction> captor = ArgumentCaptor.forClass(AdminAction.class);
+        verify(repository).save(captor.capture());
+        AdminAction saved = captor.getValue();
+        assertThat(saved.getAdminUser()).isSameAs(admin);
+        assertThat(saved.getActionType()).isEqualTo(AdminActionType.DISMISS_REPORT);
+        assertThat(saved.getTargetType()).isEqualTo(AdminActionTargetType.REPORT);
+        assertThat(saved.getTargetId()).isEqualTo(42L);
+        assertThat(saved.getNotes()).isEqualTo("frivolous claim");
+        assertThat(saved.getDetails()).isEqualTo(Map.of("k", "v"));
+    }
+
+    @Test
+    void record_nullDetails_storedAsEmptyMap() {
+        User admin = User.builder().id(7L).build();
+        when(userRepository.findById(7L)).thenReturn(Optional.of(admin));
+        when(repository.save(any(AdminAction.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service.record(7L, AdminActionType.LIFT_BAN, AdminActionTargetType.BAN, 1L, "n", null);
+
+        ArgumentCaptor<AdminAction> captor = ArgumentCaptor.forClass(AdminAction.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getDetails()).isEqualTo(Map.of());
+    }
+}
+```
+
+Run: `cd backend && ./mvnw test -Dtest=AdminActionServiceTest -q`
+Expected: PASS.
+
+- [ ] **Step 7: Write integration test for `AdminActionRepository`**
+
+```java
+// backend/src/test/java/com/slparcelauctions/backend/admin/audit/AdminActionRepositoryTest.java
+package com.slparcelauctions.backend.admin.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class AdminActionRepositoryTest {
+
+    @Autowired AdminActionRepository repository;
+    @Autowired AdminActionService service;
+    @Autowired UserRepository userRepo;
+
+    private Long adminId;
+
+    @BeforeEach
+    void seed() {
+        adminId = userRepo.save(User.builder()
+            .email("admin-" + UUID.randomUUID() + "@x.com")
+            .passwordHash("x").role(Role.ADMIN).tokenVersion(1L).build()).getId();
+    }
+
+    @AfterEach
+    void cleanup() {
+        repository.deleteAll();
+        userRepo.deleteById(adminId);
+    }
+
+    @Test
+    void writeAndQuery_byTargetUser() {
+        service.record(adminId, AdminActionType.PROMOTE_USER,
+            AdminActionTargetType.USER, 100L, "promoted", Map.of());
+        service.record(adminId, AdminActionType.DEMOTE_USER,
+            AdminActionTargetType.USER, 100L, "demoted", Map.of());
+        service.record(adminId, AdminActionType.LIFT_BAN,
+            AdminActionTargetType.BAN, 999L, "lifted", Map.of());
+
+        var page = repository.findByTargetTypeAndTargetIdOrderByCreatedAtDesc(
+            AdminActionTargetType.USER, 100L, PageRequest.of(0, 10));
+
+        assertThat(page.getTotalElements()).isEqualTo(2L);
+        assertThat(page.getContent().get(0).getActionType())
+            .isEqualTo(AdminActionType.DEMOTE_USER); // newest first
+    }
+}
+```
+
+Run: `cd backend && ./mvnw test -Dtest=AdminActionRepositoryTest -q`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/admin/audit/ \
+        backend/src/test/java/com/slparcelauctions/backend/admin/audit/
+
+git commit -m "$(cat <<'EOF'
+feat(admin): admin_actions audit table + AdminActionService helper
+
+New entity (admin_actions) with AdminActionType (10 values, sub-spec 2
+set) and AdminActionTargetType (USER, LISTING, REPORT, FRAUD_FLAG, BAN).
+AdminActionService.record(...) is the single entry point every later
+admin write action calls. Sub-spec 1's fraud-flag actions continue to
+self-audit on FraudFlag.resolvedBy/adminNotes and do NOT write here.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `AdminAuctionService.reinstate` shared primitive + sub-spec 1 refactor + standalone endpoint
+
+**Goal:** Extract sub-spec 1's reinstate auction-state-change logic into a shared `AdminAuctionService` so both fraud-flag-resolution and report-resolution paths can call it. Add the standalone endpoint used by user-detail Listings tab "Reinstate" button.
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/AdminAuctionService.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/dto/AdminAuctionReinstateResponse.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/AdminAuctionController.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/dto/ReinstateAuctionRequest.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/admin/AdminFraudFlagService.java` (refactor `reinstate` to delegate)
+- Test: `backend/src/test/java/com/slparcelauctions/backend/admin/AdminAuctionServiceTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/admin/AdminAuctionControllerSliceTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/admin/AdminAuctionReinstateIntegrationTest.java`
+
+- [ ] **Step 1: Create `AdminAuctionService`**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/AdminAuctionService.java
+package com.slparcelauctions.backend.admin;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.admin.exception.AuctionNotSuspendedException;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
+import com.slparcelauctions.backend.bot.BotMonitorLifecycleService;
+import com.slparcelauctions.backend.notification.NotificationPublisher;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Shared primitive for "flip SUSPENDED auction back to ACTIVE." Called
+ * from sub-spec 1's fraud-flag reinstate path AND from sub-spec 2's
+ * standalone /admin/auctions/{id}/reinstate endpoint. Auction-state-only
+ * — caller is responsible for any flag/report state changes and audit
+ * row writing (different callers want different audit semantics).
+ */
+@Service
+@RequiredArgsConstructor
+public class AdminAuctionService {
+
+    private final AuctionRepository auctionRepo;
+    private final BotMonitorLifecycleService botMonitorLifecycleService;
+    private final NotificationPublisher notificationPublisher;
+    private final Clock clock;
+
+    @Transactional
+    public AdminAuctionReinstateResult reinstate(
+            Long auctionId,
+            Optional<OffsetDateTime> fallbackSuspendedFrom) {
+
+        Auction auction = auctionRepo.findByIdForUpdate(auctionId)
+            .orElseThrow(() -> new AuctionNotFoundException(auctionId));
+        if (auction.getStatus() != AuctionStatus.SUSPENDED) {
+            throw new AuctionNotSuspendedException(auction.getStatus());
+        }
+
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        OffsetDateTime suspendedFrom = auction.getSuspendedAt() != null
+            ? auction.getSuspendedAt()
+            : fallbackSuspendedFrom.orElse(now); // 0-extension if no record
+
+        Duration suspensionDuration = Duration.between(suspendedFrom, now);
+        OffsetDateTime newEndsAt = auction.getEndsAt().plus(suspensionDuration);
+        if (newEndsAt.isBefore(now)) {
+            newEndsAt = now.plusHours(1);
+        }
+
+        auction.setStatus(AuctionStatus.ACTIVE);
+        auction.setSuspendedAt(null);
+        auction.setEndsAt(newEndsAt);
+        auctionRepo.save(auction);
+
+        botMonitorLifecycleService.onAuctionResumed(auction);
+
+        notificationPublisher.listingReinstated(
+            auction.getSeller().getId(), auction.getId(),
+            auction.getTitle(), newEndsAt);
+
+        return new AdminAuctionReinstateResult(auction, suspensionDuration, newEndsAt);
+    }
+
+    public record AdminAuctionReinstateResult(
+        Auction auction, Duration suspensionDuration, OffsetDateTime newEndsAt
+    ) {}
+}
+```
+
+- [ ] **Step 2: Create response DTO**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/dto/AdminAuctionReinstateResponse.java
+package com.slparcelauctions.backend.admin.dto;
+
+import java.time.OffsetDateTime;
+
+import com.slparcelauctions.backend.auction.AuctionStatus;
+
+public record AdminAuctionReinstateResponse(
+    Long auctionId,
+    AuctionStatus status,
+    OffsetDateTime newEndsAt,
+    long suspensionDurationSeconds
+) {}
+```
+
+- [ ] **Step 3: Create request DTO**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/dto/ReinstateAuctionRequest.java
+package com.slparcelauctions.backend.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ReinstateAuctionRequest(
+    @NotBlank @Size(max = 1000) String notes
+) {}
+```
+
+- [ ] **Step 4: Create `AdminAuctionController`**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/AdminAuctionController.java
+package com.slparcelauctions.backend.admin;
+
+import java.util.Optional;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.admin.AdminAuctionService.AdminAuctionReinstateResult;
+import com.slparcelauctions.backend.admin.audit.AdminActionService;
+import com.slparcelauctions.backend.admin.audit.AdminActionTargetType;
+import com.slparcelauctions.backend.admin.audit.AdminActionType;
+import com.slparcelauctions.backend.admin.dto.AdminAuctionReinstateResponse;
+import com.slparcelauctions.backend.admin.dto.ReinstateAuctionRequest;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/admin/auctions")
+@RequiredArgsConstructor
+public class AdminAuctionController {
+
+    private final AdminAuctionService adminAuctionService;
+    private final AdminActionService adminActionService;
+
+    @PostMapping("/{id}/reinstate")
+    public AdminAuctionReinstateResponse reinstate(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody ReinstateAuctionRequest body,
+            @AuthenticationPrincipal AuthPrincipal admin) {
+
+        AdminAuctionReinstateResult result = adminAuctionService.reinstate(id, Optional.empty());
+        adminActionService.record(admin.userId(),
+            AdminActionType.REINSTATE_LISTING, AdminActionTargetType.LISTING, id,
+            body.notes(), null);
+
+        return new AdminAuctionReinstateResponse(
+            result.auction().getId(),
+            result.auction().getStatus(),
+            result.newEndsAt(),
+            result.suspensionDuration().toSeconds());
+    }
+}
+```
+
+- [ ] **Step 5: Refactor `AdminFraudFlagService.reinstate` to delegate**
+
+In `AdminFraudFlagService.java`, change the constructor deps:
+- REMOVE: `AuctionRepository auctionRepository`, `BotMonitorLifecycleService botMonitorLifecycleService`, `NotificationPublisher notificationPublisher`
+- ADD: `AdminAuctionService adminAuctionService`
+- KEEP: `FraudFlagRepository fraudFlagRepository`, `UserRepository userRepository`, `Clock clock`
+
+Replace the body of `reinstate(Long flagId, Long adminUserId, String adminNotes)` with:
+
+```java
+@Transactional
+public AdminFraudFlagDetailDto reinstate(Long flagId, Long adminUserId, String adminNotes) {
+    FraudFlag flag = fraudFlagRepository.findById(flagId)
+        .orElseThrow(() -> new FraudFlagNotFoundException(flagId));
+    if (flag.isResolved()) {
+        throw new FraudFlagAlreadyResolvedException(flagId);
+    }
+    Auction auction = flag.getAuction();
+    if (auction == null || auction.getStatus() != AuctionStatus.SUSPENDED) {
+        throw new AuctionNotSuspendedException(auction == null ? null : auction.getStatus());
+    }
+
+    // Delegate auction-state change + notification to the shared primitive.
+    adminAuctionService.reinstate(auction.getId(), Optional.of(flag.getDetectedAt()));
+
+    // Resolve the flag separately. Fraud flags continue to self-audit
+    // via FraudFlag.resolvedBy + adminNotes (no admin_actions row).
+    OffsetDateTime now = OffsetDateTime.now(clock);
+    User admin = userRepository.findById(adminUserId)
+        .orElseThrow(() -> new IllegalStateException("Admin user not found: " + adminUserId));
+    flag.setResolved(true);
+    flag.setResolvedAt(now);
+    flag.setResolvedBy(admin);
+    flag.setAdminNotes(adminNotes);
+    fraudFlagRepository.save(flag);
+
+    return detail(flagId);
+}
+```
+
+Imports to add: `java.util.Optional`, `com.slparcelauctions.backend.admin.AdminAuctionService`, `com.slparcelauctions.backend.admin.exception.AuctionNotSuspendedException`. Remove imports that are no longer used (`Duration`, `BotMonitorLifecycleService`, `NotificationPublisher`, `AuctionRepository`).
+
+- [ ] **Step 6: Run sub-spec 1's reinstate tests to confirm refactor preserves behavior**
+
+Run: `cd backend && ./mvnw test -Dtest=AdminFraudFlagServiceDismissReinstateTest,AdminFraudFlagReinstateIntegrationTest -q`
+Expected: PASS. If any test fails, the refactor leaked behavior — fix and re-run.
+
+- [ ] **Step 7: Write `AdminAuctionServiceTest` (unit, Mockito)**
+
+```java
+// backend/src/test/java/com/slparcelauctions/backend/admin/AdminAuctionServiceTest.java
+package com.slparcelauctions.backend.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.slparcelauctions.backend.admin.exception.AuctionNotSuspendedException;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.bot.BotMonitorLifecycleService;
+import com.slparcelauctions.backend.notification.NotificationPublisher;
+import com.slparcelauctions.backend.user.User;
+
+@ExtendWith(MockitoExtension.class)
+class AdminAuctionServiceTest {
+
+    @Mock AuctionRepository auctionRepo;
+    @Mock BotMonitorLifecycleService botMonitorLifecycle;
+    @Mock NotificationPublisher notificationPublisher;
+
+    private final Clock clock = Clock.fixed(Instant.parse("2026-04-26T12:00:00Z"), ZoneOffset.UTC);
+
+    private AdminAuctionService service() {
+        return new AdminAuctionService(auctionRepo, botMonitorLifecycle, notificationPublisher, clock);
+    }
+
+    private Auction makeAuction(AuctionStatus status, OffsetDateTime endsAt, OffsetDateTime suspendedAt) {
+        User seller = User.builder().id(1L).build();
+        Auction a = Auction.builder()
+            .id(100L).seller(seller).title("test").status(status)
+            .endsAt(endsAt).suspendedAt(suspendedAt).build();
+        return a;
+    }
+
+    @Test
+    void reinstate_happyPath_extendsEndsAt_withSuspendedAt() {
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        OffsetDateTime suspendedAt = now.minusHours(6);
+        OffsetDateTime endsAt = now.plusHours(2);
+        Auction a = makeAuction(AuctionStatus.SUSPENDED, endsAt, suspendedAt);
+        when(auctionRepo.findByIdForUpdate(100L)).thenReturn(Optional.of(a));
+        when(auctionRepo.save(any(Auction.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        var result = service().reinstate(100L, Optional.empty());
+
+        assertThat(a.getStatus()).isEqualTo(AuctionStatus.ACTIVE);
+        assertThat(a.getSuspendedAt()).isNull();
+        assertThat(a.getEndsAt()).isEqualTo(endsAt.plusHours(6));
+        verify(botMonitorLifecycle).onAuctionResumed(a);
+        verify(notificationPublisher).listingReinstated(1L, 100L, "test", a.getEndsAt());
+        assertThat(result.suspensionDuration().toHours()).isEqualTo(6L);
+    }
+
+    @Test
+    void reinstate_fallbackUsedWhenSuspendedAtNull() {
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        OffsetDateTime fallback = now.minusHours(3);
+        Auction a = makeAuction(AuctionStatus.SUSPENDED, now.plusHours(2), null);
+        when(auctionRepo.findByIdForUpdate(100L)).thenReturn(Optional.of(a));
+        when(auctionRepo.save(any(Auction.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service().reinstate(100L, Optional.of(fallback));
+
+        assertThat(a.getEndsAt().toEpochSecond())
+            .isEqualTo(now.plusHours(2).plusHours(3).toEpochSecond());
+    }
+
+    @Test
+    void reinstate_zeroExtensionWhenBothNull() {
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        OffsetDateTime endsAt = now.plusHours(2);
+        Auction a = makeAuction(AuctionStatus.SUSPENDED, endsAt, null);
+        when(auctionRepo.findByIdForUpdate(100L)).thenReturn(Optional.of(a));
+        when(auctionRepo.save(any(Auction.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service().reinstate(100L, Optional.empty());
+
+        assertThat(a.getEndsAt()).isEqualTo(endsAt); // 0-extension
+    }
+
+    @Test
+    void reinstate_clampsPastEndsAt_toNowPlus1h() {
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        // endsAt in the past + suspendedAt also in the past with no math saving it
+        Auction a = makeAuction(AuctionStatus.SUSPENDED,
+            now.minusDays(1), now.minusDays(2));
+        when(auctionRepo.findByIdForUpdate(100L)).thenReturn(Optional.of(a));
+        when(auctionRepo.save(any(Auction.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service().reinstate(100L, Optional.empty());
+
+        // Math: endsAt + (now - suspendedAt) = (-1d) + (2d) = +1d > now → fine
+        // Construct an actually-past case:
+        Auction b = makeAuction(AuctionStatus.SUSPENDED,
+            now.minusDays(2), now.minusDays(1));
+        when(auctionRepo.findByIdForUpdate(101L)).thenReturn(Optional.of(b));
+        service().reinstate(101L, Optional.empty());
+        // (-2d) + (1d) = -1d → clamp to now+1h
+        assertThat(b.getEndsAt()).isEqualTo(now.plusHours(1));
+    }
+
+    @Test
+    void reinstate_throwsWhenNotSuspended() {
+        Auction a = makeAuction(AuctionStatus.CANCELLED, OffsetDateTime.now(clock).plusHours(1), null);
+        when(auctionRepo.findByIdForUpdate(100L)).thenReturn(Optional.of(a));
+
+        assertThatThrownBy(() -> service().reinstate(100L, Optional.empty()))
+            .isInstanceOf(AuctionNotSuspendedException.class);
+        verify(botMonitorLifecycle, never()).onAuctionResumed(any());
+    }
+}
+```
+
+Run: `cd backend && ./mvnw test -Dtest=AdminAuctionServiceTest -q`
+Expected: PASS.
+
+- [ ] **Step 8: Write controller slice test**
+
+```java
+// backend/src/test/java/com/slparcelauctions/backend/admin/AdminAuctionControllerSliceTest.java
+package com.slparcelauctions.backend.admin;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.slparcelauctions.backend.admin.AdminAuctionService.AdminAuctionReinstateResult;
+import com.slparcelauctions.backend.admin.audit.AdminActionService;
+import com.slparcelauctions.backend.admin.audit.AdminActionType;
+import com.slparcelauctions.backend.admin.audit.AdminActionTargetType;
+import com.slparcelauctions.backend.admin.exception.AuctionNotSuspendedException;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.user.Role;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class AdminAuctionControllerSliceTest {
+
+    @Autowired MockMvc mvc;
+    @Autowired JwtService jwtService;
+
+    @MockitoBean AdminAuctionService adminAuctionService;
+    @MockitoBean AdminActionService adminActionService;
+
+    private String adminToken() {
+        return jwtService.issueAccessToken(new AuthPrincipal(99L, "a@x.com", 1L, Role.ADMIN));
+    }
+
+    @Test
+    void reinstate_anonymous_returns401() throws Exception {
+        mvc.perform(post("/api/v1/admin/auctions/100/reinstate")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"notes\":\"x\"}"))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void reinstate_userRole_returns403() throws Exception {
+        String token = jwtService.issueAccessToken(new AuthPrincipal(2L, "u@x.com", 1L, Role.USER));
+        mvc.perform(post("/api/v1/admin/auctions/100/reinstate")
+            .header("Authorization", "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"notes\":\"x\"}"))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void reinstate_emptyNotes_returns400() throws Exception {
+        mvc.perform(post("/api/v1/admin/auctions/100/reinstate")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"notes\":\"\"}"))
+           .andExpect(status().isBadRequest())
+           .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"));
+    }
+
+    @Test
+    void reinstate_notSuspended_returns409() throws Exception {
+        when(adminAuctionService.reinstate(eq(100L), any()))
+            .thenThrow(new AuctionNotSuspendedException(AuctionStatus.CANCELLED));
+
+        mvc.perform(post("/api/v1/admin/auctions/100/reinstate")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"notes\":\"x\"}"))
+           .andExpect(status().isConflict())
+           .andExpect(jsonPath("$.code").value("AUCTION_NOT_SUSPENDED"))
+           .andExpect(jsonPath("$.details.currentStatus").value("CANCELLED"));
+    }
+
+    @Test
+    void reinstate_admin_returns200_writesAudit() throws Exception {
+        Auction a = Auction.builder().id(100L).status(AuctionStatus.ACTIVE)
+            .endsAt(OffsetDateTime.parse("2026-05-01T00:00:00Z")).build();
+        when(adminAuctionService.reinstate(eq(100L), any()))
+            .thenReturn(new AdminAuctionReinstateResult(a, Duration.ofHours(6),
+                OffsetDateTime.parse("2026-05-01T00:00:00Z")));
+
+        mvc.perform(post("/api/v1/admin/auctions/100/reinstate")
+            .header("Authorization", "Bearer " + adminToken())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"notes\":\"verified\"}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.auctionId").value(100))
+           .andExpect(jsonPath("$.status").value("ACTIVE"));
+
+        verify(adminActionService).record(eq(99L),
+            eq(AdminActionType.REINSTATE_LISTING),
+            eq(AdminActionTargetType.LISTING),
+            eq(100L), eq("verified"), any());
+    }
+}
+```
+
+Run: `cd backend && ./mvnw test -Dtest=AdminAuctionControllerSliceTest -q`
+Expected: PASS.
+
+- [ ] **Step 9: Write integration test (full flow + audit row)**
+
+```java
+// backend/src/test/java/com/slparcelauctions/backend/admin/AdminAuctionReinstateIntegrationTest.java
+package com.slparcelauctions.backend.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.slparcelauctions.backend.admin.audit.AdminActionRepository;
+import com.slparcelauctions.backend.admin.audit.AdminActionService;
+import com.slparcelauctions.backend.admin.audit.AdminActionTargetType;
+import com.slparcelauctions.backend.admin.audit.AdminActionType;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.VerificationMethod;
+import com.slparcelauctions.backend.auction.VerificationTier;
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationRepository;
+import com.slparcelauctions.backend.notification.NotificationWsBroadcasterPort;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.parcel.ParcelRepository;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class AdminAuctionReinstateIntegrationTest {
+
+    @Autowired AdminAuctionService service;
+    @Autowired AdminActionService adminActionService;
+    @Autowired AdminActionRepository auditRepo;
+    @Autowired AuctionRepository auctionRepo;
+    @Autowired ParcelRepository parcelRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired NotificationRepository notifRepo;
+
+    @MockitoBean NotificationWsBroadcasterPort wsBroadcaster;
+
+    private Long sellerId, adminId, parcelId, auctionId;
+
+    @BeforeEach
+    void seed() {
+        User seller = userRepo.save(User.builder()
+            .email("seller-" + UUID.randomUUID() + "@x.com")
+            .passwordHash("x").role(Role.USER).tokenVersion(1L)
+            .slAvatarUuid(UUID.randomUUID()).build());
+        sellerId = seller.getId();
+        User admin = userRepo.save(User.builder()
+            .email("admin-" + UUID.randomUUID() + "@x.com")
+            .passwordHash("x").role(Role.ADMIN).tokenVersion(1L).build());
+        adminId = admin.getId();
+
+        Parcel parcel = parcelRepo.save(Parcel.builder()
+            .slParcelUuid(UUID.randomUUID()).regionName("R")
+            .ownerUuid(seller.getSlAvatarUuid()).areaSqm(1024)
+            .positionX(BigDecimal.ZERO).positionY(BigDecimal.ZERO).positionZ(BigDecimal.ZERO)
+            .build());
+        parcelId = parcel.getId();
+
+        Auction auction = auctionRepo.save(Auction.builder()
+            .seller(seller).parcel(parcel).title("Test")
+            .status(AuctionStatus.SUSPENDED)
+            .suspendedAt(OffsetDateTime.now().minusHours(3))
+            .verificationTier(VerificationTier.MANUAL)
+            .verificationMethod(VerificationMethod.MANUAL_UUID)
+            .startingBid(1L).endsAt(OffsetDateTime.now().plusHours(2))
+            .build());
+        auctionId = auction.getId();
+    }
+
+    @AfterEach
+    void cleanup() {
+        auditRepo.deleteAll();
+        notifRepo.deleteAll();
+        auctionRepo.deleteById(auctionId);
+        parcelRepo.deleteById(parcelId);
+        userRepo.deleteById(sellerId);
+        userRepo.deleteById(adminId);
+    }
+
+    @Test
+    void reinstate_endToEnd() {
+        var result = service.reinstate(auctionId, Optional.empty());
+        adminActionService.record(adminId, AdminActionType.REINSTATE_LISTING,
+            AdminActionTargetType.LISTING, auctionId, "verified", null);
+
+        Auction reloaded = auctionRepo.findById(auctionId).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(AuctionStatus.ACTIVE);
+        assertThat(reloaded.getSuspendedAt()).isNull();
+        assertThat(result.suspensionDuration().toHours()).isGreaterThanOrEqualTo(2L);
+
+        assertThat(notifRepo.findAll())
+            .anyMatch(n -> n.getCategory() == NotificationCategory.LISTING_REINSTATED
+                        && n.getUserId().equals(sellerId));
+
+        assertThat(auditRepo.findAll())
+            .anyMatch(a -> a.getActionType() == AdminActionType.REINSTATE_LISTING
+                        && a.getTargetId().equals(auctionId));
+    }
+}
+```
+
+Run: `cd backend && ./mvnw test -Dtest=AdminAuctionReinstateIntegrationTest -q`
+Expected: PASS.
+
+- [ ] **Step 10: Run full backend tests to confirm sub-spec 1 still passes**
+
+Run: `cd backend && ./mvnw test -q`
+Expected: PASS. Re-run once if `AuctionRepositoryOwnershipCheckTest` flakes.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/admin/AdminAuctionService.java \
+        backend/src/main/java/com/slparcelauctions/backend/admin/AdminAuctionController.java \
+        backend/src/main/java/com/slparcelauctions/backend/admin/dto/AdminAuctionReinstateResponse.java \
+        backend/src/main/java/com/slparcelauctions/backend/admin/dto/ReinstateAuctionRequest.java \
+        backend/src/main/java/com/slparcelauctions/backend/admin/AdminFraudFlagService.java \
+        backend/src/test/java/com/slparcelauctions/backend/admin/AdminAuctionServiceTest.java \
+        backend/src/test/java/com/slparcelauctions/backend/admin/AdminAuctionControllerSliceTest.java \
+        backend/src/test/java/com/slparcelauctions/backend/admin/AdminAuctionReinstateIntegrationTest.java
+
+git commit -m "$(cat <<'EOF'
+feat(admin): AdminAuctionService.reinstate shared primitive + standalone endpoint
+
+Sub-spec 1's fraud-flag reinstate refactored to delegate to a new shared
+AdminAuctionService.reinstate(auctionId, fallbackSuspendedFrom). New
+endpoint POST /api/v1/admin/auctions/{id}/reinstate writes an
+admin_actions audit row (action=REINSTATE_LISTING). Used by user-detail
+Listings tab Reinstate button for SUSPENDED auctions that lack a fraud
+flag (sub-spec 2 admin-suspend path).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `CancellationLog.cancelledByAdminId` + `cancelByAdmin` + `LISTING_REMOVED_BY_ADMIN` + cause-neutral fanout copy
+
+**Goal:** Add admin-cancel path that skips the penalty ladder, sends LISTING_REMOVED_BY_ADMIN to the seller, and reuses the bidder fan-out (with cause-neutral copy update). Foundation for the reports queue's "Cancel listing" admin action.
+
+**Files:**
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLog.java` (add `cancelledByAdminId` column)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLogRepository.java` (update query)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/CancellationService.java` (add `cancelByAdmin` method)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationCategory.java` (add `LISTING_REMOVED_BY_ADMIN`)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationCategoryCheckConstraintInitializer.java` (auto-syncs but verify)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisher.java` (add `listingRemovedByAdmin` + update fanout body)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java` (impl + cause-neutral fanout copy)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationDataBuilder.java` (add `listingRemovedByAdmin`)
+- Test: `backend/src/test/java/com/slparcelauctions/backend/auction/CancellationServiceCancelByAdminTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/auction/CancellationLogRepositoryTest.java` (extend if exists)
+
+- [ ] **Step 1: Add `cancelledByAdminId` to `CancellationLog` entity**
+
+In `CancellationLog.java`, add the field next to `penaltyAmountL`:
+
+```java
+@Column(name = "cancelled_by_admin_id")
+private Long cancelledByAdminId;
+```
+
+- [ ] **Step 2: Update `countPriorOffensesWithBids` query to exclude admin cancels**
+
+In `CancellationLogRepository.java`, replace the `@Query`:
+
+```java
+@Query("SELECT count(c) FROM CancellationLog c "
+        + "WHERE c.seller.id = :sellerId "
+        + "AND c.hadBids = true "
+        + "AND c.cancelledByAdminId IS NULL")
+long countPriorOffensesWithBids(@Param("sellerId") Long sellerId);
+```
+
+- [ ] **Step 3: Add `LISTING_REMOVED_BY_ADMIN` to NotificationCategory enum**
+
+In `NotificationCategory.java`, add adjacent to `LISTING_CANCELLED_BY_SELLER`:
+
+```java
+LISTING_REMOVED_BY_ADMIN(NotificationGroup.LISTING_STATUS),
+```
+
+- [ ] **Step 4: Add `listingRemovedByAdmin` to `NotificationPublisher` interface**
+
+```java
+// in NotificationPublisher.java, near listingReinstated
+void listingRemovedByAdmin(long sellerUserId, long auctionId, String parcelName, String reason);
+```
+
+- [ ] **Step 5: Implement `listingRemovedByAdmin` in `NotificationPublisherImpl`**
+
+Locate `listingReinstated` (~line 264), add directly below:
+
+```java
+@Override
+public void listingRemovedByAdmin(long sellerUserId, long auctionId, String parcelName, String reason) {
+    String title = "Listing removed: " + parcelName;
+    String body = "Your listing has been removed by SLPA staff. Reason: " + reason + ".";
+    notificationService.publish(new NotificationEvent(
+        sellerUserId, NotificationCategory.LISTING_REMOVED_BY_ADMIN, title, body,
+        NotificationDataBuilder.listingRemovedByAdmin(auctionId, parcelName, reason),
+        null
+    ));
+}
+```
+
+- [ ] **Step 6: Update `listingCancelledBySellerFanout` body to be cause-neutral**
+
+In `NotificationPublisherImpl.java`, locate `listingCancelledBySellerFanout` (~lines 299-327). Replace the title and body strings:
+
+```java
+// OLD:
+// String title = "Listing cancelled: " + parcelName;
+// String body = "The seller cancelled this listing. Reason: " + reason + ".";
+
+// NEW (cause-neutral — applies to both seller-cancel and admin-cancel callers):
+String title = "Auction cancelled: " + parcelName;
+String body = "This auction has been cancelled. Your active proxy bid is no longer in effect. Reason: " + reason + ".";
+```
+
+- [ ] **Step 7: Add `listingRemovedByAdmin` to `NotificationDataBuilder`**
+
+In `NotificationDataBuilder.java`, add near `listingCancelledBySeller`:
+
+```java
+public static Map<String, Object> listingRemovedByAdmin(long auctionId, String parcelName, String reason) {
+    Map<String, Object> m = base(auctionId, parcelName);
+    m.put("reason", reason);
+    return m;
+}
+```
+
+- [ ] **Step 8: Add `cancelByAdmin` to `CancellationService`**
+
+Append to `CancellationService.java`:
+
+```java
+@Transactional
+public Auction cancelByAdmin(Long auctionId, Long adminUserId, String notes) {
+    Auction a = auctionRepo.findByIdForUpdate(auctionId)
+        .orElseThrow(() -> new AuctionNotFoundException(auctionId));
+    if (!CANCELLABLE.contains(a.getStatus())) {
+        throw new InvalidAuctionStateException(a.getId(), a.getStatus(), "ADMIN_CANCEL");
+    }
+
+    // Skip penalty ladder. Skip seller-row lock — no seller-side state changes.
+    boolean hadBids = a.getBidCount() != null && a.getBidCount() > 0;
+    AuctionStatus from = a.getStatus();
+
+    logRepo.save(CancellationLog.builder()
+        .auction(a).seller(a.getSeller())
+        .cancelledFromStatus(from.name())
+        .hadBids(hadBids)
+        .reason(notes)
+        .penaltyKind(CancellationOffenseKind.NONE)
+        .penaltyAmountL(null)
+        .cancelledByAdminId(adminUserId)
+        .build());
+
+    a.setStatus(AuctionStatus.CANCELLED);
+    auctionRepo.save(a);
+
+    monitorLifecycle.onAuctionClosed(a);
+    broadcastPublisher.publishStatusChanged(a);
+
+    // Seller side: distinct LISTING_REMOVED_BY_ADMIN category.
+    notificationPublisher.listingRemovedByAdmin(
+        a.getSeller().getId(), a.getId(), a.getTitle(), notes);
+
+    // Bidder side: same fan-out as seller-driven cancel (cause-neutral copy
+    // applies to both callers). Bidders need to know their proxy is gone.
+    if (hadBids) {
+        var bidderIds = bidRepo.findDistinctBidderUserIdsByAuctionId(a.getId());
+        notificationPublisher.listingCancelledBySellerFanout(
+            a.getId(), bidderIds, a.getTitle(), notes);
+    }
+
+    return a;
+}
+```
+
+- [ ] **Step 9: Write integration test**
+
+```java
+// backend/src/test/java/com/slparcelauctions/backend/auction/CancellationServiceCancelByAdminTest.java
+package com.slparcelauctions.backend.auction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationRepository;
+import com.slparcelauctions.backend.notification.NotificationWsBroadcasterPort;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.parcel.ParcelRepository;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class CancellationServiceCancelByAdminTest {
+
+    @Autowired CancellationService cancellationService;
+    @Autowired CancellationLogRepository logRepo;
+    @Autowired AuctionRepository auctionRepo;
+    @Autowired ParcelRepository parcelRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired NotificationRepository notifRepo;
+
+    @MockitoBean NotificationWsBroadcasterPort wsBroadcaster;
+
+    private Long sellerId, adminId, parcelId, auctionId;
+
+    @BeforeEach
+    void seed() {
+        User seller = userRepo.save(User.builder()
+            .email("seller-" + UUID.randomUUID() + "@x.com")
+            .passwordHash("x").role(Role.USER).tokenVersion(1L).build());
+        sellerId = seller.getId();
+        adminId = userRepo.save(User.builder()
+            .email("admin-" + UUID.randomUUID() + "@x.com")
+            .passwordHash("x").role(Role.ADMIN).tokenVersion(1L).build()).getId();
+
+        Parcel parcel = parcelRepo.save(Parcel.builder()
+            .slParcelUuid(UUID.randomUUID()).regionName("R")
+            .ownerUuid(UUID.randomUUID()).areaSqm(512)
+            .positionX(BigDecimal.ZERO).positionY(BigDecimal.ZERO).positionZ(BigDecimal.ZERO)
+            .build());
+        parcelId = parcel.getId();
+
+        Auction auction = auctionRepo.save(Auction.builder()
+            .seller(seller).parcel(parcel).title("Test")
+            .status(AuctionStatus.ACTIVE)
+            .verificationTier(VerificationTier.MANUAL)
+            .verificationMethod(VerificationMethod.MANUAL_UUID)
+            .startingBid(1L).endsAt(OffsetDateTime.now().plusHours(2))
+            .bidCount(0)
+            .build());
+        auctionId = auction.getId();
+    }
+
+    @AfterEach
+    void cleanup() {
+        notifRepo.deleteAll();
+        logRepo.deleteAll();
+        auctionRepo.deleteById(auctionId);
+        parcelRepo.deleteById(parcelId);
+        userRepo.deleteById(sellerId);
+        userRepo.deleteById(adminId);
+    }
+
+    @Test
+    void cancelByAdmin_flipsCancelled_writesLogWithCancelledByAdminId() {
+        cancellationService.cancelByAdmin(auctionId, adminId, "removed for TOS violation");
+
+        Auction reloaded = auctionRepo.findById(auctionId).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(AuctionStatus.CANCELLED);
+
+        var logs = logRepo.findAll();
+        var log = logs.stream().filter(l -> l.getAuction().getId().equals(auctionId))
+            .findFirst().orElseThrow();
+        assertThat(log.getCancelledByAdminId()).isEqualTo(adminId);
+        assertThat(log.getPenaltyKind()).isEqualTo(CancellationOffenseKind.NONE);
+    }
+
+    @Test
+    void cancelByAdmin_doesNotIncrementSellerCancelledWithBidsCounter() {
+        long before = userRepo.findById(sellerId).orElseThrow().getCancelledWithBids();
+        cancellationService.cancelByAdmin(auctionId, adminId, "removed");
+        long after = userRepo.findById(sellerId).orElseThrow().getCancelledWithBids();
+        assertThat(after).isEqualTo(before);
+    }
+
+    @Test
+    void cancelByAdmin_priorOffensesQueryExcludesAdminCancel() {
+        // Seed an admin-cancel for sellerId.
+        cancellationService.cancelByAdmin(auctionId, adminId, "removed");
+        long count = logRepo.countPriorOffensesWithBids(sellerId);
+        assertThat(count).isZero();
+    }
+
+    @Test
+    void cancelByAdmin_publishesListingRemovedByAdminToSeller() {
+        cancellationService.cancelByAdmin(auctionId, adminId, "removed");
+
+        assertThat(notifRepo.findAll())
+            .anyMatch(n -> n.getCategory() == NotificationCategory.LISTING_REMOVED_BY_ADMIN
+                        && n.getUserId().equals(sellerId));
+    }
+}
+```
+
+Run: `cd backend && ./mvnw test -Dtest=CancellationServiceCancelByAdminTest -q`
+Expected: PASS.
+
+- [ ] **Step 10: Verify existing seller-cancel tests still pass with cause-neutral copy update**
+
+Run: `cd backend && ./mvnw test -Dtest='*Cancellation*' -q`
+Expected: PASS. If any existing test asserts the OLD body string ("The seller cancelled this listing"), update its assertion to match the new cause-neutral copy ("This auction has been cancelled").
+
+- [ ] **Step 11: Run full backend test suite**
+
+Run: `cd backend && ./mvnw test -q`
+Expected: PASS.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLog.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLogRepository.java \
+        backend/src/main/java/com/slparcelauctions/backend/auction/CancellationService.java \
+        backend/src/main/java/com/slparcelauctions/backend/notification/ \
+        backend/src/test/java/com/slparcelauctions/backend/auction/CancellationServiceCancelByAdminTest.java
+
+git commit -m "$(cat <<'EOF'
+feat(admin): cancelByAdmin path skips penalty ladder + LISTING_REMOVED_BY_ADMIN
+
+CancellationLog.cancelledByAdminId column added; countPriorOffensesWithBids
+excludes admin-cancel rows so they don't bump the seller's penalty ladder.
+Seller gets distinct LISTING_REMOVED_BY_ADMIN notification; bidders get
+the existing seller-cancel fan-out (body copy made cause-neutral so it
+works for both callers). seller.cancelledWithBids is NOT incremented.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `SuspensionService.suspendByAdmin` + `LISTING_WARNED` notification category
+
+**Goal:** Add admin-driven suspend path (no fraud flag) + new LISTING_WARNED category for warn-seller report action.
+
+**Files:**
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/SuspensionService.java` (add `suspendByAdmin`)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationCategory.java` (add `LISTING_WARNED`)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisher.java` (add `listingWarned`)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java` (impl)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationDataBuilder.java` (add `listingWarned`)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImLinkResolver.java` (add LISTING_WARNED + LISTING_REMOVED_BY_ADMIN switch entries — required because the switch is exhaustive over the enum; sub-spec 1 Task 7 hit this same trap)
+- Test: `backend/src/test/java/com/slparcelauctions/backend/auction/monitoring/SuspensionServiceSuspendByAdminTest.java`
+
+- [ ] **Step 1: Add `LISTING_WARNED` enum value**
+
+In `NotificationCategory.java`, add (between LISTING_REMOVED_BY_ADMIN from Task 3 and the next existing value):
+
+```java
+LISTING_WARNED(NotificationGroup.LISTING_STATUS),
+```
+
+- [ ] **Step 2: Update SlImLinkResolver to handle the two new categories**
+
+`SlImLinkResolver` has an exhaustive switch over `NotificationCategory`. Adding new enum values requires updating the switch. Locate `SlImLinkResolver.java` (under `notification/slim/`). Add cases for `LISTING_WARNED` and `LISTING_REMOVED_BY_ADMIN` that resolve to the auction detail URL (same pattern as `LISTING_SUSPENDED`):
+
+```java
+case LISTING_WARNED, LISTING_REMOVED_BY_ADMIN ->
+    baseUrl + "/auction/" + data.get("auctionId");
+```
+
+If the existing switch already groups `LISTING_*` cases, add the two new constants to the same arm.
+
+- [ ] **Step 3: Add publisher interface method**
+
+In `NotificationPublisher.java`:
+
+```java
+void listingWarned(long sellerUserId, long auctionId, String parcelName, String notes);
+```
+
+- [ ] **Step 4: Implement in `NotificationPublisherImpl`**
+
+Add (near `listingSuspended`):
+
+```java
+@Override
+public void listingWarned(long sellerUserId, long auctionId, String parcelName, String notes) {
+    String title = "Warning on your listing: " + parcelName;
+    String body = "An admin has reviewed reports on this listing and issued a warning. Notes: " + notes;
+    notificationService.publish(new NotificationEvent(
+        sellerUserId, NotificationCategory.LISTING_WARNED, title, body,
+        NotificationDataBuilder.listingWarned(auctionId, parcelName, notes),
+        null
+    ));
+}
+```
+
+- [ ] **Step 5: Add `NotificationDataBuilder.listingWarned`**
+
+```java
+public static Map<String, Object> listingWarned(long auctionId, String parcelName, String notes) {
+    Map<String, Object> m = base(auctionId, parcelName);
+    m.put("notes", notes);
+    return m;
+}
+```
+
+- [ ] **Step 6: Add `suspendByAdmin` to `SuspensionService`**
+
+Append to `SuspensionService.java`:
+
+```java
+/**
+ * Admin-driven suspension. No FraudFlag created — admin reason is captured
+ * in the admin_actions audit row written by the caller. Sets suspendedAt
+ * if currently null, mirroring suspendForOwnershipChange.
+ */
+@Transactional
+public void suspendByAdmin(Auction auction, Long adminUserId, String notes) {
+    OffsetDateTime now = OffsetDateTime.now(clock);
+    auction.setStatus(AuctionStatus.SUSPENDED);
+    if (auction.getSuspendedAt() == null) {
+        auction.setSuspendedAt(now);
+    }
+    auctionRepo.save(auction);
+
+    monitorLifecycle.onAuctionClosed(auction);
+
+    notificationPublisher.listingSuspended(
+        auction.getSeller().getId(), auction.getId(),
+        auction.getTitle(), "Suspended by SLPA staff");
+}
+```
+
+- [ ] **Step 7: Write integration test**
+
+```java
+// backend/src/test/java/com/slparcelauctions/backend/auction/monitoring/SuspensionServiceSuspendByAdminTest.java
+package com.slparcelauctions.backend.auction.monitoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.VerificationMethod;
+import com.slparcelauctions.backend.auction.VerificationTier;
+import com.slparcelauctions.backend.auction.fraud.FraudFlagRepository;
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationRepository;
+import com.slparcelauctions.backend.notification.NotificationWsBroadcasterPort;
+import com.slparcelauctions.backend.parcel.Parcel;
+import com.slparcelauctions.backend.parcel.ParcelRepository;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false"
+})
+class SuspensionServiceSuspendByAdminTest {
+
+    @Autowired SuspensionService suspensionService;
+    @Autowired AuctionRepository auctionRepo;
+    @Autowired ParcelRepository parcelRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired FraudFlagRepository fraudFlagRepo;
+    @Autowired NotificationRepository notifRepo;
+
+    @MockitoBean NotificationWsBroadcasterPort wsBroadcaster;
+
+    private Long sellerId, adminId, parcelId, auctionId;
+
+    @BeforeEach
+    void seed() {
+        User seller = userRepo.save(User.builder()
+            .email("seller-" + UUID.randomUUID() + "@x.com")
+            .passwordHash("x").role(Role.USER).tokenVersion(1L)
+            .slAvatarUuid(UUID.randomUUID()).build());
+        sellerId = seller.getId();
+        adminId = userRepo.save(User.builder()
+            .email("admin-" + UUID.randomUUID() + "@x.com")
+            .passwordHash("x").role(Role.ADMIN).tokenVersion(1L).build()).getId();
+
+        Parcel parcel = parcelRepo.save(Parcel.builder()
+            .slParcelUuid(UUID.randomUUID()).regionName("R")
+            .ownerUuid(seller.getSlAvatarUuid()).areaSqm(1024)
+            .positionX(BigDecimal.ZERO).positionY(BigDecimal.ZERO).positionZ(BigDecimal.ZERO)
+            .build());
+        parcelId = parcel.getId();
+
+        Auction auction = auctionRepo.save(Auction.builder()
+            .seller(seller).parcel(parcel).title("Test")
+            .status(AuctionStatus.ACTIVE)
+            .verificationTier(VerificationTier.MANUAL)
+            .verificationMethod(VerificationMethod.MANUAL_UUID)
+            .startingBid(1L).endsAt(OffsetDateTime.now().plusHours(2))
+            .build());
+        auctionId = auction.getId();
+    }
+
+    @AfterEach
+    void cleanup() {
+        notifRepo.deleteAll();
+        fraudFlagRepo.findByAuctionId(auctionId).forEach(fraudFlagRepo::delete);
+        auctionRepo.deleteById(auctionId);
+        parcelRepo.deleteById(parcelId);
+        userRepo.deleteById(sellerId);
+        userRepo.deleteById(adminId);
+    }
+
+    @Test
+    void suspendByAdmin_flipsSuspended_setsSuspendedAt_noFraudFlag() {
+        Auction auction = auctionRepo.findById(auctionId).orElseThrow();
+        suspensionService.suspendByAdmin(auction, adminId, "TOS abuse");
+
+        Auction reloaded = auctionRepo.findById(auctionId).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(AuctionStatus.SUSPENDED);
+        assertThat(reloaded.getSuspendedAt()).isNotNull();
+        assertThat(fraudFlagRepo.findByAuctionId(auctionId)).isEmpty();
+    }
+
+    @Test
+    void suspendByAdmin_publishesListingSuspendedToSeller() {
+        Auction auction = auctionRepo.findById(auctionId).orElseThrow();
+        suspensionService.suspendByAdmin(auction, adminId, "TOS abuse");
+
+        assertThat(notifRepo.findAll())
+            .anyMatch(n -> n.getCategory() == NotificationCategory.LISTING_SUSPENDED
+                        && n.getUserId().equals(sellerId));
+    }
+}
+```
+
+Run: `cd backend && ./mvnw test -Dtest=SuspensionServiceSuspendByAdminTest -q`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/SuspensionService.java \
+        backend/src/main/java/com/slparcelauctions/backend/notification/ \
+        backend/src/test/java/com/slparcelauctions/backend/auction/monitoring/SuspensionServiceSuspendByAdminTest.java
+
+git commit -m "$(cat <<'EOF'
+feat(admin): suspendByAdmin path + LISTING_WARNED category
+
+SuspensionService.suspendByAdmin flips ACTIVE→SUSPENDED, sets suspendedAt
+if null, calls onAuctionClosed (cancels bot monitor), publishes existing
+LISTING_SUSPENDED with admin-flavored reason text. No FraudFlag created
+— admin reason captured in admin_actions audit. New LISTING_WARNED
+category (used by report's warn-seller action in Task 6).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `ListingReport` entity + user-facing endpoints + `User.dismissedReportsCount`
+
+**Goal:** Foundation for the reports feature — entity, repository, user-facing POST/GET endpoints, frivolous counter on User.
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReport.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReportReason.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReportStatus.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReportRepository.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/UserReportController.java` (user-facing endpoints under /api/v1/auctions/...)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/UserReportService.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/dto/ReportRequest.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/dto/MyReportResponse.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/exception/CannotReportOwnListingException.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/exception/MustBeVerifiedToReportException.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/exception/AuctionNotReportableException.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/exception/UserReportExceptionHandler.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/user/User.java` (add `dismissedReportsCount`)
+- Test: `backend/src/test/java/com/slparcelauctions/backend/admin/reports/UserReportServiceTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/admin/reports/UserReportControllerSliceTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/admin/reports/ListingReportRepositoryTest.java`
+
+- [ ] **Step 1: Create enums**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReportReason.java
+package com.slparcelauctions.backend.admin.reports;
+
+public enum ListingReportReason {
+    INACCURATE_DESCRIPTION,
+    WRONG_TAGS,
+    SHILL_BIDDING,
+    FRAUDULENT_SELLER,
+    DUPLICATE_LISTING,
+    NOT_ACTUALLY_FOR_SALE,
+    TOS_VIOLATION,
+    OTHER
+}
+```
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReportStatus.java
+package com.slparcelauctions.backend.admin.reports;
+
+public enum ListingReportStatus {
+    OPEN, REVIEWED, DISMISSED, ACTION_TAKEN
+}
+```
+
+- [ ] **Step 2: Create `ListingReport` entity**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReport.java
+package com.slparcelauctions.backend.admin.reports;
+
+import java.time.OffsetDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.user.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "listing_reports",
+    uniqueConstraints = @UniqueConstraint(name = "uk_listing_reports_auction_reporter",
+        columnNames = {"auction_id", "reporter_id"}),
+    indexes = {
+        @Index(name = "idx_listing_reports_status", columnList = "status, auction_id"),
+        @Index(name = "idx_listing_reports_auction", columnList = "auction_id, updated_at DESC")
+    })
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class ListingReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "auction_id", nullable = false)
+    private Auction auction;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
+
+    @Column(length = 100, nullable = false)
+    private String subject;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30, nullable = false)
+    private ListingReportReason reason;
+
+    @Column(columnDefinition = "text", nullable = false)
+    private String details;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    @Builder.Default
+    private ListingReportStatus status = ListingReportStatus.OPEN;
+
+    @Column(name = "admin_notes", columnDefinition = "text")
+    private String adminNotes;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewed_by")
+    private User reviewedBy;
+
+    @Column(name = "reviewed_at")
+    private OffsetDateTime reviewedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+}
+```
+
+- [ ] **Step 3: Create `ListingReportRepository`**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReportRepository.java
+package com.slparcelauctions.backend.admin.reports;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ListingReportRepository extends JpaRepository<ListingReport, Long> {
+
+    Optional<ListingReport> findByAuctionIdAndReporterId(Long auctionId, Long reporterId);
+
+    List<ListingReport> findByAuctionIdOrderByCreatedAtDesc(Long auctionId);
+
+    long countByStatus(ListingReportStatus status);
+}
+```
+
+- [ ] **Step 4: Add `dismissedReportsCount` to `User` entity**
+
+In `User.java`, add next to `cancelledWithBids`:
+
+```java
+@Column(name = "dismissed_reports_count", nullable = false)
+@Builder.Default
+private long dismissedReportsCount = 0L;
+```
+
+- [ ] **Step 5: Create exception classes**
+
+```java
+// CannotReportOwnListingException.java
+package com.slparcelauctions.backend.admin.reports.exception;
+
+public class CannotReportOwnListingException extends RuntimeException {
+    public CannotReportOwnListingException() { super("Cannot report your own listing"); }
+}
+
+// MustBeVerifiedToReportException.java
+package com.slparcelauctions.backend.admin.reports.exception;
+
+public class MustBeVerifiedToReportException extends RuntimeException {
+    public MustBeVerifiedToReportException() { super("Verify your SL avatar to report listings"); }
+}
+
+// AuctionNotReportableException.java
+package com.slparcelauctions.backend.admin.reports.exception;
+
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import lombok.Getter;
+
+@Getter
+public class AuctionNotReportableException extends RuntimeException {
+    private final AuctionStatus currentStatus;
+    public AuctionNotReportableException(AuctionStatus s) {
+        super("Auction is " + s + ", not reportable");
+        this.currentStatus = s;
+    }
+}
+```
+
+- [ ] **Step 6: Create `UserReportExceptionHandler`**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/reports/exception/UserReportExceptionHandler.java
+package com.slparcelauctions.backend.admin.reports.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.slparcelauctions.backend.admin.reports")
+public class UserReportExceptionHandler {
+
+    @ExceptionHandler(CannotReportOwnListingException.class)
+    public ProblemDetail handleOwnListing(CannotReportOwnListingException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.CONFLICT);
+        pd.setTitle(ex.getMessage());
+        pd.setProperty("code", "CANNOT_REPORT_OWN_LISTING");
+        return pd;
+    }
+
+    @ExceptionHandler(MustBeVerifiedToReportException.class)
+    public ProblemDetail handleNotVerified(MustBeVerifiedToReportException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.FORBIDDEN);
+        pd.setTitle(ex.getMessage());
+        pd.setProperty("code", "VERIFICATION_REQUIRED");
+        return pd;
+    }
+
+    @ExceptionHandler(AuctionNotReportableException.class)
+    public ProblemDetail handleNotActive(AuctionNotReportableException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.CONFLICT);
+        pd.setTitle(ex.getMessage());
+        pd.setProperty("code", "AUCTION_NOT_REPORTABLE");
+        pd.setProperty("currentStatus", ex.getCurrentStatus().name());
+        return pd;
+    }
+}
+```
+
+- [ ] **Step 7: Create DTOs**
+
+```java
+// ReportRequest.java
+package com.slparcelauctions.backend.admin.reports.dto;
+
+import com.slparcelauctions.backend.admin.reports.ListingReportReason;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ReportRequest(
+    @NotBlank @Size(max = 100) String subject,
+    @NotNull ListingReportReason reason,
+    @NotBlank @Size(max = 2000) String details
+) {}
+
+// MyReportResponse.java
+package com.slparcelauctions.backend.admin.reports.dto;
+
+import java.time.OffsetDateTime;
+
+import com.slparcelauctions.backend.admin.reports.ListingReportReason;
+import com.slparcelauctions.backend.admin.reports.ListingReportStatus;
+
+public record MyReportResponse(
+    Long id, String subject, ListingReportReason reason, String details,
+    ListingReportStatus status, OffsetDateTime createdAt, OffsetDateTime updatedAt
+) {}
+```
+
+- [ ] **Step 8: Create `UserReportService`**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/reports/UserReportService.java
+package com.slparcelauctions.backend.admin.reports;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.admin.reports.dto.MyReportResponse;
+import com.slparcelauctions.backend.admin.reports.dto.ReportRequest;
+import com.slparcelauctions.backend.admin.reports.exception.AuctionNotReportableException;
+import com.slparcelauctions.backend.admin.reports.exception.CannotReportOwnListingException;
+import com.slparcelauctions.backend.admin.reports.exception.MustBeVerifiedToReportException;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserReportService {
+
+    private final ListingReportRepository repo;
+    private final AuctionRepository auctionRepo;
+    private final UserRepository userRepo;
+
+    @Transactional
+    public MyReportResponse upsertReport(Long auctionId, Long reporterId, ReportRequest req) {
+        Auction auction = auctionRepo.findById(auctionId)
+            .orElseThrow(() -> new AuctionNotFoundException(auctionId));
+        User reporter = userRepo.findById(reporterId)
+            .orElseThrow(() -> new IllegalStateException("Reporter not found: " + reporterId));
+
+        if (!Boolean.TRUE.equals(reporter.getVerified())) {
+            throw new MustBeVerifiedToReportException();
+        }
+        if (auction.getSeller().getId().equals(reporterId)) {
+            throw new CannotReportOwnListingException();
+        }
+        if (auction.getStatus() != AuctionStatus.ACTIVE) {
+            throw new AuctionNotReportableException(auction.getStatus());
+        }
+
+        ListingReport report = repo.findByAuctionIdAndReporterId(auctionId, reporterId)
+            .orElseGet(() -> ListingReport.builder()
+                .auction(auction).reporter(reporter)
+                .build());
+        report.setSubject(req.subject());
+        report.setReason(req.reason());
+        report.setDetails(req.details());
+        report.setStatus(ListingReportStatus.OPEN); // resubmit resets to OPEN
+        report.setReviewedBy(null);
+        report.setReviewedAt(null);
+        report.setAdminNotes(null);
+        ListingReport saved = repo.save(report);
+        return toMyReport(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<MyReportResponse> findMyReport(Long auctionId, Long reporterId) {
+        return repo.findByAuctionIdAndReporterId(auctionId, reporterId)
+            .map(this::toMyReport);
+    }
+
+    private MyReportResponse toMyReport(ListingReport r) {
+        return new MyReportResponse(r.getId(), r.getSubject(), r.getReason(), r.getDetails(),
+            r.getStatus(), r.getCreatedAt(), r.getUpdatedAt());
+    }
+}
+```
+
+- [ ] **Step 9: Create `UserReportController`**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/reports/UserReportController.java
+package com.slparcelauctions.backend.admin.reports;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.admin.reports.dto.MyReportResponse;
+import com.slparcelauctions.backend.admin.reports.dto.ReportRequest;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/auctions/{auctionId}")
+@RequiredArgsConstructor
+public class UserReportController {
+
+    private final UserReportService service;
+
+    @PostMapping("/report")
+    public MyReportResponse report(
+            @PathVariable Long auctionId,
+            @Valid @RequestBody ReportRequest body,
+            @AuthenticationPrincipal AuthPrincipal principal) {
+        return service.upsertReport(auctionId, principal.userId(), body);
+    }
+
+    @GetMapping("/my-report")
+    public ResponseEntity<MyReportResponse> myReport(
+            @PathVariable Long auctionId,
+            @AuthenticationPrincipal AuthPrincipal principal) {
+        return service.findMyReport(auctionId, principal.userId())
+            .map(ResponseEntity::ok)
+            .orElse(ResponseEntity.noContent().build());
+    }
+}
+```
+
+- [ ] **Step 10: Write integration test for the upsert + my-report flow**
+
+```java
+// backend/src/test/java/com/slparcelauctions/backend/admin/reports/UserReportServiceTest.java
+// (Integration test using @SpringBootTest pattern; covers:
+//  - first POST creates report with status=OPEN
+//  - resubmit upserts and resets status=OPEN even when previously DISMISSED
+//  - own-listing throws CannotReportOwnListingException
+//  - unverified reporter throws MustBeVerifiedToReportException
+//  - non-ACTIVE auction throws AuctionNotReportableException
+//  - findMyReport returns Optional.empty when no row, populated when exists)
+//
+// Use the same seeding pattern as Task 3's CancellationServiceCancelByAdminTest.
+// Assert against return-DTO shape.
+```
+
+The implementer writes the full test file mirroring Task 3's seeding pattern. Test cases above are MANDATORY — each case is an `@Test` method.
+
+Run: `cd backend && ./mvnw test -Dtest=UserReportServiceTest -q`
+Expected: PASS.
+
+- [ ] **Step 11: Write controller slice test**
+
+```java
+// backend/src/test/java/com/slparcelauctions/backend/admin/reports/UserReportControllerSliceTest.java
+// @SpringBootTest + @AutoConfigureMockMvc + @MockitoBean UserReportService
+// Test cases:
+//  - POST anonymous → 401
+//  - POST verified user → 200 with MyReportResponse body
+//  - POST unverified user → 403 with code:VERIFICATION_REQUIRED
+//  - POST own-listing → 409 with code:CANNOT_REPORT_OWN_LISTING
+//  - POST non-ACTIVE auction → 409 with code:AUCTION_NOT_REPORTABLE
+//  - POST blank subject → 400
+//  - POST details > 2000 chars → 400
+//  - GET my-report no row → 204
+//  - GET my-report with row → 200 with body
+```
+
+Mirror sub-spec 1's `AdminFraudFlagControllerWriteSliceTest` patterns. Mock service throws each exception type to verify the error handler response shapes.
+
+Run: `cd backend && ./mvnw test -Dtest=UserReportControllerSliceTest -q`
+Expected: PASS.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/admin/reports/ \
+        backend/src/main/java/com/slparcelauctions/backend/user/User.java \
+        backend/src/test/java/com/slparcelauctions/backend/admin/reports/
+
+git commit -m "$(cat <<'EOF'
+feat(admin): ListingReport entity + user-facing report endpoints
+
+POST /api/v1/auctions/{id}/report — upsert by (auction_id, reporter_id),
+resubmit resets status=OPEN, gates: must-be-verified, not-own-listing,
+auction-must-be-ACTIVE.
+GET /api/v1/auctions/{id}/my-report — returns existing report (200) or
+204; powers the auction-detail Reported✓ button state.
+User.dismissedReportsCount column added (frivolous-counter target).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `AdminReportService` + `AdminReportController` + stats `openReports` extension
+
+**Goal:** Admin queue (listing-grouped) + per-listing detail + 4 admin actions (dismiss / warn / suspend / cancel) + dashboard stats `openReports` field.
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/AdminReportService.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/AdminReportController.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/dto/AdminReportListingRowDto.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/dto/AdminReportDetailDto.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/dto/AdminReportActionRequest.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/exception/ReportNotFoundException.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/admin/reports/ListingReportRepository.java` (add listing-grouped projection query, sibling-count helpers)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/admin/exception/AdminExceptionHandler.java` (handle `ReportNotFoundException`)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/admin/AdminStatsService.java` (add `openReports` to QueueStats)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/admin/dto/AdminStatsResponse.java` (add `openReports` field)
+- Test: `backend/src/test/java/com/slparcelauctions/backend/admin/reports/AdminReportServiceTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/admin/reports/AdminReportControllerSliceTest.java`
+- Test: extend `backend/src/test/java/com/slparcelauctions/backend/admin/AdminStatsServiceTest.java` (verify openReports plumbing)
+
+- [ ] **Step 1: Add new repository methods**
+
+```java
+// in ListingReportRepository.java
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+@Query("""
+    SELECT new com.slparcelauctions.backend.admin.reports.dto.AdminReportListingRowDto(
+        r.auction.id, r.auction.title, r.auction.status,
+        r.auction.parcel.regionName, r.auction.seller.id, r.auction.seller.displayName,
+        COUNT(r), MAX(r.updatedAt))
+    FROM ListingReport r
+    WHERE r.status = :status
+    GROUP BY r.auction.id, r.auction.title, r.auction.status,
+             r.auction.parcel.regionName, r.auction.seller.id, r.auction.seller.displayName
+    ORDER BY COUNT(r) DESC, MAX(r.updatedAt) DESC
+""")
+Page<AdminReportListingRowDto> findListingsGroupedByStatus(
+    @Param("status") ListingReportStatus status, Pageable pageable);
+
+// Equivalent for ALL (no filter) — implementer adds a sibling method or uses Specification.
+
+@Query("SELECT count(r) FROM ListingReport r WHERE r.auction.id = :auctionId AND r.status = 'OPEN'")
+long countOpenByAuctionId(@Param("auctionId") Long auctionId);
+```
+
+- [ ] **Step 2: Create DTOs**
+
+```java
+// AdminReportListingRowDto.java
+package com.slparcelauctions.backend.admin.reports.dto;
+
+import java.time.OffsetDateTime;
+
+import com.slparcelauctions.backend.auction.AuctionStatus;
+
+public record AdminReportListingRowDto(
+    Long auctionId, String auctionTitle, AuctionStatus auctionStatus,
+    String parcelRegionName, Long sellerUserId, String sellerDisplayName,
+    Long openReportCount, OffsetDateTime latestReportAt
+) {}
+
+// AdminReportDetailDto.java
+package com.slparcelauctions.backend.admin.reports.dto;
+
+import java.time.OffsetDateTime;
+
+import com.slparcelauctions.backend.admin.reports.ListingReportReason;
+import com.slparcelauctions.backend.admin.reports.ListingReportStatus;
+
+public record AdminReportDetailDto(
+    Long id, ListingReportReason reason, String subject, String details,
+    ListingReportStatus status, String adminNotes,
+    OffsetDateTime createdAt, OffsetDateTime updatedAt, OffsetDateTime reviewedAt,
+    Long reporterUserId, String reporterDisplayName, long reporterDismissedReportsCount,
+    String reviewedByDisplayName
+) {}
+
+// AdminReportActionRequest.java
+package com.slparcelauctions.backend.admin.reports.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminReportActionRequest(@NotBlank @Size(max = 1000) String notes) {}
+```
+
+- [ ] **Step 3: Create `ReportNotFoundException` + handler entry**
+
+```java
+// ReportNotFoundException.java
+package com.slparcelauctions.backend.admin.reports.exception;
+
+public class ReportNotFoundException extends RuntimeException {
+    public ReportNotFoundException(Long id) { super("Report not found: " + id); }
+}
+```
+
+In `AdminExceptionHandler.java`, add:
+
+```java
+@ExceptionHandler(ReportNotFoundException.class)
+public ResponseEntity<AdminApiError> handleReportNotFound(ReportNotFoundException ex) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND)
+        .body(AdminApiError.of("REPORT_NOT_FOUND", ex.getMessage()));
+}
+```
+
+Plus an import for `ReportNotFoundException`.
+
+- [ ] **Step 4: Create `AdminReportService`**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/reports/AdminReportService.java
+package com.slparcelauctions.backend.admin.reports;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.admin.audit.AdminActionService;
+import com.slparcelauctions.backend.admin.audit.AdminActionTargetType;
+import com.slparcelauctions.backend.admin.audit.AdminActionType;
+import com.slparcelauctions.backend.admin.reports.dto.AdminReportDetailDto;
+import com.slparcelauctions.backend.admin.reports.dto.AdminReportListingRowDto;
+import com.slparcelauctions.backend.admin.reports.exception.ReportNotFoundException;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.CancellationService;
+import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
+import com.slparcelauctions.backend.auction.monitoring.SuspensionService;
+import com.slparcelauctions.backend.common.PagedResponse;
+import com.slparcelauctions.backend.notification.NotificationPublisher;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminReportService {
+
+    private final ListingReportRepository repo;
+    private final AuctionRepository auctionRepo;
+    private final UserRepository userRepo;
+    private final SuspensionService suspensionService;
+    private final CancellationService cancellationService;
+    private final NotificationPublisher notificationPublisher;
+    private final AdminActionService adminActionService;
+    private final Clock clock;
+
+    @Transactional(readOnly = true)
+    public PagedResponse<AdminReportListingRowDto> listGrouped(
+            ListingReportStatus statusFilter, Pageable pageable) {
+        Page<AdminReportListingRowDto> page = repo.findListingsGroupedByStatus(statusFilter, pageable);
+        return PagedResponse.from(page);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminReportDetailDto> findByListing(Long auctionId) {
+        return repo.findByAuctionIdOrderByCreatedAtDesc(auctionId).stream()
+            .map(this::toDetail).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public AdminReportDetailDto findOne(Long reportId) {
+        ListingReport r = repo.findById(reportId)
+            .orElseThrow(() -> new ReportNotFoundException(reportId));
+        return toDetail(r);
+    }
+
+    @Transactional
+    public AdminReportDetailDto dismiss(Long reportId, Long adminUserId, String notes) {
+        ListingReport r = repo.findById(reportId)
+            .orElseThrow(() -> new ReportNotFoundException(reportId));
+        User admin = userRepo.findById(adminUserId).orElseThrow();
+        OffsetDateTime now = OffsetDateTime.now(clock);
+
+        r.setStatus(ListingReportStatus.DISMISSED);
+        r.setReviewedBy(admin); r.setReviewedAt(now); r.setAdminNotes(notes);
+        repo.save(r);
+
+        // Increment frivolous counter on the reporter.
+        User reporter = r.getReporter();
+        reporter.setDismissedReportsCount(reporter.getDismissedReportsCount() + 1);
+        userRepo.save(reporter);
+
+        adminActionService.record(adminUserId, AdminActionType.DISMISS_REPORT,
+            AdminActionTargetType.REPORT, reportId, notes,
+            Map.of("auctionId", r.getAuction().getId(),
+                   "reporterId", reporter.getId()));
+
+        return toDetail(r);
+    }
+
+    @Transactional
+    public void warnSeller(Long auctionId, Long adminUserId, String notes) {
+        Auction auction = requireAuction(auctionId);
+        User admin = userRepo.findById(adminUserId).orElseThrow();
+        OffsetDateTime now = OffsetDateTime.now(clock);
+
+        // Only OPEN reports — preserve deliberate per-report DISMISSED decisions.
+        repo.findByAuctionIdOrderByCreatedAtDesc(auctionId).stream()
+            .filter(r -> r.getStatus() == ListingReportStatus.OPEN)
+            .forEach(r -> {
+                r.setStatus(ListingReportStatus.REVIEWED);
+                r.setReviewedBy(admin); r.setReviewedAt(now); r.setAdminNotes(notes);
+                repo.save(r);
+            });
+
+        notificationPublisher.listingWarned(
+            auction.getSeller().getId(), auction.getId(), auction.getTitle(), notes);
+
+        adminActionService.record(adminUserId, AdminActionType.WARN_SELLER_FROM_REPORT,
+            AdminActionTargetType.LISTING, auctionId, notes, null);
+    }
+
+    @Transactional
+    public void suspend(Long auctionId, Long adminUserId, String notes) {
+        Auction auction = requireAuction(auctionId);
+        suspensionService.suspendByAdmin(auction, adminUserId, notes);
+
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        User admin = userRepo.findById(adminUserId).orElseThrow();
+        repo.findByAuctionIdOrderByCreatedAtDesc(auctionId).stream()
+            .filter(r -> r.getStatus() == ListingReportStatus.OPEN)
+            .forEach(r -> {
+                r.setStatus(ListingReportStatus.ACTION_TAKEN);
+                r.setReviewedBy(admin); r.setReviewedAt(now); r.setAdminNotes(notes);
+                repo.save(r);
+            });
+
+        adminActionService.record(adminUserId, AdminActionType.SUSPEND_LISTING_FROM_REPORT,
+            AdminActionTargetType.LISTING, auctionId, notes, null);
+    }
+
+    @Transactional
+    public void cancel(Long auctionId, Long adminUserId, String notes) {
+        cancellationService.cancelByAdmin(auctionId, adminUserId, notes);
+
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        User admin = userRepo.findById(adminUserId).orElseThrow();
+        repo.findByAuctionIdOrderByCreatedAtDesc(auctionId).stream()
+            .filter(r -> r.getStatus() == ListingReportStatus.OPEN)
+            .forEach(r -> {
+                r.setStatus(ListingReportStatus.ACTION_TAKEN);
+                r.setReviewedBy(admin); r.setReviewedAt(now); r.setAdminNotes(notes);
+                repo.save(r);
+            });
+
+        adminActionService.record(adminUserId, AdminActionType.CANCEL_LISTING_FROM_REPORT,
+            AdminActionTargetType.LISTING, auctionId, notes, null);
+    }
+
+    private Auction requireAuction(Long auctionId) {
+        return auctionRepo.findById(auctionId)
+            .orElseThrow(() -> new AuctionNotFoundException(auctionId));
+    }
+
+    private AdminReportDetailDto toDetail(ListingReport r) {
+        User reporter = r.getReporter();
+        return new AdminReportDetailDto(
+            r.getId(), r.getReason(), r.getSubject(), r.getDetails(),
+            r.getStatus(), r.getAdminNotes(),
+            r.getCreatedAt(), r.getUpdatedAt(), r.getReviewedAt(),
+            reporter.getId(), reporter.getDisplayName(), reporter.getDismissedReportsCount(),
+            r.getReviewedBy() == null ? null : r.getReviewedBy().getDisplayName());
+    }
+}
+```
+
+- [ ] **Step 5: Create `AdminReportController`**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/reports/AdminReportController.java
+package com.slparcelauctions.backend.admin.reports;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.admin.reports.dto.AdminReportActionRequest;
+import com.slparcelauctions.backend.admin.reports.dto.AdminReportDetailDto;
+import com.slparcelauctions.backend.admin.reports.dto.AdminReportListingRowDto;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.common.PagedResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/admin/reports")
+@RequiredArgsConstructor
+public class AdminReportController {
+
+    private final AdminReportService service;
+
+    @GetMapping
+    public PagedResponse<AdminReportListingRowDto> list(
+            @RequestParam(defaultValue = "open") String status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "25") int size) {
+        ListingReportStatus filter = "open".equalsIgnoreCase(status)
+            ? ListingReportStatus.OPEN
+            : "reviewed".equalsIgnoreCase(status) ? ListingReportStatus.REVIEWED
+            : null;
+        // For "all", fall through with null — the service handles it.
+        return service.listGrouped(filter == null ? ListingReportStatus.OPEN : filter,
+            PageRequest.of(page, Math.min(size, 100)));
+        // NOTE: simplified — real impl handles "all" with a separate method or Specification.
+        // Implementer should add a service method `listAllGrouped(Pageable)` for status=all.
+    }
+
+    @GetMapping("/listing/{auctionId}")
+    public List<AdminReportDetailDto> byListing(@PathVariable Long auctionId) {
+        return service.findByListing(auctionId);
+    }
+
+    @GetMapping("/{id}")
+    public AdminReportDetailDto findOne(@PathVariable Long id) {
+        return service.findOne(id);
+    }
+
+    @PostMapping("/{id}/dismiss")
+    public AdminReportDetailDto dismiss(@PathVariable Long id,
+            @Valid @RequestBody AdminReportActionRequest body,
+            @AuthenticationPrincipal AuthPrincipal admin) {
+        return service.dismiss(id, admin.userId(), body.notes());
+    }
+
+    @PostMapping("/listing/{auctionId}/warn-seller")
+    public void warnSeller(@PathVariable Long auctionId,
+            @Valid @RequestBody AdminReportActionRequest body,
+            @AuthenticationPrincipal AuthPrincipal admin) {
+        service.warnSeller(auctionId, admin.userId(), body.notes());
+    }
+
+    @PostMapping("/listing/{auctionId}/suspend")
+    public void suspend(@PathVariable Long auctionId,
+            @Valid @RequestBody AdminReportActionRequest body,
+            @AuthenticationPrincipal AuthPrincipal admin) {
+        service.suspend(auctionId, admin.userId(), body.notes());
+    }
+
+    @PostMapping("/listing/{auctionId}/cancel")
+    public void cancel(@PathVariable Long auctionId,
+            @Valid @RequestBody AdminReportActionRequest body,
+            @AuthenticationPrincipal AuthPrincipal admin) {
+        service.cancel(auctionId, admin.userId(), body.notes());
+    }
+}
+```
+
+- [ ] **Step 6: Extend `AdminStatsService` and `AdminStatsResponse` with `openReports`**
+
+In `AdminStatsResponse.java`, add `openReports` to `QueueStats`:
+
+```java
+public record QueueStats(
+    long openFraudFlags,
+    long openReports,
+    long pendingPayments,
+    long activeDisputes
+) {}
+```
+
+In `AdminStatsService.java`, inject `ListingReportRepository`, add to `compute()`:
+
+```java
+QueueStats queues = new QueueStats(
+    fraudFlagRepository.countByResolved(false),
+    listingReportRepository.countByStatus(ListingReportStatus.OPEN),
+    escrowRepository.countByState(EscrowState.ESCROW_PENDING),
+    escrowRepository.countByState(EscrowState.DISPUTED)
+);
+```
+
+Update `AdminStatsServiceTest` (unit) to include the new field in the assertion.
+
+- [ ] **Step 7: Write `AdminReportServiceTest` integration test**
+
+```java
+// covers: listGrouped sorting, findByListing, dismiss increments counter,
+// warn-seller only touches OPEN (DISMISSED unchanged), suspend marks OPEN as
+// ACTION_TAKEN + flips auction SUSPENDED, cancel similarly.
+//
+// Mirror Task 3's seeding pattern. Mock NotificationWsBroadcasterPort.
+```
+
+Run: `cd backend && ./mvnw test -Dtest=AdminReportServiceTest -q`
+Expected: PASS.
+
+- [ ] **Step 8: Write `AdminReportControllerSliceTest`**
+
+Mirror sub-spec 1 controller-slice patterns. Cover: 401/403 gates per endpoint; 404 on report-not-found; happy-path 200s with mock service returns.
+
+Run: `cd backend && ./mvnw test -Dtest=AdminReportControllerSliceTest -q`
+Expected: PASS.
+
+- [ ] **Step 9: Run full backend tests**
+
+Run: `cd backend && ./mvnw test -q`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/admin/reports/ \
+        backend/src/main/java/com/slparcelauctions/backend/admin/exception/AdminExceptionHandler.java \
+        backend/src/main/java/com/slparcelauctions/backend/admin/AdminStatsService.java \
+        backend/src/main/java/com/slparcelauctions/backend/admin/dto/AdminStatsResponse.java \
+        backend/src/test/java/com/slparcelauctions/backend/admin/reports/ \
+        backend/src/test/java/com/slparcelauctions/backend/admin/AdminStatsServiceTest.java
+
+git commit -m "$(cat <<'EOF'
+feat(admin): admin reports queue + dismiss/warn/suspend/cancel actions
+
+GET /api/v1/admin/reports — listing-grouped (sorted reportCount DESC,
+latestReportAt DESC), GET /listing/{id}, GET /{id}.
+POST /{id}/dismiss — marks DISMISSED, increments reporter's
+dismissedReportsCount.
+POST /listing/{id}/warn-seller|suspend|cancel — listing-level actions
+that touch ONLY OPEN reports (DISMISSED preserved). Suspend/Cancel
+delegate to SuspensionService.suspendByAdmin / CancellationService.
+cancelByAdmin. All actions write admin_actions audit rows.
+Dashboard stats gain openReports for the 4-up needs-attention row.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `Ban` entity + `BanCheckService` + Redis cache + `RefreshToken` IPs query
+
+**Goal:** Foundation for ban system — entity, repository (with active-ban queries), `BanCheckService` (cached), `BanCacheInvalidator`, plus the `RefreshToken` distinct-IPs query for admin user-detail "Recent IPs" modal.
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/ban/Ban.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanType.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanReasonCategory.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanRepository.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanCheckService.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanCacheInvalidator.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/ban/exception/UserBannedException.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/ban/exception/UserBannedExceptionHandler.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/UserIpProjection.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auth/RefreshTokenRepository.java` (add `findIpSummaryByUserId`)
+- Test: `backend/src/test/java/com/slparcelauctions/backend/admin/ban/BanRepositoryTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/admin/ban/BanCheckServiceTest.java`
+
+- [ ] **Step 1: Create enums**
+
+```java
+// BanType.java
+package com.slparcelauctions.backend.admin.ban;
+
+public enum BanType { IP, AVATAR, BOTH }
+
+// BanReasonCategory.java
+package com.slparcelauctions.backend.admin.ban;
+
+public enum BanReasonCategory { SHILL_BIDDING, FRAUDULENT_SELLER, TOS_ABUSE, SPAM, OTHER }
+```
+
+- [ ] **Step 2: Create `Ban` entity**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/ban/Ban.java
+package com.slparcelauctions.backend.admin.ban;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import com.slparcelauctions.backend.user.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "bans", indexes = {
+    @Index(name = "idx_bans_ip", columnList = "ip_address"),
+    @Index(name = "idx_bans_avatar", columnList = "sl_avatar_uuid"),
+    @Index(name = "idx_bans_active",
+        columnList = "lifted_at, expires_at")
+})
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class Ban {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ban_type", length = 10, nullable = false)
+    private BanType banType;
+
+    @Column(name = "ip_address", length = 45)
+    private String ipAddress;
+
+    @Column(name = "sl_avatar_uuid")
+    private UUID slAvatarUuid;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reason_category", length = 30, nullable = false)
+    private BanReasonCategory reasonCategory;
+
+    @Column(name = "reason_text", columnDefinition = "text", nullable = false)
+    private String reasonText;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "banned_by", nullable = false)
+    private User bannedBy;
+
+    @Column(name = "expires_at")
+    private OffsetDateTime expiresAt;
+
+    @Column(name = "lifted_at")
+    private OffsetDateTime liftedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lifted_by")
+    private User liftedBy;
+
+    @Column(name = "lifted_reason", columnDefinition = "text")
+    private String liftedReason;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+}
+```
+
+Note: `INET` Postgres type for `ip_address` would be ideal, but Hibernate/Postgres mapping requires custom converters. Sub-spec 2 uses `VARCHAR(45)` (covers IPv4 + IPv6). The DB-level CHECK constraint enforcing the type-matches-fields invariant is enforced at the **service level** (sub-spec 2 doesn't ship a DB CHECK constraint to keep the JPA mapping simple).
+
+- [ ] **Step 3: Create `BanRepository`**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanRepository.java
+package com.slparcelauctions.backend.admin.ban;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BanRepository extends JpaRepository<Ban, Long> {
+
+    @Query("""
+        SELECT b FROM Ban b
+        WHERE b.liftedAt IS NULL
+          AND (b.expiresAt IS NULL OR b.expiresAt > :now)
+          AND (b.banType = com.slparcelauctions.backend.admin.ban.BanType.IP
+               OR b.banType = com.slparcelauctions.backend.admin.ban.BanType.BOTH)
+          AND b.ipAddress = :ip
+    """)
+    List<Ban> findActiveByIp(@Param("ip") String ip, @Param("now") OffsetDateTime now);
+
+    @Query("""
+        SELECT b FROM Ban b
+        WHERE b.liftedAt IS NULL
+          AND (b.expiresAt IS NULL OR b.expiresAt > :now)
+          AND (b.banType = com.slparcelauctions.backend.admin.ban.BanType.AVATAR
+               OR b.banType = com.slparcelauctions.backend.admin.ban.BanType.BOTH)
+          AND b.slAvatarUuid = :uuid
+    """)
+    List<Ban> findActiveByAvatar(@Param("uuid") UUID uuid, @Param("now") OffsetDateTime now);
+
+    @Query("""
+        SELECT b FROM Ban b
+        WHERE b.liftedAt IS NULL
+          AND (b.expiresAt IS NULL OR b.expiresAt > :now)
+    """)
+    Page<Ban> findActive(@Param("now") OffsetDateTime now, Pageable pageable);
+
+    @Query("""
+        SELECT b FROM Ban b
+        WHERE b.liftedAt IS NOT NULL
+           OR (b.expiresAt IS NOT NULL AND b.expiresAt <= :now)
+    """)
+    Page<Ban> findHistory(@Param("now") OffsetDateTime now, Pageable pageable);
+
+    boolean existsBySlAvatarUuidAndLiftedAtIsNullAndExpiresAtIsNullOrSlAvatarUuidAndLiftedAtIsNullAndExpiresAtAfter(
+        UUID uuid, UUID uuid2, OffsetDateTime now);
+    // Note: above derived-query is awkward; implementer may use a custom @Query
+    // returning boolean for "does the user have an active AVATAR-or-BOTH ban".
+}
+```
+
+- [ ] **Step 4: Create `UserBannedException` + handler**
+
+```java
+// UserBannedException.java
+package com.slparcelauctions.backend.admin.ban.exception;
+
+import java.time.OffsetDateTime;
+import lombok.Getter;
+
+@Getter
+public class UserBannedException extends RuntimeException {
+    private final OffsetDateTime expiresAt; // null = permanent
+    public UserBannedException(OffsetDateTime expiresAt) {
+        super("Account is suspended");
+        this.expiresAt = expiresAt;
+    }
+}
+```
+
+```java
+// UserBannedExceptionHandler.java — global, NOT admin-scoped (this exception
+// is thrown from user-facing endpoints like login/bid).
+package com.slparcelauctions.backend.admin.ban.exception;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class UserBannedExceptionHandler {
+
+    @ExceptionHandler(UserBannedException.class)
+    public ProblemDetail handleBanned(UserBannedException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.FORBIDDEN);
+        pd.setTitle("Account suspended");
+        pd.setProperty("code", "USER_BANNED");
+        pd.setProperty("expiresAt", ex.getExpiresAt() == null ? null : ex.getExpiresAt().toString());
+        return pd;
+    }
+}
+```
+
+- [ ] **Step 5: Create `BanCheckService` (Redis-cached)**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanCheckService.java
+package com.slparcelauctions.backend.admin.ban;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.admin.ban.exception.UserBannedException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BanCheckService {
+
+    private static final Duration CACHE_TTL = Duration.ofMinutes(5);
+    private static final String IP_KEY = "bans:active:ip:";
+    private static final String AVATAR_KEY = "bans:active:avatar:";
+    private static final String NEGATIVE = "0";
+
+    private final BanRepository banRepository;
+    private final StringRedisTemplate redis;
+    private final Clock clock;
+
+    @Transactional(readOnly = true)
+    public void assertNotBanned(String ipAddress, UUID slAvatarUuid) {
+        if (ipAddress != null && !ipAddress.isBlank() && checkIp(ipAddress)) {
+            // already threw
+        }
+        if (slAvatarUuid != null) {
+            checkAvatar(slAvatarUuid);
+        }
+    }
+
+    private boolean checkIp(String ip) {
+        String cached = redis.opsForValue().get(IP_KEY + ip);
+        if (NEGATIVE.equals(cached)) return false;
+        if (cached != null) {
+            // cached as a serialized expiresAt epoch-second or "perm"
+            throw new UserBannedException("perm".equals(cached) ? null
+                : OffsetDateTime.parse(cached));
+        }
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        List<Ban> hits = banRepository.findActiveByIp(ip, now);
+        if (hits.isEmpty()) {
+            redis.opsForValue().set(IP_KEY + ip, NEGATIVE, CACHE_TTL);
+            return false;
+        }
+        Ban ban = hits.get(0);
+        String value = ban.getExpiresAt() == null ? "perm" : ban.getExpiresAt().toString();
+        redis.opsForValue().set(IP_KEY + ip, value, CACHE_TTL);
+        throw new UserBannedException(ban.getExpiresAt());
+    }
+
+    private void checkAvatar(UUID uuid) {
+        String key = AVATAR_KEY + uuid;
+        String cached = redis.opsForValue().get(key);
+        if (NEGATIVE.equals(cached)) return;
+        if (cached != null) {
+            throw new UserBannedException("perm".equals(cached) ? null
+                : OffsetDateTime.parse(cached));
+        }
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        List<Ban> hits = banRepository.findActiveByAvatar(uuid, now);
+        if (hits.isEmpty()) {
+            redis.opsForValue().set(key, NEGATIVE, CACHE_TTL);
+            return;
+        }
+        Ban ban = hits.get(0);
+        String value = ban.getExpiresAt() == null ? "perm" : ban.getExpiresAt().toString();
+        redis.opsForValue().set(key, value, CACHE_TTL);
+        throw new UserBannedException(ban.getExpiresAt());
+    }
+}
+```
+
+- [ ] **Step 6: Create `BanCacheInvalidator`**
+
+```java
+// backend/src/main/java/com/slparcelauctions/backend/admin/ban/BanCacheInvalidator.java
+package com.slparcelauctions.backend.admin.ban;
+
+import java.util.UUID;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class BanCacheInvalidator {
+
+    private static final String IP_KEY = "bans:active:ip:";
+    private static final String AVATAR_KEY = "bans:active:avatar:";
+
+    private final StringRedisTemplate redis;
+
+    public void invalidate(String ipAddress, UUID slAvatarUuid) {
+        if (ipAddress != null && !ipAddress.isBlank()) {
+            redis.delete(IP_KEY + ipAddress);
+        }
+        if (slAvatarUuid != null) {
+            redis.delete(AVATAR_KEY + slAvatarUuid);
+        }
+    }
+}
+```
+
+- [ ] **Step 7: Create `UserIpProjection` + add `findIpSummaryByUserId` to `RefreshTokenRepository`**
+
+```java
+// UserIpProjection.java
+package com.slparcelauctions.backend.admin.users.dto;
+
+import java.time.OffsetDateTime;
+
+public record UserIpProjection(
+    String ipAddress, OffsetDateTime firstSeenAt, OffsetDateTime lastSeenAt, long sessionCount
+) {}
+```
+
+In `RefreshTokenRepository.java`:
+
+```java
+import com.slparcelauctions.backend.admin.users.dto.UserIpProjection;
+
+@Query("""
+    SELECT new com.slparcelauctions.backend.admin.users.dto.UserIpProjection(
+        rt.ipAddress, MIN(rt.createdAt), MAX(rt.lastUsedAt), COUNT(rt.id))
+    FROM RefreshToken rt
+    WHERE rt.userId = :userId AND rt.ipAddress IS NOT NULL
+    GROUP BY rt.ipAddress
+    ORDER BY MIN(rt.createdAt) ASC
+""")
+List<UserIpProjection> findIpSummaryByUserId(@Param("userId") Long userId);
+```
+
+- [ ] **Step 8: Write `BanRepositoryTest` integration test**
+
+Cover:
+- active ban (no expiry) found by IP
+- active ban (no expiry) found by avatar
+- expired ban not returned
+- lifted ban not returned
+- BOTH ban returned by both IP and avatar queries
+- IP-only ban not returned by avatar query
+
+Use the same seeding pattern as Task 3.
+
+- [ ] **Step 9: Write `BanCheckServiceTest`**
+
+Mock `BanRepository` and `StringRedisTemplate`. Cover:
+- cache hit (negative) — no DB query
+- cache hit (positive, perm) — throws with null expiresAt
+- cache miss → DB hit positive → cached → throws
+- cache miss → DB hit empty → cached as negative
+- assertNotBanned(null, null) is no-op (no throws, no DB queries)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/admin/ban/ \
+        backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/UserIpProjection.java \
+        backend/src/main/java/com/slparcelauctions/backend/auth/RefreshTokenRepository.java \
+        backend/src/test/java/com/slparcelauctions/backend/admin/ban/
+
+git commit -m "$(cat <<'EOF'
+feat(admin): Ban entity + BanCheckService + Redis cache + IP history query
+
+bans table with type/identifiers/reason/expires/lifted columns. Active
+ban predicate: liftedAt IS NULL AND (expiresAt IS NULL OR > now). Type
+matched on ip+avatar respectively, BOTH bans hit both queries.
+BanCheckService caches positive AND negative results with 5-min TTL;
+BanCacheInvalidator clears keys on create/lift. RefreshTokenRepository
+gains findIpSummaryByUserId for the user-detail Recent IPs modal.
+UserBannedException → 403 with code:USER_BANNED.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Ban enforcement at 6 paths
+
+**Goal:** Wire `BanCheckService.assertNotBanned` into register, login, SL-verify, bid, listing-create, listing-cancel. Listing-create needs `HttpServletRequest` added to controller + service.
+
+**Files:**
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auth/AuthService.java` (call in register + login)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/sl/SlVerificationService.java` (call before SL avatar link)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/BidService.java` (call before bid placement)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/AuctionController.java` (add HttpServletRequest)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/AuctionService.java` (add ipAddress arg + call BanCheckService)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/CancellationService.java` (call before cancel — only seller-driven `cancel(...)`, NOT `cancelByAdmin`)
+- Test: `backend/src/test/java/com/slparcelauctions/backend/admin/ban/BanEnforcementIntegrationTest.java`
+
+- [ ] **Step 1: Wire BanCheckService into AuthService**
+
+In `AuthService.java`, inject `BanCheckService banCheckService`. In `register(...)`:
+
+```java
+public AuthResult register(RegisterRequest request, HttpServletRequest httpReq) {
+    String ip = httpReq.getRemoteAddr();
+    banCheckService.assertNotBanned(ip, null);
+    // ... existing logic
+}
+```
+
+Same pattern in `login(...)`.
+
+- [ ] **Step 2: Wire BanCheckService into SlVerificationService**
+
+In `SlVerificationService.java` (or wherever the SL-verify avatar-link logic lives — find via `grep -rn "@PostMapping.*verify"` in `sl/` package), call `banCheckService.assertNotBanned(null, slAvatarUuid)` BEFORE the avatar is linked to the user.
+
+- [ ] **Step 3: Wire BanCheckService into BidService**
+
+In `BidService.placeBid(...)`, call before any bid logic:
+
+```java
+public BidResponse placeBid(Long auctionId, Long bidderId, long amount, String ipAddress) {
+    User bidder = userRepo.findById(bidderId).orElseThrow();
+    banCheckService.assertNotBanned(ipAddress, bidder.getSlAvatarUuid());
+    // ... existing logic
+}
+```
+
+- [ ] **Step 4: Add HttpServletRequest to AuctionController.create + AuctionService.create**
+
+```java
+// AuctionController.java
+@PostMapping("/auctions")
+@ResponseStatus(HttpStatus.CREATED)
+public SellerAuctionResponse create(
+        @AuthenticationPrincipal AuthPrincipal principal,
+        @Valid @RequestBody AuctionCreateRequest req,
+        HttpServletRequest httpRequest) {
+    requireVerified(principal.userId());
+    String ip = httpRequest.getRemoteAddr();
+    Auction created = auctionService.create(principal.userId(), req, ip);
+    return mapper.toSellerResponse(created, null);
+}
+```
+
+```java
+// AuctionService.java
+public Auction create(Long sellerId, AuctionCreateRequest req, String ipAddress) {
+    User seller = userRepo.findById(sellerId).orElseThrow();
+    banCheckService.assertNotBanned(ipAddress, seller.getSlAvatarUuid());
+    // ... existing logic
+}
+```
+
+Inject `BanCheckService` into `AuctionService`. Update any existing tests calling `auctionService.create(sellerId, req)` to pass `null` or `""` as the IP arg.
+
+- [ ] **Step 5: Wire BanCheckService into seller-driven CancellationService.cancel**
+
+In `CancellationService.cancel(Long auctionId, String reason)`, accept an additional `String ipAddress` arg (or look up seller's last-known IP — simpler: change the signature).
+
+The cleanest path: change `cancel` signature to accept `ipAddress`. Update the controller calling it to pass IP via `HttpServletRequest`. The cancel-by-admin path does NOT need this check (admin's own IP isn't subject to bans).
+
+```java
+@Transactional
+public Auction cancel(Long auctionId, String reason, String ipAddress) {
+    Auction a = auctionRepo.findByIdForUpdate(auctionId)
+        .orElseThrow(() -> new AuctionNotFoundException(auctionId));
+    User seller = userRepo.findByIdForUpdate(a.getSeller().getId()).orElseThrow();
+    banCheckService.assertNotBanned(ipAddress, seller.getSlAvatarUuid());
+    // ... existing logic
+}
+```
+
+The AuctionController's cancel endpoint adds `HttpServletRequest httpRequest` and passes IP.
+
+- [ ] **Step 6: Write `BanEnforcementIntegrationTest`**
+
+```java
+// covers: AVATAR ban blocks bid for that user
+//        : IP ban blocks register/login from that IP
+//        : BOTH ban blocks both
+//        : lifted ban allows action again (after cache flush)
+//        : assertNotBanned with both null is no-op
+//
+// Use a real Redis (Spring Data Redis with TestContainers, or a mock)
+// — if the project uses an embedded/test Redis, follow that pattern.
+// Otherwise mock StringRedisTemplate at the integration boundary.
+```
+
+- [ ] **Step 7: Run full backend tests**
+
+Run: `cd backend && ./mvnw test -q`
+
+Expected: PASS. **Many existing tests calling `auctionService.create(...)` or `cancellationService.cancel(...)` will need their signatures updated.** This is a sweeping change — implementer should `grep -rn "auctionService.create\|cancellationService.cancel("` and update each call site.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -u
+git add backend/src/test/java/com/slparcelauctions/backend/admin/ban/
+
+git commit -m "$(cat <<'EOF'
+feat(admin): ban enforcement at 6 paths (register/login/SL-verify/bid/list/cancel)
+
+BanCheckService.assertNotBanned wired into:
+- AuthService.register (IP)
+- AuthService.login (IP)
+- SlVerificationService (avatar UUID)
+- BidService.placeBid (IP + linked avatar)
+- AuctionService.create (IP + linked avatar; AuctionController gains
+  HttpServletRequest)
+- CancellationService.cancel (IP + linked avatar; cancelByAdmin NOT
+  ban-checked since admin's own IP isn't subject to user bans)
+
+Banned seller can no longer cancel-and-sell circumvent. Existing call
+sites of auctionService.create / cancellationService.cancel updated to
+match new signatures.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: `AdminBanController` + `AdminBanService`
+
+**Goal:** Admin endpoints for listing/creating/lifting bans + tv-bump on AVATAR-or-BOTH bans + cache invalidation + admin_actions writes.
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/ban/AdminBanController.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/ban/AdminBanService.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/ban/dto/AdminBanRowDto.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/ban/dto/CreateBanRequest.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/ban/dto/LiftBanRequest.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/ban/exception/BanNotFoundException.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/ban/exception/BanAlreadyLiftedException.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/ban/exception/BanTypeFieldMismatchException.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/admin/exception/AdminExceptionHandler.java` (add 3 new handlers)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java` (add `bumpTokenVersion`)
+- Test: `backend/src/test/java/com/slparcelauctions/backend/admin/ban/AdminBanServiceTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/admin/ban/AdminBanControllerSliceTest.java`
+
+- [ ] **Step 1: Add `bumpTokenVersion` to UserRepository**
+
+```java
+// in UserRepository.java
+import org.springframework.data.jpa.repository.Modifying;
+
+@Modifying
+@Query("UPDATE User u SET u.tokenVersion = u.tokenVersion + 1 WHERE u.id = :userId")
+int bumpTokenVersion(@Param("userId") Long userId);
+```
+
+- [ ] **Step 2: Create exception classes**
+
+```java
+// BanNotFoundException.java
+package com.slparcelauctions.backend.admin.ban.exception;
+public class BanNotFoundException extends RuntimeException {
+    public BanNotFoundException(Long id) { super("Ban not found: " + id); }
+}
+
+// BanAlreadyLiftedException.java
+package com.slparcelauctions.backend.admin.ban.exception;
+public class BanAlreadyLiftedException extends RuntimeException {
+    public BanAlreadyLiftedException(Long id) { super("Ban " + id + " already lifted"); }
+}
+
+// BanTypeFieldMismatchException.java
+package com.slparcelauctions.backend.admin.ban.exception;
+public class BanTypeFieldMismatchException extends RuntimeException {
+    public BanTypeFieldMismatchException(String message) { super(message); }
+}
+```
+
+- [ ] **Step 3: Add handlers in `AdminExceptionHandler`**
+
+```java
+@ExceptionHandler(BanNotFoundException.class)
+public ResponseEntity<AdminApiError> handleBanNotFound(BanNotFoundException ex) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND)
+        .body(AdminApiError.of("BAN_NOT_FOUND", ex.getMessage()));
+}
+
+@ExceptionHandler(BanAlreadyLiftedException.class)
+public ResponseEntity<AdminApiError> handleBanAlreadyLifted(BanAlreadyLiftedException ex) {
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(AdminApiError.of("BAN_ALREADY_LIFTED", ex.getMessage()));
+}
+
+@ExceptionHandler(BanTypeFieldMismatchException.class)
+public ResponseEntity<AdminApiError> handleBanTypeMismatch(BanTypeFieldMismatchException ex) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(AdminApiError.of("BAN_TYPE_FIELD_MISMATCH", ex.getMessage()));
+}
+```
+
+- [ ] **Step 4: Create DTOs**
+
+```java
+// AdminBanRowDto.java — full row for list endpoint
+package com.slparcelauctions.backend.admin.ban.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import com.slparcelauctions.backend.admin.ban.BanReasonCategory;
+import com.slparcelauctions.backend.admin.ban.BanType;
+
+public record AdminBanRowDto(
+    Long id, BanType banType, String ipAddress, UUID slAvatarUuid,
+    Long avatarLinkedUserId, String avatarLinkedDisplayName,
+    String firstSeenIp,
+    BanReasonCategory reasonCategory, String reasonText,
+    Long bannedByUserId, String bannedByDisplayName,
+    OffsetDateTime expiresAt, OffsetDateTime createdAt,
+    OffsetDateTime liftedAt, Long liftedByUserId, String liftedByDisplayName,
+    String liftedReason
+) {}
+
+// CreateBanRequest.java
+package com.slparcelauctions.backend.admin.ban.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import com.slparcelauctions.backend.admin.ban.BanReasonCategory;
+import com.slparcelauctions.backend.admin.ban.BanType;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateBanRequest(
+    @NotNull BanType banType,
+    String ipAddress,
+    UUID slAvatarUuid,
+    OffsetDateTime expiresAt,
+    @NotNull BanReasonCategory reasonCategory,
+    @NotBlank @Size(max = 1000) String reasonText
+) {}
+
+// LiftBanRequest.java
+package com.slparcelauctions.backend.admin.ban.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record LiftBanRequest(@NotBlank @Size(max = 1000) String liftedReason) {}
+```
+
+- [ ] **Step 5: Create `AdminBanService`**
+
+The service:
+- `list(active|history, BanType filter, Pageable)` — returns `PagedResponse<AdminBanRowDto>`. Joins to User for avatar-linked-display-name. For AVATAR rows, also joins to RefreshToken for first-seen IP.
+- `create(CreateBanRequest req, Long adminUserId)` — validates type-matches-fields invariant (throws `BanTypeFieldMismatchException` if not). Saves Ban row. If banType in {AVATAR, BOTH} AND avatar maps to a registered user → `userRepo.bumpTokenVersion(user.getId())`. Invalidates Redis cache. Writes admin_actions.
+- `lift(Long banId, Long adminUserId, String liftedReason)` — 404 if not found, 409 if already lifted. Sets liftedAt/liftedBy/liftedReason. Invalidates Redis cache. Writes admin_actions.
+
+Implementer writes the full body — pattern is clear from Task 6's `AdminReportService`.
+
+- [ ] **Step 6: Create `AdminBanController`**
+
+```java
+@RestController
+@RequestMapping("/api/v1/admin/bans")
+@RequiredArgsConstructor
+public class AdminBanController {
+
+    private final AdminBanService service;
+
+    @GetMapping
+    public PagedResponse<AdminBanRowDto> list(
+            @RequestParam(defaultValue = "active") String status,
+            @RequestParam(required = false) BanType type,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "25") int size) {
+        return service.list(status, type, PageRequest.of(page, Math.min(size, 100)));
+    }
+
+    @PostMapping
+    public AdminBanRowDto create(
+            @Valid @RequestBody CreateBanRequest body,
+            @AuthenticationPrincipal AuthPrincipal admin) {
+        return service.create(body, admin.userId());
+    }
+
+    @PostMapping("/{id}/lift")
+    public AdminBanRowDto lift(
+            @PathVariable Long id,
+            @Valid @RequestBody LiftBanRequest body,
+            @AuthenticationPrincipal AuthPrincipal admin) {
+        return service.lift(id, admin.userId(), body.liftedReason());
+    }
+}
+```
+
+- [ ] **Step 7: Tests**
+
+`AdminBanServiceTest` — Mockito unit tests covering type-matches-fields validation, tv-bump only when avatar maps to a user, cache invalidation called on create+lift, lift-already-lifted throws.
+
+`AdminBanControllerSliceTest` — `@SpringBootTest + @AutoConfigureMockMvc`, auth gates per endpoint, validation errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/admin/ban/AdminBanController.java \
+        backend/src/main/java/com/slparcelauctions/backend/admin/ban/AdminBanService.java \
+        backend/src/main/java/com/slparcelauctions/backend/admin/ban/dto/ \
+        backend/src/main/java/com/slparcelauctions/backend/admin/ban/exception/ \
+        backend/src/main/java/com/slparcelauctions/backend/admin/exception/AdminExceptionHandler.java \
+        backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java \
+        backend/src/test/java/com/slparcelauctions/backend/admin/ban/
+
+git commit -m "$(cat <<'EOF'
+feat(admin): admin ban CRUD + tv-bump + cache invalidation
+
+GET /api/v1/admin/bans?status=active|history&type=IP|AVATAR|BOTH —
+paginated list with first-seen-IP for AVATAR rows.
+POST /api/v1/admin/bans — type-matches-fields validation, AVATAR/BOTH
+bans bump matching user's tokenVersion (next refresh fails),
+BanCacheInvalidator flushes Redis keys, admin_actions row written.
+POST /api/v1/admin/bans/{id}/lift — sets lifted columns, flushes cache.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: `AdminUserController` + `AdminUserService` + role mgmt + `AdminAudit` read endpoint
+
+**Goal:** Admin user search + detail page (6 tabs + actions) + audit log read endpoint.
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/users/AdminUserController.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/users/AdminUserService.java` (read-only: search, detail, tab data)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/users/AdminRoleService.java` (write: promote, demote, reset-counter)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/*` (8+ DTOs — see step list)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/users/exception/*` (`SelfDemoteException`, `UserAlreadyAdminException`, `UserNotAdminException`)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/admin/audit/AdminAuditController.java` (`GET /api/v1/admin/audit`)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/admin/exception/AdminExceptionHandler.java` (add 3 new handlers)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java` (admin user-search query)
+- Tests: per-service unit + per-controller slice
+
+The endpoints map exactly to spec §4.6 — implementer reads the spec section + writes the controller methods. Each tab endpoint is a small `findBy*Paginated(userId, Pageable)` query against existing repos:
+
+- `listings` — `auctionRepository.findBySellerIdOrderByCreatedAtDesc(userId, pageable)`
+- `bids` — `bidRepository.findByBidderIdOrderByCreatedAtDesc(userId, pageable)` (add if not present)
+- `cancellations` — `cancellationLogRepository.findBySellerIdOrderByCancelledAtDesc(userId, pageable)` (add)
+- `reports` — combined query: reports filed by user OR reports against user's listings, with a `direction` discriminator (`FILED_BY` | `AGAINST_LISTING`)
+- `fraud-flags` — `fraudFlagRepository.findByAuctionSellerIdOrderByDetectedAtDesc(userId, pageable)` (add — sub-spec 1's repo extension may need a new method)
+- `moderation` — `adminActionRepository.findByTargetTypeAndTargetIdOrderByCreatedAtDesc(USER, userId, pageable)` (already exists from Task 1)
+
+Each tab endpoint returns a flat `PagedResponse<TabRowDto>` shape — the frontend renders rows. DTOs are small projections.
+
+**Promote/demote/reset-counter:**
+- `POST /admin/users/{id}/promote` — 409 ALREADY_ADMIN if current role is ADMIN. Else flips role, bumps tv, writes admin_actions.
+- `POST /admin/users/{id}/demote` — 409 SELF_DEMOTE_FORBIDDEN if `id == admin.userId()`. 409 NOT_ADMIN if current role is USER. Else flips role, bumps tv, writes admin_actions.
+- `POST /admin/users/{id}/reset-frivolous-counter` — sets `dismissedReportsCount = 0`, writes admin_actions.
+
+**Audit read:**
+- `GET /api/v1/admin/audit?targetType=&targetId=&adminUserId=&page=&size=25` — paginated. Queries `AdminActionRepository` with the appropriate `findBy*` derived method based on which params are set.
+
+- [ ] **Step 1: Create exceptions** (3 classes — pattern from Task 9)
+- [ ] **Step 2: Add handlers in `AdminExceptionHandler`** (3 new handlers — pattern from Task 9)
+- [ ] **Step 3: Add user-search query to UserRepository**
+
+```java
+@Query("""
+    SELECT u FROM User u
+    WHERE (:uuid IS NOT NULL AND u.slAvatarUuid = :uuid)
+       OR (:uuid IS NULL AND :search IS NOT NULL AND
+           (LOWER(u.email) LIKE LOWER(CONCAT('%', :search, '%'))
+            OR LOWER(COALESCE(u.displayName, '')) LIKE LOWER(CONCAT('%', :search, '%'))
+            OR LOWER(COALESCE(u.slDisplayName, '')) LIKE LOWER(CONCAT('%', :search, '%'))))
+       OR (:search IS NULL AND :uuid IS NULL)
+    ORDER BY u.createdAt DESC
+""")
+Page<User> searchAdmin(@Param("search") String search, @Param("uuid") UUID uuidOrNull, Pageable pageable);
+```
+
+The controller parses the search input — if it parses as a UUID, pass `uuid=parsed, search=null`; else `uuid=null, search=raw`.
+
+- [ ] **Steps 4-12: Build DTOs, services, controller, audit controller, tests**
+
+The implementer writes each per-spec section (§4.6). Patterns established in Tasks 1, 6, 9 cover everything needed.
+
+- [ ] **Step 13: Run full backend tests**
+
+```bash
+cd backend && ./mvnw test -q
+```
+
+- [ ] **Step 14: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(admin): admin user search + user-detail tabs + role mgmt + audit read
+
+GET /api/v1/admin/users — single-search across email/displayName/
+slDisplayName/slAvatarUuid (UUID-mode if input parses).
+GET /admin/users/{id} — profile + stats + activeBan summary.
+GET /admin/users/{id}/{listings|bids|cancellations|reports|fraud-flags|
+moderation} — paginated tab data.
+GET /admin/users/{id}/ips — distinct IPs from RefreshToken history.
+POST /admin/users/{id}/promote — 409 ALREADY_ADMIN, else flip + tv bump.
+POST /admin/users/{id}/demote — 409 SELF_DEMOTE_FORBIDDEN, 409 NOT_ADMIN,
+else flip + tv bump.
+POST /admin/users/{id}/reset-frivolous-counter — zeroes counter.
+GET /admin/audit — paginated audit log (filter by targetType+targetId
+or by adminUserId).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Frontend foundations (lib/admin types/api/queryKeys/MSW) + dashboard 4-up
+
+**Goal:** Extend sub-spec 1's `lib/admin/*` with reports/bans/users types + api + queryKeys + MSW handlers. Update dashboard to 4-up needs-attention row including Open reports.
+
+**Files:**
+- Modify: `frontend/src/lib/admin/types.ts` (add report, ban, user, audit types)
+- Modify: `frontend/src/lib/admin/api.ts` (add reports, bans, users, audit endpoints)
+- Modify: `frontend/src/lib/admin/queryKeys.ts` (add new keys)
+- Modify: `frontend/src/test/msw/handlers.ts` (add report/ban/user MSW handlers)
+- Modify: `frontend/src/components/admin/AdminShell.tsx` (add Reports / Bans / Users sidebar items + badges)
+- Modify: `frontend/src/components/admin/dashboard/AdminDashboardPage.tsx` (4-up needs-attention row)
+
+- [ ] **Step 1: Extend `lib/admin/types.ts`**
+
+Add types matching the backend DTOs from Tasks 5-10. Mirror the existing fraud-flag-related types' shape (record-style, exhaustive enum unions).
+
+Required additions: `ListingReportReason`, `ListingReportStatus`, `BanType`, `BanReasonCategory`, `AdminReportListingRow`, `AdminReportDetail`, `AdminBanRow`, `AdminUserSummary`, `AdminUserDetail`, `UserIpProjection`, `AdminAction`, `AdminActionType`, `AdminActionTargetType`, `MyReportResponse`. Plus update `AdminStatsResponse.queues` to include `openReports: number`.
+
+- [ ] **Step 2: Extend `lib/admin/api.ts`**
+
+Add api groups: `adminApi.reports`, `adminApi.bans`, `adminApi.users`, `adminApi.audit`, `adminApi.auctions` (for the standalone reinstate endpoint), `userReportsApi` (for the auction-detail report button + my-report).
+
+Each method follows the existing `apiClient.get<T>(url)` / `apiClient.post(url, body)` pattern.
+
+- [ ] **Step 3: Extend `lib/admin/queryKeys.ts`**
+
+Mirror existing `adminQueryKeys` shape:
+
+```ts
+reports: () => [...adminQueryKeys.all, "reports"] as const,
+reportsList: (filters) => [...adminQueryKeys.reports(), "list", filters] as const,
+reportListing: (auctionId) => [...adminQueryKeys.reports(), "listing", auctionId] as const,
+report: (id) => [...adminQueryKeys.reports(), "detail", id] as const,
+bans: () => [...adminQueryKeys.all, "bans"] as const,
+bansList: (filters) => [...adminQueryKeys.bans(), "list", filters] as const,
+users: () => [...adminQueryKeys.all, "users"] as const,
+usersList: (filters) => [...adminQueryKeys.users(), "list", filters] as const,
+user: (id) => [...adminQueryKeys.users(), "detail", id] as const,
+userTab: (id, tab, filters) => [...adminQueryKeys.user(id), tab, filters] as const,
+userIps: (id) => [...adminQueryKeys.user(id), "ips"] as const,
+audit: (filters) => [...adminQueryKeys.all, "audit", filters] as const,
+myReport: (auctionId) => ["auction", auctionId, "my-report"] as const,
+```
+
+- [ ] **Step 4: Add MSW handlers**
+
+In `frontend/src/test/msw/handlers.ts`, extend `adminHandlers` with new factory methods covering the new endpoints. Pattern from sub-spec 1 fraud-flag handlers — happy-path success returns + 409/403/404 variants per endpoint.
+
+- [ ] **Step 5: Update `AdminShell` sidebar items**
+
+Add Reports / Bans / Users items below Fraud Flags. Each gets a badge from the appropriate stats field (Reports → `data.queues.openReports`).
+
+```tsx
+const items: SidebarItem[] = [
+  { label: "Dashboard", href: "/admin" },
+  { label: "Fraud Flags", href: "/admin/fraud-flags",
+    badge: stats?.queues.openFraudFlags },
+  { label: "Reports", href: "/admin/reports",
+    badge: stats?.queues.openReports },
+  { label: "Bans", href: "/admin/bans" },
+  { label: "Users", href: "/admin/users" },
+];
+```
+
+- [ ] **Step 6: Update dashboard 4-up**
+
+In `AdminDashboardPage.tsx`, change the needs-attention grid from 3-column to 4-column and add the Open reports card:
+
+```tsx
+<div className="grid grid-cols-4 gap-3 mb-7">
+  <QueueCard label="Open fraud flags" value={data.queues.openFraudFlags} tone="fraud"
+    subtext="Click to triage" href="/admin/fraud-flags" />
+  <QueueCard label="Open reports" value={data.queues.openReports} tone="fraud"
+    subtext="Click to triage" href="/admin/reports" />
+  <QueueCard label="Pending payments" value={data.queues.pendingPayments} tone="warning"
+    subtext="Awaiting winner L$" />
+  <QueueCard label="Active disputes" value={data.queues.activeDisputes} tone="warning"
+    subtext="Escrow disputed" />
+</div>
+```
+
+- [ ] **Step 7: Run typecheck + tests**
+
+Run: `cd frontend && npx tsc --noEmit && npm test -- --run`
+Expected: PASS (sub-spec 1's `AdminDashboardPage.test.tsx` may need a fixture update for the new `openReports` field).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/lib/admin/ \
+        frontend/src/test/msw/handlers.ts \
+        frontend/src/components/admin/AdminShell.tsx \
+        frontend/src/components/admin/dashboard/
+
+git commit -m "$(cat <<'EOF'
+feat(admin): frontend foundations + dashboard 4-up
+
+lib/admin/{types,api,queryKeys} extended with reports/bans/users/audit
+shapes. MSW adminHandlers gain new factory methods.
+AdminShell sidebar adds Reports / Bans / Users items (Reports gets the
+open-reports badge). AdminDashboardPage needs-attention row goes 4-up
+including Open reports card.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Frontend reports UI (button + modal + admin queue + slide-over)
+
+**Goal:** User-facing report button + modal on auction detail. Admin reports queue page at `/admin/reports` with listing-grouped table + slide-over (560px) with 4 actions + per-report dismiss + shared notes textarea.
+
+**Files:**
+- Create: `frontend/src/components/auction/ReportListingButton.tsx`
+- Create: `frontend/src/components/auction/ReportListingModal.tsx`
+- Create: `frontend/src/hooks/auction/useMyReport.ts`
+- Create: `frontend/src/hooks/auction/useSubmitReport.ts`
+- Modify: `frontend/src/app/auction/[id]/AuctionDetailClient.tsx` (insert `<ReportListingButton>` in title row)
+- Create: `frontend/src/app/admin/reports/page.tsx`
+- Create: `frontend/src/components/admin/reports/AdminReportsListPage.tsx`
+- Create: `frontend/src/components/admin/reports/AdminReportsTable.tsx`
+- Create: `frontend/src/components/admin/reports/AdminReportsFilters.tsx`
+- Create: `frontend/src/components/admin/reports/AdminReportSlideOver.tsx`
+- Create: `frontend/src/components/admin/reports/AdminReportListingHeader.tsx`
+- Create: `frontend/src/components/admin/reports/AdminReportCard.tsx` (single-report card with Dismiss button)
+- Create: `frontend/src/hooks/admin/useAdminReportsList.ts`
+- Create: `frontend/src/hooks/admin/useAdminReportsByListing.ts`
+- Create: `frontend/src/hooks/admin/useDismissReport.ts`
+- Create: `frontend/src/hooks/admin/useWarnSeller.ts`
+- Create: `frontend/src/hooks/admin/useSuspendListingFromReport.ts`
+- Create: `frontend/src/hooks/admin/useCancelListingFromReport.ts`
+- Tests: companion `*.test.tsx` for button, modal, list page, slide-over
+
+The patterns match sub-spec 1's fraud-flag UI exactly (URL state with `?status=` and `?auctionId=` for slide-over open, mutations invalidate both list-cache and stats-cache, slide-over with prev/next arrows). Implementer mirrors `AdminFraudFlagsListPage` and friends.
+
+**Auction detail integration**: `<ReportListingButton>` in the title row state machine matches spec §5.1:
+- Anonymous → hidden
+- Logged-in unverified → disabled with tooltip "Verify your SL avatar to report listings"
+- Logged-in verified, current user is seller → hidden
+- `useMyReport(auctionId)` returns 204 → button enabled "Report"
+- `useMyReport(auctionId)` returns row with `status === "DISMISSED"` → button enabled "Report"
+- Otherwise → "Reported ✓" disabled
+
+Tests cover: button state matrix, modal field validation, mutation success → button flips, mutation error → toast.
+
+- [ ] **Step 1-12**: Implementer scaffolds each file in order. Estimated 600-700 lines of frontend code.
+
+- [ ] **Step 13: Run typecheck + tests + lint**
+
+```bash
+cd frontend && npx tsc --noEmit && npm test -- --run && npm run lint
+```
+
+Expected: PASS. Pre-existing `CodeDisplay.test.tsx` TS error — known, not introduced by this task.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(admin): /admin/reports queue + auction-detail Report button
+
+Auction detail (/auction/[id]) gains Report button in title row with
+state machine (hidden anon/own-listing, disabled unverified, "Reported ✓"
+after submit, re-enables after admin dismisses). Modal: subject (100) +
+reason dropdown + details (2000) + disclosure block. Submit upserts
+report row.
+/admin/reports listing-grouped queue (sorted reportCount DESC) with
+slide-over (560px) showing all reports for that listing, 4 actions
+(Warn / Suspend / Cancel / Ban seller →), per-report Dismiss, shared
+notes textarea, prev/next arrows. Mutations invalidate reports + stats.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Frontend bans UI (page + create modal)
+
+**Goal:** Admin bans page at `/admin/bans` with Active/History tabs + create-ban modal (with type selector, identifier inputs, expiry, reason category, side-effect note, user-search autocomplete on no-pre-fill case).
+
+**Files:**
+- Create: `frontend/src/app/admin/bans/page.tsx`
+- Create: `frontend/src/components/admin/bans/AdminBansPage.tsx`
+- Create: `frontend/src/components/admin/bans/AdminBansTable.tsx`
+- Create: `frontend/src/components/admin/bans/AdminBansFilters.tsx`
+- Create: `frontend/src/components/admin/bans/CreateBanModal.tsx`
+- Create: `frontend/src/components/admin/bans/LiftBanModal.tsx`
+- Create: `frontend/src/components/admin/bans/UserSearchAutocomplete.tsx`
+- Create: `frontend/src/hooks/admin/useAdminBansList.ts`
+- Create: `frontend/src/hooks/admin/useCreateBan.ts`
+- Create: `frontend/src/hooks/admin/useLiftBan.ts`
+- Create: `frontend/src/hooks/admin/useUserSearch.ts` (for autocomplete)
+- Tests: companion test files
+
+Patterns match Task 12. The user-search autocomplete is a thin debounced typeahead querying `GET /api/v1/admin/users?search=...` and rendering up to 5 result rows in a popover.
+
+Create modal supports two entry modes:
+- **Pre-filled** (from `/admin/users/{id}` "+ Add another ban…" button): receives initial `slAvatarUuid` + most-recent IP via props; user can edit
+- **Blank** (from `/admin/bans` "+ Create ban" button): renders the user-search autocomplete; user picks a result → modal pre-fills
+
+Both modes hit the same `POST /api/v1/admin/bans` endpoint.
+
+- [ ] **Step 1-9**: Implementer scaffolds each file. Estimated 400 lines of frontend code.
+- [ ] **Step 10: Run typecheck + tests + lint**
+- [ ] **Step 11: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(admin): /admin/bans page + create/lift modals
+
+Active / History tabs, type filter pills (IP/AVATAR/BOTH), table with
+identifier UUID linked to user-detail and first-seen-IP for AVATAR rows.
+Create-ban modal: type selector, identifier inputs (conditional on type),
+expiry (Permanent or date picker), reason category dropdown + reason text,
+side-effect note (tv-bump + cache flush). User-search autocomplete on
+the no-pre-fill case. Lift modal with required notes textarea.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Frontend users UI (search + detail page)
+
+**Goal:** Admin user search at `/admin/users` + user-detail page at `/admin/users/{id}` with profile + 5 stat cards + 6 tabs + 280px right rail with active-ban callout + action buttons + Recent IPs modal.
+
+**Files:**
+- Create: `frontend/src/app/admin/users/page.tsx`
+- Create: `frontend/src/app/admin/users/[id]/page.tsx`
+- Create: `frontend/src/components/admin/users/AdminUsersSearchPage.tsx`
+- Create: `frontend/src/components/admin/users/AdminUsersTable.tsx`
+- Create: `frontend/src/components/admin/users/AdminUserDetailPage.tsx`
+- Create: `frontend/src/components/admin/users/UserProfileHeader.tsx`
+- Create: `frontend/src/components/admin/users/UserStatsCards.tsx`
+- Create: `frontend/src/components/admin/users/UserTabsNav.tsx`
+- Create: `frontend/src/components/admin/users/tabs/ListingsTab.tsx` (with Reinstate button per row when SUSPENDED)
+- Create: `frontend/src/components/admin/users/tabs/BidsTab.tsx`
+- Create: `frontend/src/components/admin/users/tabs/CancellationsTab.tsx`
+- Create: `frontend/src/components/admin/users/tabs/ReportsTab.tsx` (filed-by + against split)
+- Create: `frontend/src/components/admin/users/tabs/FraudFlagsTab.tsx`
+- Create: `frontend/src/components/admin/users/tabs/ModerationTab.tsx`
+- Create: `frontend/src/components/admin/users/UserActionsRail.tsx` (right-rail with promote/demote/reset/ban shortcut/active-ban callout)
+- Create: `frontend/src/components/admin/users/RecentIpsModal.tsx`
+- Create: `frontend/src/components/admin/users/ConfirmActionModal.tsx` (notes-required confirmation for promote/demote/reset)
+- Create: `frontend/src/components/admin/users/ReinstateListingModal.tsx` (notes-required for the per-row Reinstate button)
+- Create: `frontend/src/hooks/admin/useAdminUsersList.ts`
+- Create: `frontend/src/hooks/admin/useAdminUser.ts` (detail)
+- Create: `frontend/src/hooks/admin/useAdminUserListings.ts` (and 5 sibling tab hooks)
+- Create: `frontend/src/hooks/admin/useAdminUserIps.ts`
+- Create: `frontend/src/hooks/admin/usePromoteUser.ts`
+- Create: `frontend/src/hooks/admin/useDemoteUser.ts`
+- Create: `frontend/src/hooks/admin/useResetFrivolousCounter.ts`
+- Create: `frontend/src/hooks/admin/useReinstateAuction.ts` (POST /admin/auctions/{id}/reinstate)
+- Tests: companion test files
+
+Patterns established. Implementer scaffolds in dependency order: hooks → leaf components → page composition.
+
+Self-demote 409 handling: the demote mutation's `onError` checks `code === "SELF_DEMOTE_FORBIDDEN"` and surfaces the toast "You cannot demote yourself."
+
+Reinstate-from-listings-tab: per row when `status === "SUSPENDED"`, render a small "Reinstate" button → opens `<ReinstateListingModal>` with notes textarea → calls `useReinstateAuction()`. Success → invalidate `useAdminUserListings(id, page)` and `["admin", "stats"]`. Error 409 → toast.
+
+- [ ] **Step 1-22**: Implementer scaffolds each file. Estimated 1000+ lines of frontend code.
+- [ ] **Step 23: Run typecheck + tests + lint**
+- [ ] **Step 24: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(admin): /admin/users search + user-detail page
+
+/admin/users — single search box, paginated table with display name +
+activity meta, role/verified/banned chips.
+/admin/users/{id} — profile header + 5 stat cards + 6-tab history
+(Listings/Bids/Cancellations/Reports/Fraud flags/Moderation) + 280px
+right rail (active-ban callout, Promote/Demote/Reset/+Add ban actions,
+Recent IPs modal). Listings tab gets per-row Reinstate button for
+SUSPENDED auctions calling /admin/auctions/{id}/reinstate. Demote 409
+SELF_DEMOTE_FORBIDDEN surfaces toast. All admin write actions require
+notes (confirmation modal).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15: Cross-cutting docs + manual test + push branch + open PR
+
+**Goal:** Close out the sub-spec — DEFERRED_WORK ledger sweep, FOOTGUNS additions (F.103+), DESIGN.md §8 notes, full test suite run, branch push, PR open (NOT auto-merged).
+
+**Files:**
+- Modify: `docs/implementation/DEFERRED_WORK.md`
+- Modify: `docs/implementation/FOOTGUNS.md`
+- Modify: `docs/initial-design/DESIGN.md`
+
+- [ ] **Step 1: Run full backend test suite**
+
+```bash
+cd backend && ./mvnw test -q
+```
+
+Expected: PASS. Re-run if `AuctionRepositoryOwnershipCheckTest` flakes.
+
+- [ ] **Step 2: Run full frontend tests + typecheck + lint**
+
+```bash
+cd frontend && npx tsc --noEmit && npm test -- --run && npm run lint
+```
+
+Expected: PASS, lint clean (pre-existing warnings only).
+
+- [ ] **Step 3: Update DEFERRED_WORK.md**
+
+Read first. Then:
+- **Close** entries that sub-spec 2 ships:
+  - "Account deletion UI" cascade-rules-shared-with-bans entry — sub-spec 2 establishes the admin role + admin actions audit; account deletion can be revisited in sub-spec 4 with a cleaner home.
+  - Any entries explicitly saying "blocked on admin user mgmt" or "blocked on bans" — sub-spec 2 unblocks.
+- **Modify** entries with narrowed scope:
+  - "Non-dev admin endpoint for ownership-monitor trigger" (Epic 03) — admin foundation now exists, only the endpoint + button remain.
+- **Add** entries deferred from sub-spec 2:
+  - `REPORT_THRESHOLD_REACHED` admin-targeted notification (re-add trigger: "if admins miss high-report listings").
+  - Admin "Send notification to user" surface — out of scope, indefinite.
+  - Frivolous-reporter automatic privilege revocation — counter ships, automatic revoke deferred to "operational data shows the threshold is needed."
+  - Realtime ban broadcast / forced-logout WebSocket — tv-bump on next refresh sufficient; revisit if forced-logout latency becomes a complaint.
+  - ProxyBid bidder fan-out from admin-cancel — manual-bid fan-out ships, proxy-bid fan-out can come if proxy-bidder feedback shows missing notifications.
+
+- [ ] **Step 4: Update FOOTGUNS.md (F.103+)**
+
+Append:
+
+```markdown
+### F.103 — Admin-cancel must NOT bump the seller's penalty ladder
+
+`CancellationLog.cancelledByAdminId IS NULL` is the load-bearing predicate
+in `countPriorOffensesWithBids`. Without it, every admin-removed listing
+counts as a seller offense — a seller who's been wrongly reported but
+exonerated would still climb the ladder. Test
+`CancellationServiceCancelByAdminTest.priorOffensesQueryExcludesAdminCancel`
+is the canary.
+
+### F.104 — Cause-neutral fanout body string
+
+`NotificationPublisher.listingCancelledBySellerFanout` body strings
+("This auction has been cancelled. Your active proxy bid is no longer
+in effect.") are deliberately cause-neutral so admin-cancel can call the
+same method. If anyone reverts the body to seller-attributed copy ("The
+seller cancelled..."), bidders on admin-cancelled auctions get a
+misleading message. Existing seller-cancel tests assert against the
+new copy — they're the canary.
+
+### F.105 — Listing-level report actions touch ONLY OPEN reports
+
+`AdminReportService.warnSeller / suspend / cancel` filter to OPEN status
+when batching the report-state-change. DISMISSED reports stay DISMISSED
+because each represents a deliberate per-report decision (with the
+reporter's frivolous counter already incremented). Reclassifying them
+on a listing-level action would undo that decision.
+
+### F.106 — Ban cache TTL = 5 min; create/lift flushes immediately
+
+`BanCheckService` caches both positive AND negative results with 5-min
+TTL. `BanCacheInvalidator.invalidate(ip, uuid)` is called on ban-create
+and ban-lift to clear the keys immediately. The 5-min cap limits the
+worst-case stale window to 5 min — acceptable because admin actions are
+infrequent and a banned user being one bid late to be blocked is a
+non-event.
+
+### F.107 — Listing-creation IP capture didn't exist before
+
+`AuctionController.create` and `AuctionService.create` gained
+`HttpServletRequest` / `String ipAddress` parameters in sub-spec 2. Any
+test calling `auctionService.create(sellerId, req)` directly fails with
+a method-not-found compile error — pass `null` or `""` as the new third
+arg. The integration tests in this sub-spec already do this; older tests
+that haven't been touched in a while may need a sweep.
+
+### F.108 — Self-demote returns 409, NOT 403
+
+A current admin trying to demote themselves gets `409 SELF_DEMOTE_FORBIDDEN`
+from `AdminRoleService.demote`. The 409 is intentional — they have
+permission to call the endpoint (they're an admin), but the operation
+is forbidden by business rule. The frontend toast surfaces "You cannot
+demote yourself."
+```
+
+- [ ] **Step 5: Append DESIGN.md §8 sub-spec 2 notes**
+
+After sub-spec 1's notes subsection:
+
+```markdown
+### Notes (Epic 10 sub-spec 2 — Reports + Bans + Admin enforcement + User mgmt, 2026-04-26)
+
+- Listing reports: users flag with subject + reason + details. Upsert by
+  (auction, reporter) — resubmit replaces and resets status to OPEN
+  (issue-still-happening escape valve). Reports are ALWAYS informational
+  — admin acts manually.
+- Admin queue is listing-grouped, sorted reportCount DESC. Listing-level
+  actions (warn/suspend/cancel) only touch OPEN reports — DISMISSED
+  reports preserve the admin's prior per-report decision (and the
+  reporter's frivolous counter increment).
+- Bans block at 6 paths: register, login, SL-verify, bid, listing
+  creation, listing cancellation. The cancel-path check prevents banned
+  sellers from circumventing via cancel-and-sell. Cached in Redis with
+  5-min TTL.
+- Multi-ban stacking: one user can have AVATAR + IP bans concurrently as
+  separate rows. Active = liftedAt IS NULL AND (expiresAt IS NULL OR > now).
+- Admin-cancel skips the seller penalty ladder. `CancellationLog.
+  cancelledByAdminId` excludes the row from `countPriorOffensesWithBids`.
+  Distinct seller notification (LISTING_REMOVED_BY_ADMIN) plus
+  cause-neutral bidder fan-out (LISTING_CANCELLED_BY_SELLER reused).
+- Admin reinstate is a shared primitive (`AdminAuctionService.reinstate`)
+  used by both fraud-flag-resolution (sub-spec 1) and the standalone
+  `/admin/auctions/{id}/reinstate` endpoint (called from the user-detail
+  Listings tab Reinstate button when status=SUSPENDED).
+- `admin_actions` audit table writes from sub-spec 2 forward. Sub-spec 1
+  fraud-flag actions continue to self-audit on FraudFlag.resolvedBy +
+  adminNotes — no backfill.
+- Frivolous reporter tracking: counter only this sub-spec
+  (`User.dismissedReportsCount`). Automatic privilege revocation deferred.
+- Self-demote returns 409 SELF_DEMOTE_FORBIDDEN. Promote doesn't need
+  the guard (you're already admin to reach the page).
+```
+
+- [ ] **Step 6: Commit docs**
+
+```bash
+git add docs/implementation/DEFERRED_WORK.md \
+        docs/implementation/FOOTGUNS.md \
+        docs/initial-design/DESIGN.md
+
+git commit -m "$(cat <<'EOF'
+docs(epic-10-sub-2): close X deferred entries, modify Y; FOOTGUNS x6; DESIGN.md notes
+
+Closes admin-mgmt-blocking entries (account-deletion cascade, fraud-flag
+admin endpoint dependencies). Modifies ownership-monitor admin-trigger
+entry (foundation now exists). Adds REPORT_THRESHOLD_REACHED, "Send
+notification to user", frivolous-reporter automatic revocation,
+forced-logout WebSocket, and ProxyBid fan-out as deferred items.
+FOOTGUNS F.103-F.108 cover penalty-ladder exclusion, cause-neutral
+fanout copy, listing-action OPEN-only filter, ban cache TTL,
+listing-creation IP capture method-signature change, and self-demote
+409 semantics. DESIGN.md §8 gains sub-spec 2 notes.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 7: Push branch**
+
+```bash
+git push -u origin task/10-sub-2-reports-bans-admin-enforcement
+```
+
+- [ ] **Step 8: Open PR (DO NOT auto-merge, base = `dev`)**
+
+```bash
+gh pr create --base dev --title "Epic 10 sub-spec 2 — Reports + Bans + Admin enforcement + User mgmt" --body "$(cat <<'EOF'
+## Summary
+
+- `ListingReport` entity + user-facing report endpoints (upsert + my-report)
+- Admin reports queue at /admin/reports (listing-grouped + slide-over with 4 actions)
+- `Ban` entity + Redis cache + 6-path enforcement (register/login/SL-verify/bid/listing-create/listing-cancel)
+- Admin bans page at /admin/bans + create/lift modals + first-seen-IP for AVATAR rows
+- Admin user search at /admin/users + user-detail at /admin/users/{id} with 6 tabs + 280px right rail
+- `admin_actions` audit table + audit read endpoint (per-user via Moderation tab)
+- `AdminAuctionService.reinstate` shared primitive + standalone /admin/auctions/{id}/reinstate
+- Sub-spec 1's fraud-flag reinstate refactored to delegate (net behavior unchanged)
+- `CancellationService.cancelByAdmin` skips penalty ladder; cause-neutral bidder fanout body
+- New notification categories: LISTING_WARNED, LISTING_REMOVED_BY_ADMIN
+- Dashboard 4-up needs-attention row (Open reports added)
+- Auction detail Report button + modal
+
+## Test plan
+
+- [ ] Backend: `cd backend && ./mvnw test` — all green
+- [ ] Frontend: `cd frontend && npx tsc --noEmit && npm test && npm run lint` — all green
+- [ ] Manual: user reports a listing → modal flow → button flips to Reported ✓
+- [ ] Manual: admin dismisses → button re-enables (re-submit replaces row + resets OPEN)
+- [ ] Manual: admin warns seller (different report) → seller gets LISTING_WARNED
+- [ ] Manual: admin suspends from reports → seller gets LISTING_SUSPENDED, all open reports → ACTION_TAKEN, DISMISSED reports stay DISMISSED
+- [ ] Manual: admin reinstates from user-detail Listings tab → auction → ACTIVE, seller gets LISTING_REINSTATED
+- [ ] Manual: admin cancels from reports → seller gets LISTING_REMOVED_BY_ADMIN, bidders get cause-neutral cancel notification, no penalty applied (cancellation_log row has cancelledByAdminId, seller.cancelledWithBids unchanged)
+- [ ] Manual: admin creates AVATAR ban on logged-in user → user invalidates on next refresh (tv bump)
+- [ ] Manual: banned user attempts bid → 403 USER_BANNED
+- [ ] Manual: admin lifts ban → user can act again (after Redis cache flush)
+- [ ] Manual: admin self-demote → 409 SELF_DEMOTE_FORBIDDEN
+
+## Out of scope (next sub-specs)
+
+- Bot pool health, escrow dispute resolution, terminal secret rotation → sub-spec 3
+- Reminder schedulers, account deletion UI, audit-log viewer page → sub-spec 4
+- REPORT_THRESHOLD_REACHED admin-targeted notification — deferred
+- Frivolous-reporter automatic revocation — counter only this sub-spec
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Stop after PR creation. Report PR URL.
+
+---
+
+## Self-review checklist (run mentally before each task starts execution)
+
+- ✅ **Spec coverage:** every section of the spec maps to a task. Reports (§4.1, §4.4, §5.1-§5.3) → Tasks 5, 6, 12. Bans (§4.2, §4.3, §4.5, §5.4) → Tasks 7, 8, 9, 13. AdminAction audit (§4.11) → Task 1, 10. AdminAuctionService (§4.7) → Task 2. Cancel/Suspend by admin (§4.8, §4.9) → Tasks 3, 4. Notification categories (§4.10) → Tasks 3, 4. User mgmt (§4.6, §5.5) → Tasks 10, 14. Dashboard 4-up (§5.6) → Task 11. Wrap-up (§9, §10) → Task 15.
+- ✅ **No placeholders:** every step has either real code, a real command, or an explicit "implementer follows pattern from Task N" reference. The pattern-reference shortcuts in tasks 9, 10, 13, 14 are tighter than tasks 1-7 because the patterns are established by then.
+- ✅ **Type consistency:** `AdminAction*` types stable across tasks 1, 6, 9, 10. `ListingReport*` stable across 5, 6, 12. `Ban*` stable across 7, 8, 9, 13. `AdminAuctionReinstateResult` defined in task 2, used in task 14. URL paths consistent (`/api/v1/admin/reports/...`, `/api/v1/admin/bans/...`, `/api/v1/admin/users/...`, `/api/v1/admin/auctions/{id}/reinstate`, `/api/v1/admin/audit`).
+- ✅ **TDD throughout:** every backend code change has a test. Frontend tests cover hooks + components.
+- ✅ **Bite-sized:** no step does more than one thing. Each commit is self-contained and reviewable.
+
+
+
+

--- a/docs/superpowers/specs/2026-04-26-epic-10-sub-2-reports-bans-admin-enforcement.md
+++ b/docs/superpowers/specs/2026-04-26-epic-10-sub-2-reports-bans-admin-enforcement.md
@@ -1,0 +1,869 @@
+# Epic 10 Sub-spec 2 — Listing Reports + Bans + Admin Enforcement + Admin User Mgmt
+
+> **Status:** Design
+> **Epic:** 10 (Admin & Moderation)
+> **Sub-spec:** 2 of 4
+> **Branch hint:** `task/10-sub-2-reports-bans-admin-enforcement`
+> **Read first:** [`docs/implementation/CONVENTIONS.md`](../../implementation/CONVENTIONS.md), [`docs/implementation/DEFERRED_WORK.md`](../../implementation/DEFERRED_WORK.md), [`docs/implementation/FOOTGUNS.md`](../../implementation/FOOTGUNS.md), and the sub-spec 1 spec for fraud-flag and admin-foundation context.
+
+---
+
+## 1. Goal
+
+Sub-spec 2 ships the moderation loop: users report listings, admins triage from a queue, admins ban offenders, admins manage users. Builds on sub-spec 1's admin role + section shell + fraud-flag triage.
+
+When this lands:
+- Verified users can flag a listing with subject + reason + details.
+- An admin sees the report queue (sorted by report count per listing), drills into a listing's reports, and takes action: warn the seller, suspend the listing, cancel the listing, or pivot to the seller's user-detail page to ban them.
+- Admins can create bans by IP, SL avatar, or both. Bans block register, login, bid, listing creation, and listing cancellation. Cached in Redis with 5-minute TTL.
+- Admins can search users, drill into a user's full history (listings, bids, cancellations, reports filed/against, fraud flags, moderation log), promote/demote roles, lift bans, and reset frivolous-reporter counters.
+- All admin write actions are persisted in a new `admin_actions` audit table.
+
+## 2. Scope
+
+### In scope
+
+- `ListingReport` entity + report POST endpoint + admin queue/detail/action endpoints
+- `Ban` entity + Redis cache + ban-check enforcement at register/login/SL-verify/bid/listing-create/listing-cancel
+- `AdminAction` audit table + read endpoint
+- Admin user search + user-detail page (6 tabs + action panel + ban-create modal)
+- `User.dismissedReportsCount` counter (frivolous tracking — counter only, no automatic privilege revocation)
+- `CancellationLog.cancelledByAdminId` column + `CancellationService.cancelByAdmin` path that skips the penalty ladder
+- `AdminAuctionService.reinstate` shared primitive — sub-spec 1's fraud-flag reinstate refactored to delegate to it; new standalone `POST /admin/auctions/{id}/reinstate` endpoint
+- Two new notification categories: `LISTING_WARNED`, `LISTING_REMOVED_BY_ADMIN`
+- Frontend pages: `/admin/reports`, `/admin/bans`, `/admin/users`, `/admin/users/{id}`, plus dashboard's 4-up needs-attention row, Report button + modal on `/auction/[id]`
+
+### Out of scope (later sub-specs within Epic 10)
+
+- Account deletion (`DELETE /me` 501) → sub-spec 4
+- Admin "send notification to user" surface → indefinite
+- Realtime ban broadcast / forced-logout WebSocket — tv-bump on next refresh is enough
+- Frivolous-reporter automatic privilege revocation (counter only this sub-spec)
+- 3-report threshold notification (`REPORT_THRESHOLD_REACHED`) — listing-grouped queue + dashboard counter cover the visibility need; deferred with re-add trigger ("if admins miss high-report listings")
+- Bot pool health, escrow dispute resolution, terminal secret rotation → sub-spec 3
+- Reminder schedulers, audit log viewer page → sub-spec 4
+
+---
+
+## 3. Architecture
+
+```
+Frontend
+  /auction/[id]                    — Report button + modal (verified, not own listing)
+  /admin                           — needs-attention row 4-up: fraud + reports + payments + disputes
+  /admin/reports                   — listing-grouped queue + slide-over (4 actions + per-report dismiss)
+  /admin/bans                      — Active / History tabs + Create-ban modal
+  /admin/users                     — single-search box + paginated table
+  /admin/users/{id}                — profile + 5 stats + 6 tabs + 280px right rail
+  /admin/users/{id} → ban modal    — pre-filled from user; multi-ban stacking allowed
+
+Backend (com.slparcelauctions.backend.admin)
+  reports/                         — AdminReportController, AdminReportService, ListingReport entity
+  ban/                             — AdminBanController, AdminBanService, BanCheckService, Ban entity
+  users/                           — AdminUserController, AdminUserService (read), AdminRoleService (promote/demote)
+  audit/                           — AdminAction entity, AdminActionRepository, AdminAuditController
+  AdminAuctionService              — shared primitive: reinstate(auction, adminUserId, notes, fallbackSuspendedFrom)
+
+Cross-cutting
+  ListingReport.upsert() on duplicate (auction, reporter)
+  Ban + Redis cache (5-min TTL, invalidated on create/lift)
+  CancellationService.cancelByAdmin (no penalty ladder)
+  SuspensionService.suspendByAdmin (admin reason, no fraud flag)
+  Sub-spec 1 AdminFraudFlagService.reinstate refactored to delegate
+```
+
+The admin package gains four new sub-packages (`reports`, `ban`, `users`, `audit`) and a shared `AdminAuctionService` used by both sub-specs 1 and 2. No new top-level domains; everything reads from existing User/Auction/Bid/Cancellation/RefreshToken tables.
+
+---
+
+## 4. Backend pieces
+
+### 4.1 `ListingReport` entity
+
+```java
+@Entity
+@Table(name = "listing_reports",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"auction_id", "reporter_id"}))
+public class ListingReport {
+    @Id @GeneratedValue Long id;
+    @ManyToOne(fetch = LAZY, optional = false) @JoinColumn(name = "auction_id") Auction auction;
+    @ManyToOne(fetch = LAZY, optional = false) @JoinColumn(name = "reporter_id") User reporter;
+
+    @Column(length = 100, nullable = false) String subject;
+
+    @Enumerated(EnumType.STRING) @Column(length = 30, nullable = false)
+    ListingReportReason reason;
+    // INACCURATE_DESCRIPTION, WRONG_TAGS, SHILL_BIDDING, FRAUDULENT_SELLER,
+    // DUPLICATE_LISTING, NOT_ACTUALLY_FOR_SALE, TOS_VIOLATION, OTHER
+
+    @Column(columnDefinition = "text", nullable = false) String details; // max 2000 char (validated)
+
+    @Enumerated(EnumType.STRING) @Column(length = 20, nullable = false)
+    ListingReportStatus status; // OPEN, REVIEWED, DISMISSED, ACTION_TAKEN
+
+    @Column(name = "admin_notes", columnDefinition = "text") String adminNotes;
+    @ManyToOne(fetch = LAZY) @JoinColumn(name = "reviewed_by") User reviewedBy;
+    @Column(name = "reviewed_at") OffsetDateTime reviewedAt;
+
+    @CreationTimestamp OffsetDateTime createdAt;
+    @UpdateTimestamp OffsetDateTime updatedAt;
+}
+```
+
+UPSERT semantics: `POST /api/v1/auctions/{id}/report` from a user who already has an OPEN/DISMISSED/REVIEWED report on this auction REPLACES the row's subject/reason/details/status (resets to OPEN). Implementation: `findByAuctionIdAndReporterId(...).orElseGet(new)` then save. Update `updatedAt` via `@UpdateTimestamp`.
+
+ACTION_TAKEN: set on all OPEN reports for a listing when admin clicks Suspend or Cancel via the reports queue. Different from REVIEWED (set by Warn-seller).
+
+### 4.2 `Ban` entity + `BanCheckService` + Redis cache
+
+```java
+@Entity
+@Table(name = "bans")
+@Check(constraints = """
+    (ban_type = 'IP'     AND ip_address IS NOT NULL AND sl_avatar_uuid IS NULL) OR
+    (ban_type = 'AVATAR' AND ip_address IS NULL     AND sl_avatar_uuid IS NOT NULL) OR
+    (ban_type = 'BOTH'   AND ip_address IS NOT NULL AND sl_avatar_uuid IS NOT NULL)
+""")
+public class Ban {
+    @Id @GeneratedValue Long id;
+
+    @Enumerated(EnumType.STRING) @Column(name = "ban_type", length = 10, nullable = false)
+    BanType banType; // IP, AVATAR, BOTH
+
+    @Column(name = "ip_address", columnDefinition = "inet") String ipAddress;
+    @Column(name = "sl_avatar_uuid") UUID slAvatarUuid;
+
+    @Enumerated(EnumType.STRING) @Column(name = "reason_category", length = 30, nullable = false)
+    BanReasonCategory reasonCategory; // SHILL_BIDDING, FRAUDULENT_SELLER, TOS_ABUSE, SPAM, OTHER
+
+    @Column(name = "reason_text", columnDefinition = "text", nullable = false) String reasonText;
+
+    @ManyToOne(fetch = LAZY, optional = false) @JoinColumn(name = "banned_by") User bannedBy;
+    @Column(name = "expires_at") OffsetDateTime expiresAt; // null = permanent
+
+    @Column(name = "lifted_at") OffsetDateTime liftedAt;
+    @ManyToOne(fetch = LAZY) @JoinColumn(name = "lifted_by") User liftedBy;
+    @Column(name = "lifted_reason", columnDefinition = "text") String liftedReason;
+
+    @CreationTimestamp OffsetDateTime createdAt;
+}
+```
+
+**Active ban predicate**: `liftedAt IS NULL AND (expiresAt IS NULL OR expiresAt > NOW())`. Encoded as `BanRepository.findActiveByIpAddress(String)` and `findActiveBySlAvatarUuid(UUID)` derived queries via `@Query` (the temporal check needs explicit JPQL — see snippet below).
+
+```java
+@Query("""
+    SELECT b FROM Ban b
+    WHERE b.liftedAt IS NULL
+      AND (b.expiresAt IS NULL OR b.expiresAt > :now)
+      AND (b.banType = 'IP' OR b.banType = 'BOTH')
+      AND b.ipAddress = :ip
+""")
+List<Ban> findActiveByIpAddress(@Param("ip") String ip, @Param("now") OffsetDateTime now);
+```
+
+Symmetric query for `findActiveBySlAvatarUuid(UUID, OffsetDateTime)`.
+
+**`BanCheckService`** — single entry point for enforcement:
+
+```java
+public class BanCheckService {
+    public void assertNotBanned(String ipAddress, UUID slAvatarUuid) {
+        Ban hit = lookupCachedActive(ipAddress, slAvatarUuid);
+        if (hit != null) {
+            throw new UserBannedException(hit.getId(), hit.getExpiresAt());
+        }
+    }
+    // Looks up Redis (5-min TTL) keyed bans:active:ip:<ip> and bans:active:avatar:<uuid>
+    // Cache miss → DB query → cache result (or empty marker)
+    // Cache invalidated on ban-create / ban-lift
+}
+```
+
+**`UserBannedException` → 403** with body `{code: USER_BANNED, expiresAt: <ISO8601 | null>}`. Handled by `AdminExceptionHandler` (sub-spec 1) for admin endpoints; user-facing endpoints route through `GlobalExceptionHandler`.
+
+**Cache keys**:
+- `bans:active:ip:<ip>` → JSON-encoded ban-id-list (or empty marker `[]`). TTL 5 min.
+- `bans:active:avatar:<uuid>` → same shape.
+- Both cleared by `BanCacheInvalidator.invalidate(ip, slAvatarUuid)` on create + lift, called inside the ban-write transaction's afterCommit hook.
+
+**Token-version bump** on AVATAR/BOTH ban creation: `userRepository.findBySlAvatarUuid(uuid).ifPresent(u -> userRepository.bumpTokenVersion(u.getId()))`. Existing primitive — no new code beyond the call. The user's outstanding access token becomes invalid on next refresh; their session redirects to login (existing behavior).
+
+### 4.3 Ban enforcement points
+
+| Path | Calls | What's checked |
+|------|-------|----------------|
+| `POST /api/v1/auth/register` | `assertNotBanned(ipAddress, null)` | IP only |
+| `POST /api/v1/auth/login` | `assertNotBanned(ipAddress, null)` | IP only |
+| `POST /api/v1/sl/verify` | `assertNotBanned(null, slAvatarUuid)` | SL avatar from header |
+| `POST /api/v1/auctions/{id}/bid` | `assertNotBanned(ipAddress, user.slAvatarUuid)` | both |
+| `POST /api/v1/auctions` (listing creation) | `assertNotBanned(ipAddress, user.slAvatarUuid)` | both |
+| `POST /api/v1/auctions/{id}/cancel` | `assertNotBanned(ipAddress, user.slAvatarUuid)` | both — banned seller can't circumvent via cancel-and-sell |
+
+**Wrinkle for listing creation**: `AuctionController` doesn't currently capture client IP. Sub-spec 2 adds `HttpServletRequest` parameter to the `POST /api/v1/auctions` controller method; `getRemoteAddr()` is used (matches existing `BidController` pattern at line ~65).
+
+**Orthogonal to existing `User.bannedFromListing` flag** (4th-offense penalty-ladder result). That flag still independently blocks listing creation. Sub-spec 2 does NOT touch it. Both checks fire on listing-creation entry; either one rejects.
+
+### 4.4 `AdminReportController` + service
+
+**User-facing endpoints** (`/api/v1/auctions/{id}/...`):
+
+```
+POST /api/v1/auctions/{id}/report
+  Body: { subject (1-100), reason (enum), details (1-2000) }
+  Auth: verified user, not the seller
+  Auction state: must be ACTIVE
+  Behavior: upsert by (auction_id, reporter_id) — resubmit replaces.
+            Resubmit resets status to OPEN even if previously DISMISSED/REVIEWED.
+            Returns the persisted report (200 OK).
+
+GET /api/v1/auctions/{id}/my-report
+  Auth: any authenticated user
+  Returns the current user's report on this auction, or 204 No Content.
+  Used by frontend to flip the button to "Reported ✓".
+```
+
+**Admin endpoints** (`/api/v1/admin/reports/...`):
+
+```
+GET /api/v1/admin/reports?status=open|reviewed|all&page&size=25
+  Returns LISTING-GROUPED rows (one per auction) sorted by reportCount DESC, latestReportAt DESC.
+  Implementation: GROUP BY auction with COUNT and MAX(updated_at) projections.
+  Each row: auctionId, auctionTitle, auctionStatus, parcelRegionName, sellerUserId,
+            sellerDisplayName, openReportCount, latestReportAt, topReason (most common).
+
+GET /api/v1/admin/reports/listing/{auctionId}
+  Returns all reports for one listing: ordered detectedAt DESC.
+  Each report includes reporter (id, displayName, dismissedReportsCount) for the
+  hyperlink-to-user-detail anchor.
+
+GET /api/v1/admin/reports/{id}
+  Single report detail.
+
+POST /api/v1/admin/reports/{id}/dismiss
+  Body: { notes (1-1000) }
+  Marks status=DISMISSED, sets reviewedBy/reviewedAt/adminNotes.
+  Increments reporter.dismissedReportsCount.
+  Writes admin_actions row (DISMISS_REPORT).
+
+POST /api/v1/admin/reports/listing/{auctionId}/warn-seller
+  Body: { notes (1-1000) }
+  Marks ONLY the OPEN reports for this listing as REVIEWED (with adminNotes).
+  DISMISSED reports stay DISMISSED — those represent deliberate per-report
+  decisions (with the reporter's frivolous counter already incremented) and
+  must not be reclassified by a listing-level action.
+  Sends LISTING_WARNED notification to seller.
+  Writes admin_actions row (WARN_SELLER_FROM_REPORT) targetType=LISTING.
+
+POST /api/v1/admin/reports/listing/{auctionId}/suspend
+  Body: { notes (1-1000) }
+  Calls SuspensionService.suspendByAdmin(auction, adminUserId, notes).
+  Marks ONLY the OPEN reports as ACTION_TAKEN. DISMISSED reports stay DISMISSED.
+  Writes admin_actions row (SUSPEND_LISTING_FROM_REPORT).
+
+POST /api/v1/admin/reports/listing/{auctionId}/cancel
+  Body: { notes (1-1000) }
+  Calls CancellationService.cancelByAdmin(auctionId, adminUserId, notes).
+  Marks ONLY the OPEN reports as ACTION_TAKEN. DISMISSED reports stay DISMISSED.
+  Writes admin_actions row (CANCEL_LISTING_FROM_REPORT).
+```
+
+All admin endpoints fail-fast 403 if not `ROLE_ADMIN` (existing matcher from sub-spec 1).
+
+### 4.5 `AdminBanController` + service
+
+```
+GET /api/v1/admin/bans?status=active|history&type=IP|AVATAR|BOTH&page&size=25
+  status=active default. type filter optional (omit for all types).
+  Each row: id, banType, ipAddress (if IP/BOTH), slAvatarUuid (if AVATAR/BOTH),
+            avatarLinkedUserId (if avatar maps to a registered user),
+            firstSeenIp (for AVATAR rows: the user's earliest RefreshToken.ipAddress),
+            reasonCategory, reasonText, bannedByDisplayName, expiresAt, createdAt,
+            liftedAt, liftedByDisplayName, liftedReason.
+
+POST /api/v1/admin/bans
+  Body: { banType, ipAddress?, slAvatarUuid?, expiresAt?, reasonCategory, reasonText (1-1000) }
+  Validation: type-matches-fields invariant enforced server-side (same as DB CHECK).
+  On create:
+    1. Save Ban row.
+    2. If banType in {AVATAR, BOTH} and a user has slAvatarUuid: bump that user's tokenVersion.
+    3. Invalidate Redis cache for ip and/or uuid keys.
+    4. Write admin_actions row (CREATE_BAN) targetType=BAN, targetId=newBan.id.
+  Returns the persisted ban row.
+
+POST /api/v1/admin/bans/{id}/lift
+  Body: { liftedReason (1-1000) }
+  Sets liftedAt=now, liftedBy=admin, liftedReason.
+  Invalidates Redis cache for the ban's ip/avatar.
+  Writes admin_actions row (LIFT_BAN).
+```
+
+### 4.6 `AdminUserController` + service + role mgmt
+
+```
+GET /api/v1/admin/users?search=&page&size=25
+  Single search box: backend tries
+    - exact match on slAvatarUuid (if input parses as UUID)
+    - case-insensitive substring match on email
+    - case-insensitive substring match on displayName
+    - case-insensitive substring match on slDisplayName
+  Empty search → most-recent users (createdAt DESC).
+  Each row: id, displayName, email, slAvatarUuid, slDisplayName, role, verified,
+            completedSales, cancelledWithBids, hasActiveBan (boolean derived from Ban table).
+
+GET /api/v1/admin/users/{id}
+  Returns the user's profile + stats:
+    id, displayName, email, slAvatarUuid, slDisplayName, role, verified, createdAt,
+    completedSales, cancelledWithBids, escrowExpiredUnfulfilled,
+    dismissedReportsCount, penaltyBalanceOwed, listingSuspensionUntil,
+    bannedFromListing (the existing penalty flag), activeBanSummary (id + banType + reasonText + expiresAt | null).
+
+GET /api/v1/admin/users/{id}/listings|bids|cancellations|reports|fraud-flags|moderation
+  Six tab endpoints, each paginated.
+  - listings: User's auctions (where seller_id = userId)
+  - bids: Bid history (manual bids only; proxy-derived bids excluded for clarity)
+  - cancellations: cancellation_log rows for this user as seller
+  - reports: union of (reports filed by user) + (reports against user's listings) with a
+             "direction" discriminator on each row (FILED_BY | AGAINST_LISTING)
+  - fraud-flags: FraudFlag rows where the underlying auction's seller = userId
+  - moderation: AdminAction rows where targetType=USER and targetId=userId
+
+GET /api/v1/admin/users/{id}/ips
+  Distinct ipAddress values from RefreshToken table for this user, ordered earliest-first.
+  Each row: ipAddress, firstSeenAt, lastSeenAt, sessionCount.
+  Used by the "Recent IPs" modal on user-detail and by the bans page's first-seen-IP column.
+
+POST /api/v1/admin/users/{id}/promote
+  Body: { notes (1-1000) }
+  Validation: target user must currently be USER. 409 ALREADY_ADMIN otherwise.
+  Behavior: User.role = ADMIN; bump tokenVersion.
+  Writes admin_actions row (PROMOTE_USER).
+
+POST /api/v1/admin/users/{id}/demote
+  Body: { notes (1-1000) }
+  Validation:
+    - Target user must currently be ADMIN. 409 NOT_ADMIN otherwise.
+    - Target user MUST NOT be the calling admin. 409 SELF_DEMOTE_FORBIDDEN otherwise.
+  Behavior: User.role = USER; bump tokenVersion.
+  Writes admin_actions row (DEMOTE_USER).
+
+POST /api/v1/admin/users/{id}/reset-frivolous-counter
+  Body: { notes (1-1000) }
+  Behavior: User.dismissedReportsCount = 0.
+  Writes admin_actions row (RESET_FRIVOLOUS_COUNTER).
+```
+
+### 4.7 `AdminAuctionService.reinstate` shared primitive
+
+```java
+public class AdminAuctionService {
+
+    @Transactional
+    public AdminAuctionReinstateResult reinstate(
+            Long auctionId, Long adminUserId, String notes,
+            Optional<OffsetDateTime> fallbackSuspendedFrom) {
+
+        Auction auction = auctionRepo.findByIdForUpdate(auctionId)
+            .orElseThrow(() -> new AuctionNotFoundException(auctionId));
+        if (auction.getStatus() != AuctionStatus.SUSPENDED) {
+            throw new AuctionNotSuspendedException(auction.getStatus());
+        }
+
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        OffsetDateTime suspendedFrom = auction.getSuspendedAt() != null
+            ? auction.getSuspendedAt()
+            : fallbackSuspendedFrom.orElse(now); // 0-extension if no record
+
+        Duration suspensionDuration = Duration.between(suspendedFrom, now);
+        OffsetDateTime newEndsAt = auction.getEndsAt().plus(suspensionDuration);
+        if (newEndsAt.isBefore(now)) {
+            newEndsAt = now.plusHours(1);  // clamp
+        }
+
+        auction.setStatus(AuctionStatus.ACTIVE);
+        auction.setSuspendedAt(null);
+        auction.setEndsAt(newEndsAt);
+        auctionRepo.save(auction);
+
+        botMonitorLifecycleService.onAuctionResumed(auction);
+
+        notificationPublisher.listingReinstated(
+            auction.getSeller().getId(), auction.getId(),
+            auction.getTitle(), newEndsAt);
+
+        // Audit row written by caller (caller decides target_type — LISTING for the
+        // standalone endpoint, FRAUD_FLAG-context-bound for the sub-spec 1 path).
+        return new AdminAuctionReinstateResult(auction, suspensionDuration, newEndsAt);
+    }
+}
+```
+
+**Sub-spec 1 refactor**: `AdminFraudFlagService.reinstate(flagId, adminUserId, notes)` decomposes:
+1. Load flag → 404 if missing → 409 if already resolved → check auction non-null
+2. Call `adminAuctionService.reinstate(flag.auction.id, adminUserId, notes, Optional.of(flag.detectedAt))`
+3. Mark flag resolved with notes
+4. Write admin_actions row (no — sub-spec 1 didn't write to admin_actions for fraud flags; flag.resolvedBy is the audit. Stays that way to avoid a breaking change.)
+
+Net behavior: identical to sub-spec 1 today. The refactor extracts the auction-state-change into a reusable service.
+
+**New endpoint**: `POST /api/v1/admin/auctions/{id}/reinstate` body `{notes}`. Calls `adminAuctionService.reinstate(id, adminUserId, notes, Optional.empty())` then writes `admin_actions` row (REINSTATE_LISTING, target_type=LISTING). Used by the user-detail Listings tab "Reinstate" button (visible per row when status=SUSPENDED).
+
+### 4.8 `SuspensionService.suspendByAdmin` (new path)
+
+Adds an admin-driven suspension entry point alongside the existing ownership-monitor / bot-monitor / cancel-and-sell paths.
+
+```java
+@Transactional
+public void suspendByAdmin(Auction auction, Long adminUserId, String notes) {
+    OffsetDateTime now = OffsetDateTime.now(clock);
+    auction.setStatus(AuctionStatus.SUSPENDED);
+    if (auction.getSuspendedAt() == null) {
+        auction.setSuspendedAt(now);
+    }
+    auctionRepo.save(auction);
+
+    // No FraudFlag created — admin reason, not a fraud-detection event.
+    monitorLifecycle.onAuctionClosed(auction);
+
+    notificationPublisher.listingSuspended(
+        auction.getSeller().getId(), auction.getId(),
+        auction.getTitle(), "Suspended by SLPA staff");
+    // Existing LISTING_SUSPENDED category; reason text differs from fraud-driven reasons.
+}
+```
+
+The reports-queue `POST .../suspend` endpoint calls this.
+
+### 4.9 `CancellationService.cancelByAdmin` (new path)
+
+```java
+@Transactional
+public Auction cancelByAdmin(Long auctionId, Long adminUserId, String notes) {
+    Auction a = auctionRepo.findByIdForUpdate(auctionId)
+        .orElseThrow(() -> new AuctionNotFoundException(auctionId));
+    if (!CANCELLABLE.contains(a.getStatus())) {
+        throw new InvalidAuctionStateException(a.getId(), a.getStatus(), "ADMIN_CANCEL");
+    }
+    User admin = userRepo.findById(adminUserId).orElseThrow();
+
+    // Skip penalty ladder. Skip seller-row lock (no seller-side state changes).
+    logRepo.save(CancellationLog.builder()
+        .auction(a).seller(a.getSeller())
+        .cancelledFromStatus(a.getStatus().name())
+        .hadBids(a.getBidCount() != null && a.getBidCount() > 0)
+        .reason(notes)
+        .penaltyKind(CancellationOffenseKind.NONE)
+        .penaltyAmountL(null)
+        .cancelledByAdminId(adminUserId)  // NEW field
+        .build());
+
+    a.setStatus(AuctionStatus.CANCELLED);
+    auctionRepo.save(a);
+
+    monitorLifecycle.onAuctionClosed(a);
+    broadcastPublisher.publishStatusChanged(a);
+
+    // Seller side: distinct LISTING_REMOVED_BY_ADMIN category.
+    notificationPublisher.listingRemovedByAdmin(
+        a.getSeller().getId(), a.getId(), a.getTitle(), notes);
+
+    // Bidder side: same fan-out as seller-driven cancel — bidders need to know
+    // their proxy max won't fire. Reuses LISTING_CANCELLED_BY_SELLER category
+    // for bidders since the bidder's outcome is identical regardless of cause
+    // (auction is gone, proxy is wasted). Body copy is cause-neutral so it
+    // works for both seller-cancel and admin-cancel callers.
+    notificationPublisher.listingCancelledBySellerFanout(
+        a.getId(), a.getTitle(), bidderUserIds(a), notes);
+
+    return a;
+}
+```
+
+The existing `listingCancelledBySellerFanout` method body is updated so the title/body strings are cause-neutral ("This auction has been cancelled. Your active proxy bid is no longer in effect.") instead of seller-attributed. That copy applies cleanly to both callers (seller-cancel and admin-cancel).
+
+`bidderUserIds(a)` returns distinct user ids from `Bid` and `ProxyBid` rows on the auction (excluding the seller, who already gets the seller-side notification). Reuses the same query the existing seller-cancel fan-out uses — sub-spec 2 doesn't add new query infrastructure.
+
+**`CancellationLog.cancelledByAdminId`** — new nullable column. The existing `countPriorOffensesWithBids` query updated:
+
+```java
+@Query("""
+    SELECT COUNT(c) FROM CancellationLog c
+    WHERE c.seller.id = :sellerId
+      AND c.hadBids = true
+      AND c.penaltyKind <> 'NONE'
+      AND c.cancelledByAdminId IS NULL
+""")
+long countPriorOffensesWithBids(@Param("sellerId") Long sellerId);
+```
+
+Admin-cancel rows don't count as seller offenses. Existing `seller.cancelledWithBids` counter — also NOT incremented on admin cancel. The penalty ladder index stays consistent for the seller's actual choices.
+
+### 4.10 New notification categories
+
+```java
+LISTING_WARNED(NotificationGroup.LISTING_STATUS),
+LISTING_REMOVED_BY_ADMIN(NotificationGroup.LISTING_STATUS),
+```
+
+Both default ON (LISTING_STATUS group default). Standard notification flow — in-app row + SL IM dispatch via existing channel.
+
+`NotificationPublisher` gains:
+```java
+void listingWarned(long sellerUserId, long auctionId, String parcelName, String notes);
+void listingRemovedByAdmin(long sellerUserId, long auctionId, String parcelName, String reason);
+```
+
+### 4.11 `AdminAction` audit table
+
+```java
+@Entity @Table(name = "admin_actions",
+    indexes = {
+        @Index(columnList = "target_type, target_id, created_at DESC"),
+        @Index(columnList = "admin_user_id, created_at DESC")
+    })
+public class AdminAction {
+    @Id @GeneratedValue Long id;
+    @ManyToOne(fetch = LAZY, optional = false) @JoinColumn(name = "admin_user_id") User adminUser;
+    @Enumerated(EnumType.STRING) @Column(length = 40, nullable = false) AdminActionType actionType;
+    @Enumerated(EnumType.STRING) @Column(length = 20, nullable = false) AdminActionTargetType targetType;
+    @Column(name = "target_id", nullable = false) Long targetId;
+    @Column(columnDefinition = "text") String notes;
+    @JdbcTypeCode(SqlTypes.JSON) @Column(columnDefinition = "jsonb") Map<String, Object> details;
+    @CreationTimestamp OffsetDateTime createdAt;
+}
+
+enum AdminActionType {
+    DISMISS_REPORT, WARN_SELLER_FROM_REPORT, SUSPEND_LISTING_FROM_REPORT, CANCEL_LISTING_FROM_REPORT,
+    CREATE_BAN, LIFT_BAN,
+    PROMOTE_USER, DEMOTE_USER, RESET_FRIVOLOUS_COUNTER,
+    REINSTATE_LISTING
+}
+enum AdminActionTargetType { USER, LISTING, REPORT, FRAUD_FLAG, BAN }
+```
+
+Sub-spec 1's fraud-flag actions are NOT backfilled; their audit is the FraudFlag row itself. Sub-spec 2 forward only.
+
+`GET /api/v1/admin/audit?targetType=&targetId=&adminUserId=&page&size=25` — paginated, sort `createdAt DESC`. The user-detail Moderation tab queries `targetType=USER&targetId={userId}`.
+
+### 4.12 `User.dismissedReportsCount`
+
+```java
+@Column(name = "dismissed_reports_count", nullable = false)
+@Builder.Default
+private long dismissedReportsCount = 0L;
+```
+
+Increments inside the dismiss-report transaction:
+```java
+reporter.setDismissedReportsCount(reporter.getDismissedReportsCount() + 1);
+userRepo.save(reporter);
+```
+
+No automatic privilege revocation. Surfaces on the admin user-detail stats card. Reset endpoint zeroes it.
+
+---
+
+## 5. Frontend pieces
+
+### 5.1 Auction-detail Report button + modal
+
+**Button placement**: title row of `/auction/[id]`, right side, neutral border, flag icon (⚐) + "Report" label. State machine:
+- Anonymous user → hidden
+- Logged-in but not verified → disabled with tooltip "Verify your SL avatar to report listings"
+- Logged-in verified, current user is the seller → hidden
+- Logged-in verified, not seller, no existing report → enabled
+- Logged-in verified, not seller, existing report (any status) → "Reported ✓" disabled. Click does nothing. Modal NOT opened. (Reporter must wait until admin DISMISSES — at which point existing-report query returns 204 — to file again.)
+
+Hook: `useMyReport(auctionId)` queries `GET /api/v1/auctions/{id}/my-report` (cached, only fires when user is verified). Determines button state.
+
+Wait — the button-state spec above conflicts with the resubmit-after-dismiss flow. Let me reconcile:
+
+Actually, the GET /api/v1/auctions/{id}/my-report endpoint should return the existing report regardless of status (unless dismissed AND admin reset something). The frontend reads the `status` field:
+- No existing row → 204 → button shows "Report"
+- Existing row, status in {OPEN, REVIEWED, ACTION_TAKEN} → button shows "Reported ✓" disabled
+- Existing row, status = DISMISSED → button shows "Report" enabled (allows resubmit)
+
+This way the button automatically re-enables after admin dismisses, and the resubmit upserts the row back to OPEN. Modal opens BLANK on resubmit (per Q decision; modal does not pre-fill).
+
+### 5.2 Report modal
+
+3 fields (subject 100, reason dropdown, details 2000) + disclosure block + Cancel/Submit buttons. On submit: `POST .../report`, success toast "Report submitted. Our team will review it.", invalidate `useMyReport(auctionId)` so button updates. Failure → toast "Couldn't submit report" + leaves modal open.
+
+### 5.3 Admin reports queue page
+
+Listing-grouped table at `/admin/reports`. Filter pills (Open/Reviewed/All). 5 columns: report-count (right-aligned, prominent, color-tinted on count >= 3), listing (title + region + auction id + seller + time-left), latestReportAt, top-reason badge, auctionStatus.
+
+URL state: `?status=open|reviewed|all&page=N&auctionId=N` (auctionId opens the slide-over).
+
+Click row → URL gains `auctionId=N` → slide-over (560px) opens with:
+- Header: open-count badge + auction context + "View listing" link + close
+- 4 action buttons (Warn / Suspend / Cancel / Ban seller — last navigates to `/admin/users/{sellerId}`)
+- All reports for this listing as cards: reporter name (linked to `/admin/users/{reporterId}`), reason badge, subject, details, per-report Dismiss button
+- Shared notes textarea at bottom (used by whichever main action button fires)
+
+Mutations invalidate both `["admin", "reports"]` and `["admin", "stats"]` query keys.
+
+### 5.4 Admin bans page
+
+`/admin/bans` with Active / History tabs. Type filter pills (All/IP/Avatar/Both). Table columns: type badge (red IP / purple AVATAR / amber BOTH), identifiers (UUID linked to user-detail when applicable, plus first-seen-IP for AVATAR rows), reason (truncated), bannedBy, expires, Lift action.
+
+Create-ban modal:
+- Type selector (3-up: IP only / Avatar only / Both)
+- Identifier inputs (conditional on type)
+  - User-search autocomplete: types user name → backend returns matches → select user → fills slAvatarUuid AND/OR most-recent IP
+  - Direct UUID/IP input (manual paste)
+- Expiry: Permanent / Pick date…
+- Reason category dropdown (SHILL_BIDDING / FRAUDULENT_SELLER / TOS_ABUSE / SPAM / OTHER) + reason-text textarea (1-1000, required)
+- Side-effect note explaining tv-bump + cache flush
+- Cancel / Create ban actions
+
+Pre-filled variant (from user-detail "+ Add another ban" button): SL UUID and most-recent IP populated from the user record.
+
+### 5.5 Admin user search + detail
+
+`/admin/users` — single search input + paginated table. 7 columns: display name (with `{N} sold · {N} cancelled` muted under), email, slAvatarUuid (truncated), role chip, verified chip, banned chip (if active ban matches user's slAvatarUuid), member since.
+
+`/admin/users/{id}` — profile header (Banned chip + email + truncated UUID + verified + last-seen + role chip), 5 stat cards (sold, cancelled-w-bids, escrow-expired, dismissed-reports, penalty-owed L$), 6 tabs (Listings / Bids / Cancellations / Reports / Fraud flags / Moderation).
+
+**280px right rail**:
+- Active-ban callout (if any active ban) — type, expiry, reason, bannedBy, "Lift ban with notes…" button
+- Action buttons stacked: Promote (USER only), Demote (ADMIN only, disabled with reason inline if N/A; self-demote returns 409 SELF_DEMOTE_FORBIDDEN), Reset frivolous counter (only when count > 0), "+ Add another ban…"
+- Quick links: Public profile, Copy SL UUID, Recent IPs (modal)
+
+**"Recent IPs" modal**: list of distinct IPs from `RefreshToken` for this user, sorted earliest-first, with first/last-seen timestamps and session count. Each row has a "Ban this IP" button that opens the ban-create modal pre-filled with type=IP and the chosen IP.
+
+**Listings tab — Reinstate button**: per row when `status === "SUSPENDED"`, "Reinstate" action button opens a notes modal. On submit, calls `POST /api/v1/admin/auctions/{id}/reinstate` with `{notes}`. Success → invalidate `["admin", "users", id, "listings"]` and `["admin", "stats"]`. Failure → 409 toast.
+
+### 5.6 Dashboard 4-up
+
+Sub-spec 1's dashboard's needs-attention row gains a 4th card (Open reports → `/admin/reports?status=open`) in single 4-up row. Card sizes shrink (24px value glyph instead of 32px). Future cards add to the same row.
+
+`AdminStatsResponse.queues` gains `openReports: number`. The frontend `QueueCard` renders identical for the new card.
+
+### 5.7 Mutations follow the established pattern
+
+All admin write mutations:
+- Use `useMutation` with `onSuccess` invalidating BOTH the relevant list cache AND `["admin", "stats"]` (keeps the dashboard counts honest).
+- 409 paths handled by reading the `code` field from the error body, with specific toast copy per code (`ALREADY_RESOLVED`, `AUCTION_NOT_SUSPENDED`, `SELF_DEMOTE_FORBIDDEN`, `USER_BANNED`, etc.).
+- All write actions require non-empty notes; 400 `VALIDATION_FAILED` if empty.
+
+---
+
+## 6. Data flow scenarios
+
+### 6.1 User reports a listing (first time)
+
+1. Verified user lands on `/auction/893`. `useMyReport(893)` returns 204 → button shows "Report" enabled.
+2. User clicks → modal opens blank. User types subject + selects "Shill bidding" + types details. Submits.
+3. Backend `POST /api/v1/auctions/893/report` validates (verified, not seller, auction ACTIVE), upserts a ListingReport with status=OPEN.
+4. Response 200. Frontend invalidates `useMyReport(893)` → button flips to "Reported ✓" disabled.
+5. Toast: "Report submitted. Our team will review it."
+6. No notification to admin this sub-spec (deferred). Admin sees the report on next visit to `/admin/reports`.
+
+### 6.2 User resubmits after admin dismisses
+
+1. Admin dismisses report. `report.status = DISMISSED`. Reporter's `dismissedReportsCount += 1`.
+2. User reloads `/auction/893`. `useMyReport(893)` now returns the dismissed report → frontend reads `status === "DISMISSED"` → button re-enables to "Report".
+3. User clicks → modal opens BLANK (per design decision — pre-fill explicitly rejected).
+4. Submit upserts the SAME row (matching unique key on auction+reporter), resets status to OPEN.
+
+### 6.3 Admin triages a listing with 5 reports
+
+1. Admin clicks Reports in sidebar. List shows 5 listings, top one has report count 5.
+2. Admin clicks the top row. Slide-over opens.
+3. Admin reads the 5 reports. Decides 3 are credible (shill-bidding pattern). Decides on Suspend.
+4. Admin types notes "Verified shill pattern from same IP across 3 accounts." Clicks Suspend.
+5. Backend: `SuspensionService.suspendByAdmin(auction, adminUserId, notes)` flips status, sets suspendedAt if null, calls `monitorLifecycle.onAuctionClosed`, publishes `LISTING_SUSPENDED` to seller. Then marks all OPEN reports for this listing as ACTION_TAKEN with adminNotes. Then writes admin_actions row.
+6. Slide-over closes. Reports list cache invalidated. Stats counter ticks down.
+7. Seller (in-app + SL IM): "Listing suspended: Beachfront 1024m². Reason: Suspended by SLPA staff. Contact support for details."
+
+### 6.4 Admin reinstates a wrongly-suspended listing (from user-detail)
+
+1. Admin navigates to `/admin/users/4218`. Listings tab shows 17 listings; top one is SUSPENDED.
+2. Admin clicks "Reinstate" on the row. Notes modal opens.
+3. Admin types "Reviewed reports — clear false positives. Restoring." Clicks Reinstate.
+4. Backend: `AdminAuctionService.reinstate(auctionId, adminUserId, notes, Optional.empty())`. suspendedFrom = auction.suspendedAt (set by sub-spec 2's suspendByAdmin). Computes duration, extends endsAt, flips status, clears suspendedAt, re-engages bot monitor (if BOT-tier), publishes `LISTING_REINSTATED`.
+5. Backend writes admin_actions row (REINSTATE_LISTING, target_type=LISTING).
+6. Frontend invalidates listings tab + stats. Toast: "Auction reinstated."
+7. Seller notification: "Your auction has been reinstated. All existing bids and proxy maxes are preserved. Ends Apr 28, 14:35 UTC."
+8. Reports remain in their current state (ACTION_TAKEN). Admin can dismiss them separately if they want to clear the historical fact (but typically they won't — actioned reports are part of the audit trail).
+
+### 6.5 Admin creates a ban on a user with active session
+
+1. From `/admin/users/4218`, admin clicks "+ Add another ban…" or follows the report queue's "Ban seller" link. Modal opens pre-filled with the user's slAvatarUuid.
+2. Admin selects type=AVATAR, expiry=Permanent, reason=SHILL_BIDDING + reason text. Submits.
+3. Backend: validate type-matches-fields → save Ban row → bump tokenVersion on the user (since slAvatarUuid maps) → invalidate Redis cache key `bans:active:avatar:<uuid>` → write admin_actions.
+4. The user is currently logged in. Their access token is still valid (carries old tv) until expiry. On their next access-token refresh (within ~15 min), the new tv invalidates → 401 → frontend redirects to login. They can't login back in (banned IP/avatar — login endpoint hits BanCheckService).
+
+### 6.6 Banned user attempts to bid
+
+1. Banned user opens `/auction/893` while their cached page still works (browser SW or cached SSR).
+2. They try to place a bid. `POST /api/v1/auctions/893/bid` reaches `BidController` which captures IP via `httpRequest.getRemoteAddr()`. Service calls `BanCheckService.assertNotBanned(ip, user.slAvatarUuid)`.
+3. Cache miss → DB query → finds active AVATAR ban → cached for 5 min → throws `UserBannedException`.
+4. Response 403 `{code: USER_BANNED, expiresAt: null}`.
+5. Frontend toast: "Your account is suspended. Contact support if you believe this is in error."
+
+### 6.7 Race: admin deletes their own admin role
+
+1. Heath navigates to `/admin/users/{heath_id}` (his own detail page). Demote button visible.
+2. Heath clicks Demote → notes modal → submits.
+3. Backend `POST /admin/users/{heath_id}/demote`: target user = current user → throws `SelfDemoteException` → 409 `{code: SELF_DEMOTE_FORBIDDEN}`.
+4. Frontend toast: "You cannot demote yourself." Modal stays open. Heath can cancel.
+
+---
+
+## 7. Error handling
+
+`AdminExceptionHandler` (sub-spec 1) extended with new exception types:
+
+| Exception | HTTP | Body code |
+|-----------|------|-----------|
+| `ListingReportNotFoundException` | 404 | `REPORT_NOT_FOUND` |
+| `BanNotFoundException` | 404 | `BAN_NOT_FOUND` |
+| `BanAlreadyLiftedException` | 409 | `BAN_ALREADY_LIFTED` |
+| `BanTypeFieldMismatchException` | 400 | `BAN_TYPE_FIELD_MISMATCH` |
+| `SelfDemoteException` | 409 | `SELF_DEMOTE_FORBIDDEN` |
+| `UserAlreadyAdminException` | 409 | `ALREADY_ADMIN` |
+| `UserNotAdminException` | 409 | `NOT_ADMIN` |
+| `AlreadyReportedByUserException` | (no — upsert means resubmit succeeds) | — |
+| `CannotReportOwnListingException` | 409 | `CANNOT_REPORT_OWN_LISTING` |
+| `MustBeVerifiedToReportException` | 403 | `VERIFICATION_REQUIRED` |
+| `AuctionNotActiveForReportException` | 409 | `AUCTION_NOT_REPORTABLE` |
+
+`UserBannedException` → 403 `{code: USER_BANNED, expiresAt: <iso8601 \| null>}` — handled by `GlobalExceptionHandler` (user-facing path) so the existing user-facing endpoints get the same error shape. Sub-spec 2 adds the handler if not present.
+
+---
+
+## 8. Testing strategy
+
+### Backend
+
+#### Unit tests (Mockito)
+
+- `AdminReportServiceTest` — dismiss happy path, dismiss already-dismissed (idempotent re-write — no error since notes update is allowed), warn/suspend/cancel batching of OPEN reports for a listing, frivolous-counter increment on dismiss.
+- `AdminBanServiceTest` — create-ban write flow (with Redis cache invalidation mock), tv-bump only when slAvatarUuid maps to a user, lift-ban write flow with cache invalidation.
+- `BanCheckServiceTest` — cache-hit path (no DB query), cache-miss path (DB query + write back), expired ban not enforced, lifted ban not enforced, type-mismatched ban (IP-only ban does NOT trigger on a UUID-only check) not enforced.
+- `AdminUserServiceTest` — search routing (UUID-mode vs substring-mode), promote validates ALREADY_ADMIN, demote validates NOT_ADMIN + self-demote, reset-counter zeroes the field.
+- `AdminAuctionServiceTest` — reinstate happy path with explicit `suspendedAt`, reinstate with fallbackSuspendedFrom (sub-spec 1 path simulation), reinstate with neither (0-extension), reinstate auction-not-suspended throws, endsAt clamping when math yields past.
+- `CancellationServiceCancelByAdminTest` — admin cancel does NOT increment seller.cancelledWithBids, does NOT charge penalty, log row has cancelledByAdminId set, sends LISTING_REMOVED_BY_ADMIN.
+
+#### Slice tests (`@SpringBootTest + @AutoConfigureMockMvc`)
+
+- `AdminReportControllerSliceTest` — all admin endpoints: 401 anon, 403 USER, 200 ADMIN; body validation; 409 paths.
+- `AdminBanControllerSliceTest` — same auth gates; create-ban with type-mismatch returns 400; lift returns 409 if already lifted.
+- `AdminUserControllerSliceTest` — search response shape; promote/demote 409 paths; self-demote 409.
+- `AdminAuctionControllerSliceTest` — reinstate auth gates + 409 AUCTION_NOT_SUSPENDED.
+- `AuctionReportControllerSliceTest` — user-facing report endpoint: anonymous 401, unverified 403, own listing 409, non-ACTIVE auction 409, valid report 200, resubmit 200 (upsert).
+
+#### Integration tests (`@SpringBootTest + @ActiveProfiles("dev")` + 9-line scheduler-disable property block)
+
+- `ReportsFullFlowIntegrationTest` — user submits report → admin dismisses → user resubmits (upsert verified) → admin warns (REVIEWED + LISTING_WARNED) → admin suspends (ACTION_TAKEN on all OPEN + LISTING_SUSPENDED + admin_actions row).
+- `BansEnforcementIntegrationTest` — create AVATAR ban → BanCheckService rejects bid by user with that avatar → lift ban → BanCheckService allows bid (after Redis cache flush). Repeat for IP and BOTH.
+- `BansSessionInvalidationIntegrationTest` — create AVATAR ban → tokenVersion bumps on user → user's old access token returns 401 on next request.
+- `AdminCancelBypassesPenaltyLadderIntegrationTest` — seller has 2 prior offenses → admin cancels → log row written with cancelledByAdminId → query countPriorOffensesWithBids still returns 2 (admin cancel excluded) → seller.cancelledWithBids unchanged.
+- `AdminAuctionReinstateIntegrationTest` — admin suspends listing via reports queue (no fraud flag created) → admin reinstates via /admin/auctions/{id}/reinstate → auction status flips ACTIVE, suspendedAt cleared, endsAt extended, MONITOR_AUCTION row spawned (BOT tier), LISTING_REINSTATED notification, admin_actions row written.
+- `FrivolousCounterIntegrationTest` — user reports 3 times → admin dismisses each → user.dismissedReportsCount = 3 → admin resets counter → field = 0, admin_actions row written.
+
+### Frontend (Vitest + React Testing Library)
+
+- `ReportButton.test.tsx` — state matrix: anonymous (hidden), unverified (disabled with tooltip), seller (hidden), reportable (enabled), already-reported (disabled "Reported ✓"), dismissed-by-admin (re-enabled).
+- `ReportModal.test.tsx` — field validation, submit flow, error handling.
+- `AdminReportsListPage.test.tsx` — listing-grouped rendering, slide-over open on row click, action button flow, per-report dismiss flow.
+- `AdminBansListPage.test.tsx` — active/history tab toggle, type filter, lift action.
+- `BanCreateModal.test.tsx` — type-selector conditionals (IP fields render for IP/BOTH, avatar field renders for AVATAR/BOTH), user-search autocomplete, validation.
+- `AdminUsersSearchPage.test.tsx` — single-search input, results table with all columns including activity meta.
+- `AdminUserDetailPage.test.tsx` — profile + stats + tab navigation; action buttons fire mutations and invalidate caches.
+- `RecentIpsModal.test.tsx` — fetches and displays IP list; "Ban this IP" button opens ban-create modal pre-filled.
+
+### Manual test plan (run before merge)
+
+1. Sign in as USER → `/auction/[id]` → report a listing → verify modal flow, button flips to "Reported ✓".
+2. Sign in as admin → `/admin/reports` → see the report → drill into slide-over → dismiss with notes → verify report status DISMISSED, frivolous counter on user-detail = 1.
+3. Resubmit the report as the original user → button enabled again → submit → verify button flips back to "Reported ✓" and admin sees a fresh OPEN report.
+4. Admin warns seller (different report) → verify seller gets `LISTING_WARNED` notification.
+5. Admin suspends listing (different report) → verify seller gets `LISTING_SUSPENDED` notification, all open reports for that listing → ACTION_TAKEN. Verify auction stays SUSPENDED until admin reinstates.
+6. Admin reinstates from user-detail Listings tab → verify auction → ACTIVE, endsAt extended, seller gets `LISTING_REINSTATED`.
+7. Admin admin-cancels another listing → verify seller gets `LISTING_REMOVED_BY_ADMIN`, no penalty applied (cancellation_log row has `cancelledByAdminId`, `seller.cancelledWithBids` unchanged).
+8. Admin creates AVATAR ban on a user → user is logged in → verify on next refresh, user is logged out (tv bump).
+9. Banned user attempts bid → 403 with USER_BANNED code.
+10. Admin lifts ban with notes → user logs in normally, can bid again.
+11. Admin self-demote test → 409.
+12. Admin creates ban via "Recent IPs" modal → verify IP-type ban is created with the chosen IP.
+
+---
+
+## 9. Documentation updates (in this sub-spec PR)
+
+- `docs/initial-design/DESIGN.md` — append "Notes (Epic 10 sub-spec 2)" subsection to §8.
+- `docs/implementation/DEFERRED_WORK.md`:
+  - Close: ban system (Epic 03/05/06 deferred entries that mentioned "needs admin role"), listing reports (Epic 03 PARCEL-code-rate-tracking subset that mentions reports infrastructure).
+  - Modify: account deletion entry (sub-spec 4 target retained).
+  - Add: `REPORT_THRESHOLD_REACHED` admin notification, with re-add trigger ("admins missing high-report listings").
+- `docs/implementation/FOOTGUNS.md` — append F.103–F.10X (numbers verified at write time):
+  - Ban-cache TTL is 5min; admin-create flushes immediately, but a 5-min stale-window exists where a banned avatar could still bid if cached pre-ban. Acceptable tradeoff.
+  - `BanCheckService.assertNotBanned(null, null)` is a no-op — both args optional. Caller responsible for passing what they have.
+  - Listing-grouped reports queue uses GROUP BY auction_id; querying by status="open" is the operational query and must hit the index `(status, auction_id)`. Add explicit composite index if EXPLAIN reveals seq scan at scale.
+  - Resubmit upsert resets status to OPEN — admin who dismissed a report sees it pop back into queue if reporter re-files. This is intentional (escape valve for "issue still happening") but admins should know.
+  - `cancelByAdmin` writes `CancellationLog` rows with `cancelledByAdminId`; the existing `countPriorOffensesWithBids` query MUST exclude these or admin cancels accidentally count as seller offenses. Test covers it.
+- `CLAUDE.md` (root) — short paragraph noting reports/bans/admin-user-mgmt under existing admin section.
+
+---
+
+## 10. Sub-spec wrap-up checklist
+
+- [ ] All backend tests pass (`./mvnw test`)
+- [ ] All frontend tests pass (`npm test`) + lint clean (`npm run lint`)
+- [ ] Manual test plan run (12 scenarios)
+- [ ] DEFERRED_WORK.md updated (close/modify/add)
+- [ ] FOOTGUNS.md updated with new entries (numbers continuous after sub-spec 1's F.102)
+- [ ] DESIGN.md §8 gains sub-spec 2 notes subsection
+- [ ] CLAUDE.md root reference updated if section structure warrants
+
+---
+
+## 11. Risks & rollback
+
+**Rollback**: revert the merge. JPA `ddl-auto: update` does not auto-drop the new columns/tables (`listing_reports`, `bans`, `admin_actions`, `User.dismissedReportsCount`, `CancellationLog.cancelledByAdminId`). All remain as orphan schema objects — Hibernate ignores. A follow-up SQL would clean up if rollback is permanent.
+
+**Risk: Redis cache desync with bans table.** Mitigation: cache invalidation runs in afterCommit hook of ban-write transaction; cache TTL caps stale-window at 5 min even in the worst case. Documented.
+
+**Risk: ban-check IP from `getRemoteAddr()` is the proxy IP, not real client IP** if the app is behind a load balancer that doesn't set `X-Forwarded-For`. Same risk applies to existing IP-capture code (RefreshToken, Bid) — sub-spec 2 doesn't make this worse. Pre-launch ops checklist item.
+
+**Risk: ListingReport unique constraint upsert race.** Two concurrent POSTs from the same user would collide. JPA's `INSERT ... ON CONFLICT DO UPDATE` is the right idiom; or a try-catch on `DataIntegrityViolationException` retrying as update. Use the latter (Spring Data idiomatic), narrow window — concurrent posts from the same user are rare.
+
+**Risk: Admin-bumped tokenVersion races with in-flight refresh.** The user has 1 second of grace window where their refresh could succeed with the old tv. Acceptable — the next request after that is rejected.
+
+**Risk: `firstSeenIp` column on bans page reads from RefreshToken history**, which is a join — could be slow at scale. Mitigate by capping the join to most-recent N tokens and noting the limit on the column tooltip. Sub-day operational concern at current scale.
+
+---
+
+## 12. Open questions / explicitly resolved
+
+- **3-report threshold notification**: ✅ deferred (DEFERRED_WORK).
+- **Frivolous reporter automatic revocation**: ✅ counter only this sub-spec, no automatic revoke.
+- **Admin-cancel skips penalty ladder**: ✅ confirmed via separate `cancelByAdmin` path + `cancelledByAdminId` exclusion.
+- **Reinstate path for admin-suspended listings**: ✅ extracted `AdminAuctionService.reinstate` shared primitive; standalone endpoint + user-detail Listings tab button.
+- **Multi-ban stacking**: ✅ allowed; same user can have AVATAR + IP bans.
+- **First-seen IP on bans list**: ✅ shown for AVATAR rows.
+- **Reason categories on ban**: ✅ preset enum + free text.
+- **Modal autocomplete for ban-create from /admin/bans**: ✅ user-search autocomplete.
+- **IP history exposed on user-detail**: ✅ "Recent IPs" modal.
+- **Self-demote guard**: ✅ 409 SELF_DEMOTE_FORBIDDEN.
+- **Resubmit pre-fill**: ✅ blank, not pre-filled.
+- **Frivolous reports disclosure on report modal**: ✅ kept.
+- **Dashboard 4-up layout**: ✅ 4-up single row.
+
+---
+
+## 13. Glossary
+
+| Term | Meaning |
+|---|---|
+| Listing report | A user-filed flag on an auction. Subject + reason + details. Upsert by (auction, reporter). |
+| Frivolous reporter | A user whose `dismissedReportsCount` is non-zero. Counter only — no automatic privilege revocation this sub-spec. |
+| Ban | A row in the `bans` table. Active = not lifted AND not expired. By IP, SL avatar, or both. |
+| Admin-cancel | Admin-driven listing cancellation via `CancellationService.cancelByAdmin`. Skips penalty ladder. |
+| Admin-suspend | Admin-driven listing suspension via `SuspensionService.suspendByAdmin`. No fraud flag created. |
+| Reinstate | Restoring SUSPENDED auction to ACTIVE via shared `AdminAuctionService.reinstate`. Independent of why it was suspended. |
+| `admin_actions` | Audit table — every admin write action sub-spec 2 forward. Indexed by (target_type, target_id) for "what happened to this user/listing/etc." queries. |
+| Sibling | Another open report on the same auction (or another open fraud flag — same concept from sub-spec 1). |

--- a/frontend/src/app/admin/bans/page.tsx
+++ b/frontend/src/app/admin/bans/page.tsx
@@ -1,0 +1,5 @@
+import { AdminBansPage } from "@/components/admin/bans/AdminBansPage";
+
+export default function AdminBansRoute() {
+  return <AdminBansPage />;
+}

--- a/frontend/src/app/admin/reports/page.tsx
+++ b/frontend/src/app/admin/reports/page.tsx
@@ -1,0 +1,5 @@
+import { AdminReportsListPage } from "@/components/admin/reports/AdminReportsListPage";
+
+export default function AdminReportsRoute() {
+  return <AdminReportsListPage />;
+}

--- a/frontend/src/app/admin/users/[id]/page.tsx
+++ b/frontend/src/app/admin/users/[id]/page.tsx
@@ -1,0 +1,16 @@
+import { AdminUserDetailPage } from "@/components/admin/users/AdminUserDetailPage";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function AdminUserDetailRoute({ params }: Props) {
+  const { id } = await params;
+  const userId = parseInt(id, 10);
+
+  if (!Number.isFinite(userId) || userId <= 0) {
+    return <div className="py-12 text-body-sm text-error">Invalid user ID.</div>;
+  }
+
+  return <AdminUserDetailPage userId={userId} />;
+}

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,0 +1,5 @@
+import { AdminUsersSearchPage } from "@/components/admin/users/AdminUsersSearchPage";
+
+export default function AdminUsersRoute() {
+  return <AdminUsersSearchPage />;
+}

--- a/frontend/src/app/auction/[id]/AuctionDetailClient.tsx
+++ b/frontend/src/app/auction/[id]/AuctionDetailClient.tsx
@@ -30,6 +30,7 @@ import { AuctionEndedRow } from "@/components/auction/AuctionEndedRow";
 import { formatRemainingLabel } from "@/components/auction/SnipeExtensionBanner";
 import { StickyBidBar } from "@/components/auction/StickyBidBar";
 import { BidSheet } from "@/components/auction/BidSheet";
+import { ReportListingButton } from "@/components/auction/ReportListingButton";
 
 /**
  * Client shell for the auction detail page.
@@ -380,7 +381,15 @@ export function AuctionDetailClient({ initialAuction, initialBidPage }: Props) {
             snapshotUrl={auction.parcel.snapshotUrl}
             regionName={auction.parcel.regionName}
           />
-          <ParcelInfoPanel auction={auction} />
+          <ParcelInfoPanel
+            auction={auction}
+            reportButton={
+              <ReportListingButton
+                auctionId={id}
+                sellerId={auction.sellerId}
+              />
+            }
+          />
           <VisitInSecondLifeBlock
             regionName={auction.parcel.regionName}
             positionX={auction.parcel.positionX}

--- a/frontend/src/components/admin/AdminShell.test.tsx
+++ b/frontend/src/components/admin/AdminShell.test.tsx
@@ -49,7 +49,7 @@ describe("AdminShell", () => {
     server.use(
       authHandlers.refreshSuccess(mockAdminUser),
       adminHandlers.statsSuccess({
-        queues: { openFraudFlags: 5, pendingPayments: 0, activeDisputes: 0 },
+        queues: { openFraudFlags: 5, openReports: 0, pendingPayments: 0, activeDisputes: 0 },
         platform: {
           activeListings: 0,
           totalUsers: 0,

--- a/frontend/src/components/admin/AdminShell.tsx
+++ b/frontend/src/components/admin/AdminShell.tsx
@@ -22,6 +22,9 @@ export function AdminShell({ children }: { children: ReactNode }) {
   const items: SidebarItem[] = [
     { label: "Dashboard", href: "/admin" },
     { label: "Fraud Flags", href: "/admin/fraud-flags", badge: stats?.queues.openFraudFlags },
+    { label: "Reports", href: "/admin/reports", badge: stats?.queues.openReports },
+    { label: "Bans", href: "/admin/bans" },
+    { label: "Users", href: "/admin/users" },
   ];
 
   return (

--- a/frontend/src/components/admin/bans/AdminBansFilters.tsx
+++ b/frontend/src/components/admin/bans/AdminBansFilters.tsx
@@ -1,0 +1,69 @@
+"use client";
+import { cn } from "@/lib/cn";
+import type { BanType } from "@/lib/admin/types";
+
+export type BanListStatus = "active" | "history";
+export type BanTypeFilter = BanType | "ALL";
+
+const STATUS_TABS: Array<{ value: BanListStatus; label: string }> = [
+  { value: "active", label: "Active" },
+  { value: "history", label: "History" },
+];
+
+const TYPE_PILLS: Array<{ value: BanTypeFilter; label: string }> = [
+  { value: "ALL", label: "All" },
+  { value: "IP", label: "IP" },
+  { value: "AVATAR", label: "Avatar" },
+  { value: "BOTH", label: "Both" },
+];
+
+type Props = {
+  status: BanListStatus;
+  typeFilter: BanTypeFilter;
+  onStatusChange: (s: BanListStatus) => void;
+  onTypeChange: (t: BanTypeFilter) => void;
+};
+
+export function AdminBansFilters({ status, typeFilter, onStatusChange, onTypeChange }: Props) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2 border-b border-outline-variant">
+        {STATUS_TABS.map((tab) => (
+          <button
+            key={tab.value}
+            type="button"
+            onClick={() => onStatusChange(tab.value)}
+            data-testid={`tab-${tab.value}`}
+            className={cn(
+              "px-4 py-2 text-label-md font-medium border-b-2 -mb-px transition-colors",
+              status === tab.value
+                ? "border-primary text-primary"
+                : "border-transparent text-on-surface-variant hover:text-on-surface"
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-2" role="group" aria-label="Ban type filter">
+        {TYPE_PILLS.map((pill) => (
+          <button
+            key={pill.value}
+            type="button"
+            onClick={() => onTypeChange(pill.value)}
+            data-testid={`type-pill-${pill.value}`}
+            className={cn(
+              "px-3 py-1.5 rounded-full text-label-sm transition-colors",
+              typeFilter === pill.value
+                ? "bg-secondary-container text-on-secondary-container font-medium"
+                : "bg-surface-container text-on-surface-variant hover:bg-surface-container-high"
+            )}
+          >
+            {pill.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/bans/AdminBansPage.test.tsx
+++ b/frontend/src/components/admin/bans/AdminBansPage.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderWithProviders, screen, waitFor } from "@/test/render";
+import { server } from "@/test/msw/server";
+import { adminHandlers } from "@/test/msw/handlers";
+import { AdminBansPage } from "./AdminBansPage";
+import type { AdminBanRow } from "@/lib/admin/types";
+
+const mockReplace = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/admin/bans"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: mockReplace,
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+function makeBan(overrides: Partial<AdminBanRow> = {}): AdminBanRow {
+  return {
+    id: 1,
+    banType: "IP",
+    ipAddress: "10.0.0.1",
+    slAvatarUuid: null,
+    avatarLinkedUserId: null,
+    avatarLinkedDisplayName: null,
+    firstSeenIp: null,
+    reasonCategory: "TOS_ABUSE",
+    reasonText: "Repeated ToS violations",
+    bannedByUserId: 1,
+    bannedByDisplayName: "AdminUser",
+    expiresAt: null,
+    createdAt: "2026-04-01T10:00:00Z",
+    liftedAt: null,
+    liftedByUserId: null,
+    liftedByDisplayName: null,
+    liftedReason: null,
+    ...overrides,
+  };
+}
+
+describe("AdminBansPage", () => {
+  beforeEach(() => {
+    mockReplace.mockReset();
+  });
+
+  it("renders rows from MSW seed", async () => {
+    server.use(
+      adminHandlers.bansListSuccess([
+        makeBan({ id: 1, ipAddress: "10.0.0.1" }),
+        makeBan({ id: 2, ipAddress: "10.0.0.2" }),
+      ])
+    );
+
+    renderWithProviders(<AdminBansPage />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("bans-table")).toBeInTheDocument()
+    );
+    expect(screen.getByTestId("ban-row-1")).toBeInTheDocument();
+    expect(screen.getByTestId("ban-row-2")).toBeInTheDocument();
+  });
+
+  it("tab toggle updates URL", async () => {
+    server.use(adminHandlers.bansListSuccess([]));
+    renderWithProviders(<AdminBansPage />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("tab-history")).toBeInTheDocument()
+    );
+
+    screen.getByTestId("tab-history").click();
+
+    expect(mockReplace).toHaveBeenCalledWith(
+      expect.stringContaining("tab=history"),
+      expect.anything()
+    );
+  });
+
+  it("type filter pill narrows rows client-side", async () => {
+    server.use(
+      adminHandlers.bansListSuccess([
+        makeBan({ id: 1, banType: "IP", ipAddress: "10.0.0.1" }),
+        makeBan({ id: 2, banType: "AVATAR", slAvatarUuid: "aaaa-bbbb", ipAddress: null }),
+      ])
+    );
+
+    const { useSearchParams } = await import("next/navigation");
+    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams("type=IP") as ReturnType<typeof useSearchParams>);
+
+    renderWithProviders(<AdminBansPage />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("bans-table")).toBeInTheDocument()
+    );
+
+    expect(screen.getByTestId("ban-row-1")).toBeInTheDocument();
+    expect(screen.queryByTestId("ban-row-2")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/admin/bans/AdminBansPage.tsx
+++ b/frontend/src/components/admin/bans/AdminBansPage.tsx
@@ -1,0 +1,139 @@
+"use client";
+import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useAdminBansList } from "@/hooks/admin/useAdminBansList";
+import { AdminBansFilters, type BanListStatus, type BanTypeFilter } from "./AdminBansFilters";
+import { AdminBansTable } from "./AdminBansTable";
+import { CreateBanModal } from "./CreateBanModal";
+import { LiftBanModal } from "./LiftBanModal";
+import { Button } from "@/components/ui/Button";
+import { Pagination } from "@/components/ui/Pagination";
+import type { AdminBanRow, BanType } from "@/lib/admin/types";
+
+const PAGE_SIZE = 25;
+
+function parseStatus(raw: string | null): BanListStatus {
+  if (raw === "history") return "history";
+  return "active";
+}
+
+function parseTypeFilter(raw: string | null): BanTypeFilter {
+  if (raw === "IP" || raw === "AVATAR" || raw === "BOTH") return raw;
+  return "ALL";
+}
+
+export function AdminBansPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const status = parseStatus(searchParams?.get("tab") ?? null);
+  const typeFilter = parseTypeFilter(searchParams?.get("type") ?? null);
+  const page = Math.max(0, parseInt(searchParams?.get("page") ?? "0", 10) || 0);
+
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+  const [liftTarget, setLiftTarget] = useState<AdminBanRow | null>(null);
+
+  const { data: list, isLoading, isError } = useAdminBansList({
+    status,
+    page,
+    size: PAGE_SIZE,
+  });
+
+  const filteredRows =
+    list?.content.filter((row) => typeFilter === "ALL" || row.banType === (typeFilter as BanType)) ??
+    [];
+
+  function buildUrl(overrides: {
+    tab?: BanListStatus;
+    type?: BanTypeFilter;
+    page?: number;
+  }): string {
+    const params = new URLSearchParams();
+    const nextTab = overrides.tab ?? status;
+    const nextType = overrides.type ?? typeFilter;
+    const nextPage = overrides.page ?? page;
+    if (nextTab !== "active") params.set("tab", nextTab);
+    if (nextType !== "ALL") params.set("type", nextType);
+    if (nextPage > 0) params.set("page", String(nextPage));
+    const qs = params.toString();
+    return qs ? `/admin/bans?${qs}` : "/admin/bans";
+  }
+
+  const handleStatusChange = (s: BanListStatus) => {
+    router.replace(buildUrl({ tab: s, type: "ALL", page: 0 }), { scroll: false });
+  };
+
+  const handleTypeChange = (t: BanTypeFilter) => {
+    router.replace(buildUrl({ type: t, page: 0 }), { scroll: false });
+  };
+
+  const handlePage = (p: number) => {
+    router.replace(buildUrl({ page: p }), { scroll: false });
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-semibold">Bans</h1>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => setCreateModalOpen(true)}
+          data-testid="create-ban-btn"
+        >
+          + Create ban
+        </Button>
+      </div>
+
+      <div className="mb-4">
+        <AdminBansFilters
+          status={status}
+          typeFilter={typeFilter}
+          onStatusChange={handleStatusChange}
+          onTypeChange={handleTypeChange}
+        />
+      </div>
+
+      {isLoading && (
+        <div className="text-body-sm text-on-surface-variant py-8">Loading…</div>
+      )}
+
+      {isError && (
+        <div className="text-body-sm text-error py-8">
+          Could not load bans. Refresh to retry.
+        </div>
+      )}
+
+      {list && (
+        <>
+          <AdminBansTable
+            rows={filteredRows}
+            onLift={setLiftTarget}
+            showLift={status === "active"}
+          />
+          {list.totalPages > 1 && (
+            <div className="mt-4">
+              <Pagination
+                page={list.number}
+                totalPages={list.totalPages}
+                onPageChange={handlePage}
+              />
+            </div>
+          )}
+        </>
+      )}
+
+      <CreateBanModal
+        open={createModalOpen}
+        onClose={() => setCreateModalOpen(false)}
+      />
+
+      {liftTarget && (
+        <LiftBanModal
+          ban={liftTarget}
+          onClose={() => setLiftTarget(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/bans/AdminBansTable.tsx
+++ b/frontend/src/components/admin/bans/AdminBansTable.tsx
@@ -1,0 +1,144 @@
+"use client";
+import Link from "next/link";
+import { BanTypeBadge } from "./BanTypeBadge";
+import { Button } from "@/components/ui/Button";
+import type { AdminBanRow } from "@/lib/admin/types";
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatExpiry(expiresAt: string | null): string {
+  if (!expiresAt) return "Permanent";
+  const d = new Date(expiresAt);
+  const now = Date.now();
+  const diffMs = d.getTime() - now;
+  const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+  const abs = formatDate(expiresAt);
+  if (diffDays <= 0) return `${abs} (expired)`;
+  return `${abs} (in ${diffDays}d)`;
+}
+
+function truncate(str: string, max: number): string {
+  return str.length > max ? `${str.slice(0, max)}…` : str;
+}
+
+type Props = {
+  rows: AdminBanRow[];
+  onLift: (ban: AdminBanRow) => void;
+  showLift: boolean;
+};
+
+export function AdminBansTable({ rows, onLift, showLift }: Props) {
+  if (rows.length === 0) {
+    return (
+      <div
+        className="py-12 text-center text-body-sm text-on-surface-variant"
+        data-testid="empty-state"
+      >
+        No bans match the current filter.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-default border border-outline-variant">
+      <table className="w-full text-body-sm" data-testid="bans-table">
+        <thead className="sticky top-0 bg-surface-container-low border-b border-outline-variant">
+          <tr>
+            <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium w-[70px]">
+              Type
+            </th>
+            <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">
+              Identifier
+            </th>
+            <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">
+              Reason
+            </th>
+            <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium w-[110px]">
+              Banned By
+            </th>
+            <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium w-[160px]">
+              Expires
+            </th>
+            {showLift && (
+              <th className="px-3 py-2.5 text-right text-label-sm text-on-surface-variant font-medium w-[80px]">
+                Action
+              </th>
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr
+              key={row.id}
+              data-testid={`ban-row-${row.id}`}
+              className="border-b border-outline-variant/50"
+            >
+              <td className="px-3 py-2.5">
+                <BanTypeBadge banType={row.banType} />
+              </td>
+              <td className="px-3 py-2.5 text-on-surface">
+                {(row.banType === "AVATAR" || row.banType === "BOTH") && row.slAvatarUuid && (
+                  <div className="flex items-center gap-1 font-mono text-[11px]">
+                    {row.avatarLinkedUserId ? (
+                      <Link
+                        href={`/admin/users/${row.avatarLinkedUserId}`}
+                        className="text-primary underline underline-offset-2 hover:opacity-80"
+                        data-testid={`avatar-link-${row.id}`}
+                      >
+                        {row.avatarLinkedDisplayName ?? truncate(row.slAvatarUuid, 16)}
+                      </Link>
+                    ) : (
+                      <span className="text-on-surface-variant">{truncate(row.slAvatarUuid, 24)}</span>
+                    )}
+                  </div>
+                )}
+                {(row.banType === "IP" || row.banType === "BOTH") && row.ipAddress && (
+                  <div className="font-mono text-[11px] text-on-surface-variant">
+                    {row.ipAddress}
+                  </div>
+                )}
+                {row.banType === "AVATAR" && row.firstSeenIp && (
+                  <div className="font-mono text-[10px] text-on-surface-variant/70 mt-0.5">
+                    first seen: {row.firstSeenIp}
+                  </div>
+                )}
+              </td>
+              <td className="px-3 py-2.5 text-on-surface-variant max-w-[200px]">
+                <div className="text-[10px] text-on-surface-variant/70 uppercase tracking-wide">
+                  {row.reasonCategory}
+                </div>
+                <div className="line-clamp-2">{row.reasonText}</div>
+              </td>
+              <td className="px-3 py-2.5 text-on-surface-variant">
+                {row.bannedByDisplayName ?? `#${row.bannedByUserId}`}
+              </td>
+              <td className="px-3 py-2.5 text-on-surface-variant text-[11px]">
+                {formatExpiry(row.expiresAt)}
+              </td>
+              {showLift && (
+                <td className="px-3 py-2.5 text-right">
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => onLift(row)}
+                    data-testid={`lift-btn-${row.id}`}
+                  >
+                    Lift
+                  </Button>
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/bans/BanTypeBadge.tsx
+++ b/frontend/src/components/admin/bans/BanTypeBadge.tsx
@@ -1,0 +1,21 @@
+"use client";
+import type { BanType } from "@/lib/admin/types";
+
+const TONE_CLASSES: Record<BanType, string> = {
+  IP: "bg-error-container text-on-error-container",
+  AVATAR: "bg-secondary-container text-on-secondary-container",
+  BOTH: "bg-tertiary-container text-on-tertiary-container",
+};
+
+type Props = { banType: BanType };
+
+export function BanTypeBadge({ banType }: Props) {
+  return (
+    <span
+      className={`${TONE_CLASSES[banType]} px-2 py-0.5 rounded-full text-[10px] font-medium`}
+      data-testid={`ban-type-badge-${banType}`}
+    >
+      {banType}
+    </span>
+  );
+}

--- a/frontend/src/components/admin/bans/CreateBanModal.test.tsx
+++ b/frontend/src/components/admin/bans/CreateBanModal.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderWithProviders, screen, waitFor, userEvent } from "@/test/render";
+import { server } from "@/test/msw/server";
+import { adminHandlers } from "@/test/msw/handlers";
+import { CreateBanModal } from "./CreateBanModal";
+import type { AdminBanRow } from "@/lib/admin/types";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/admin/bans"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+function makeBan(overrides: Partial<AdminBanRow> = {}): AdminBanRow {
+  return {
+    id: 1,
+    banType: "IP",
+    ipAddress: "10.0.0.1",
+    slAvatarUuid: null,
+    avatarLinkedUserId: null,
+    avatarLinkedDisplayName: null,
+    firstSeenIp: null,
+    reasonCategory: "TOS_ABUSE",
+    reasonText: "Repeated ToS violations",
+    bannedByUserId: 1,
+    bannedByDisplayName: "AdminUser",
+    expiresAt: null,
+    createdAt: "2026-04-01T10:00:00Z",
+    liftedAt: null,
+    liftedByUserId: null,
+    liftedByDisplayName: null,
+    liftedReason: null,
+    ...overrides,
+  };
+}
+
+describe("CreateBanModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows IP field for IP type, hides avatar field", () => {
+    renderWithProviders(
+      <CreateBanModal open={true} onClose={vi.fn()} />
+    );
+
+    expect(screen.getByTestId("ip-address-input")).toBeInTheDocument();
+    expect(screen.queryByTestId("avatar-uuid-input")).not.toBeInTheDocument();
+  });
+
+  it("shows avatar field and hides IP field when switching to AVATAR type", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <CreateBanModal open={true} onClose={vi.fn()} />
+    );
+
+    await user.click(screen.getByTestId("ban-type-btn-AVATAR"));
+
+    expect(screen.queryByTestId("ip-address-input")).not.toBeInTheDocument();
+    expect(screen.getByTestId("avatar-uuid-input")).toBeInTheDocument();
+  });
+
+  it("shows both fields for BOTH type", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <CreateBanModal open={true} onClose={vi.fn()} />
+    );
+
+    await user.click(screen.getByTestId("ban-type-btn-BOTH"));
+
+    expect(screen.getByTestId("ip-address-input")).toBeInTheDocument();
+    expect(screen.getByTestId("avatar-uuid-input")).toBeInTheDocument();
+  });
+
+  it("calls adminApi.bans.create with correct body on success", async () => {
+    const ban = makeBan({ id: 42, banType: "IP", ipAddress: "1.2.3.4" });
+    server.use(adminHandlers.createBanSuccess(ban));
+    server.use(adminHandlers.statsSuccess());
+
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <CreateBanModal open={true} onClose={onClose} />
+    );
+
+    await user.type(screen.getByTestId("ip-address-input"), "1.2.3.4");
+    await user.type(screen.getByTestId("reason-text-textarea"), "Testing IP ban");
+
+    await user.click(screen.getByTestId("create-ban-submit"));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("shows toast on BAN_TYPE_FIELD_MISMATCH 400 error", async () => {
+    server.use(
+      adminHandlers.ban409TypeFieldMismatch(1)
+    );
+
+    renderWithProviders(
+      <CreateBanModal open={true} onClose={vi.fn()} />
+    );
+
+    const user = userEvent.setup();
+    await user.type(screen.getByTestId("ip-address-input"), "1.2.3.4");
+    await user.type(screen.getByTestId("reason-text-textarea"), "Testing");
+
+    await user.click(screen.getByTestId("create-ban-submit"));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/Ban created/) === null || screen.queryByText(/don't match/)
+      ).toBe(true)
+    );
+  });
+
+  it("does not render when open=false", () => {
+    renderWithProviders(
+      <CreateBanModal open={false} onClose={vi.fn()} />
+    );
+    expect(screen.queryByTestId("create-ban-modal")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/admin/bans/CreateBanModal.tsx
+++ b/frontend/src/components/admin/bans/CreateBanModal.tsx
@@ -1,0 +1,283 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useCreateBan } from "@/hooks/admin/useCreateBan";
+import { Button } from "@/components/ui/Button";
+import { UserSearchAutocomplete } from "./UserSearchAutocomplete";
+import type { BanType, BanReasonCategory, AdminUserSummary } from "@/lib/admin/types";
+
+const BAN_TYPES: BanType[] = ["IP", "AVATAR", "BOTH"];
+
+const REASON_CATEGORIES: Array<{ value: BanReasonCategory; label: string }> = [
+  { value: "SHILL_BIDDING", label: "Shill Bidding" },
+  { value: "FRAUDULENT_SELLER", label: "Fraudulent Seller" },
+  { value: "TOS_ABUSE", label: "ToS Abuse" },
+  { value: "SPAM", label: "Spam" },
+  { value: "OTHER", label: "Other" },
+];
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  initialSlAvatarUuid?: string;
+  initialIpAddress?: string;
+};
+
+export function CreateBanModal({ open, onClose, initialSlAvatarUuid, initialIpAddress }: Props) {
+  const [banType, setBanType] = useState<BanType>("IP");
+  const [slAvatarUuid, setSlAvatarUuid] = useState(initialSlAvatarUuid ?? "");
+  const [ipAddress, setIpAddress] = useState(initialIpAddress ?? "");
+  const [expiresMode, setExpiresMode] = useState<"permanent" | "date">("permanent");
+  const [expiresDate, setExpiresDate] = useState("");
+  const [reasonCategory, setReasonCategory] = useState<BanReasonCategory>("OTHER");
+  const [reasonText, setReasonText] = useState("");
+
+  const createBan = useCreateBan();
+
+  const hasPreFill = Boolean(initialSlAvatarUuid) || Boolean(initialIpAddress);
+
+  useEffect(() => {
+    if (!open) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- `open` is external source of truth; resetting form state on open is intentional
+    setSlAvatarUuid(initialSlAvatarUuid ?? "");
+    setIpAddress(initialIpAddress ?? "");
+    setBanType(initialSlAvatarUuid && initialIpAddress ? "BOTH" : initialSlAvatarUuid ? "AVATAR" : "IP");
+    setExpiresMode("permanent");
+    setExpiresDate("");
+    setReasonCategory("OTHER");
+    setReasonText("");
+  }, [open, initialSlAvatarUuid, initialIpAddress]);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  function handleUserSelect(user: AdminUserSummary) {
+    if (user.slAvatarUuid) setSlAvatarUuid(user.slAvatarUuid);
+  }
+
+  const canSubmit =
+    reasonText.trim().length > 0 &&
+    (banType === "IP" || banType === "BOTH" ? ipAddress.trim().length > 0 : true) &&
+    (banType === "AVATAR" || banType === "BOTH" ? slAvatarUuid.trim().length > 0 : true) &&
+    (expiresMode === "date" ? expiresDate.length > 0 : true) &&
+    !createBan.isPending;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+
+    createBan.mutate(
+      {
+        banType,
+        ipAddress: banType === "AVATAR" ? null : ipAddress.trim() || null,
+        slAvatarUuid: banType === "IP" ? null : slAvatarUuid.trim() || null,
+        expiresAt:
+          expiresMode === "permanent" ? null : new Date(expiresDate).toISOString(),
+        reasonCategory,
+        reasonText: reasonText.trim(),
+      },
+      { onSuccess: onClose }
+    );
+  }
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40 bg-inverse-surface/20"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Create ban"
+        data-testid="create-ban-modal"
+        className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      >
+        <div
+          className="w-full max-w-lg rounded-default bg-surface-container-low border border-outline-variant shadow-elevated p-6 flex flex-col gap-4 max-h-[90vh] overflow-y-auto"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center justify-between">
+            <h2 className="text-title-md font-semibold text-on-surface">Create ban</h2>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="p-1.5 rounded-default text-on-surface-variant hover:bg-surface-container"
+            >
+              ✕
+            </button>
+          </div>
+
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            {!hasPreFill && (
+              <div className="flex flex-col gap-1">
+                <label className="text-label-md font-medium text-on-surface">
+                  Search user (optional)
+                </label>
+                <UserSearchAutocomplete onSelect={handleUserSelect} />
+                <p className="text-[11px] text-on-surface-variant">
+                  Selecting a user fills the avatar UUID below.
+                </p>
+              </div>
+            )}
+
+            <div className="flex flex-col gap-1">
+              <label className="text-label-md font-medium text-on-surface">Ban type</label>
+              <div className="flex items-center gap-2">
+                {BAN_TYPES.map((t) => (
+                  <button
+                    key={t}
+                    type="button"
+                    onClick={() => setBanType(t)}
+                    data-testid={`ban-type-btn-${t}`}
+                    className={`px-3 py-1.5 rounded-full text-label-sm transition-colors ${
+                      banType === t
+                        ? "bg-secondary-container text-on-secondary-container font-medium"
+                        : "bg-surface-container text-on-surface-variant hover:bg-surface-container-high"
+                    }`}
+                  >
+                    {t}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {(banType === "IP" || banType === "BOTH") && (
+              <div className="flex flex-col gap-1">
+                <label htmlFor="ip-address" className="text-label-md font-medium text-on-surface">
+                  IP address <span className="text-error">*</span>
+                </label>
+                <input
+                  id="ip-address"
+                  type="text"
+                  value={ipAddress}
+                  onChange={(e) => setIpAddress(e.target.value)}
+                  placeholder="192.168.0.1"
+                  data-testid="ip-address-input"
+                  className="w-full rounded-default bg-surface-container px-4 py-2 text-body-md text-on-surface placeholder:text-on-surface-variant ring-1 ring-outline-variant focus:outline-none focus:ring-primary font-mono"
+                />
+              </div>
+            )}
+
+            {(banType === "AVATAR" || banType === "BOTH") && (
+              <div className="flex flex-col gap-1">
+                <label htmlFor="avatar-uuid" className="text-label-md font-medium text-on-surface">
+                  Avatar UUID <span className="text-error">*</span>
+                </label>
+                <input
+                  id="avatar-uuid"
+                  type="text"
+                  value={slAvatarUuid}
+                  onChange={(e) => setSlAvatarUuid(e.target.value)}
+                  placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                  data-testid="avatar-uuid-input"
+                  className="w-full rounded-default bg-surface-container px-4 py-2 text-body-md text-on-surface placeholder:text-on-surface-variant ring-1 ring-outline-variant focus:outline-none focus:ring-primary font-mono"
+                />
+              </div>
+            )}
+
+            <div className="flex flex-col gap-1">
+              <label className="text-label-md font-medium text-on-surface">Expiry</label>
+              <div className="flex items-center gap-3">
+                <label className="flex items-center gap-1.5 text-body-sm text-on-surface cursor-pointer">
+                  <input
+                    type="radio"
+                    name="expiry-mode"
+                    value="permanent"
+                    checked={expiresMode === "permanent"}
+                    onChange={() => setExpiresMode("permanent")}
+                    data-testid="expiry-permanent"
+                  />
+                  Permanent
+                </label>
+                <label className="flex items-center gap-1.5 text-body-sm text-on-surface cursor-pointer">
+                  <input
+                    type="radio"
+                    name="expiry-mode"
+                    value="date"
+                    checked={expiresMode === "date"}
+                    onChange={() => setExpiresMode("date")}
+                    data-testid="expiry-date-radio"
+                  />
+                  Until date
+                </label>
+              </div>
+              {expiresMode === "date" && (
+                <input
+                  type="datetime-local"
+                  value={expiresDate}
+                  onChange={(e) => setExpiresDate(e.target.value)}
+                  data-testid="expiry-date-input"
+                  className="mt-1 rounded-default bg-surface-container px-4 py-2 text-body-md text-on-surface ring-1 ring-outline-variant focus:outline-none focus:ring-primary"
+                />
+              )}
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <label htmlFor="reason-category" className="text-label-md font-medium text-on-surface">
+                Reason category
+              </label>
+              <select
+                id="reason-category"
+                value={reasonCategory}
+                onChange={(e) => setReasonCategory(e.target.value as BanReasonCategory)}
+                data-testid="reason-category-select"
+                className="w-full rounded-default bg-surface-container px-4 py-2 text-body-md text-on-surface ring-1 ring-outline-variant focus:outline-none focus:ring-primary"
+              >
+                {REASON_CATEGORIES.map((c) => (
+                  <option key={c.value} value={c.value}>
+                    {c.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <label htmlFor="reason-text" className="text-label-md font-medium text-on-surface">
+                Reason details <span className="text-error">*</span>
+              </label>
+              <textarea
+                id="reason-text"
+                rows={3}
+                value={reasonText}
+                disabled={createBan.isPending}
+                onChange={(e) => setReasonText(e.target.value)}
+                placeholder="Describe the reason for this ban…"
+                data-testid="reason-text-textarea"
+                className="w-full resize-y rounded-default bg-surface-container px-4 py-3 text-on-surface placeholder:text-on-surface-variant ring-1 ring-outline-variant transition-all focus:outline-none focus:ring-primary disabled:opacity-50"
+              />
+            </div>
+
+            <div className="rounded-default bg-tertiary-container/30 border border-tertiary-container px-4 py-3 text-body-sm text-on-surface-variant">
+              On create: token version bumps for any user with this avatar UUID — their session
+              invalidates on next refresh. Ban cache flushes immediately.
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <Button variant="secondary" type="button" onClick={onClose} disabled={createBan.isPending}>
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                type="submit"
+                disabled={!canSubmit}
+                loading={createBan.isPending}
+                data-testid="create-ban-submit"
+              >
+                Create ban
+              </Button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/admin/bans/LiftBanModal.test.tsx
+++ b/frontend/src/components/admin/bans/LiftBanModal.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderWithProviders, screen, waitFor, userEvent } from "@/test/render";
+import { server } from "@/test/msw/server";
+import { adminHandlers } from "@/test/msw/handlers";
+import { LiftBanModal } from "./LiftBanModal";
+import type { AdminBanRow } from "@/lib/admin/types";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/admin/bans"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+function makeBan(overrides: Partial<AdminBanRow> = {}): AdminBanRow {
+  return {
+    id: 10,
+    banType: "IP",
+    ipAddress: "10.0.0.1",
+    slAvatarUuid: null,
+    avatarLinkedUserId: null,
+    avatarLinkedDisplayName: null,
+    firstSeenIp: null,
+    reasonCategory: "TOS_ABUSE",
+    reasonText: "Repeated ToS violations",
+    bannedByUserId: 1,
+    bannedByDisplayName: "AdminUser",
+    expiresAt: null,
+    createdAt: "2026-04-01T10:00:00Z",
+    liftedAt: null,
+    liftedByUserId: null,
+    liftedByDisplayName: null,
+    liftedReason: null,
+    ...overrides,
+  };
+}
+
+describe("LiftBanModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("submit button is disabled when notes are empty", () => {
+    renderWithProviders(
+      <LiftBanModal ban={makeBan()} onClose={vi.fn()} />
+    );
+    expect(screen.getByTestId("lift-ban-submit")).toBeDisabled();
+  });
+
+  it("calls lift mutation on submit and closes modal", async () => {
+    const ban = makeBan({ id: 10 });
+    server.use(adminHandlers.liftBanSuccess(ban));
+    server.use(adminHandlers.statsSuccess());
+
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <LiftBanModal ban={ban} onClose={onClose} />
+    );
+
+    await user.type(screen.getByTestId("lift-reason-textarea"), "Reason to lift this ban");
+    await user.click(screen.getByTestId("lift-ban-submit"));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("shows toast on BAN_ALREADY_LIFTED 409 error", async () => {
+    const ban = makeBan({ id: 10 });
+    server.use(adminHandlers.ban409AlreadyLifted(10));
+    server.use(adminHandlers.bansListSuccess([]));
+
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <LiftBanModal ban={ban} onClose={vi.fn()} />
+    );
+
+    await user.type(screen.getByTestId("lift-reason-textarea"), "Lifting it");
+    await user.click(screen.getByTestId("lift-ban-submit"));
+
+    await waitFor(() =>
+      expect(screen.getByText(/already lifted/i)).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/components/admin/bans/LiftBanModal.tsx
+++ b/frontend/src/components/admin/bans/LiftBanModal.tsx
@@ -1,0 +1,115 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useLiftBan } from "@/hooks/admin/useLiftBan";
+import { Button } from "@/components/ui/Button";
+import { BanTypeBadge } from "./BanTypeBadge";
+import type { AdminBanRow } from "@/lib/admin/types";
+
+const NOTES_MAX = 1000;
+
+type Props = {
+  ban: AdminBanRow;
+  onClose: () => void;
+};
+
+export function LiftBanModal({ ban, onClose }: Props) {
+  const [liftedReason, setLiftedReason] = useState("");
+  const liftBan = useLiftBan();
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  const canSubmit = liftedReason.trim().length > 0 && !liftBan.isPending;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    liftBan.mutate(
+      { id: ban.id, liftedReason },
+      { onSuccess: onClose }
+    );
+  }
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40 bg-inverse-surface/20"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Lift ban"
+        data-testid="lift-ban-modal"
+        className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      >
+        <div
+          className="w-full max-w-md rounded-default bg-surface-container-low border border-outline-variant shadow-elevated p-6 flex flex-col gap-4"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-start justify-between gap-2">
+            <div>
+              <h2 className="text-title-md font-semibold text-on-surface">Lift ban</h2>
+              <div className="mt-1 flex items-center gap-2">
+                <BanTypeBadge banType={ban.banType} />
+                <span className="text-body-sm text-on-surface-variant">
+                  {ban.avatarLinkedDisplayName ?? ban.slAvatarUuid ?? ban.ipAddress ?? `#${ban.id}`}
+                </span>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="p-1.5 rounded-default text-on-surface-variant hover:bg-surface-container"
+            >
+              ✕
+            </button>
+          </div>
+
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <label className="text-label-md font-medium text-on-surface" htmlFor="lift-reason">
+                Reason for lifting <span className="text-error">*</span>
+              </label>
+              <textarea
+                id="lift-reason"
+                rows={4}
+                value={liftedReason}
+                disabled={liftBan.isPending}
+                onChange={(e) => setLiftedReason(e.target.value.slice(0, NOTES_MAX))}
+                placeholder="Explain why this ban is being lifted…"
+                data-testid="lift-reason-textarea"
+                className="w-full resize-y rounded-default bg-surface-container px-4 py-3 text-on-surface placeholder:text-on-surface-variant ring-1 ring-outline-variant transition-all focus:outline-none focus:ring-primary disabled:opacity-50"
+              />
+              <div className="self-end text-label-sm text-on-surface-variant">
+                {liftedReason.length} / {NOTES_MAX}
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <Button variant="secondary" type="button" onClick={onClose} disabled={liftBan.isPending}>
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                type="submit"
+                disabled={!canSubmit}
+                loading={liftBan.isPending}
+                data-testid="lift-ban-submit"
+              >
+                Lift ban
+              </Button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/admin/bans/UserSearchAutocomplete.tsx
+++ b/frontend/src/components/admin/bans/UserSearchAutocomplete.tsx
@@ -1,0 +1,77 @@
+"use client";
+import { useState, useRef, useEffect } from "react";
+import { useUserSearch } from "@/hooks/admin/useUserSearch";
+import type { AdminUserSummary } from "@/lib/admin/types";
+
+type Props = {
+  onSelect: (user: AdminUserSummary) => void;
+  placeholder?: string;
+};
+
+export function UserSearchAutocomplete({ onSelect, placeholder = "Search by name or email…" }: Props) {
+  const [query, setQuery] = useState("");
+  const [closedForQuery, setClosedForQuery] = useState("");
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const { data, isFetching } = useUserSearch(query);
+  const results = data?.content ?? [];
+
+  const open = closedForQuery !== query && query.length >= 2 && results.length > 0;
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setClosedForQuery(query);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [query]);
+
+  function handleSelect(user: AdminUserSummary) {
+    const name = user.displayName ?? user.email;
+    setQuery(name);
+    setClosedForQuery(name);
+    onSelect(user);
+  }
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onFocus={() => setClosedForQuery("")}
+        placeholder={placeholder}
+        data-testid="user-search-input"
+        className="w-full rounded-default bg-surface-container px-4 py-2 text-body-md text-on-surface placeholder:text-on-surface-variant ring-1 ring-outline-variant focus:outline-none focus:ring-primary"
+      />
+      {isFetching && (
+        <div className="absolute right-3 top-2.5 text-on-surface-variant text-[11px]">…</div>
+      )}
+      {open && (
+        <ul
+          role="listbox"
+          data-testid="user-search-dropdown"
+          className="absolute z-50 left-0 right-0 mt-1 rounded-default bg-surface-container-low border border-outline-variant shadow-elevated overflow-hidden"
+        >
+          {results.map((user) => (
+            <li
+              key={user.id}
+              role="option"
+              aria-selected={false}
+              onClick={() => handleSelect(user)}
+              data-testid={`user-option-${user.id}`}
+              className="flex flex-col px-4 py-2 cursor-pointer hover:bg-surface-container transition-colors"
+            >
+              <span className="text-body-sm font-medium text-on-surface">
+                {user.displayName ?? "(no display name)"}
+              </span>
+              <span className="text-[11px] text-on-surface-variant">{user.email}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/dashboard/AdminDashboardPage.test.tsx
+++ b/frontend/src/components/admin/dashboard/AdminDashboardPage.test.tsx
@@ -15,10 +15,10 @@ function wrap() {
 }
 
 describe("AdminDashboardPage", () => {
-  it("renders all 9 numbers from the API response", async () => {
+  it("renders all 10 numbers from the API response", async () => {
     server.use(
       adminHandlers.statsSuccess({
-        queues: { openFraudFlags: 7, pendingPayments: 3, activeDisputes: 1 },
+        queues: { openFraudFlags: 7, openReports: 5, pendingPayments: 3, activeDisputes: 1 },
         platform: {
           activeListings: 42,
           totalUsers: 381,
@@ -33,6 +33,7 @@ describe("AdminDashboardPage", () => {
     wrap();
 
     await waitFor(() => expect(screen.queryByText("7")).not.toBeNull());
+    expect(screen.getByText("5")).toBeInTheDocument();
     expect(screen.getByText("3")).toBeInTheDocument();
     expect(screen.getByText("1")).toBeInTheDocument();
     expect(screen.getByText("42")).toBeInTheDocument();
@@ -41,5 +42,6 @@ describe("AdminDashboardPage", () => {
     expect(screen.getByText("156")).toBeInTheDocument();
     expect(screen.getByText("L$ 4,827,500")).toBeInTheDocument();
     expect(screen.getByText("L$ 241,375")).toBeInTheDocument();
+    expect(screen.getByText("Open reports")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/admin/dashboard/AdminDashboardPage.tsx
+++ b/frontend/src/components/admin/dashboard/AdminDashboardPage.tsx
@@ -26,13 +26,20 @@ export function AdminDashboardPage() {
       <div className="text-xs opacity-60 mt-0.5 mb-6">Platform overview · lifetime</div>
 
       <div className="text-[11px] uppercase tracking-wide opacity-60 mb-2">Needs attention</div>
-      <div className="grid grid-cols-3 gap-3 mb-7">
+      <div className="grid grid-cols-4 gap-3 mb-7">
         <QueueCard
           label="Open fraud flags"
           value={data.queues.openFraudFlags}
           tone="fraud"
           subtext="Click to triage"
           href="/admin/fraud-flags"
+        />
+        <QueueCard
+          label="Open reports"
+          value={data.queues.openReports}
+          tone="fraud"
+          subtext="Click to triage"
+          href="/admin/reports"
         />
         <QueueCard
           label="Pending payments"

--- a/frontend/src/components/admin/reports/AdminReportCard.tsx
+++ b/frontend/src/components/admin/reports/AdminReportCard.tsx
@@ -1,0 +1,96 @@
+"use client";
+import Link from "next/link";
+import { Button } from "@/components/ui/Button";
+import { ReasonBadge } from "./ReasonBadge";
+import { useDismissReport } from "@/hooks/admin/useDismissReport";
+import type { AdminReportDetail } from "@/lib/admin/types";
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+type Props = {
+  report: AdminReportDetail;
+  onDismissed?: () => void;
+};
+
+export function AdminReportCard({ report, onDismissed }: Props) {
+  const dismiss = useDismissReport();
+
+  const handleDismiss = () => {
+    dismiss.mutate(
+      { reportId: report.id, notes: "" },
+      { onSuccess: () => { onDismissed?.(); } }
+    );
+  };
+
+  const isDismissed = report.status === "DISMISSED";
+
+  return (
+    <div
+      className="rounded-default border border-outline-variant bg-surface-container px-4 py-3 flex flex-col gap-2"
+      data-testid={`report-card-${report.id}`}
+    >
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <div className="flex items-center gap-2 flex-wrap">
+          <ReasonBadge reason={report.reason} />
+          {isDismissed && (
+            <span className="text-[10px] font-medium text-on-surface-variant bg-surface-container-high px-2 py-0.5 rounded-full">
+              Dismissed
+            </span>
+          )}
+        </div>
+        <span className="text-label-sm text-on-surface-variant">
+          {formatDateTime(report.createdAt)}
+        </span>
+      </div>
+
+      <div className="text-label-md font-medium text-on-surface">{report.subject}</div>
+
+      {report.details && (
+        <div className="text-body-sm text-on-surface-variant whitespace-pre-wrap">
+          {report.details}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between gap-2 mt-1">
+        <div className="text-body-sm text-on-surface-variant">
+          By{" "}
+          {report.reporterDisplayName ? (
+            <Link
+              href={`/admin/users/${report.reporterUserId}`}
+              className="text-primary underline underline-offset-2"
+            >
+              {report.reporterDisplayName}
+            </Link>
+          ) : (
+            <span>Unknown</span>
+          )}
+          {report.reporterDismissedReportsCount > 0 && (
+            <span className="ml-1 text-error text-[11px]">
+              ({report.reporterDismissedReportsCount} prior dismissed)
+            </span>
+          )}
+        </div>
+
+        {!isDismissed && (
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleDismiss}
+            loading={dismiss.isPending}
+            data-testid={`dismiss-report-btn-${report.id}`}
+          >
+            Dismiss
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/reports/AdminReportSlideOver.test.tsx
+++ b/frontend/src/components/admin/reports/AdminReportSlideOver.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderWithProviders, screen, waitFor, userEvent } from "@/test/render";
+import { server } from "@/test/msw/server";
+import { adminHandlers } from "@/test/msw/handlers";
+import { AdminReportSlideOver } from "./AdminReportSlideOver";
+import type { AdminReportListingRow, AdminReportDetail } from "@/lib/admin/types";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/admin/reports"),
+  useRouter: () => ({
+    push: mockPush,
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+const listingRow: AdminReportListingRow = {
+  auctionId: 10,
+  auctionTitle: "Test Parcel Auction",
+  auctionStatus: "ACTIVE",
+  parcelRegionName: "Heterocera",
+  sellerUserId: 7,
+  sellerDisplayName: "Seller One",
+  openReportCount: 1,
+  latestReportAt: "2026-04-01T10:00:00Z",
+};
+
+const mockReport: AdminReportDetail = {
+  id: 1,
+  reason: "SHILL_BIDDING",
+  subject: "Suspicious bidding",
+  details: "The same alt account keeps bidding.",
+  status: "OPEN",
+  adminNotes: null,
+  createdAt: "2026-04-01T10:00:00Z",
+  updatedAt: "2026-04-01T10:00:00Z",
+  reviewedAt: null,
+  reporterUserId: 42,
+  reporterDisplayName: "ReporterUser",
+  reporterDismissedReportsCount: 0,
+  reviewedByDisplayName: null,
+};
+
+describe("AdminReportSlideOver", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+  });
+
+  it("renders nothing when auctionId is null", () => {
+    renderWithProviders(
+      <AdminReportSlideOver
+        auctionId={null}
+        listingRow={null}
+        hasPrev={false}
+        hasNext={false}
+        onPrev={vi.fn()}
+        onNext={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.queryByTestId("admin-report-slideover")).not.toBeInTheDocument();
+  });
+
+  it("renders slide-over with listing info and reports", async () => {
+    server.use(
+      adminHandlers.reportsByListingSuccess(10, [mockReport])
+    );
+
+    renderWithProviders(
+      <AdminReportSlideOver
+        auctionId={10}
+        listingRow={listingRow}
+        hasPrev={false}
+        hasNext={false}
+        onPrev={vi.fn()}
+        onNext={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("admin-report-slideover")).toBeInTheDocument()
+    );
+    expect(screen.getByText("Test Parcel Auction")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByTestId("report-card-1")).toBeInTheDocument()
+    );
+  });
+
+  it("closes on ESC", async () => {
+    server.use(adminHandlers.reportsByListingSuccess(10, []));
+    const onClose = vi.fn();
+    renderWithProviders(
+      <AdminReportSlideOver
+        auctionId={10}
+        listingRow={listingRow}
+        hasPrev={false}
+        hasNext={false}
+        onPrev={vi.fn()}
+        onNext={vi.fn()}
+        onClose={onClose}
+      />
+    );
+    const user = userEvent.setup();
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("Ban seller button navigates to /admin/users/{sellerId}", async () => {
+    server.use(adminHandlers.reportsByListingSuccess(10, []));
+    renderWithProviders(
+      <AdminReportSlideOver
+        auctionId={10}
+        listingRow={listingRow}
+        hasPrev={false}
+        hasNext={false}
+        onPrev={vi.fn()}
+        onNext={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("ban-seller-btn")).toBeInTheDocument()
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("ban-seller-btn"));
+    expect(mockPush).toHaveBeenCalledWith("/admin/users/7");
+  });
+});

--- a/frontend/src/components/admin/reports/AdminReportSlideOver.tsx
+++ b/frontend/src/components/admin/reports/AdminReportSlideOver.tsx
@@ -1,0 +1,270 @@
+"use client";
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useAdminReportsByListing } from "@/hooks/admin/useAdminReportsByListing";
+import { useWarnSeller } from "@/hooks/admin/useWarnSeller";
+import { useSuspendListingFromReport } from "@/hooks/admin/useSuspendListingFromReport";
+import { useCancelListingFromReport } from "@/hooks/admin/useCancelListingFromReport";
+import { Button } from "@/components/ui/Button";
+import { AdminReportCard } from "./AdminReportCard";
+import type { AdminReportListingRow } from "@/lib/admin/types";
+
+const NOTES_MAX = 1000;
+
+type Props = {
+  auctionId: number | null;
+  listingRow: AdminReportListingRow | null;
+  hasPrev: boolean;
+  hasNext: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+  onClose: () => void;
+};
+
+export function AdminReportSlideOver({
+  auctionId,
+  listingRow,
+  hasPrev,
+  hasNext,
+  onPrev,
+  onNext,
+  onClose,
+}: Props) {
+  const router = useRouter();
+  const [notes, setNotes] = useState("");
+
+  const { data: reports, isLoading } = useAdminReportsByListing(auctionId);
+  const warnSeller = useWarnSeller();
+  const suspendListing = useSuspendListingFromReport();
+  const cancelListing = useCancelListingFromReport();
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setNotes("");
+  }, [auctionId]);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  if (!auctionId) return null;
+
+  const isPending =
+    warnSeller.isPending ||
+    suspendListing.isPending ||
+    cancelListing.isPending;
+  const notesEmpty = notes.trim().length === 0;
+  const canAct = !notesEmpty && !isPending;
+
+  const openCount = reports?.filter((r) => r.status === "OPEN").length ?? 0;
+
+  const handleWarn = () => {
+    if (!canAct) return;
+    warnSeller.mutate(
+      { auctionId, notes },
+      { onSuccess: () => { onClose(); } }
+    );
+  };
+
+  const handleSuspend = () => {
+    if (!canAct) return;
+    suspendListing.mutate(
+      { auctionId, notes },
+      { onSuccess: () => { onClose(); } }
+    );
+  };
+
+  const handleCancel = () => {
+    if (!canAct) return;
+    cancelListing.mutate(
+      { auctionId, notes },
+      { onSuccess: () => { onClose(); } }
+    );
+  };
+
+  const handleBanSeller = () => {
+    if (!listingRow) return;
+    router.push(`/admin/users/${listingRow.sellerUserId}`);
+  };
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-30 bg-inverse-surface/20"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <aside
+        className="fixed top-16 right-0 bottom-0 z-40 w-[560px] flex flex-col bg-surface-container-low border-l border-outline-variant shadow-elevated overflow-hidden"
+        data-testid="admin-report-slideover"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Listing reports detail"
+      >
+        {/* Navigation bar */}
+        <div className="flex items-center justify-between px-5 py-3 border-b border-outline-variant shrink-0">
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={onPrev}
+              disabled={!hasPrev}
+              aria-label="Previous listing"
+              className="p-1.5 rounded-default text-on-surface-variant hover:bg-surface-container disabled:opacity-30 disabled:pointer-events-none"
+            >
+              ←
+            </button>
+            <button
+              type="button"
+              onClick={onNext}
+              disabled={!hasNext}
+              aria-label="Next listing"
+              className="p-1.5 rounded-default text-on-surface-variant hover:bg-surface-container disabled:opacity-30 disabled:pointer-events-none"
+            >
+              →
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="p-1.5 rounded-default text-on-surface-variant hover:bg-surface-container"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4 flex flex-col gap-4">
+          {isLoading && (
+            <div className="text-body-sm text-on-surface-variant">Loading…</div>
+          )}
+
+          {listingRow && (
+            <>
+              {/* Header */}
+              <div className="flex items-start justify-between gap-2 flex-wrap">
+                <div className="flex flex-col gap-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="text-label-sm font-medium bg-error-container text-on-error-container px-2 py-0.5 rounded-full">
+                      {openCount} open report{openCount !== 1 ? "s" : ""}
+                    </span>
+                    <span
+                      className="text-label-sm px-2 py-0.5 rounded-full bg-surface-container text-on-surface-variant"
+                      data-testid="auction-status-chip"
+                    >
+                      {listingRow.auctionStatus}
+                    </span>
+                  </div>
+                  <div className="text-title-md font-semibold text-on-surface">
+                    {listingRow.auctionTitle}
+                  </div>
+                  <div className="text-body-sm text-on-surface-variant">
+                    Auction #{listingRow.auctionId}
+                    {listingRow.sellerDisplayName && (
+                      <span>
+                        {" "}
+                        · Seller:{" "}
+                        <Link
+                          href={`/admin/users/${listingRow.sellerUserId}`}
+                          className="text-primary underline underline-offset-2"
+                        >
+                          {listingRow.sellerDisplayName}
+                        </Link>
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              {/* Actions row */}
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={handleWarn}
+                  disabled={!canAct}
+                  loading={warnSeller.isPending}
+                  data-testid="warn-seller-btn"
+                >
+                  Warn seller
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={handleSuspend}
+                  disabled={!canAct}
+                  loading={suspendListing.isPending}
+                  data-testid="suspend-listing-btn"
+                >
+                  Suspend listing
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={handleCancel}
+                  disabled={!canAct}
+                  loading={cancelListing.isPending}
+                  data-testid="cancel-listing-btn"
+                >
+                  Cancel listing
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={handleBanSeller}
+                  data-testid="ban-seller-btn"
+                >
+                  Ban seller →
+                </Button>
+              </div>
+
+              {/* Reports list */}
+              {reports && reports.length > 0 && (
+                <div className="flex flex-col gap-3">
+                  <div className="text-label-md font-medium text-on-surface">
+                    Reports ({reports.length})
+                  </div>
+                  {reports.map((report) => (
+                    <AdminReportCard key={report.id} report={report} />
+                  ))}
+                </div>
+              )}
+
+              {reports && reports.length === 0 && (
+                <div className="text-body-sm text-on-surface-variant">
+                  No reports found for this listing.
+                </div>
+              )}
+
+              {/* Shared notes */}
+              <div className="flex flex-col gap-1">
+                <label className="text-label-md font-medium text-on-surface">
+                  Admin notes <span className="text-error">*</span>
+                  <span className="text-on-surface-variant font-normal ml-1">
+                    (required for Warn / Suspend / Cancel)
+                  </span>
+                </label>
+                <textarea
+                  rows={4}
+                  value={notes}
+                  disabled={isPending}
+                  onChange={(e) => setNotes(e.target.value.slice(0, NOTES_MAX))}
+                  placeholder="Notes for this action…"
+                  data-testid="admin-report-notes"
+                  className="w-full resize-y rounded-default bg-surface-container px-4 py-3 text-on-surface placeholder:text-on-surface-variant ring-1 ring-outline-variant transition-all focus:outline-none focus:ring-primary disabled:opacity-50"
+                />
+                <div className="self-end text-label-sm text-on-surface-variant">
+                  {notes.length} / {NOTES_MAX}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/frontend/src/components/admin/reports/AdminReportsFilters.tsx
+++ b/frontend/src/components/admin/reports/AdminReportsFilters.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { cn } from "@/lib/cn";
+
+export type ReportListStatus = "open" | "reviewed" | "all";
+
+const STATUS_PILLS: Array<{ value: ReportListStatus; label: string }> = [
+  { value: "open", label: "Open" },
+  { value: "reviewed", label: "Reviewed" },
+  { value: "all", label: "All" },
+];
+
+type Props = {
+  status: ReportListStatus;
+  onStatusChange: (s: ReportListStatus) => void;
+};
+
+export function AdminReportsFilters({ status, onStatusChange }: Props) {
+  return (
+    <div className="flex items-center gap-2" role="group" aria-label="Report status filter">
+      {STATUS_PILLS.map((pill) => (
+        <button
+          key={pill.value}
+          type="button"
+          onClick={() => onStatusChange(pill.value)}
+          data-testid={`status-pill-${pill.value}`}
+          className={cn(
+            "px-3 py-1.5 rounded-full text-label-sm transition-colors",
+            status === pill.value
+              ? "bg-secondary-container text-on-secondary-container font-medium"
+              : "bg-surface-container text-on-surface-variant hover:bg-surface-container-high"
+          )}
+        >
+          {pill.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/reports/AdminReportsListPage.test.tsx
+++ b/frontend/src/components/admin/reports/AdminReportsListPage.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderWithProviders, screen, waitFor } from "@/test/render";
+import { server } from "@/test/msw/server";
+import { adminHandlers } from "@/test/msw/handlers";
+import { AdminReportsListPage } from "./AdminReportsListPage";
+import type { AdminReportListingRow } from "@/lib/admin/types";
+
+const mockReplace = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/admin/reports"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: mockReplace,
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+function makeRow(overrides: Partial<AdminReportListingRow> = {}): AdminReportListingRow {
+  return {
+    auctionId: 10,
+    auctionTitle: "Test Parcel Auction",
+    auctionStatus: "ACTIVE",
+    parcelRegionName: "Heterocera",
+    sellerUserId: 7,
+    sellerDisplayName: "Seller One",
+    openReportCount: 2,
+    latestReportAt: "2026-04-01T10:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("AdminReportsListPage", () => {
+  beforeEach(() => {
+    mockReplace.mockReset();
+  });
+
+  it("renders rows from MSW seed", async () => {
+    server.use(
+      adminHandlers.reportsListSuccess([
+        makeRow({ auctionId: 10, auctionTitle: "Parcel Alpha" }),
+        makeRow({ auctionId: 11, auctionTitle: "Parcel Beta" }),
+      ])
+    );
+
+    renderWithProviders(<AdminReportsListPage />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("reports-table")).toBeInTheDocument()
+    );
+    expect(screen.getByText("Parcel Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Parcel Beta")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no rows returned", async () => {
+    server.use(adminHandlers.reportsListSuccess([]));
+
+    renderWithProviders(<AdminReportsListPage />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("empty-state")).toBeInTheDocument()
+    );
+    expect(screen.getByText(/No reports match/)).toBeInTheDocument();
+  });
+
+  it("clicking a row updates URL with auctionId", async () => {
+    server.use(
+      adminHandlers.reportsListSuccess([
+        makeRow({ auctionId: 42, auctionTitle: "Click Me" }),
+      ])
+    );
+
+    renderWithProviders(<AdminReportsListPage />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("report-row-42")).toBeInTheDocument()
+    );
+
+    screen.getByTestId("report-row-42").click();
+
+    expect(mockReplace).toHaveBeenCalledWith(
+      expect.stringContaining("auctionId=42"),
+      expect.anything()
+    );
+  });
+});

--- a/frontend/src/components/admin/reports/AdminReportsListPage.tsx
+++ b/frontend/src/components/admin/reports/AdminReportsListPage.tsx
@@ -1,0 +1,135 @@
+"use client";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useAdminReportsList } from "@/hooks/admin/useAdminReportsList";
+import { AdminReportsFilters, type ReportListStatus } from "./AdminReportsFilters";
+import { AdminReportsTable } from "./AdminReportsTable";
+import { AdminReportSlideOver } from "./AdminReportSlideOver";
+import { Pagination } from "@/components/ui/Pagination";
+
+const PAGE_SIZE = 25;
+
+function parseAuctionId(raw: string | null): number | null {
+  if (!raw) return null;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+function parseStatus(raw: string | null): ReportListStatus {
+  if (raw === "reviewed" || raw === "all") return raw;
+  return "open";
+}
+
+export function AdminReportsListPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const status = parseStatus(searchParams?.get("status") ?? null);
+  const page = Math.max(0, parseInt(searchParams?.get("page") ?? "0", 10) || 0);
+  const auctionId = parseAuctionId(searchParams?.get("auctionId") ?? null);
+
+  const { data: list, isLoading, isError } = useAdminReportsList({
+    status,
+    page,
+    size: PAGE_SIZE,
+  });
+
+  const ids = list?.content.map((r) => r.auctionId) ?? [];
+  const idx = auctionId !== null ? ids.indexOf(auctionId) : -1;
+  const listingRow = auctionId !== null
+    ? (list?.content.find((r) => r.auctionId === auctionId) ?? null)
+    : null;
+
+  function buildUrl(overrides: {
+    status?: ReportListStatus;
+    page?: number;
+    auctionId?: number | null;
+  }): string {
+    const params = new URLSearchParams();
+    const nextStatus = overrides.status ?? status;
+    const nextPage = overrides.page ?? page;
+    const nextAuctionId = "auctionId" in overrides ? overrides.auctionId : auctionId;
+    if (nextStatus !== "open") params.set("status", nextStatus);
+    if (nextPage > 0) params.set("page", String(nextPage));
+    if (nextAuctionId !== null && nextAuctionId !== undefined)
+      params.set("auctionId", String(nextAuctionId));
+    const qs = params.toString();
+    return qs ? `/admin/reports?${qs}` : "/admin/reports";
+  }
+
+  const handleStatusChange = (s: ReportListStatus) => {
+    router.replace(buildUrl({ status: s, page: 0, auctionId: null }), { scroll: false });
+  };
+
+  const handleSelect = (id: number) => {
+    router.replace(buildUrl({ auctionId: id }), { scroll: false });
+  };
+
+  const handleClose = () => {
+    router.replace(buildUrl({ auctionId: null }), { scroll: false });
+  };
+
+  const handlePrev = () => {
+    if (idx > 0)
+      router.replace(buildUrl({ auctionId: ids[idx - 1] }), { scroll: false });
+  };
+
+  const handleNext = () => {
+    if (idx < ids.length - 1)
+      router.replace(buildUrl({ auctionId: ids[idx + 1] }), { scroll: false });
+  };
+
+  const handlePage = (p: number) => {
+    router.replace(buildUrl({ page: p, auctionId: null }), { scroll: false });
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-semibold">Reports</h1>
+      </div>
+
+      <div className="mb-4">
+        <AdminReportsFilters status={status} onStatusChange={handleStatusChange} />
+      </div>
+
+      {isLoading && (
+        <div className="text-body-sm text-on-surface-variant py-8">Loading…</div>
+      )}
+
+      {isError && (
+        <div className="text-body-sm text-error py-8">
+          Could not load reports. Refresh to retry.
+        </div>
+      )}
+
+      {list && (
+        <>
+          <AdminReportsTable
+            rows={list.content}
+            selectedAuctionId={auctionId}
+            onSelect={handleSelect}
+          />
+          {list.totalPages > 1 && (
+            <div className="mt-4">
+              <Pagination
+                page={list.number}
+                totalPages={list.totalPages}
+                onPageChange={handlePage}
+              />
+            </div>
+          )}
+        </>
+      )}
+
+      <AdminReportSlideOver
+        auctionId={auctionId}
+        listingRow={listingRow}
+        hasPrev={idx > 0}
+        hasNext={idx !== -1 && idx < ids.length - 1}
+        onPrev={handlePrev}
+        onNext={handleNext}
+        onClose={handleClose}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/admin/reports/AdminReportsTable.tsx
+++ b/frontend/src/components/admin/reports/AdminReportsTable.tsx
@@ -1,0 +1,105 @@
+"use client";
+import { cn } from "@/lib/cn";
+import type { AdminReportListingRow, AuctionStatus } from "@/lib/admin/types";
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+const STATUS_CLASSES: Partial<Record<AuctionStatus, string>> = {
+  SUSPENDED: "text-error font-medium",
+  DISPUTED: "text-tertiary font-medium",
+};
+
+type Props = {
+  rows: AdminReportListingRow[];
+  selectedAuctionId: number | null;
+  onSelect: (auctionId: number) => void;
+};
+
+export function AdminReportsTable({ rows, selectedAuctionId, onSelect }: Props) {
+  if (rows.length === 0) {
+    return (
+      <div
+        className="py-12 text-center text-body-sm text-on-surface-variant"
+        data-testid="empty-state"
+      >
+        No reports match the current filter.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-default border border-outline-variant">
+      <table className="w-full text-body-sm" data-testid="reports-table">
+        <thead className="sticky top-0 bg-surface-container-low border-b border-outline-variant">
+          <tr>
+            <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium w-[90px]">
+              Latest
+            </th>
+            <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">
+              Listing
+            </th>
+            <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium w-[100px]">
+              Seller
+            </th>
+            <th className="px-3 py-2.5 text-right text-label-sm text-on-surface-variant font-medium w-[70px]">
+              Reports
+            </th>
+            <th className="px-3 py-2.5 text-right text-label-sm text-on-surface-variant font-medium w-[100px]">
+              Status
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const statusClass =
+              STATUS_CLASSES[row.auctionStatus] ?? "text-on-surface";
+            return (
+              <tr
+                key={row.auctionId}
+                role="row"
+                data-testid={`report-row-${row.auctionId}`}
+                onClick={() => onSelect(row.auctionId)}
+                className={cn(
+                  "border-b border-outline-variant/50 cursor-pointer transition-colors",
+                  selectedAuctionId === row.auctionId
+                    ? "bg-secondary-container/30"
+                    : "hover:bg-surface-container"
+                )}
+              >
+                <td className="px-3 py-2.5 text-on-surface-variant whitespace-nowrap">
+                  {formatDate(row.latestReportAt)}
+                </td>
+                <td className="px-3 py-2.5 text-on-surface">
+                  <div className="font-medium line-clamp-1">
+                    {row.auctionTitle ?? "(no title)"}
+                  </div>
+                  {row.parcelRegionName && (
+                    <div className="text-on-surface-variant text-[11px]">
+                      {row.parcelRegionName}
+                    </div>
+                  )}
+                </td>
+                <td className="px-3 py-2.5 text-on-surface-variant">
+                  {row.sellerDisplayName ?? "—"}
+                </td>
+                <td className="px-3 py-2.5 text-right font-medium text-on-surface">
+                  {row.openReportCount}
+                </td>
+                <td className={cn("px-3 py-2.5 text-right", statusClass)}>
+                  {row.auctionStatus}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/reports/ReasonBadge.tsx
+++ b/frontend/src/components/admin/reports/ReasonBadge.tsx
@@ -1,0 +1,18 @@
+"use client";
+import {
+  REPORT_REASON_FAMILY,
+  REPORT_REASON_LABEL,
+  REPORT_FAMILY_TONE_CLASSES,
+} from "@/lib/admin/reportReasonStyle";
+import type { ListingReportReason } from "@/lib/admin/types";
+
+type Props = { reason: ListingReportReason };
+
+export function ReasonBadge({ reason }: Props) {
+  const tone = REPORT_FAMILY_TONE_CLASSES[REPORT_REASON_FAMILY[reason]];
+  return (
+    <span className={`${tone} px-2 py-0.5 rounded-full text-[10px] font-medium`}>
+      {REPORT_REASON_LABEL[reason]}
+    </span>
+  );
+}

--- a/frontend/src/components/admin/users/AdminUserDetailPage.test.tsx
+++ b/frontend/src/components/admin/users/AdminUserDetailPage.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderWithProviders, screen, waitFor } from "@/test/render";
+import { server } from "@/test/msw/server";
+import { adminHandlers } from "@/test/msw/handlers";
+import { AdminUserDetailPage } from "./AdminUserDetailPage";
+import type { AdminUserDetail } from "@/lib/admin/types";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/admin/users/10"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+function makeUser(overrides: Partial<AdminUserDetail> = {}): AdminUserDetail {
+  return {
+    id: 10,
+    email: "detail@example.com",
+    displayName: "Detail User",
+    slAvatarUuid: "aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb",
+    slDisplayName: "DetailUser Resident",
+    role: "USER",
+    verified: true,
+    verifiedAt: "2026-04-14T12:00:00Z",
+    createdAt: "2026-04-01T10:00:00Z",
+    completedSales: 3,
+    cancelledWithBids: 1,
+    escrowExpiredUnfulfilled: 0,
+    dismissedReportsCount: 0,
+    penaltyBalanceOwed: 500,
+    listingSuspensionUntil: null,
+    bannedFromListing: false,
+    activeBan: null,
+    ...overrides,
+  };
+}
+
+describe("AdminUserDetailPage", () => {
+  it("renders loading state before data arrives", () => {
+    // Don't register the handler — let it hang
+    renderWithProviders(<AdminUserDetailPage userId={10} />);
+    // Should show loading indicator initially since query hasn't resolved
+    expect(screen.getByTestId("user-detail-loading")).toBeInTheDocument();
+  });
+
+  it("renders profile header, stats, and tabs after data loads", async () => {
+    const user = makeUser();
+    server.use(adminHandlers.userDetailSuccess(user));
+    server.use(adminHandlers.userListingsSuccess(10, []));
+
+    renderWithProviders(<AdminUserDetailPage userId={10} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("user-detail-page")).toBeInTheDocument()
+    );
+
+    expect(screen.getByTestId("user-profile-header")).toBeInTheDocument();
+    expect(screen.getByTestId("user-stats-cards")).toBeInTheDocument();
+    expect(screen.getByTestId("user-tabs-nav")).toBeInTheDocument();
+    expect(screen.getByTestId("user-actions-rail")).toBeInTheDocument();
+  });
+
+  it("shows display name in profile header", async () => {
+    server.use(adminHandlers.userDetailSuccess(makeUser({ displayName: "Specific Name" })));
+    server.use(adminHandlers.userListingsSuccess(10, []));
+
+    renderWithProviders(<AdminUserDetailPage userId={10} />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Specific Name")).toBeInTheDocument()
+    );
+  });
+
+  it("shows ADMIN chip when user is admin", async () => {
+    server.use(adminHandlers.userDetailSuccess(makeUser({ role: "ADMIN" })));
+    server.use(adminHandlers.userListingsSuccess(10, []));
+
+    renderWithProviders(<AdminUserDetailPage userId={10} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("admin-chip")).toBeInTheDocument()
+    );
+  });
+
+  it("shows BANNED chip when user has active ban", async () => {
+    server.use(
+      adminHandlers.userDetailSuccess(
+        makeUser({
+          activeBan: {
+            id: 1,
+            banType: "AVATAR",
+            reasonText: "Test ban",
+            expiresAt: null,
+          },
+        })
+      )
+    );
+    server.use(adminHandlers.userListingsSuccess(10, []));
+
+    renderWithProviders(<AdminUserDetailPage userId={10} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("banned-chip")).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/components/admin/users/AdminUserDetailPage.tsx
+++ b/frontend/src/components/admin/users/AdminUserDetailPage.tsx
@@ -1,0 +1,62 @@
+"use client";
+import { useState } from "react";
+import { useAdminUser } from "@/hooks/admin/useAdminUser";
+import { UserProfileHeader } from "./UserProfileHeader";
+import { UserStatsCards } from "./UserStatsCards";
+import { UserTabsNav, type UserTab } from "./UserTabsNav";
+import { ListingsTab } from "./tabs/ListingsTab";
+import { BidsTab } from "./tabs/BidsTab";
+import { CancellationsTab } from "./tabs/CancellationsTab";
+import { ReportsTab } from "./tabs/ReportsTab";
+import { FraudFlagsTab } from "./tabs/FraudFlagsTab";
+import { ModerationTab } from "./tabs/ModerationTab";
+import { UserActionsRail } from "./UserActionsRail";
+
+type Props = {
+  userId: number;
+};
+
+export function AdminUserDetailPage({ userId }: Props) {
+  const [activeTab, setActiveTab] = useState<UserTab>("listings");
+  const { data: user, isLoading, isError, refetch } = useAdminUser(userId);
+
+  if (isLoading) {
+    return (
+      <div className="py-12 text-body-sm text-on-surface-variant" data-testid="user-detail-loading">
+        Loading user…
+      </div>
+    );
+  }
+
+  if (isError || !user) {
+    return (
+      <div className="py-12 text-body-sm text-error" data-testid="user-detail-error">
+        Could not load user. Refresh to retry.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="grid grid-cols-[1fr_280px] gap-6 items-start"
+      data-testid="user-detail-page"
+    >
+      <div className="min-w-0">
+        <UserProfileHeader user={user} />
+        <UserStatsCards stats={user} />
+        <UserTabsNav active={activeTab} onChange={setActiveTab} />
+
+        {activeTab === "listings" && <ListingsTab userId={userId} />}
+        {activeTab === "bids" && <BidsTab userId={userId} />}
+        {activeTab === "cancellations" && <CancellationsTab userId={userId} />}
+        {activeTab === "reports" && <ReportsTab userId={userId} />}
+        {activeTab === "fraudFlags" && <FraudFlagsTab userId={userId} />}
+        {activeTab === "moderation" && <ModerationTab userId={userId} />}
+      </div>
+
+      <div className="sticky top-6">
+        <UserActionsRail user={user} onRefresh={() => refetch()} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/users/AdminUsersSearchPage.tsx
+++ b/frontend/src/components/admin/users/AdminUsersSearchPage.tsx
@@ -1,0 +1,78 @@
+"use client";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useAdminUsersList } from "@/hooks/admin/useAdminUsersList";
+import { AdminUsersTable } from "./AdminUsersTable";
+import { Pagination } from "@/components/ui/Pagination";
+
+const PAGE_SIZE = 25;
+
+function SkeletonRows() {
+  return (
+    <div className="space-y-2 py-4" aria-busy="true">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="h-12 rounded-default bg-surface-container animate-pulse" />
+      ))}
+    </div>
+  );
+}
+
+export function AdminUsersSearchPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const search = searchParams?.get("search") ?? "";
+  const page = Math.max(0, parseInt(searchParams?.get("page") ?? "0", 10) || 0);
+
+  const filters = { search: search || undefined, page, size: PAGE_SIZE };
+  const { data, isLoading, isError } = useAdminUsersList(filters);
+
+  function navigate(overrides: { search?: string; page?: number }) {
+    const params = new URLSearchParams();
+    const nextSearch = "search" in overrides ? overrides.search : search;
+    const nextPage = overrides.page ?? 0;
+    if (nextSearch) params.set("search", nextSearch);
+    if (nextPage > 0) params.set("page", String(nextPage));
+    const qs = params.toString();
+    router.push(qs ? `/admin/users?${qs}` : "/admin/users");
+  }
+
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold mb-4">Users</h1>
+
+      <input
+        key={search}
+        defaultValue={search}
+        placeholder="Search by email, display name, SL display name, or paste a UUID"
+        data-testid="user-search-input"
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            const v = (e.target as HTMLInputElement).value.trim();
+            navigate({ search: v || undefined, page: 0 });
+          }
+        }}
+        className="w-full mb-4 rounded-default bg-surface-container px-4 py-2.5 text-body-md text-on-surface placeholder:text-on-surface-variant ring-1 ring-outline-variant focus:outline-none focus:ring-primary"
+      />
+
+      {isLoading && <SkeletonRows />}
+
+      {isError && (
+        <div className="text-body-sm text-error py-6">Could not load users. Refresh to retry.</div>
+      )}
+
+      {data && (
+        <>
+          <AdminUsersTable rows={data.content} />
+          {data.totalPages > 1 && (
+            <div className="mt-4">
+              <Pagination
+                page={data.number}
+                totalPages={data.totalPages}
+                onPageChange={(p) => navigate({ page: p })}
+              />
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/users/AdminUsersTable.test.tsx
+++ b/frontend/src/components/admin/users/AdminUsersTable.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderWithProviders, screen } from "@/test/render";
+import { AdminUsersTable } from "./AdminUsersTable";
+import type { AdminUserSummary } from "@/lib/admin/types";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/admin/users"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+function makeUser(overrides: Partial<AdminUserSummary> = {}): AdminUserSummary {
+  return {
+    id: 1,
+    email: "user@example.com",
+    displayName: "Test User",
+    slAvatarUuid: null,
+    slDisplayName: null,
+    role: "USER",
+    verified: false,
+    hasActiveBan: false,
+    completedSales: 0,
+    cancelledWithBids: 0,
+    createdAt: "2026-04-01T10:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("AdminUsersTable", () => {
+  it("shows empty state when no rows", () => {
+    renderWithProviders(<AdminUsersTable rows={[]} />);
+    expect(screen.getByTestId("empty-state")).toBeInTheDocument();
+  });
+
+  it("renders rows for each user", () => {
+    const users = [
+      makeUser({ id: 1, displayName: "Alice" }),
+      makeUser({ id: 2, displayName: "Bob" }),
+      makeUser({ id: 3, displayName: "Charlie" }),
+    ];
+    renderWithProviders(<AdminUsersTable rows={users} />);
+
+    expect(screen.getByTestId("users-table")).toBeInTheDocument();
+    expect(screen.getByTestId("user-row-1")).toBeInTheDocument();
+    expect(screen.getByTestId("user-row-2")).toBeInTheDocument();
+    expect(screen.getByTestId("user-row-3")).toBeInTheDocument();
+  });
+
+  it("shows ADMIN chip for admin users", () => {
+    renderWithProviders(<AdminUsersTable rows={[makeUser({ id: 5, role: "ADMIN" })]} />);
+    expect(screen.getByText("ADMIN")).toBeInTheDocument();
+  });
+
+  it("shows BANNED chip for users with active ban", () => {
+    renderWithProviders(<AdminUsersTable rows={[makeUser({ id: 6, hasActiveBan: true })]} />);
+    expect(screen.getByText("BANNED")).toBeInTheDocument();
+  });
+
+  it("shows cancelled-with-bids count in error color when nonzero", () => {
+    renderWithProviders(
+      <AdminUsersTable rows={[makeUser({ id: 7, cancelledWithBids: 3 })]} />
+    );
+    const row = screen.getByTestId("user-row-7");
+    expect(row).toBeInTheDocument();
+    expect(row.textContent).toContain("3 cancelled");
+  });
+
+  it("links to /admin/users/:id for each row", () => {
+    renderWithProviders(<AdminUsersTable rows={[makeUser({ id: 42, displayName: "Link Test" })]} />);
+    const link = screen.getByTestId("user-link-42");
+    expect(link).toHaveAttribute("href", "/admin/users/42");
+  });
+});

--- a/frontend/src/components/admin/users/AdminUsersTable.tsx
+++ b/frontend/src/components/admin/users/AdminUsersTable.tsx
@@ -1,0 +1,114 @@
+import Link from "next/link";
+import type { AdminUserSummary } from "@/lib/admin/types";
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function truncateUuid(uuid: string): string {
+  return uuid.length > 20 ? `${uuid.slice(0, 8)}…${uuid.slice(-4)}` : uuid;
+}
+
+type Props = {
+  rows: AdminUserSummary[];
+};
+
+export function AdminUsersTable({ rows }: Props) {
+  if (rows.length === 0) {
+    return (
+      <div
+        className="py-12 text-center text-body-sm text-on-surface-variant"
+        data-testid="empty-state"
+      >
+        No users found.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-default border border-outline-variant" data-testid="users-table">
+      <table className="w-full text-body-sm">
+        <thead className="bg-surface-container-low border-b border-outline-variant">
+          <tr>
+            <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Name</th>
+            <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Email</th>
+            <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">SL UUID</th>
+            <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Role</th>
+            <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Verified</th>
+            <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Status</th>
+            <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Member since</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr
+              key={row.id}
+              data-testid={`user-row-${row.id}`}
+              className="border-b border-outline-variant/50 hover:bg-surface-container/50 cursor-pointer"
+            >
+              <td className="px-3 py-2.5">
+                <Link
+                  href={`/admin/users/${row.id}`}
+                  className="block"
+                  data-testid={`user-link-${row.id}`}
+                >
+                  <div className="text-on-surface font-medium">
+                    {row.displayName ?? row.email}
+                  </div>
+                  <div className="text-[11px] text-on-surface-variant mt-0.5">
+                    {row.completedSales} sold
+                    {row.cancelledWithBids > 0 && (
+                      <span className="text-error"> · {row.cancelledWithBids} cancelled</span>
+                    )}
+                  </div>
+                </Link>
+              </td>
+              <td className="px-3 py-2.5 text-on-surface-variant">{row.email}</td>
+              <td className="px-3 py-2.5">
+                {row.slAvatarUuid ? (
+                  <span className="font-mono text-[11px] text-on-surface-variant" title={row.slAvatarUuid}>
+                    {truncateUuid(row.slAvatarUuid)}
+                  </span>
+                ) : (
+                  <span className="text-on-surface-variant/50">—</span>
+                )}
+              </td>
+              <td className="px-3 py-2.5">
+                {row.role === "ADMIN" ? (
+                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold bg-tertiary-container text-on-tertiary-container">
+                    ADMIN
+                  </span>
+                ) : (
+                  <span className="text-[11px] text-on-surface-variant">User</span>
+                )}
+              </td>
+              <td className="px-3 py-2.5">
+                {row.verified ? (
+                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold bg-secondary-container text-on-secondary-container">
+                    Yes
+                  </span>
+                ) : (
+                  <span className="text-[11px] text-on-surface-variant">No</span>
+                )}
+              </td>
+              <td className="px-3 py-2.5">
+                {row.hasActiveBan ? (
+                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold bg-error text-on-error">
+                    BANNED
+                  </span>
+                ) : (
+                  <span className="text-[11px] text-on-surface-variant">—</span>
+                )}
+              </td>
+              <td className="px-3 py-2.5 text-on-surface-variant text-[11px]">{formatDate(row.createdAt)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/users/ConfirmActionModal.tsx
+++ b/frontend/src/components/admin/users/ConfirmActionModal.tsx
@@ -1,0 +1,128 @@
+"use client";
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/Button";
+
+const NOTES_MAX = 1000;
+
+type Props = {
+  open: boolean;
+  title: string;
+  description?: string;
+  confirmLabel: string;
+  confirmVariant?: "primary" | "destructive";
+  isPending?: boolean;
+  onConfirm: (notes: string) => void;
+  onClose: () => void;
+};
+
+export function ConfirmActionModal({
+  open,
+  title,
+  description,
+  confirmLabel,
+  confirmVariant = "primary",
+  isPending = false,
+  onConfirm,
+  onClose,
+}: Props) {
+  const [notes, setNotes] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setNotes("");
+  }, [open]);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  const canSubmit = notes.trim().length > 0 && !isPending;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    onConfirm(notes.trim());
+  }
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40 bg-inverse-surface/20"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        data-testid="confirm-action-modal"
+        className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      >
+        <div
+          className="w-full max-w-md rounded-default bg-surface-container-low border border-outline-variant shadow-elevated p-6 flex flex-col gap-4"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-start justify-between gap-2">
+            <div>
+              <h2 className="text-title-md font-semibold text-on-surface">{title}</h2>
+              {description && (
+                <p className="mt-1 text-body-sm text-on-surface-variant">{description}</p>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="p-1.5 rounded-default text-on-surface-variant hover:bg-surface-container"
+            >
+              ✕
+            </button>
+          </div>
+
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <label htmlFor="action-notes" className="text-label-md font-medium text-on-surface">
+                Notes <span className="text-error">*</span>
+              </label>
+              <textarea
+                id="action-notes"
+                rows={4}
+                value={notes}
+                disabled={isPending}
+                onChange={(e) => setNotes(e.target.value.slice(0, NOTES_MAX))}
+                placeholder="Explain the reason for this action…"
+                data-testid="action-notes-textarea"
+                className="w-full resize-y rounded-default bg-surface-container px-4 py-3 text-on-surface placeholder:text-on-surface-variant ring-1 ring-outline-variant transition-all focus:outline-none focus:ring-primary disabled:opacity-50"
+              />
+              <div className="self-end text-label-sm text-on-surface-variant">
+                {notes.length} / {NOTES_MAX}
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <Button variant="secondary" type="button" onClick={onClose} disabled={isPending}>
+                Cancel
+              </Button>
+              <Button
+                variant={confirmVariant}
+                type="submit"
+                disabled={!canSubmit}
+                loading={isPending}
+                data-testid="confirm-action-submit"
+              >
+                {confirmLabel}
+              </Button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/admin/users/RecentIpsModal.tsx
+++ b/frontend/src/components/admin/users/RecentIpsModal.tsx
@@ -1,0 +1,120 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useAdminUserIps } from "@/hooks/admin/useAdminUserIps";
+import { CreateBanModal } from "@/components/admin/bans/CreateBanModal";
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+type Props = {
+  userId: number;
+  onClose: () => void;
+};
+
+export function RecentIpsModal({ userId, onClose }: Props) {
+  const { data, isLoading, isError } = useAdminUserIps(userId);
+  const [banIp, setBanIp] = useState<string | null>(null);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40 bg-inverse-surface/20"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Recent IPs"
+        data-testid="recent-ips-modal"
+        className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      >
+        <div
+          className="w-full max-w-lg rounded-default bg-surface-container-low border border-outline-variant shadow-elevated p-6 flex flex-col gap-4 max-h-[80vh] overflow-y-auto"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center justify-between">
+            <h2 className="text-title-md font-semibold text-on-surface">Recent IPs</h2>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="p-1.5 rounded-default text-on-surface-variant hover:bg-surface-container"
+            >
+              ✕
+            </button>
+          </div>
+
+          {isLoading && (
+            <div className="text-body-sm text-on-surface-variant py-4">Loading IPs…</div>
+          )}
+
+          {isError && (
+            <div className="text-body-sm text-error py-4">Could not load IPs.</div>
+          )}
+
+          {data && data.length === 0 && (
+            <div className="text-body-sm text-on-surface-variant py-4">No IP history found.</div>
+          )}
+
+          {data && data.length > 0 && (
+            <div className="overflow-x-auto rounded-default border border-outline-variant">
+              <table className="w-full text-body-sm">
+                <thead className="bg-surface-container-low border-b border-outline-variant">
+                  <tr>
+                    <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">IP Address</th>
+                    <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Sessions</th>
+                    <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Last seen</th>
+                    <th className="px-3 py-2.5 w-[80px]" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.map((row) => (
+                    <tr
+                      key={row.ipAddress}
+                      className="border-b border-outline-variant/50"
+                      data-testid={`ip-row-${row.ipAddress}`}
+                    >
+                      <td className="px-3 py-2.5 font-mono text-[11px] text-on-surface">{row.ipAddress}</td>
+                      <td className="px-3 py-2.5 text-on-surface-variant">{row.sessionCount}</td>
+                      <td className="px-3 py-2.5 text-on-surface-variant text-[11px]">{formatDate(row.lastSeenAt)}</td>
+                      <td className="px-3 py-2.5 text-right">
+                        <button
+                          type="button"
+                          onClick={() => setBanIp(row.ipAddress)}
+                          data-testid={`ban-ip-btn-${row.ipAddress}`}
+                          className="text-[11px] text-error hover:underline underline-offset-2"
+                        >
+                          Ban IP
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <CreateBanModal
+        open={banIp !== null}
+        onClose={() => setBanIp(null)}
+        initialIpAddress={banIp ?? undefined}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/admin/users/ReinstateListingModal.tsx
+++ b/frontend/src/components/admin/users/ReinstateListingModal.tsx
@@ -1,0 +1,113 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useReinstateAuction } from "@/hooks/admin/useReinstateAuction";
+import { Button } from "@/components/ui/Button";
+import type { AdminUserListingRow } from "@/lib/admin/types";
+
+const NOTES_MAX = 1000;
+
+type Props = {
+  auction: AdminUserListingRow;
+  userId: number;
+  onClose: () => void;
+};
+
+export function ReinstateListingModal({ auction, userId, onClose }: Props) {
+  const [notes, setNotes] = useState("");
+  const reinstate = useReinstateAuction(userId);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  const canSubmit = notes.trim().length > 0 && !reinstate.isPending;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    reinstate.mutate(
+      { auctionId: auction.auctionId, notes: notes.trim() },
+      { onSuccess: onClose }
+    );
+  }
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40 bg-inverse-surface/20"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Reinstate listing"
+        data-testid="reinstate-listing-modal"
+        className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      >
+        <div
+          className="w-full max-w-md rounded-default bg-surface-container-low border border-outline-variant shadow-elevated p-6 flex flex-col gap-4"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-start justify-between gap-2">
+            <div>
+              <h2 className="text-title-md font-semibold text-on-surface">Reinstate listing</h2>
+              <p className="mt-1 text-body-sm text-on-surface-variant line-clamp-2">
+                {auction.title}
+                {auction.regionName ? ` · ${auction.regionName}` : ""}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="p-1.5 rounded-default text-on-surface-variant hover:bg-surface-container"
+            >
+              ✕
+            </button>
+          </div>
+
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <label htmlFor="reinstate-notes" className="text-label-md font-medium text-on-surface">
+                Notes <span className="text-error">*</span>
+              </label>
+              <textarea
+                id="reinstate-notes"
+                rows={4}
+                value={notes}
+                disabled={reinstate.isPending}
+                onChange={(e) => setNotes(e.target.value.slice(0, NOTES_MAX))}
+                placeholder="Explain why this listing is being reinstated…"
+                data-testid="reinstate-notes-textarea"
+                className="w-full resize-y rounded-default bg-surface-container px-4 py-3 text-on-surface placeholder:text-on-surface-variant ring-1 ring-outline-variant transition-all focus:outline-none focus:ring-primary disabled:opacity-50"
+              />
+              <div className="self-end text-label-sm text-on-surface-variant">
+                {notes.length} / {NOTES_MAX}
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <Button variant="secondary" type="button" onClick={onClose} disabled={reinstate.isPending}>
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                type="submit"
+                disabled={!canSubmit}
+                loading={reinstate.isPending}
+                data-testid="reinstate-listing-submit"
+              >
+                Reinstate
+              </Button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/admin/users/UserActionsRail.test.tsx
+++ b/frontend/src/components/admin/users/UserActionsRail.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderWithProviders, screen } from "@/test/render";
+import { UserActionsRail } from "./UserActionsRail";
+import type { AdminUserDetail } from "@/lib/admin/types";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/admin/users/1"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+function makeUser(overrides: Partial<AdminUserDetail> = {}): AdminUserDetail {
+  return {
+    id: 1,
+    email: "user@example.com",
+    displayName: "Test User",
+    slAvatarUuid: "11111111-2222-3333-4444-555555555555",
+    slDisplayName: "TestUser Resident",
+    role: "USER",
+    verified: true,
+    verifiedAt: "2026-04-14T12:00:00Z",
+    createdAt: "2026-04-01T10:00:00Z",
+    completedSales: 5,
+    cancelledWithBids: 0,
+    escrowExpiredUnfulfilled: 0,
+    dismissedReportsCount: 0,
+    penaltyBalanceOwed: 0,
+    listingSuspensionUntil: null,
+    bannedFromListing: false,
+    activeBan: null,
+    ...overrides,
+  };
+}
+
+describe("UserActionsRail", () => {
+  it("shows Promote button when role is USER", () => {
+    const user = makeUser({ role: "USER" });
+    renderWithProviders(<UserActionsRail user={user} onRefresh={vi.fn()} />);
+    expect(screen.getByTestId("promote-btn")).toBeInTheDocument();
+    expect(screen.queryByTestId("demote-btn")).not.toBeInTheDocument();
+  });
+
+  it("shows Demote button when role is ADMIN", () => {
+    const user = makeUser({ role: "ADMIN" });
+    renderWithProviders(<UserActionsRail user={user} onRefresh={vi.fn()} />);
+    expect(screen.getByTestId("demote-btn")).toBeInTheDocument();
+    expect(screen.queryByTestId("promote-btn")).not.toBeInTheDocument();
+  });
+
+  it("shows active ban callout when user has an active ban", () => {
+    const user = makeUser({
+      activeBan: {
+        id: 99,
+        banType: "AVATAR",
+        reasonText: "Shill bidding detected",
+        expiresAt: null,
+      },
+    });
+    renderWithProviders(<UserActionsRail user={user} onRefresh={vi.fn()} />);
+    expect(screen.getByTestId("lift-ban-btn")).toBeInTheDocument();
+    expect(screen.getByText("Shill bidding detected")).toBeInTheDocument();
+  });
+
+  it("does not show active ban callout when no active ban", () => {
+    const user = makeUser({ activeBan: null });
+    renderWithProviders(<UserActionsRail user={user} onRefresh={vi.fn()} />);
+    expect(screen.queryByTestId("lift-ban-btn")).not.toBeInTheDocument();
+  });
+
+  it("shows Reset counter button when cancelledWithBids > 0", () => {
+    const user = makeUser({ cancelledWithBids: 3 });
+    renderWithProviders(<UserActionsRail user={user} onRefresh={vi.fn()} />);
+    expect(screen.getByTestId("reset-frivolous-btn")).toBeInTheDocument();
+  });
+
+  it("does not show Reset counter button when cancelledWithBids is 0", () => {
+    const user = makeUser({ cancelledWithBids: 0 });
+    renderWithProviders(<UserActionsRail user={user} onRefresh={vi.fn()} />);
+    expect(screen.queryByTestId("reset-frivolous-btn")).not.toBeInTheDocument();
+  });
+
+  it("shows Recent IPs button", () => {
+    renderWithProviders(<UserActionsRail user={makeUser()} onRefresh={vi.fn()} />);
+    expect(screen.getByTestId("recent-ips-btn")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/admin/users/UserActionsRail.tsx
+++ b/frontend/src/components/admin/users/UserActionsRail.tsx
@@ -1,0 +1,242 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+import { usePromoteUser } from "@/hooks/admin/usePromoteUser";
+import { useDemoteUser } from "@/hooks/admin/useDemoteUser";
+import { useResetFrivolousCounter } from "@/hooks/admin/useResetFrivolousCounter";
+import { ConfirmActionModal } from "./ConfirmActionModal";
+import { RecentIpsModal } from "./RecentIpsModal";
+import { CreateBanModal } from "@/components/admin/bans/CreateBanModal";
+import { LiftBanModal } from "@/components/admin/bans/LiftBanModal";
+import { Button } from "@/components/ui/Button";
+import type { AdminUserDetail, AdminBanRow } from "@/lib/admin/types";
+
+type Action = "promote" | "demote" | "resetFrivolous" | null;
+
+type Props = {
+  user: AdminUserDetail;
+  onRefresh: () => void;
+};
+
+export function UserActionsRail({ user, onRefresh }: Props) {
+  const [pendingAction, setPendingAction] = useState<Action>(null);
+  const [showIps, setShowIps] = useState(false);
+  const [showCreateBan, setShowCreateBan] = useState(false);
+  const [showLiftBan, setShowLiftBan] = useState(false);
+
+  const promote = usePromoteUser(user.id);
+  const demote = useDemoteUser(user.id);
+  const resetFrivolous = useResetFrivolousCounter(user.id);
+
+  const activeBanAsRow: AdminBanRow | null = user.activeBan
+    ? {
+        id: user.activeBan.id,
+        banType: user.activeBan.banType,
+        ipAddress: null,
+        slAvatarUuid: user.slAvatarUuid,
+        avatarLinkedUserId: user.id,
+        avatarLinkedDisplayName: user.displayName,
+        firstSeenIp: null,
+        reasonCategory: "OTHER",
+        reasonText: user.activeBan.reasonText,
+        bannedByUserId: 0,
+        bannedByDisplayName: null,
+        expiresAt: user.activeBan.expiresAt,
+        createdAt: new Date().toISOString(),
+        liftedAt: null,
+        liftedByUserId: null,
+        liftedByDisplayName: null,
+        liftedReason: null,
+      }
+    : null;
+
+  function handleConfirm(notes: string) {
+    if (pendingAction === "promote") {
+      promote.mutate(notes, { onSuccess: () => { setPendingAction(null); onRefresh(); } });
+    } else if (pendingAction === "demote") {
+      demote.mutate(notes, { onSuccess: () => { setPendingAction(null); onRefresh(); } });
+    } else if (pendingAction === "resetFrivolous") {
+      resetFrivolous.mutate(notes, { onSuccess: () => { setPendingAction(null); onRefresh(); } });
+    }
+  }
+
+  const isMutating = promote.isPending || demote.isPending || resetFrivolous.isPending;
+
+  const modalProps = {
+    promote: {
+      title: "Promote to admin",
+      description: `Grant ${user.displayName ?? user.email} admin privileges?`,
+      confirmLabel: "Promote",
+      confirmVariant: "primary" as const,
+    },
+    demote: {
+      title: "Demote from admin",
+      description: `Remove admin privileges from ${user.displayName ?? user.email}?`,
+      confirmLabel: "Demote",
+      confirmVariant: "destructive" as const,
+    },
+    resetFrivolous: {
+      title: "Reset frivolous counter",
+      description: `Reset the frivolous cancellation counter for ${user.displayName ?? user.email}?`,
+      confirmLabel: "Reset",
+      confirmVariant: "primary" as const,
+    },
+  };
+
+  const currentModal = pendingAction ? modalProps[pendingAction] : null;
+
+  return (
+    <aside
+      className="w-[280px] shrink-0 flex flex-col gap-3"
+      data-testid="user-actions-rail"
+    >
+      {/* Active ban callout */}
+      {user.activeBan && (
+        <div className="rounded-default bg-error-container border border-error/20 p-4 flex flex-col gap-2">
+          <div className="text-label-sm font-semibold text-on-error-container">Active ban</div>
+          <div className="text-body-sm text-on-error-container/80 line-clamp-3">
+            {user.activeBan.reasonText}
+          </div>
+          {user.activeBan.expiresAt && (
+            <div className="text-[11px] text-on-error-container/70">
+              Expires {new Date(user.activeBan.expiresAt).toLocaleDateString()}
+            </div>
+          )}
+          {activeBanAsRow && (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setShowLiftBan(true)}
+              data-testid="lift-ban-btn"
+            >
+              Lift ban
+            </Button>
+          )}
+        </div>
+      )}
+
+      {/* Role actions */}
+      <div className="rounded-default bg-surface-container border border-outline-variant p-4 flex flex-col gap-2">
+        <div className="text-label-sm font-medium text-on-surface-variant mb-1">Role</div>
+
+        {user.role === "USER" && (
+          <Button
+            variant="secondary"
+            size="sm"
+            fullWidth
+            onClick={() => setPendingAction("promote")}
+            data-testid="promote-btn"
+          >
+            Promote to admin
+          </Button>
+        )}
+
+        {user.role === "ADMIN" && (
+          <Button
+            variant="destructive"
+            size="sm"
+            fullWidth
+            onClick={() => setPendingAction("demote")}
+            data-testid="demote-btn"
+          >
+            Demote from admin
+          </Button>
+        )}
+      </div>
+
+      {/* Frivolous counter */}
+      {user.cancelledWithBids > 0 && (
+        <div className="rounded-default bg-surface-container border border-outline-variant p-4 flex flex-col gap-2">
+          <div className="text-label-sm font-medium text-on-surface-variant mb-1">
+            Frivolous cancellations: {user.cancelledWithBids}
+          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            fullWidth
+            onClick={() => setPendingAction("resetFrivolous")}
+            data-testid="reset-frivolous-btn"
+          >
+            Reset counter
+          </Button>
+        </div>
+      )}
+
+      {/* Bans */}
+      <div className="rounded-default bg-surface-container border border-outline-variant p-4 flex flex-col gap-2">
+        <div className="text-label-sm font-medium text-on-surface-variant mb-1">Bans</div>
+        <Button
+          variant="secondary"
+          size="sm"
+          fullWidth
+          onClick={() => setShowCreateBan(true)}
+          data-testid="add-ban-btn"
+        >
+          + Add ban
+        </Button>
+      </div>
+
+      {/* Quick links */}
+      <div className="rounded-default bg-surface-container border border-outline-variant p-4 flex flex-col gap-2">
+        <div className="text-label-sm font-medium text-on-surface-variant mb-1">Quick links</div>
+        <Link
+          href={`/users/${user.id}`}
+          className="text-body-sm text-primary hover:underline underline-offset-2"
+          target="_blank"
+          data-testid="public-profile-link"
+        >
+          Public profile
+        </Link>
+        {user.slAvatarUuid && (
+          <button
+            type="button"
+            onClick={() => navigator.clipboard.writeText(user.slAvatarUuid!)}
+            className="text-left text-body-sm text-on-surface-variant hover:text-on-surface transition-colors"
+            data-testid="copy-uuid-btn"
+          >
+            Copy SL UUID
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => setShowIps(true)}
+          className="text-left text-body-sm text-on-surface-variant hover:text-on-surface transition-colors"
+          data-testid="recent-ips-btn"
+        >
+          Recent IPs
+        </button>
+      </div>
+
+      {/* Modals */}
+      {currentModal && (
+        <ConfirmActionModal
+          open={pendingAction !== null}
+          title={currentModal.title}
+          description={currentModal.description}
+          confirmLabel={currentModal.confirmLabel}
+          confirmVariant={currentModal.confirmVariant}
+          isPending={isMutating}
+          onConfirm={handleConfirm}
+          onClose={() => setPendingAction(null)}
+        />
+      )}
+
+      {showIps && (
+        <RecentIpsModal userId={user.id} onClose={() => setShowIps(false)} />
+      )}
+
+      <CreateBanModal
+        open={showCreateBan}
+        onClose={() => setShowCreateBan(false)}
+        initialSlAvatarUuid={user.slAvatarUuid ?? undefined}
+      />
+
+      {showLiftBan && activeBanAsRow && (
+        <LiftBanModal
+          ban={activeBanAsRow}
+          onClose={() => { setShowLiftBan(false); onRefresh(); }}
+        />
+      )}
+    </aside>
+  );
+}

--- a/frontend/src/components/admin/users/UserProfileHeader.tsx
+++ b/frontend/src/components/admin/users/UserProfileHeader.tsx
@@ -1,0 +1,82 @@
+import type { AdminUserDetail } from "@/lib/admin/types";
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function truncateUuid(uuid: string): string {
+  return uuid.length > 16 ? `${uuid.slice(0, 8)}…${uuid.slice(-4)}` : uuid;
+}
+
+type Props = {
+  user: AdminUserDetail;
+};
+
+export function UserProfileHeader({ user }: Props) {
+  return (
+    <div className="mb-6 pb-6 border-b border-outline-variant" data-testid="user-profile-header">
+      <div className="flex items-start gap-3 flex-wrap">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h1 className="text-2xl font-semibold text-on-surface truncate">
+              {user.displayName ?? user.email}
+            </h1>
+            {user.activeBan && (
+              <span
+                data-testid="banned-chip"
+                className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-error text-on-error"
+              >
+                BANNED
+              </span>
+            )}
+            {user.role === "ADMIN" && (
+              <span
+                data-testid="admin-chip"
+                className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-tertiary-container text-on-tertiary-container"
+              >
+                ADMIN
+              </span>
+            )}
+            {user.verified ? (
+              <span
+                data-testid="verified-chip"
+                className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-secondary-container text-on-secondary-container"
+              >
+                VERIFIED
+              </span>
+            ) : (
+              <span
+                data-testid="unverified-chip"
+                className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-surface-container-high text-on-surface-variant"
+              >
+                UNVERIFIED
+              </span>
+            )}
+          </div>
+          <div className="mt-1.5 text-body-sm text-on-surface-variant flex flex-wrap gap-x-4 gap-y-0.5">
+            <span>{user.email}</span>
+            {user.slAvatarUuid && (
+              <span
+                className="font-mono text-[11px]"
+                title={user.slAvatarUuid}
+              >
+                {truncateUuid(user.slAvatarUuid)}
+              </span>
+            )}
+            {user.slDisplayName && <span>{user.slDisplayName}</span>}
+          </div>
+        </div>
+      </div>
+      <div className="mt-2 text-[11px] text-on-surface-variant flex gap-4 flex-wrap">
+        <span>Member since {formatDate(user.createdAt)}</span>
+        {user.verifiedAt && (
+          <span>Verified {formatDate(user.verifiedAt)}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/users/UserStatsCards.tsx
+++ b/frontend/src/components/admin/users/UserStatsCards.tsx
@@ -1,0 +1,57 @@
+import type { AdminUserDetail } from "@/lib/admin/types";
+
+type Props = {
+  stats: AdminUserDetail;
+};
+
+type StatCardProps = {
+  label: string;
+  value: string | number;
+  variant?: "default" | "error" | "warning";
+};
+
+function StatCard({ label, value, variant = "default" }: StatCardProps) {
+  const valueClass =
+    variant === "error"
+      ? "text-error"
+      : variant === "warning"
+      ? "text-tertiary"
+      : "text-on-surface";
+
+  return (
+    <div className="bg-surface-container border border-outline-variant rounded-lg p-4">
+      <div className="text-[11px] text-on-surface-variant/70">{label}</div>
+      <div className={`text-2xl font-semibold mt-1.5 ${valueClass}`}>{value}</div>
+    </div>
+  );
+}
+
+export function UserStatsCards({ stats }: Props) {
+  return (
+    <div
+      className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-6"
+      data-testid="user-stats-cards"
+    >
+      <StatCard label="Completed Sales" value={stats.completedSales} />
+      <StatCard
+        label="Cancelled w/ Bids"
+        value={stats.cancelledWithBids}
+        variant={stats.cancelledWithBids > 0 ? "error" : "default"}
+      />
+      <StatCard
+        label="Escrow Expired"
+        value={stats.escrowExpiredUnfulfilled}
+        variant={stats.escrowExpiredUnfulfilled > 0 ? "error" : "default"}
+      />
+      <StatCard
+        label="Dismissed Reports"
+        value={stats.dismissedReportsCount}
+      />
+      <StatCard
+        label="Penalty Owed (L$)"
+        value={stats.penaltyBalanceOwed.toLocaleString()}
+        variant={stats.penaltyBalanceOwed > 0 ? "warning" : "default"}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/admin/users/UserTabsNav.tsx
+++ b/frontend/src/components/admin/users/UserTabsNav.tsx
@@ -1,0 +1,54 @@
+import { cn } from "@/lib/cn";
+
+export type UserTab = "listings" | "bids" | "cancellations" | "reports" | "fraudFlags" | "moderation";
+
+const TABS: Array<{ id: UserTab; label: string }> = [
+  { id: "listings", label: "Listings" },
+  { id: "bids", label: "Bids" },
+  { id: "cancellations", label: "Cancellations" },
+  { id: "reports", label: "Reports" },
+  { id: "fraudFlags", label: "Fraud flags" },
+  { id: "moderation", label: "Moderation" },
+];
+
+type Props = {
+  active: UserTab;
+  counts?: Partial<Record<UserTab, number>>;
+  onChange: (tab: UserTab) => void;
+};
+
+export function UserTabsNav({ active, counts, onChange }: Props) {
+  return (
+    <div
+      className="flex border-b border-outline-variant mb-4 overflow-x-auto"
+      data-testid="user-tabs-nav"
+      role="tablist"
+    >
+      {TABS.map(({ id, label }) => {
+        const count = counts?.[id];
+        return (
+          <button
+            key={id}
+            role="tab"
+            aria-selected={active === id}
+            data-testid={`tab-${id}`}
+            onClick={() => onChange(id)}
+            className={cn(
+              "flex items-center gap-1.5 px-4 py-2.5 text-body-sm whitespace-nowrap border-b-2 transition-colors",
+              active === id
+                ? "border-primary text-primary font-medium"
+                : "border-transparent text-on-surface-variant hover:text-on-surface"
+            )}
+          >
+            {label}
+            {count !== undefined && count > 0 && (
+              <span className="bg-surface-container-high text-on-surface-variant rounded-full px-1.5 py-0.5 text-[10px]">
+                {count}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/users/tabs/BidsTab.tsx
+++ b/frontend/src/components/admin/users/tabs/BidsTab.tsx
@@ -1,0 +1,83 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+import { useAdminUserBids } from "@/hooks/admin/useAdminUserBids";
+import { Pagination } from "@/components/ui/Pagination";
+
+const PAGE_SIZE = 25;
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+type Props = {
+  userId: number;
+};
+
+export function BidsTab({ userId }: Props) {
+  const [page, setPage] = useState(0);
+  const { data, isLoading, isError } = useAdminUserBids(userId, page, PAGE_SIZE);
+
+  if (isLoading) {
+    return <div className="py-6 text-body-sm text-on-surface-variant">Loading bids…</div>;
+  }
+
+  if (isError) {
+    return <div className="py-6 text-body-sm text-error">Could not load bids.</div>;
+  }
+
+  if (!data || data.content.length === 0) {
+    return <div className="py-6 text-body-sm text-on-surface-variant">No bids found.</div>;
+  }
+
+  return (
+    <div data-testid="bids-tab">
+      <div className="overflow-x-auto rounded-default border border-outline-variant">
+        <table className="w-full text-body-sm">
+          <thead className="bg-surface-container-low border-b border-outline-variant">
+            <tr>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Auction</th>
+              <th className="px-3 py-2.5 text-right text-label-sm text-on-surface-variant font-medium">Amount</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Placed</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.content.map((row) => (
+              <tr
+                key={row.bidId}
+                className="border-b border-outline-variant/50"
+                data-testid={`bid-row-${row.bidId}`}
+              >
+                <td className="px-3 py-2.5">
+                  <Link
+                    href={`/auction/${row.auctionId}`}
+                    className="text-primary hover:underline underline-offset-2 line-clamp-1"
+                    target="_blank"
+                  >
+                    {row.auctionTitle}
+                  </Link>
+                </td>
+                <td className="px-3 py-2.5 text-right text-on-surface font-medium">
+                  L$ {row.amount.toLocaleString()}
+                </td>
+                <td className="px-3 py-2.5 text-on-surface-variant text-[11px]">{formatDate(row.placedAt)}</td>
+                <td className="px-3 py-2.5 text-on-surface-variant">{row.auctionStatus}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {data.totalPages > 1 && (
+        <div className="mt-4">
+          <Pagination page={data.number} totalPages={data.totalPages} onPageChange={setPage} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/users/tabs/CancellationsTab.tsx
+++ b/frontend/src/components/admin/users/tabs/CancellationsTab.tsx
@@ -1,0 +1,98 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+import { useAdminUserCancellations } from "@/hooks/admin/useAdminUserCancellations";
+import { Pagination } from "@/components/ui/Pagination";
+
+const PAGE_SIZE = 25;
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+type Props = {
+  userId: number;
+};
+
+export function CancellationsTab({ userId }: Props) {
+  const [page, setPage] = useState(0);
+  const { data, isLoading, isError } = useAdminUserCancellations(userId, page, PAGE_SIZE);
+
+  if (isLoading) {
+    return <div className="py-6 text-body-sm text-on-surface-variant">Loading cancellations…</div>;
+  }
+
+  if (isError) {
+    return <div className="py-6 text-body-sm text-error">Could not load cancellations.</div>;
+  }
+
+  if (!data || data.content.length === 0) {
+    return <div className="py-6 text-body-sm text-on-surface-variant">No cancellations found.</div>;
+  }
+
+  return (
+    <div data-testid="cancellations-tab">
+      <div className="overflow-x-auto rounded-default border border-outline-variant">
+        <table className="w-full text-body-sm">
+          <thead className="bg-surface-container-low border-b border-outline-variant">
+            <tr>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Auction</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">From status</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Had bids</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Penalty</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.content.map((row) => (
+              <tr
+                key={row.logId}
+                className="border-b border-outline-variant/50"
+                data-testid={`cancellation-row-${row.logId}`}
+              >
+                <td className="px-3 py-2.5">
+                  <Link
+                    href={`/auction/${row.auctionId}`}
+                    className="text-primary hover:underline underline-offset-2 line-clamp-1"
+                    target="_blank"
+                  >
+                    {row.auctionTitle}
+                  </Link>
+                </td>
+                <td className="px-3 py-2.5 text-on-surface-variant">{row.cancelledFromStatus}</td>
+                <td className="px-3 py-2.5">
+                  {row.hadBids ? (
+                    <span className="text-error font-medium">Yes</span>
+                  ) : (
+                    <span className="text-on-surface-variant">No</span>
+                  )}
+                </td>
+                <td className="px-3 py-2.5 text-on-surface-variant">
+                  {row.penaltyKind ? (
+                    <span>
+                      {row.penaltyKind}
+                      {row.penaltyAmountL !== null && ` (L$ ${row.penaltyAmountL.toLocaleString()})`}
+                    </span>
+                  ) : (
+                    "—"
+                  )}
+                </td>
+                <td className="px-3 py-2.5 text-on-surface-variant text-[11px]">{formatDate(row.cancelledAt)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {data.totalPages > 1 && (
+        <div className="mt-4">
+          <Pagination page={data.number} totalPages={data.totalPages} onPageChange={setPage} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/users/tabs/FraudFlagsTab.tsx
+++ b/frontend/src/components/admin/users/tabs/FraudFlagsTab.tsx
@@ -1,0 +1,91 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+import { useAdminUserFraudFlags } from "@/hooks/admin/useAdminUserFraudFlags";
+import { Pagination } from "@/components/ui/Pagination";
+
+const PAGE_SIZE = 25;
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+type Props = {
+  userId: number;
+};
+
+export function FraudFlagsTab({ userId }: Props) {
+  const [page, setPage] = useState(0);
+  const { data, isLoading, isError } = useAdminUserFraudFlags(userId, page, PAGE_SIZE);
+
+  if (isLoading) {
+    return <div className="py-6 text-body-sm text-on-surface-variant">Loading fraud flags…</div>;
+  }
+
+  if (isError) {
+    return <div className="py-6 text-body-sm text-error">Could not load fraud flags.</div>;
+  }
+
+  if (!data || data.content.length === 0) {
+    return <div className="py-6 text-body-sm text-on-surface-variant">No fraud flags found.</div>;
+  }
+
+  return (
+    <div data-testid="fraud-flags-tab">
+      <div className="overflow-x-auto rounded-default border border-outline-variant">
+        <table className="w-full text-body-sm">
+          <thead className="bg-surface-container-low border-b border-outline-variant">
+            <tr>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Auction</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Reason</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Status</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Detected</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.content.map((row) => (
+              <tr
+                key={row.flagId}
+                className="border-b border-outline-variant/50"
+                data-testid={`fraud-flag-row-${row.flagId}`}
+              >
+                <td className="px-3 py-2.5">
+                  <Link
+                    href={`/auction/${row.auctionId}`}
+                    className="text-primary hover:underline underline-offset-2 line-clamp-1"
+                    target="_blank"
+                  >
+                    {row.auctionTitle}
+                  </Link>
+                </td>
+                <td className="px-3 py-2.5 text-on-surface-variant">{row.reason}</td>
+                <td className="px-3 py-2.5">
+                  {row.resolved ? (
+                    <span className="text-[11px] bg-surface-container-high px-2 py-0.5 rounded-full text-on-surface-variant">
+                      Resolved
+                    </span>
+                  ) : (
+                    <span className="text-[11px] bg-error-container px-2 py-0.5 rounded-full text-on-error-container">
+                      Open
+                    </span>
+                  )}
+                </td>
+                <td className="px-3 py-2.5 text-on-surface-variant text-[11px]">{formatDate(row.detectedAt)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {data.totalPages > 1 && (
+        <div className="mt-4">
+          <Pagination page={data.number} totalPages={data.totalPages} onPageChange={setPage} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/users/tabs/ListingsTab.tsx
+++ b/frontend/src/components/admin/users/tabs/ListingsTab.tsx
@@ -1,0 +1,126 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+import { useAdminUserListings } from "@/hooks/admin/useAdminUserListings";
+import { ReinstateListingModal } from "../ReinstateListingModal";
+import { Pagination } from "@/components/ui/Pagination";
+import { Button } from "@/components/ui/Button";
+import type { AdminUserListingRow, AuctionStatus } from "@/lib/admin/types";
+
+const PAGE_SIZE = 25;
+
+function statusLabel(status: AuctionStatus): { label: string; className: string } {
+  const map: Partial<Record<AuctionStatus, { label: string; className: string }>> = {
+    ACTIVE: { label: "Active", className: "text-primary" },
+    ENDED: { label: "Ended", className: "text-on-surface-variant" },
+    COMPLETED: { label: "Completed", className: "text-secondary" },
+    CANCELLED: { label: "Cancelled", className: "text-error" },
+    SUSPENDED: { label: "Suspended", className: "text-error font-semibold" },
+    EXPIRED: { label: "Expired", className: "text-on-surface-variant" },
+    DRAFT: { label: "Draft", className: "text-on-surface-variant" },
+  };
+  return map[status] ?? { label: status, className: "text-on-surface-variant" };
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+type Props = {
+  userId: number;
+};
+
+export function ListingsTab({ userId }: Props) {
+  const [page, setPage] = useState(0);
+  const [reinstateAuction, setReinstateAuction] = useState<AdminUserListingRow | null>(null);
+  const { data, isLoading, isError } = useAdminUserListings(userId, page, PAGE_SIZE);
+
+  if (isLoading) {
+    return <div className="py-6 text-body-sm text-on-surface-variant">Loading listings…</div>;
+  }
+
+  if (isError) {
+    return <div className="py-6 text-body-sm text-error">Could not load listings.</div>;
+  }
+
+  if (!data || data.content.length === 0) {
+    return <div className="py-6 text-body-sm text-on-surface-variant">No listings found.</div>;
+  }
+
+  return (
+    <div data-testid="listings-tab">
+      <div className="overflow-x-auto rounded-default border border-outline-variant">
+        <table className="w-full text-body-sm">
+          <thead className="bg-surface-container-low border-b border-outline-variant">
+            <tr>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Title</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Region</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Status</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Ends</th>
+              <th className="px-3 py-2.5 text-right text-label-sm text-on-surface-variant font-medium">Final bid</th>
+              <th className="px-3 py-2.5 w-[90px]" />
+            </tr>
+          </thead>
+          <tbody>
+            {data.content.map((row) => {
+              const { label, className } = statusLabel(row.status);
+              return (
+                <tr
+                  key={row.auctionId}
+                  className="border-b border-outline-variant/50"
+                  data-testid={`listing-row-${row.auctionId}`}
+                >
+                  <td className="px-3 py-2.5">
+                    <Link
+                      href={`/auction/${row.auctionId}`}
+                      className="text-primary hover:underline underline-offset-2 line-clamp-1"
+                      target="_blank"
+                    >
+                      {row.title}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-2.5 text-on-surface-variant">{row.regionName ?? "—"}</td>
+                  <td className={`px-3 py-2.5 ${className}`}>{label}</td>
+                  <td className="px-3 py-2.5 text-on-surface-variant text-[11px]">{formatDate(row.endsAt)}</td>
+                  <td className="px-3 py-2.5 text-right text-on-surface">
+                    {row.finalBidAmount !== null ? `L$ ${row.finalBidAmount.toLocaleString()}` : "—"}
+                  </td>
+                  <td className="px-3 py-2.5 text-right">
+                    {row.status === "SUSPENDED" && (
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => setReinstateAuction(row)}
+                        data-testid={`reinstate-btn-${row.auctionId}`}
+                      >
+                        Reinstate
+                      </Button>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {data.totalPages > 1 && (
+        <div className="mt-4">
+          <Pagination page={data.number} totalPages={data.totalPages} onPageChange={setPage} />
+        </div>
+      )}
+
+      {reinstateAuction && (
+        <ReinstateListingModal
+          auction={reinstateAuction}
+          userId={userId}
+          onClose={() => setReinstateAuction(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/users/tabs/ModerationTab.tsx
+++ b/frontend/src/components/admin/users/tabs/ModerationTab.tsx
@@ -1,0 +1,82 @@
+"use client";
+import { useState } from "react";
+import { useAdminUserModeration } from "@/hooks/admin/useAdminUserModeration";
+import { Pagination } from "@/components/ui/Pagination";
+
+const PAGE_SIZE = 25;
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+type Props = {
+  userId: number;
+};
+
+export function ModerationTab({ userId }: Props) {
+  const [page, setPage] = useState(0);
+  const { data, isLoading, isError } = useAdminUserModeration(userId, page, PAGE_SIZE);
+
+  if (isLoading) {
+    return <div className="py-6 text-body-sm text-on-surface-variant">Loading moderation history…</div>;
+  }
+
+  if (isError) {
+    return <div className="py-6 text-body-sm text-error">Could not load moderation history.</div>;
+  }
+
+  if (!data || data.content.length === 0) {
+    return <div className="py-6 text-body-sm text-on-surface-variant">No moderation history found.</div>;
+  }
+
+  return (
+    <div data-testid="moderation-tab">
+      <div className="overflow-x-auto rounded-default border border-outline-variant">
+        <table className="w-full text-body-sm">
+          <thead className="bg-surface-container-low border-b border-outline-variant">
+            <tr>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Action</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">By</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Notes</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.content.map((row) => (
+              <tr
+                key={row.actionId}
+                className="border-b border-outline-variant/50"
+                data-testid={`moderation-row-${row.actionId}`}
+              >
+                <td className="px-3 py-2.5">
+                  <span className="text-[10px] uppercase tracking-wide text-on-surface-variant/70">
+                    {row.actionType}
+                  </span>
+                </td>
+                <td className="px-3 py-2.5 text-on-surface-variant">
+                  {row.adminDisplayName ?? "System"}
+                </td>
+                <td className="px-3 py-2.5 text-on-surface-variant max-w-xs">
+                  <span className="line-clamp-2">{row.notes ?? "—"}</span>
+                </td>
+                <td className="px-3 py-2.5 text-on-surface-variant text-[11px]">{formatDate(row.createdAt)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {data.totalPages > 1 && (
+        <div className="mt-4">
+          <Pagination page={data.number} totalPages={data.totalPages} onPageChange={setPage} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/users/tabs/ReportsTab.tsx
+++ b/frontend/src/components/admin/users/tabs/ReportsTab.tsx
@@ -1,0 +1,93 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+import { useAdminUserReports } from "@/hooks/admin/useAdminUserReports";
+import { Pagination } from "@/components/ui/Pagination";
+
+const PAGE_SIZE = 25;
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+type Props = {
+  userId: number;
+};
+
+export function ReportsTab({ userId }: Props) {
+  const [page, setPage] = useState(0);
+  const { data, isLoading, isError } = useAdminUserReports(userId, page, PAGE_SIZE);
+
+  if (isLoading) {
+    return <div className="py-6 text-body-sm text-on-surface-variant">Loading reports…</div>;
+  }
+
+  if (isError) {
+    return <div className="py-6 text-body-sm text-error">Could not load reports.</div>;
+  }
+
+  if (!data || data.content.length === 0) {
+    return <div className="py-6 text-body-sm text-on-surface-variant">No reports found.</div>;
+  }
+
+  return (
+    <div data-testid="reports-tab">
+      <div className="overflow-x-auto rounded-default border border-outline-variant">
+        <table className="w-full text-body-sm">
+          <thead className="bg-surface-container-low border-b border-outline-variant">
+            <tr>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Auction</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Reason</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Direction</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Status</th>
+              <th className="px-3 py-2.5 text-left text-label-sm text-on-surface-variant font-medium">Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.content.map((row) => (
+              <tr
+                key={row.reportId}
+                className="border-b border-outline-variant/50"
+                data-testid={`report-row-${row.reportId}`}
+              >
+                <td className="px-3 py-2.5">
+                  <Link
+                    href={`/auction/${row.auctionId}`}
+                    className="text-primary hover:underline underline-offset-2 line-clamp-1"
+                    target="_blank"
+                  >
+                    {row.auctionTitle}
+                  </Link>
+                </td>
+                <td className="px-3 py-2.5 text-on-surface-variant">{row.reason}</td>
+                <td className="px-3 py-2.5">
+                  {row.direction === "FILED_BY" ? (
+                    <span className="text-[11px] bg-surface-container-high px-2 py-0.5 rounded-full text-on-surface-variant">
+                      Filed by
+                    </span>
+                  ) : (
+                    <span className="text-[11px] bg-error-container px-2 py-0.5 rounded-full text-on-error-container">
+                      Against listing
+                    </span>
+                  )}
+                </td>
+                <td className="px-3 py-2.5 text-on-surface-variant">{row.status}</td>
+                <td className="px-3 py-2.5 text-on-surface-variant text-[11px]">{formatDate(row.createdAt)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {data.totalPages > 1 && (
+        <div className="mt-4">
+          <Pagination page={data.number} totalPages={data.totalPages} onPageChange={setPage} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/auction/ParcelInfoPanel.tsx
+++ b/frontend/src/components/auction/ParcelInfoPanel.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from "react";
 import { MapPin, Tag as TagIcon } from "@/components/ui/icons";
 import { StatusBadge } from "@/components/ui/StatusBadge";
 import { cn } from "@/lib/cn";
@@ -35,6 +36,8 @@ import { VisitInSecondLifeButton } from "./VisitInSecondLifeButton";
 interface Props {
   auction: PublicAuctionResponse | SellerAuctionResponse;
   className?: string;
+  /** Optional action rendered in the title row (e.g. ReportListingButton). */
+  reportButton?: ReactNode;
 }
 
 const MATURITY_MAP: Record<
@@ -55,7 +58,7 @@ const MATURITY_MAP: Record<
   },
 };
 
-export function ParcelInfoPanel({ auction, className }: Props) {
+export function ParcelInfoPanel({ auction, className, reportButton }: Props) {
   const { parcel } = auction;
   // Seller-authored listing title wins the headline slot. Falls back to
   // parcel.description (legacy pre-sub-spec-2 listings) and ultimately
@@ -108,12 +111,15 @@ export function ParcelInfoPanel({ auction, className }: Props) {
             </span>
           </p>
         </div>
-        <VisitInSecondLifeButton
-          regionName={parcel.regionName}
-          positionX={x}
-          positionY={y}
-          positionZ={z}
-        />
+        <div className="flex items-center gap-2 shrink-0">
+          {reportButton}
+          <VisitInSecondLifeButton
+            regionName={parcel.regionName}
+            positionX={x}
+            positionY={y}
+            positionZ={z}
+          />
+        </div>
       </div>
 
       <div

--- a/frontend/src/components/auction/ReportListingButton.test.tsx
+++ b/frontend/src/components/auction/ReportListingButton.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderWithProviders, screen, waitFor } from "@/test/render";
+import { server } from "@/test/msw/server";
+import { adminHandlers } from "@/test/msw/handlers";
+import { ReportListingButton } from "./ReportListingButton";
+import type { AuthUser } from "@/lib/auth/session";
+
+const AUCTION_ID = 99;
+const SELLER_ID = 7;
+
+// Verified user — different from seller
+const verifiedUser: AuthUser = {
+  id: 42,
+  email: "user@example.com",
+  displayName: "Buyer",
+  slAvatarUuid: "some-uuid",
+  verified: true,
+  role: "USER",
+};
+
+// Unverified user — different from seller
+const unverifiedUser: AuthUser = {
+  ...verifiedUser,
+  verified: false,
+};
+
+// Seller themselves
+const sellerUser: AuthUser = {
+  ...verifiedUser,
+  id: SELLER_ID,
+};
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/auction/99"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+describe("ReportListingButton state machine", () => {
+  it("renders nothing for anonymous user", () => {
+    renderWithProviders(
+      <ReportListingButton auctionId={AUCTION_ID} sellerId={SELLER_ID} />,
+      { auth: "anonymous" }
+    );
+    expect(screen.queryByTestId("report-listing-btn")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for seller viewing own listing", () => {
+    server.use(adminHandlers.myReport204(AUCTION_ID));
+    renderWithProviders(
+      <ReportListingButton auctionId={AUCTION_ID} sellerId={SELLER_ID} />,
+      { auth: "authenticated", authUser: sellerUser }
+    );
+    expect(screen.queryByTestId("report-listing-btn")).not.toBeInTheDocument();
+  });
+
+  it("renders disabled button with tooltip for unverified user", async () => {
+    server.use(adminHandlers.myReport204(AUCTION_ID));
+    renderWithProviders(
+      <ReportListingButton auctionId={AUCTION_ID} sellerId={SELLER_ID} />,
+      { auth: "authenticated", authUser: unverifiedUser }
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("report-listing-btn")).toBeInTheDocument()
+    );
+    const btn = screen.getByTestId("report-listing-btn");
+    expect(btn).toBeDisabled();
+    expect(btn.getAttribute("title")).toMatch(/Verify your SL avatar/);
+  });
+
+  it("renders enabled 'Report' button when no existing report (204)", async () => {
+    server.use(adminHandlers.myReport204(AUCTION_ID));
+    renderWithProviders(
+      <ReportListingButton auctionId={AUCTION_ID} sellerId={SELLER_ID} />,
+      { auth: "authenticated", authUser: verifiedUser }
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("report-listing-btn")).toBeInTheDocument()
+    );
+    const btn = screen.getByTestId("report-listing-btn");
+    expect(btn).not.toBeDisabled();
+    expect(btn).toHaveTextContent("Report");
+  });
+
+  it("renders enabled 'Report' button when existing report is DISMISSED", async () => {
+    server.use(
+      adminHandlers.myReportSuccess(AUCTION_ID, {
+        id: 1,
+        subject: "test",
+        reason: "OTHER",
+        details: "details",
+        status: "DISMISSED",
+        createdAt: "2026-04-01T00:00:00Z",
+        updatedAt: "2026-04-01T00:00:00Z",
+      })
+    );
+    renderWithProviders(
+      <ReportListingButton auctionId={AUCTION_ID} sellerId={SELLER_ID} />,
+      { auth: "authenticated", authUser: verifiedUser }
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("report-listing-btn")).toBeInTheDocument()
+    );
+    const btn = screen.getByTestId("report-listing-btn");
+    expect(btn).not.toBeDisabled();
+    expect(btn).toHaveTextContent("Report");
+  });
+
+  it("renders disabled 'Reported ✓' button when existing OPEN report", async () => {
+    server.use(
+      adminHandlers.myReportSuccess(AUCTION_ID, {
+        id: 1,
+        subject: "test",
+        reason: "SHILL_BIDDING",
+        details: "details",
+        status: "OPEN",
+        createdAt: "2026-04-01T00:00:00Z",
+        updatedAt: "2026-04-01T00:00:00Z",
+      })
+    );
+    renderWithProviders(
+      <ReportListingButton auctionId={AUCTION_ID} sellerId={SELLER_ID} />,
+      { auth: "authenticated", authUser: verifiedUser }
+    );
+    await waitFor(() => {
+      const btn = screen.getByTestId("report-listing-btn");
+      expect(btn).toHaveTextContent("Reported ✓");
+    });
+    expect(screen.getByTestId("report-listing-btn")).toBeDisabled();
+  });
+
+  it("renders disabled 'Reported ✓' button when existing REVIEWED report", async () => {
+    server.use(
+      adminHandlers.myReportSuccess(AUCTION_ID, {
+        id: 1,
+        subject: "test",
+        reason: "OTHER",
+        details: "details",
+        status: "REVIEWED",
+        createdAt: "2026-04-01T00:00:00Z",
+        updatedAt: "2026-04-01T00:00:00Z",
+      })
+    );
+    renderWithProviders(
+      <ReportListingButton auctionId={AUCTION_ID} sellerId={SELLER_ID} />,
+      { auth: "authenticated", authUser: verifiedUser }
+    );
+    await waitFor(() => {
+      const btn = screen.getByTestId("report-listing-btn");
+      expect(btn).toHaveTextContent("Reported ✓");
+    });
+    expect(screen.getByTestId("report-listing-btn")).toBeDisabled();
+  });
+});

--- a/frontend/src/components/auction/ReportListingButton.tsx
+++ b/frontend/src/components/auction/ReportListingButton.tsx
@@ -1,0 +1,65 @@
+"use client";
+import { useState } from "react";
+import { useAuth } from "@/lib/auth";
+import { useMyReport } from "@/hooks/auction/useMyReport";
+import { ReportListingModal } from "./ReportListingModal";
+
+type Props = {
+  auctionId: number;
+  sellerId: number;
+};
+
+export function ReportListingButton({ auctionId, sellerId }: Props) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const session = useAuth();
+  const myReportQuery = useMyReport(
+    session.status === "authenticated" ? auctionId : null
+  );
+
+  // Loading state — render nothing to avoid layout flicker.
+  if (session.status === "loading") return null;
+
+  // Anonymous — don't show the button at all.
+  if (session.status === "unauthenticated") return null;
+
+  // Seller's own listing — hide button.
+  if (session.user.id === sellerId) return null;
+
+  const unverified = !session.user.verified;
+
+  // Determine disabled state from existing report status.
+  const myReport = myReportQuery.data ?? null;
+  const alreadyReported =
+    myReport !== null &&
+    myReport.status !== "DISMISSED";
+
+  const disabled = unverified || alreadyReported;
+
+  const label = alreadyReported ? "Reported ✓" : "Report";
+
+  const title = unverified
+    ? "Verify your SL avatar to report listings"
+    : undefined;
+
+  return (
+    <>
+      <button
+        type="button"
+        disabled={disabled}
+        title={title}
+        onClick={() => setModalOpen(true)}
+        data-testid="report-listing-btn"
+        className="px-3 py-1.5 rounded-default text-label-sm text-on-surface-variant bg-surface-container hover:bg-surface-container-high disabled:opacity-50 disabled:pointer-events-none transition-colors"
+      >
+        {label}
+      </button>
+
+      {modalOpen && (
+        <ReportListingModal
+          auctionId={auctionId}
+          onClose={() => setModalOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/auction/ReportListingModal.test.tsx
+++ b/frontend/src/components/auction/ReportListingModal.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderWithProviders, screen, waitFor, userEvent } from "@/test/render";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { server } from "@/test/msw/server";
+import { adminHandlers } from "@/test/msw/handlers";
+import { ToastProvider } from "@/components/ui/Toast";
+import { ReportListingModal } from "./ReportListingModal";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+
+const AUCTION_ID = 99;
+const onClose = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/auction/99"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+describe("ReportListingModal", () => {
+  it("submit button is disabled when fields are empty", () => {
+    renderWithProviders(
+      <ReportListingModal auctionId={AUCTION_ID} onClose={onClose} />,
+      { auth: "authenticated" }
+    );
+    expect(screen.getByTestId("report-submit-btn")).toBeDisabled();
+  });
+
+  it("closes on ESC", async () => {
+    const closeFn = vi.fn();
+    renderWithProviders(
+      <ReportListingModal auctionId={AUCTION_ID} onClose={closeFn} />,
+      { auth: "authenticated" }
+    );
+    const user = userEvent.setup();
+    await user.keyboard("{Escape}");
+    expect(closeFn).toHaveBeenCalled();
+  });
+
+  it("submits successfully → calls onClose and invalidates myReport cache", async () => {
+    const closeFn = vi.fn();
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    server.use(
+      adminHandlers.submitReportSuccess(AUCTION_ID, {
+        id: 1,
+        subject: "Fake auction",
+        reason: "SHILL_BIDDING",
+        details: "Bidder is the seller's alt.",
+        status: "OPEN",
+        createdAt: "2026-04-01T00:00:00Z",
+        updatedAt: "2026-04-01T00:00:00Z",
+      })
+    );
+
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { unmount } = renderWithProviders(
+      <ReportListingModal auctionId={AUCTION_ID} onClose={closeFn} />,
+      { auth: "authenticated" }
+    );
+    // Use the wrapper's qc by re-rendering inside our own wrapper
+    unmount();
+
+    const { getByTestId, getByRole } = renderWithProviders(
+      <QueryClientProvider client={qc}>
+        <ToastProvider>
+          <ReportListingModal auctionId={AUCTION_ID} onClose={closeFn} />
+        </ToastProvider>
+      </QueryClientProvider>
+    );
+
+    const user = userEvent.setup();
+
+    await user.type(getByTestId("report-subject"), "Fake auction");
+
+    const select = getByTestId("report-reason");
+    await user.selectOptions(select, "SHILL_BIDDING");
+
+    await user.type(getByTestId("report-details"), "Bidder is the seller's alt.");
+
+    const submitBtn = getByTestId("report-submit-btn");
+    expect(submitBtn).not.toBeDisabled();
+
+    await user.click(submitBtn);
+
+    await waitFor(() => {
+      expect(closeFn).toHaveBeenCalled();
+    });
+
+    const callKeys = invalidateSpy.mock.calls.map(
+      (c) => (c[0] as { queryKey?: unknown }).queryKey
+    );
+    expect(callKeys).toContainEqual(adminQueryKeys.myReport(AUCTION_ID));
+
+    void getByRole; // suppress unused-var lint
+  });
+});

--- a/frontend/src/components/auction/ReportListingModal.tsx
+++ b/frontend/src/components/auction/ReportListingModal.tsx
@@ -1,0 +1,197 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useSubmitReport } from "@/hooks/auction/useSubmitReport";
+import { Button } from "@/components/ui/Button";
+import type { ListingReportReason } from "@/lib/admin/types";
+import { REPORT_REASON_LABEL } from "@/lib/admin/reportReasonStyle";
+
+const REASONS: ListingReportReason[] = [
+  "SHILL_BIDDING",
+  "FRAUDULENT_SELLER",
+  "INACCURATE_DESCRIPTION",
+  "WRONG_TAGS",
+  "DUPLICATE_LISTING",
+  "NOT_ACTUALLY_FOR_SALE",
+  "TOS_VIOLATION",
+  "OTHER",
+];
+
+const SUBJECT_MAX = 100;
+const DETAILS_MAX = 2000;
+
+type Props = {
+  auctionId: number;
+  onClose: () => void;
+};
+
+export function ReportListingModal({ auctionId, onClose }: Props) {
+  const [subject, setSubject] = useState("");
+  const [reason, setReason] = useState<ListingReportReason | "">("");
+  const [details, setDetails] = useState("");
+
+  const submit = useSubmitReport(auctionId);
+
+  // ESC closes the modal.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  const canSubmit =
+    subject.trim().length > 0 &&
+    reason !== "" &&
+    details.trim().length > 0 &&
+    !submit.isPending;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    submit.mutate(
+      { subject: subject.trim(), reason: reason as ListingReportReason, details: details.trim() },
+      { onSuccess: () => { onClose(); } }
+    );
+  }
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-50 bg-inverse-surface/20"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="report-modal-title"
+        data-testid="report-listing-modal"
+        className="fixed inset-0 z-50 flex items-center justify-center p-4 pointer-events-none"
+      >
+        <div
+          className="pointer-events-auto w-full max-w-lg bg-surface-container-low rounded-2xl shadow-elevated flex flex-col gap-4 p-6"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center justify-between">
+            <h2
+              id="report-modal-title"
+              className="text-title-lg font-semibold text-on-surface"
+            >
+              Report listing
+            </h2>
+            <button
+              type="button"
+              aria-label="Close"
+              onClick={onClose}
+              className="p-1.5 rounded-default text-on-surface-variant hover:bg-surface-container"
+            >
+              ✕
+            </button>
+          </div>
+
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            {/* Subject */}
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="report-subject"
+                className="text-label-md font-medium text-on-surface"
+              >
+                Subject <span className="text-error">*</span>
+              </label>
+              <input
+                id="report-subject"
+                type="text"
+                value={subject}
+                maxLength={SUBJECT_MAX}
+                onChange={(e) => setSubject(e.target.value)}
+                placeholder="Brief summary of the issue"
+                data-testid="report-subject"
+                className="w-full rounded-default bg-surface-container px-4 py-2.5 text-on-surface placeholder:text-on-surface-variant ring-1 ring-outline-variant focus:outline-none focus:ring-primary text-body-md"
+              />
+              <div className="self-end text-label-sm text-on-surface-variant">
+                {subject.length} / {SUBJECT_MAX}
+              </div>
+            </div>
+
+            {/* Reason */}
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="report-reason"
+                className="text-label-md font-medium text-on-surface"
+              >
+                Reason <span className="text-error">*</span>
+              </label>
+              <select
+                id="report-reason"
+                value={reason}
+                onChange={(e) => setReason(e.target.value as ListingReportReason | "")}
+                data-testid="report-reason"
+                className="w-full rounded-default bg-surface-container px-4 py-2.5 text-on-surface ring-1 ring-outline-variant focus:outline-none focus:ring-primary text-body-md"
+              >
+                <option value="" disabled>
+                  Select a reason…
+                </option>
+                {REASONS.map((r) => (
+                  <option key={r} value={r}>
+                    {REPORT_REASON_LABEL[r]}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Details */}
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="report-details"
+                className="text-label-md font-medium text-on-surface"
+              >
+                Details <span className="text-error">*</span>
+              </label>
+              <textarea
+                id="report-details"
+                rows={5}
+                value={details}
+                onChange={(e) => setDetails(e.target.value.slice(0, DETAILS_MAX))}
+                placeholder="Describe the issue in detail…"
+                data-testid="report-details"
+                className="w-full resize-y rounded-default bg-surface-container px-4 py-3 text-on-surface placeholder:text-on-surface-variant ring-1 ring-outline-variant focus:outline-none focus:ring-primary text-body-md"
+              />
+              <div className="self-end text-label-sm text-on-surface-variant">
+                {details.length} / {DETAILS_MAX}
+              </div>
+            </div>
+
+            {/* Disclosure */}
+            <div className="rounded-default bg-surface-container px-4 py-3 text-body-sm text-on-surface-variant">
+              Your identity is shared with admin reviewers. The seller is never
+              shown who reported. Frivolous reports are tracked.
+            </div>
+
+            <div className="flex justify-end gap-3">
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={onClose}
+                disabled={submit.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                size="sm"
+                disabled={!canSubmit}
+                loading={submit.isPending}
+                data-testid="report-submit-btn"
+              >
+                Submit report
+              </Button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/hooks/admin/useAdminBansList.ts
+++ b/frontend/src/hooks/admin/useAdminBansList.ts
@@ -1,0 +1,18 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+import type { BanType } from "@/lib/admin/types";
+
+export function useAdminBansList(filters: {
+  status: "active" | "history";
+  type?: BanType;
+  page: number;
+  size: number;
+}) {
+  return useQuery({
+    queryKey: adminQueryKeys.bansList(filters),
+    queryFn: () => adminApi.bans.list(filters),
+    staleTime: 10_000,
+  });
+}

--- a/frontend/src/hooks/admin/useAdminReportsByListing.ts
+++ b/frontend/src/hooks/admin/useAdminReportsByListing.ts
@@ -1,0 +1,13 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+
+export function useAdminReportsByListing(auctionId: number | null) {
+  return useQuery({
+    queryKey: adminQueryKeys.reportListing(auctionId ?? 0),
+    queryFn: () => adminApi.reports.byListing(auctionId!),
+    enabled: auctionId != null,
+    staleTime: 10_000,
+  });
+}

--- a/frontend/src/hooks/admin/useAdminReportsList.ts
+++ b/frontend/src/hooks/admin/useAdminReportsList.ts
@@ -1,0 +1,16 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+
+export function useAdminReportsList(filters: {
+  status: "open" | "reviewed" | "all";
+  page: number;
+  size: number;
+}) {
+  return useQuery({
+    queryKey: adminQueryKeys.reportsList(filters),
+    queryFn: () => adminApi.reports.list(filters),
+    staleTime: 10_000,
+  });
+}

--- a/frontend/src/hooks/admin/useAdminUser.ts
+++ b/frontend/src/hooks/admin/useAdminUser.ts
@@ -1,0 +1,12 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+
+export function useAdminUser(id: number) {
+  return useQuery({
+    queryKey: adminQueryKeys.user(id),
+    queryFn: () => adminApi.users.detail(id),
+    staleTime: 10_000,
+  });
+}

--- a/frontend/src/hooks/admin/useAdminUserBids.ts
+++ b/frontend/src/hooks/admin/useAdminUserBids.ts
@@ -1,0 +1,12 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+
+export function useAdminUserBids(id: number, page: number, size = 25) {
+  return useQuery({
+    queryKey: adminQueryKeys.userTab(id, "bids", { page, size }),
+    queryFn: () => adminApi.users.bids(id, page, size),
+    staleTime: 10_000,
+  });
+}

--- a/frontend/src/hooks/admin/useAdminUserCancellations.ts
+++ b/frontend/src/hooks/admin/useAdminUserCancellations.ts
@@ -1,0 +1,12 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+
+export function useAdminUserCancellations(id: number, page: number, size = 25) {
+  return useQuery({
+    queryKey: adminQueryKeys.userTab(id, "cancellations", { page, size }),
+    queryFn: () => adminApi.users.cancellations(id, page, size),
+    staleTime: 10_000,
+  });
+}

--- a/frontend/src/hooks/admin/useAdminUserFraudFlags.ts
+++ b/frontend/src/hooks/admin/useAdminUserFraudFlags.ts
@@ -1,0 +1,12 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+
+export function useAdminUserFraudFlags(id: number, page: number, size = 25) {
+  return useQuery({
+    queryKey: adminQueryKeys.userTab(id, "fraudFlags", { page, size }),
+    queryFn: () => adminApi.users.fraudFlags(id, page, size),
+    staleTime: 10_000,
+  });
+}

--- a/frontend/src/hooks/admin/useAdminUserIps.ts
+++ b/frontend/src/hooks/admin/useAdminUserIps.ts
@@ -1,0 +1,13 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+
+export function useAdminUserIps(id: number, enabled = true) {
+  return useQuery({
+    queryKey: adminQueryKeys.userIps(id),
+    queryFn: () => adminApi.users.ips(id),
+    enabled,
+    staleTime: 30_000,
+  });
+}

--- a/frontend/src/hooks/admin/useAdminUserListings.ts
+++ b/frontend/src/hooks/admin/useAdminUserListings.ts
@@ -1,0 +1,12 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+
+export function useAdminUserListings(id: number, page: number, size = 25) {
+  return useQuery({
+    queryKey: adminQueryKeys.userTab(id, "listings", { page, size }),
+    queryFn: () => adminApi.users.listings(id, page, size),
+    staleTime: 10_000,
+  });
+}

--- a/frontend/src/hooks/admin/useAdminUserModeration.ts
+++ b/frontend/src/hooks/admin/useAdminUserModeration.ts
@@ -1,0 +1,12 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+
+export function useAdminUserModeration(id: number, page: number, size = 25) {
+  return useQuery({
+    queryKey: adminQueryKeys.userTab(id, "moderation", { page, size }),
+    queryFn: () => adminApi.users.moderation(id, page, size),
+    staleTime: 10_000,
+  });
+}

--- a/frontend/src/hooks/admin/useAdminUserReports.ts
+++ b/frontend/src/hooks/admin/useAdminUserReports.ts
@@ -1,0 +1,12 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+
+export function useAdminUserReports(id: number, page: number, size = 25) {
+  return useQuery({
+    queryKey: adminQueryKeys.userTab(id, "reports", { page, size }),
+    queryFn: () => adminApi.users.reports(id, page, size),
+    staleTime: 10_000,
+  });
+}

--- a/frontend/src/hooks/admin/useAdminUsersList.ts
+++ b/frontend/src/hooks/admin/useAdminUsersList.ts
@@ -1,0 +1,12 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+
+export function useAdminUsersList(filters: { search?: string; page: number; size: number }) {
+  return useQuery({
+    queryKey: adminQueryKeys.usersList(filters),
+    queryFn: () => adminApi.users.search(filters),
+    staleTime: 10_000,
+  });
+}

--- a/frontend/src/hooks/admin/useCancelListingFromReport.ts
+++ b/frontend/src/hooks/admin/useCancelListingFromReport.ts
@@ -1,0 +1,22 @@
+"use client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+import { useToast } from "@/components/ui/Toast/useToast";
+
+export function useCancelListingFromReport() {
+  const qc = useQueryClient();
+  const toast = useToast();
+  return useMutation({
+    mutationFn: ({ auctionId, notes }: { auctionId: number; notes: string }) =>
+      adminApi.reports.cancelListing(auctionId, notes),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: adminQueryKeys.reports() });
+      qc.invalidateQueries({ queryKey: adminQueryKeys.stats() });
+      toast.success("Listing cancelled.");
+    },
+    onError: () => {
+      toast.error("Couldn't cancel listing.");
+    },
+  });
+}

--- a/frontend/src/hooks/admin/useCreateBan.test.tsx
+++ b/frontend/src/hooks/admin/useCreateBan.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { type ReactNode } from "react";
+import { ToastProvider } from "@/components/ui/Toast";
+import { server } from "@/test/msw/server";
+import { adminHandlers } from "@/test/msw/handlers";
+import { useCreateBan } from "./useCreateBan";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+import type { AdminBanRow } from "@/lib/admin/types";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/admin/bans"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+function makeBan(overrides: Partial<AdminBanRow> = {}): AdminBanRow {
+  return {
+    id: 1,
+    banType: "IP",
+    ipAddress: "10.0.0.1",
+    slAvatarUuid: null,
+    avatarLinkedUserId: null,
+    avatarLinkedDisplayName: null,
+    firstSeenIp: null,
+    reasonCategory: "TOS_ABUSE",
+    reasonText: "Test",
+    bannedByUserId: 1,
+    bannedByDisplayName: "Admin",
+    expiresAt: null,
+    createdAt: "2026-04-01T10:00:00Z",
+    liftedAt: null,
+    liftedByUserId: null,
+    liftedByDisplayName: null,
+    liftedReason: null,
+    ...overrides,
+  };
+}
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe("useCreateBan", () => {
+  it("invalidates bans and stats query keys on success", async () => {
+    const ban = makeBan({ id: 1 });
+    server.use(adminHandlers.createBanSuccess(ban));
+    server.use(adminHandlers.statsSuccess());
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateBan(), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        banType: "IP",
+        ipAddress: "10.0.0.1",
+        reasonCategory: "TOS_ABUSE",
+        reasonText: "Test",
+      });
+    });
+
+    const callArgs = spy.mock.calls.map((c) => c[0]);
+    const keys = callArgs.map((a) => (a as { queryKey?: unknown }).queryKey);
+
+    expect(keys).toContainEqual(adminQueryKeys.bans());
+    expect(keys).toContainEqual(adminQueryKeys.stats());
+  });
+
+  it("shows BAN_TYPE_FIELD_MISMATCH toast on matching error code", async () => {
+    server.use(adminHandlers.ban409TypeFieldMismatch(1));
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    const { result } = renderHook(() => useCreateBan(), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutate({
+        banType: "IP",
+        ipAddress: "10.0.0.1",
+        reasonCategory: "TOS_ABUSE",
+        reasonText: "Test",
+      });
+    });
+
+    expect(result.current.isError).toBe(true);
+  });
+});

--- a/frontend/src/hooks/admin/useCreateBan.ts
+++ b/frontend/src/hooks/admin/useCreateBan.ts
@@ -1,0 +1,28 @@
+"use client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+import { useToast } from "@/components/ui/Toast/useToast";
+import { isApiError } from "@/lib/api";
+import type { CreateBanRequest } from "@/lib/admin/types";
+
+export function useCreateBan() {
+  const qc = useQueryClient();
+  const toast = useToast();
+  return useMutation({
+    mutationFn: (body: CreateBanRequest) => adminApi.bans.create(body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: adminQueryKeys.bans() });
+      qc.invalidateQueries({ queryKey: adminQueryKeys.stats() });
+      toast.success("Ban created.");
+    },
+    onError: (err) => {
+      const code = isApiError(err) ? (err.problem as { code?: string }).code : null;
+      if (code === "BAN_TYPE_FIELD_MISMATCH") {
+        toast.error("Ban type and identifier fields don't match.");
+        return;
+      }
+      toast.error("Couldn't create ban.");
+    },
+  });
+}

--- a/frontend/src/hooks/admin/useDemoteUser.test.tsx
+++ b/frontend/src/hooks/admin/useDemoteUser.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { type ReactNode } from "react";
+import { http, HttpResponse } from "msw";
+import { ToastProvider } from "@/components/ui/Toast";
+import { server } from "@/test/msw/server";
+import { adminHandlers } from "@/test/msw/handlers";
+import { useDemoteUser } from "./useDemoteUser";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/admin/users/7"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+const USER_ID = 7;
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe("useDemoteUser", () => {
+  it("invalidates user, users, and stats on success", async () => {
+    // Use a 204 response since the endpoint returns void
+    server.use(
+      http.post(`*/api/v1/admin/users/${USER_ID}/demote`, () =>
+        new HttpResponse(null, { status: 204 })
+      )
+    );
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useDemoteUser(USER_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("demote notes");
+    });
+
+    const keys = spy.mock.calls.map((c) => (c[0] as { queryKey?: unknown }).queryKey);
+    expect(keys).toContainEqual(adminQueryKeys.user(USER_ID));
+    expect(keys).toContainEqual(adminQueryKeys.users());
+    expect(keys).toContainEqual(adminQueryKeys.stats());
+  });
+
+  it("surfaces SELF_DEMOTE_FORBIDDEN as a toast error (mutation is error state)", async () => {
+    server.use(adminHandlers.demoteUser409SelfForbidden(USER_ID));
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    const { result } = renderHook(() => useDemoteUser(USER_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    // Use mutate (fire-and-forget) so the onError handler runs but the returned
+    // promise doesn't reject — the isError flag is still set in React Query.
+    await act(async () => {
+      result.current.mutate("self demote attempt");
+      // Wait for all microtasks/state updates to flush
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(result.current.isError).toBe(true);
+  });
+
+  it("surfaces NOT_ADMIN as error state", async () => {
+    server.use(adminHandlers.demoteUser409NotAdmin(USER_ID));
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    const { result } = renderHook(() => useDemoteUser(USER_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      result.current.mutate("not admin");
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(result.current.isError).toBe(true);
+  });
+});

--- a/frontend/src/hooks/admin/useDemoteUser.ts
+++ b/frontend/src/hooks/admin/useDemoteUser.ts
@@ -1,0 +1,32 @@
+"use client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+import { useToast } from "@/components/ui/Toast/useToast";
+import { isApiError } from "@/lib/api";
+
+export function useDemoteUser(userId: number) {
+  const qc = useQueryClient();
+  const toast = useToast();
+  return useMutation({
+    mutationFn: (notes: string) => adminApi.users.demote(userId, notes),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: adminQueryKeys.user(userId) });
+      qc.invalidateQueries({ queryKey: adminQueryKeys.users() });
+      qc.invalidateQueries({ queryKey: adminQueryKeys.stats() });
+      toast.success("User demoted.");
+    },
+    onError: (err) => {
+      const code = isApiError(err) ? (err.problem as { code?: string }).code : null;
+      if (code === "SELF_DEMOTE_FORBIDDEN") {
+        toast.error("You cannot demote yourself.");
+        return;
+      }
+      if (code === "NOT_ADMIN") {
+        toast.error("User is not an admin.");
+        return;
+      }
+      toast.error("Couldn't demote user.");
+    },
+  });
+}

--- a/frontend/src/hooks/admin/useDismissReport.test.tsx
+++ b/frontend/src/hooks/admin/useDismissReport.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { type ReactNode } from "react";
+import { ToastProvider } from "@/components/ui/Toast";
+import { server } from "@/test/msw/server";
+import { adminHandlers } from "@/test/msw/handlers";
+import { useDismissReport } from "./useDismissReport";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+import type { AdminReportDetail } from "@/lib/admin/types";
+
+function makeReport(overrides: Partial<AdminReportDetail> = {}): AdminReportDetail {
+  return {
+    id: 5,
+    reason: "OTHER",
+    subject: "Test report",
+    details: "Some details",
+    status: "OPEN",
+    adminNotes: null,
+    createdAt: "2026-04-01T10:00:00Z",
+    updatedAt: "2026-04-01T10:00:00Z",
+    reviewedAt: null,
+    reporterUserId: 42,
+    reporterDisplayName: "Reporter",
+    reporterDismissedReportsCount: 0,
+    reviewedByDisplayName: null,
+    ...overrides,
+  };
+}
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe("useDismissReport", () => {
+  it("invalidates both reports and stats query keys on success", async () => {
+    const report = makeReport({ id: 5 });
+    server.use(adminHandlers.dismissReportSuccess(report));
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useDismissReport(), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ reportId: 5, notes: "legitimate" });
+    });
+
+    const callArgs = spy.mock.calls.map((c) => c[0]);
+    const keys = callArgs.map((a) => (a as { queryKey?: unknown }).queryKey);
+
+    expect(keys).toContainEqual(adminQueryKeys.reports());
+    expect(keys).toContainEqual(adminQueryKeys.stats());
+  });
+});

--- a/frontend/src/hooks/admin/useDismissReport.ts
+++ b/frontend/src/hooks/admin/useDismissReport.ts
@@ -1,0 +1,28 @@
+"use client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+import { useToast } from "@/components/ui/Toast/useToast";
+import { isApiError } from "@/lib/api";
+
+export function useDismissReport() {
+  const qc = useQueryClient();
+  const toast = useToast();
+  return useMutation({
+    mutationFn: ({ reportId, notes }: { reportId: number; notes: string }) =>
+      adminApi.reports.dismiss(reportId, notes),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: adminQueryKeys.reports() });
+      qc.invalidateQueries({ queryKey: adminQueryKeys.stats() });
+      toast.success("Report dismissed.");
+    },
+    onError: (err) => {
+      if (isApiError(err) && (err.problem as { code?: string }).code === "REPORT_NOT_FOUND") {
+        toast.error("Report not found. Refreshing.");
+        qc.invalidateQueries({ queryKey: adminQueryKeys.reports() });
+        return;
+      }
+      toast.error("Couldn't dismiss report.");
+    },
+  });
+}

--- a/frontend/src/hooks/admin/useLiftBan.ts
+++ b/frontend/src/hooks/admin/useLiftBan.ts
@@ -1,0 +1,34 @@
+"use client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+import { useToast } from "@/components/ui/Toast/useToast";
+import { isApiError } from "@/lib/api";
+
+export function useLiftBan() {
+  const qc = useQueryClient();
+  const toast = useToast();
+  return useMutation({
+    mutationFn: ({ id, liftedReason }: { id: number; liftedReason: string }) =>
+      adminApi.bans.lift(id, liftedReason),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: adminQueryKeys.bans() });
+      qc.invalidateQueries({ queryKey: adminQueryKeys.stats() });
+      toast.success("Ban lifted.");
+    },
+    onError: (err) => {
+      const code = isApiError(err) ? (err.problem as { code?: string }).code : null;
+      if (code === "BAN_ALREADY_LIFTED") {
+        toast.error("Ban was already lifted. Refreshing.");
+        qc.invalidateQueries({ queryKey: adminQueryKeys.bans() });
+        return;
+      }
+      if (code === "BAN_NOT_FOUND") {
+        toast.error("Ban not found. Refreshing.");
+        qc.invalidateQueries({ queryKey: adminQueryKeys.bans() });
+        return;
+      }
+      toast.error("Couldn't lift ban.");
+    },
+  });
+}

--- a/frontend/src/hooks/admin/usePromoteUser.ts
+++ b/frontend/src/hooks/admin/usePromoteUser.ts
@@ -1,0 +1,28 @@
+"use client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+import { useToast } from "@/components/ui/Toast/useToast";
+import { isApiError } from "@/lib/api";
+
+export function usePromoteUser(userId: number) {
+  const qc = useQueryClient();
+  const toast = useToast();
+  return useMutation({
+    mutationFn: (notes: string) => adminApi.users.promote(userId, notes),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: adminQueryKeys.user(userId) });
+      qc.invalidateQueries({ queryKey: adminQueryKeys.users() });
+      qc.invalidateQueries({ queryKey: adminQueryKeys.stats() });
+      toast.success("User promoted to admin.");
+    },
+    onError: (err) => {
+      const code = isApiError(err) ? (err.problem as { code?: string }).code : null;
+      if (code === "ALREADY_ADMIN") {
+        toast.error("User is already an admin.");
+        return;
+      }
+      toast.error("Couldn't promote user.");
+    },
+  });
+}

--- a/frontend/src/hooks/admin/useReinstateAuction.test.tsx
+++ b/frontend/src/hooks/admin/useReinstateAuction.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { type ReactNode } from "react";
+import { ToastProvider } from "@/components/ui/Toast";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/msw/server";
+import { useReinstateAuction } from "./useReinstateAuction";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/admin/users/10"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+const USER_ID = 10;
+const AUCTION_ID = 55;
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe("useReinstateAuction", () => {
+  it("invalidates user listings tab and stats on success", async () => {
+    server.use(
+      http.post(`*/api/v1/admin/auctions/${AUCTION_ID}/reinstate`, () =>
+        HttpResponse.json({
+          auctionId: AUCTION_ID,
+          status: "ACTIVE",
+          newEndsAt: "2026-05-01T00:00:00Z",
+          suspensionDurationSeconds: 3600,
+        })
+      )
+    );
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useReinstateAuction(USER_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ auctionId: AUCTION_ID, notes: "reinstate notes" });
+    });
+
+    const keys = spy.mock.calls.map((c) => (c[0] as { queryKey?: unknown }).queryKey);
+    expect(keys).toContainEqual(adminQueryKeys.userTab(USER_ID, "listings", { page: 0, size: 25 }));
+    expect(keys).toContainEqual(adminQueryKeys.stats());
+  });
+
+  it("invalidates user listings on AUCTION_NOT_SUSPENDED 409", async () => {
+    server.use(
+      http.post(`*/api/v1/admin/auctions/${AUCTION_ID}/reinstate`, () =>
+        HttpResponse.json(
+          { code: "AUCTION_NOT_SUSPENDED", message: "Not suspended", details: {} },
+          { status: 409 }
+        )
+      )
+    );
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useReinstateAuction(USER_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutate({ auctionId: AUCTION_ID, notes: "try reinstate" });
+    });
+
+    // Should still be error state
+    expect(result.current.isError).toBe(true);
+    // Should still invalidate listings to refresh the stale data
+    const keys = spy.mock.calls.map((c) => (c[0] as { queryKey?: unknown }).queryKey);
+    expect(keys).toContainEqual(adminQueryKeys.userTab(USER_ID, "listings", { page: 0, size: 25 }));
+  });
+
+  it("ignores admin stats invalidation when AUCTION_NOT_SUSPENDED", async () => {
+    server.use(
+      http.post(`*/api/v1/admin/auctions/${AUCTION_ID}/reinstate`, () =>
+        HttpResponse.json(
+          { code: "AUCTION_NOT_SUSPENDED", message: "Not suspended", details: {} },
+          { status: 409 }
+        )
+      )
+    );
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const spy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useReinstateAuction(USER_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutate({ auctionId: AUCTION_ID, notes: "try reinstate" });
+    });
+
+    const keys = spy.mock.calls.map((c) => (c[0] as { queryKey?: unknown }).queryKey);
+    // stats should NOT be invalidated on 409 AUCTION_NOT_SUSPENDED path
+    expect(keys).not.toContainEqual(adminQueryKeys.stats());
+  });
+});
+

--- a/frontend/src/hooks/admin/useReinstateAuction.ts
+++ b/frontend/src/hooks/admin/useReinstateAuction.ts
@@ -1,0 +1,29 @@
+"use client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+import { useToast } from "@/components/ui/Toast/useToast";
+import { isApiError } from "@/lib/api";
+
+export function useReinstateAuction(userId: number) {
+  const qc = useQueryClient();
+  const toast = useToast();
+  return useMutation({
+    mutationFn: ({ auctionId, notes }: { auctionId: number; notes: string }) =>
+      adminApi.auctions.reinstate(auctionId, notes),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: adminQueryKeys.userTab(userId, "listings", { page: 0, size: 25 }) });
+      qc.invalidateQueries({ queryKey: adminQueryKeys.stats() });
+      toast.success("Auction reinstated.");
+    },
+    onError: (err) => {
+      const code = isApiError(err) ? (err.problem as { code?: string }).code : null;
+      if (code === "AUCTION_NOT_SUSPENDED") {
+        toast.error("Auction is no longer SUSPENDED. Refreshing.");
+        qc.invalidateQueries({ queryKey: adminQueryKeys.userTab(userId, "listings", { page: 0, size: 25 }) });
+        return;
+      }
+      toast.error("Couldn't reinstate auction.");
+    },
+  });
+}

--- a/frontend/src/hooks/admin/useResetFrivolousCounter.ts
+++ b/frontend/src/hooks/admin/useResetFrivolousCounter.ts
@@ -1,0 +1,21 @@
+"use client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+import { useToast } from "@/components/ui/Toast/useToast";
+
+export function useResetFrivolousCounter(userId: number) {
+  const qc = useQueryClient();
+  const toast = useToast();
+  return useMutation({
+    mutationFn: (notes: string) => adminApi.users.resetFrivolousCounter(userId, notes),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: adminQueryKeys.user(userId) });
+      qc.invalidateQueries({ queryKey: adminQueryKeys.stats() });
+      toast.success("Frivolous cancellation counter reset.");
+    },
+    onError: () => {
+      toast.error("Couldn't reset frivolous counter.");
+    },
+  });
+}

--- a/frontend/src/hooks/admin/useSuspendListingFromReport.ts
+++ b/frontend/src/hooks/admin/useSuspendListingFromReport.ts
@@ -1,0 +1,22 @@
+"use client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+import { useToast } from "@/components/ui/Toast/useToast";
+
+export function useSuspendListingFromReport() {
+  const qc = useQueryClient();
+  const toast = useToast();
+  return useMutation({
+    mutationFn: ({ auctionId, notes }: { auctionId: number; notes: string }) =>
+      adminApi.reports.suspendListing(auctionId, notes),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: adminQueryKeys.reports() });
+      qc.invalidateQueries({ queryKey: adminQueryKeys.stats() });
+      toast.success("Listing suspended.");
+    },
+    onError: () => {
+      toast.error("Couldn't suspend listing.");
+    },
+  });
+}

--- a/frontend/src/hooks/admin/useUserSearch.test.tsx
+++ b/frontend/src/hooks/admin/useUserSearch.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { type ReactNode } from "react";
+import { ToastProvider } from "@/components/ui/Toast";
+import { server } from "@/test/msw/server";
+import { adminHandlers } from "@/test/msw/handlers";
+import { useUserSearch } from "./useUserSearch";
+import type { AdminUserSummary } from "@/lib/admin/types";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/admin/bans"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+function makeUser(overrides: Partial<AdminUserSummary> = {}): AdminUserSummary {
+  return {
+    id: 1,
+    email: "alice@example.com",
+    displayName: "Alice",
+    slAvatarUuid: "aaaa-1111",
+    slDisplayName: null,
+    role: "USER",
+    verified: true,
+    hasActiveBan: false,
+    completedSales: 0,
+    cancelledWithBids: 0,
+    createdAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe("useUserSearch", () => {
+  it("is disabled for queries shorter than 2 chars", () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    const { result } = renderHook(() => useUserSearch("a"), {
+      wrapper: makeWrapper(qc),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("is disabled for empty query", () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    const { result } = renderHook(() => useUserSearch(""), {
+      wrapper: makeWrapper(qc),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  it("enables and fetches when query is 2+ chars", async () => {
+    const user = makeUser({ id: 5, displayName: "Alice" });
+    server.use(adminHandlers.usersSearchSuccess([user]));
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    const { result } = renderHook(() => useUserSearch("al"), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await waitFor(
+      () => expect(result.current.isSuccess).toBe(true),
+      { timeout: 1500 }
+    );
+
+    expect(result.current.data?.content[0].displayName).toBe("Alice");
+  });
+});

--- a/frontend/src/hooks/admin/useUserSearch.ts
+++ b/frontend/src/hooks/admin/useUserSearch.ts
@@ -1,0 +1,23 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+
+function useDebounce<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(t);
+  }, [value, delayMs]);
+  return debounced;
+}
+
+export function useUserSearch(query: string) {
+  const debounced = useDebounce(query, 300);
+  return useQuery({
+    queryKey: ["user-search-autocomplete", debounced],
+    queryFn: () => adminApi.users.search({ search: debounced, page: 0, size: 5 }),
+    enabled: debounced.length >= 2,
+    staleTime: 30_000,
+  });
+}

--- a/frontend/src/hooks/admin/useWarnSeller.ts
+++ b/frontend/src/hooks/admin/useWarnSeller.ts
@@ -1,0 +1,22 @@
+"use client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+import { useToast } from "@/components/ui/Toast/useToast";
+
+export function useWarnSeller() {
+  const qc = useQueryClient();
+  const toast = useToast();
+  return useMutation({
+    mutationFn: ({ auctionId, notes }: { auctionId: number; notes: string }) =>
+      adminApi.reports.warnSeller(auctionId, notes),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: adminQueryKeys.reports() });
+      qc.invalidateQueries({ queryKey: adminQueryKeys.stats() });
+      toast.success("Warning sent to seller.");
+    },
+    onError: () => {
+      toast.error("Couldn't send warning.");
+    },
+  });
+}

--- a/frontend/src/hooks/auction/useMyReport.ts
+++ b/frontend/src/hooks/auction/useMyReport.ts
@@ -1,0 +1,13 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import { userReportsApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+
+export function useMyReport(auctionId: number | null) {
+  return useQuery({
+    queryKey: adminQueryKeys.myReport(auctionId ?? 0),
+    queryFn: () => userReportsApi.myReport(auctionId!),
+    enabled: auctionId != null,
+    staleTime: 30_000,
+  });
+}

--- a/frontend/src/hooks/auction/useSubmitReport.ts
+++ b/frontend/src/hooks/auction/useSubmitReport.ts
@@ -1,0 +1,38 @@
+"use client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { userReportsApi } from "@/lib/admin/api";
+import { adminQueryKeys } from "@/lib/admin/queryKeys";
+import { useToast } from "@/components/ui/Toast/useToast";
+import { isApiError } from "@/lib/api";
+import type { ReportRequest } from "@/lib/admin/types";
+
+export function useSubmitReport(auctionId: number) {
+  const qc = useQueryClient();
+  const toast = useToast();
+
+  return useMutation({
+    mutationFn: (body: ReportRequest) => userReportsApi.submit(auctionId, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: adminQueryKeys.myReport(auctionId) });
+      toast.success("Report submitted. Our team will review it.");
+    },
+    onError: (err) => {
+      if (isApiError(err)) {
+        const code = (err.problem as { code?: string }).code;
+        if (code === "CANNOT_REPORT_OWN_LISTING") {
+          toast.error("You cannot report your own listing.");
+          return;
+        }
+        if (code === "VERIFICATION_REQUIRED") {
+          toast.error("You must verify your Second Life avatar to submit reports.");
+          return;
+        }
+        if (code === "AUCTION_NOT_REPORTABLE") {
+          toast.error("This listing is not currently reportable.");
+          return;
+        }
+      }
+      toast.error("Couldn't submit your report. Please try again.");
+    },
+  });
+}

--- a/frontend/src/lib/admin/api.ts
+++ b/frontend/src/lib/admin/api.ts
@@ -1,10 +1,27 @@
 import { api } from "@/lib/api";
 import type {
+  AdminBanRow,
   AdminFraudFlagDetail,
   AdminFraudFlagSummary,
+  AdminReportDetail,
+  AdminReportListingRow,
   AdminStatsResponse,
+  AdminUserBidRow,
+  AdminUserCancellationRow,
+  AdminUserDetail,
+  AdminUserFraudFlagRow,
+  AdminUserListingRow,
+  AdminUserModerationRow,
+  AdminUserReportRow,
+  AdminUserSummary,
+  AdminActionTargetType,
+  BanType,
+  CreateBanRequest,
   FraudFlagListStatus,
   FraudFlagReason,
+  MyReportResponse,
+  ReportRequest,
+  UserIpProjection,
 } from "./types";
 import type { Page } from "@/types/page";
 
@@ -37,5 +54,135 @@ export const adminApi = {
 
   reinstateFraudFlag(flagId: number, adminNotes: string): Promise<AdminFraudFlagDetail> {
     return api.post(`/api/v1/admin/fraud-flags/${flagId}/reinstate`, { adminNotes });
+  },
+
+  reports: {
+    list(params: { status: "open" | "reviewed" | "all"; page: number; size: number }):
+        Promise<Page<AdminReportListingRow>> {
+      const search = new URLSearchParams({
+        status: params.status,
+        page: String(params.page),
+        size: String(params.size),
+      });
+      return api.get(`/api/v1/admin/reports?${search.toString()}`);
+    },
+    byListing(auctionId: number): Promise<AdminReportDetail[]> {
+      return api.get(`/api/v1/admin/reports/listing/${auctionId}`);
+    },
+    detail(id: number): Promise<AdminReportDetail> {
+      return api.get(`/api/v1/admin/reports/${id}`);
+    },
+    dismiss(id: number, notes: string): Promise<AdminReportDetail> {
+      return api.post(`/api/v1/admin/reports/${id}/dismiss`, { notes });
+    },
+    warnSeller(auctionId: number, notes: string): Promise<void> {
+      return api.post(`/api/v1/admin/reports/listing/${auctionId}/warn-seller`, { notes });
+    },
+    suspendListing(auctionId: number, notes: string): Promise<void> {
+      return api.post(`/api/v1/admin/reports/listing/${auctionId}/suspend`, { notes });
+    },
+    cancelListing(auctionId: number, notes: string): Promise<void> {
+      return api.post(`/api/v1/admin/reports/listing/${auctionId}/cancel`, { notes });
+    },
+  },
+
+  bans: {
+    list(params: { status: "active" | "history"; type?: BanType; page: number; size: number }):
+        Promise<Page<AdminBanRow>> {
+      const search = new URLSearchParams({
+        status: params.status,
+        page: String(params.page),
+        size: String(params.size),
+      });
+      if (params.type) search.set("type", params.type);
+      return api.get(`/api/v1/admin/bans?${search.toString()}`);
+    },
+    create(body: CreateBanRequest): Promise<AdminBanRow> {
+      return api.post(`/api/v1/admin/bans`, body);
+    },
+    lift(id: number, liftedReason: string): Promise<AdminBanRow> {
+      return api.post(`/api/v1/admin/bans/${id}/lift`, { liftedReason });
+    },
+  },
+
+  users: {
+    search(params: { search?: string; page: number; size: number }):
+        Promise<Page<AdminUserSummary>> {
+      const sp = new URLSearchParams({ page: String(params.page), size: String(params.size) });
+      if (params.search) sp.set("search", params.search);
+      return api.get(`/api/v1/admin/users?${sp.toString()}`);
+    },
+    detail(id: number): Promise<AdminUserDetail> {
+      return api.get(`/api/v1/admin/users/${id}`);
+    },
+    listings(id: number, page: number, size: number): Promise<Page<AdminUserListingRow>> {
+      return api.get(`/api/v1/admin/users/${id}/listings?page=${page}&size=${size}`);
+    },
+    bids(id: number, page: number, size: number): Promise<Page<AdminUserBidRow>> {
+      return api.get(`/api/v1/admin/users/${id}/bids?page=${page}&size=${size}`);
+    },
+    cancellations(id: number, page: number, size: number): Promise<Page<AdminUserCancellationRow>> {
+      return api.get(`/api/v1/admin/users/${id}/cancellations?page=${page}&size=${size}`);
+    },
+    reports(id: number, page: number, size: number): Promise<Page<AdminUserReportRow>> {
+      return api.get(`/api/v1/admin/users/${id}/reports?page=${page}&size=${size}`);
+    },
+    fraudFlags(id: number, page: number, size: number): Promise<Page<AdminUserFraudFlagRow>> {
+      return api.get(`/api/v1/admin/users/${id}/fraud-flags?page=${page}&size=${size}`);
+    },
+    moderation(id: number, page: number, size: number): Promise<Page<AdminUserModerationRow>> {
+      return api.get(`/api/v1/admin/users/${id}/moderation?page=${page}&size=${size}`);
+    },
+    ips(id: number): Promise<UserIpProjection[]> {
+      return api.get(`/api/v1/admin/users/${id}/ips`);
+    },
+    promote(id: number, notes: string): Promise<void> {
+      return api.post(`/api/v1/admin/users/${id}/promote`, { notes });
+    },
+    demote(id: number, notes: string): Promise<void> {
+      return api.post(`/api/v1/admin/users/${id}/demote`, { notes });
+    },
+    resetFrivolousCounter(id: number, notes: string): Promise<void> {
+      return api.post(`/api/v1/admin/users/${id}/reset-frivolous-counter`, { notes });
+    },
+  },
+
+  audit: {
+    list(params: {
+      targetType?: AdminActionTargetType;
+      targetId?: number;
+      adminUserId?: number;
+      page: number;
+      size: number;
+    }): Promise<Page<AdminUserModerationRow>> {
+      const sp = new URLSearchParams({ page: String(params.page), size: String(params.size) });
+      if (params.targetType) sp.set("targetType", params.targetType);
+      if (params.targetId !== undefined) sp.set("targetId", String(params.targetId));
+      if (params.adminUserId !== undefined) sp.set("adminUserId", String(params.adminUserId));
+      return api.get(`/api/v1/admin/audit?${sp.toString()}`);
+    },
+  },
+
+  auctions: {
+    reinstate(id: number, notes: string): Promise<{
+      auctionId: number;
+      status: string;
+      newEndsAt: string;
+      suspensionDurationSeconds: number;
+    }> {
+      return api.post(`/api/v1/admin/auctions/${id}/reinstate`, { notes });
+    },
+  },
+};
+
+export const userReportsApi = {
+  submit(auctionId: number, body: ReportRequest): Promise<MyReportResponse> {
+    return api.post(`/api/v1/auctions/${auctionId}/report`, body);
+  },
+  async myReport(auctionId: number): Promise<MyReportResponse | null> {
+    const result = await api.get<MyReportResponse | undefined>(
+      `/api/v1/auctions/${auctionId}/my-report`
+    );
+    return result ?? null;
   },
 };

--- a/frontend/src/lib/admin/queryKeys.ts
+++ b/frontend/src/lib/admin/queryKeys.ts
@@ -1,4 +1,4 @@
-import type { FraudFlagListStatus, FraudFlagReason } from "./types";
+import type { AdminActionTargetType, FraudFlagListStatus, FraudFlagReason } from "./types";
 
 export const adminQueryKeys = {
   all: ["admin"] as const,
@@ -12,4 +12,29 @@ export const adminQueryKeys = {
   }) => [...adminQueryKeys.fraudFlags(), "list", filters] as const,
   fraudFlagDetail: (flagId: number) =>
     [...adminQueryKeys.fraudFlags(), "detail", flagId] as const,
+  reports: () => [...adminQueryKeys.all, "reports"] as const,
+  reportsList: (filters: { status: string; page: number; size: number }) =>
+    [...adminQueryKeys.reports(), "list", filters] as const,
+  reportListing: (auctionId: number) =>
+    [...adminQueryKeys.reports(), "listing", auctionId] as const,
+  reportDetail: (id: number) =>
+    [...adminQueryKeys.reports(), "detail", id] as const,
+  bans: () => [...adminQueryKeys.all, "bans"] as const,
+  bansList: (filters: { status: string; type?: string; page: number; size: number }) =>
+    [...adminQueryKeys.bans(), "list", filters] as const,
+  users: () => [...adminQueryKeys.all, "users"] as const,
+  usersList: (filters: { search?: string; page: number; size: number }) =>
+    [...adminQueryKeys.users(), "list", filters] as const,
+  user: (id: number) => [...adminQueryKeys.users(), "detail", id] as const,
+  userTab: (id: number, tab: string, filters: { page: number; size: number }) =>
+    [...adminQueryKeys.user(id), tab, filters] as const,
+  userIps: (id: number) => [...adminQueryKeys.user(id), "ips"] as const,
+  audit: (filters: {
+    targetType?: AdminActionTargetType;
+    targetId?: number;
+    adminUserId?: number;
+    page: number;
+    size: number;
+  }) => [...adminQueryKeys.all, "audit", filters] as const,
+  myReport: (auctionId: number) => ["auction", auctionId, "my-report"] as const,
 };

--- a/frontend/src/lib/admin/reportReasonStyle.ts
+++ b/frontend/src/lib/admin/reportReasonStyle.ts
@@ -1,0 +1,43 @@
+import type { ListingReportReason } from "./types";
+
+/**
+ * Reason family groups for ListingReportReason.
+ *
+ * Grouping rationale:
+ *   - "fraud"       — SHILL_BIDDING, FRAUDULENT_SELLER: financial fraud / trust violation
+ *   - "description" — INACCURATE_DESCRIPTION, WRONG_TAGS: listing accuracy issues
+ *   - "duplicate"   — DUPLICATE_LISTING, NOT_ACTUALLY_FOR_SALE: validity / availability
+ *   - "tos"         — TOS_VIOLATION: platform rules
+ *   - "other"       — OTHER: catch-all
+ */
+export type ReportReasonFamily = "fraud" | "description" | "duplicate" | "tos" | "other";
+
+export const REPORT_REASON_FAMILY: Record<ListingReportReason, ReportReasonFamily> = {
+  SHILL_BIDDING: "fraud",
+  FRAUDULENT_SELLER: "fraud",
+  INACCURATE_DESCRIPTION: "description",
+  WRONG_TAGS: "description",
+  DUPLICATE_LISTING: "duplicate",
+  NOT_ACTUALLY_FOR_SALE: "duplicate",
+  TOS_VIOLATION: "tos",
+  OTHER: "other",
+};
+
+export const REPORT_REASON_LABEL: Record<ListingReportReason, string> = {
+  SHILL_BIDDING: "Shill bidding",
+  FRAUDULENT_SELLER: "Fraudulent seller",
+  INACCURATE_DESCRIPTION: "Inaccurate description",
+  WRONG_TAGS: "Wrong tags",
+  DUPLICATE_LISTING: "Duplicate listing",
+  NOT_ACTUALLY_FOR_SALE: "Not for sale",
+  TOS_VIOLATION: "ToS violation",
+  OTHER: "Other",
+};
+
+export const REPORT_FAMILY_TONE_CLASSES: Record<ReportReasonFamily, string> = {
+  fraud: "bg-error-container text-on-error-container",
+  description: "bg-secondary-container text-on-secondary-container",
+  duplicate: "bg-tertiary-container text-on-tertiary-container",
+  tos: "bg-error-container text-on-error-container",
+  other: "bg-surface-container-high text-on-surface-variant",
+};

--- a/frontend/src/lib/admin/types.ts
+++ b/frontend/src/lib/admin/types.ts
@@ -23,6 +23,7 @@ export type FraudFlagListStatus = "open" | "resolved" | "all";
 export type AdminStatsResponse = {
   queues: {
     openFraudFlags: number;
+    openReports: number;
     pendingPayments: number;
     activeDisputes: number;
   };
@@ -80,4 +81,218 @@ export type AdminApiError = {
   code: string;
   message: string;
   details: Record<string, unknown>;
+};
+
+export type ListingReportReason =
+  | "INACCURATE_DESCRIPTION"
+  | "WRONG_TAGS"
+  | "SHILL_BIDDING"
+  | "FRAUDULENT_SELLER"
+  | "DUPLICATE_LISTING"
+  | "NOT_ACTUALLY_FOR_SALE"
+  | "TOS_VIOLATION"
+  | "OTHER";
+
+export type ListingReportStatus = "OPEN" | "REVIEWED" | "DISMISSED" | "ACTION_TAKEN";
+
+export type BanType = "IP" | "AVATAR" | "BOTH";
+
+export type BanReasonCategory =
+  | "SHILL_BIDDING"
+  | "FRAUDULENT_SELLER"
+  | "TOS_ABUSE"
+  | "SPAM"
+  | "OTHER";
+
+export type AdminActionType =
+  | "DISMISS_REPORT"
+  | "WARN_SELLER_FROM_REPORT"
+  | "SUSPEND_LISTING_FROM_REPORT"
+  | "CANCEL_LISTING_FROM_REPORT"
+  | "CREATE_BAN"
+  | "LIFT_BAN"
+  | "PROMOTE_USER"
+  | "DEMOTE_USER"
+  | "RESET_FRIVOLOUS_COUNTER"
+  | "REINSTATE_LISTING";
+
+export type AdminActionTargetType = "USER" | "LISTING" | "REPORT" | "FRAUD_FLAG" | "BAN";
+
+export type MyReportResponse = {
+  id: number;
+  subject: string;
+  reason: ListingReportReason;
+  details: string;
+  status: ListingReportStatus;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AdminReportListingRow = {
+  auctionId: number;
+  auctionTitle: string;
+  auctionStatus: AuctionStatus;
+  parcelRegionName: string | null;
+  sellerUserId: number;
+  sellerDisplayName: string | null;
+  openReportCount: number;
+  latestReportAt: string;
+};
+
+export type AdminReportDetail = {
+  id: number;
+  reason: ListingReportReason;
+  subject: string;
+  details: string;
+  status: ListingReportStatus;
+  adminNotes: string | null;
+  createdAt: string;
+  updatedAt: string;
+  reviewedAt: string | null;
+  reporterUserId: number;
+  reporterDisplayName: string | null;
+  reporterDismissedReportsCount: number;
+  reviewedByDisplayName: string | null;
+};
+
+export type AdminBanRow = {
+  id: number;
+  banType: BanType;
+  ipAddress: string | null;
+  slAvatarUuid: string | null;
+  avatarLinkedUserId: number | null;
+  avatarLinkedDisplayName: string | null;
+  firstSeenIp: string | null;
+  reasonCategory: BanReasonCategory;
+  reasonText: string;
+  bannedByUserId: number;
+  bannedByDisplayName: string | null;
+  expiresAt: string | null;
+  createdAt: string;
+  liftedAt: string | null;
+  liftedByUserId: number | null;
+  liftedByDisplayName: string | null;
+  liftedReason: string | null;
+};
+
+export type CreateBanRequest = {
+  banType: BanType;
+  ipAddress?: string | null;
+  slAvatarUuid?: string | null;
+  expiresAt?: string | null;
+  reasonCategory: BanReasonCategory;
+  reasonText: string;
+};
+
+export type ReportRequest = {
+  subject: string;
+  reason: ListingReportReason;
+  details: string;
+};
+
+export type ActiveBanSummary = {
+  id: number;
+  banType: BanType;
+  reasonText: string;
+  expiresAt: string | null;
+};
+
+export type AdminUserSummary = {
+  id: number;
+  email: string;
+  displayName: string | null;
+  slAvatarUuid: string | null;
+  slDisplayName: string | null;
+  role: "USER" | "ADMIN";
+  verified: boolean;
+  hasActiveBan: boolean;
+  completedSales: number;
+  cancelledWithBids: number;
+  createdAt: string;
+};
+
+export type AdminUserDetail = {
+  id: number;
+  email: string;
+  displayName: string | null;
+  slAvatarUuid: string | null;
+  slDisplayName: string | null;
+  role: "USER" | "ADMIN";
+  verified: boolean;
+  verifiedAt: string | null;
+  createdAt: string;
+  completedSales: number;
+  cancelledWithBids: number;
+  escrowExpiredUnfulfilled: number;
+  dismissedReportsCount: number;
+  penaltyBalanceOwed: number;
+  listingSuspensionUntil: string | null;
+  bannedFromListing: boolean;
+  activeBan: ActiveBanSummary | null;
+};
+
+export type AdminUserListingRow = {
+  auctionId: number;
+  title: string;
+  regionName: string | null;
+  status: AuctionStatus;
+  endsAt: string;
+  finalBidAmount: number | null;
+};
+
+export type AdminUserBidRow = {
+  bidId: number;
+  auctionId: number;
+  auctionTitle: string;
+  amount: number;
+  placedAt: string;
+  auctionStatus: AuctionStatus;
+};
+
+export type AdminUserCancellationRow = {
+  logId: number;
+  auctionId: number;
+  auctionTitle: string;
+  cancelledFromStatus: string;
+  hadBids: boolean;
+  reason: string;
+  penaltyKind: string | null;
+  penaltyAmountL: number | null;
+  cancelledByAdminId: number | null;
+  cancelledAt: string;
+};
+
+export type AdminUserReportRow = {
+  reportId: number;
+  auctionId: number;
+  auctionTitle: string;
+  reason: string;
+  status: string;
+  direction: "FILED_BY" | "AGAINST_LISTING";
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AdminUserFraudFlagRow = {
+  flagId: number;
+  auctionId: number;
+  auctionTitle: string;
+  reason: string;
+  resolved: boolean;
+  detectedAt: string;
+};
+
+export type AdminUserModerationRow = {
+  actionId: number;
+  actionType: string;
+  adminDisplayName: string | null;
+  notes: string | null;
+  createdAt: string;
+};
+
+export type UserIpProjection = {
+  ipAddress: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  sessionCount: number;
 };

--- a/frontend/src/test/msw/handlers.ts
+++ b/frontend/src/test/msw/handlers.ts
@@ -17,9 +17,18 @@ import type { CurrentUser, PublicUserProfile, UpdateProfileRequest } from "@/lib
 import type { NotificationDto } from "@/lib/notifications/types";
 import type { PreferencesDto, EditableGroup } from "@/lib/notifications/preferencesTypes";
 import type {
+  AdminBanRow,
   AdminFraudFlagDetail,
   AdminFraudFlagSummary,
+  AdminReportDetail,
+  AdminReportListingRow,
   AdminStatsResponse,
+  AdminUserDetail,
+  AdminUserFraudFlagRow,
+  AdminUserModerationRow,
+  AdminUserSummary,
+  MyReportResponse,
+  UserIpProjection,
 } from "@/lib/admin/types";
 import type { Page } from "@/types/page";
 
@@ -404,7 +413,7 @@ export function resetPreferences(): void {
 }
 
 const defaultStats: AdminStatsResponse = {
-  queues: { openFraudFlags: 0, pendingPayments: 0, activeDisputes: 0 },
+  queues: { openFraudFlags: 0, openReports: 0, pendingPayments: 0, activeDisputes: 0 },
   platform: {
     activeListings: 0,
     totalUsers: 0,
@@ -472,6 +481,259 @@ export const adminHandlers = {
         },
         { status: 409 }
       )
+    );
+  },
+
+  reportsListSuccess(rows: AdminReportListingRow[]) {
+    return http.get("*/api/v1/admin/reports", () =>
+      HttpResponse.json({
+        content: rows,
+        totalElements: rows.length,
+        totalPages: 1,
+        number: 0,
+        size: 25,
+      })
+    );
+  },
+
+  reportsByListingSuccess(auctionId: number, reports: AdminReportDetail[]) {
+    return http.get(`*/api/v1/admin/reports/listing/${auctionId}`, () =>
+      HttpResponse.json(reports)
+    );
+  },
+
+  reportDetailSuccess(report: AdminReportDetail) {
+    return http.get(`*/api/v1/admin/reports/${report.id}`, () =>
+      HttpResponse.json(report)
+    );
+  },
+
+  dismissReportSuccess(report: AdminReportDetail) {
+    return http.post(`*/api/v1/admin/reports/${report.id}/dismiss`, () =>
+      HttpResponse.json(report)
+    );
+  },
+
+  warnSellerSuccess(auctionId: number) {
+    return http.post(`*/api/v1/admin/reports/listing/${auctionId}/warn-seller`, () =>
+      new HttpResponse(null, { status: 200 })
+    );
+  },
+
+  suspendListingFromReportSuccess(auctionId: number) {
+    return http.post(`*/api/v1/admin/reports/listing/${auctionId}/suspend`, () =>
+      new HttpResponse(null, { status: 200 })
+    );
+  },
+
+  cancelListingFromReportSuccess(auctionId: number) {
+    return http.post(`*/api/v1/admin/reports/listing/${auctionId}/cancel`, () =>
+      new HttpResponse(null, { status: 200 })
+    );
+  },
+
+  bansListSuccess(rows: AdminBanRow[]) {
+    return http.get("*/api/v1/admin/bans", () =>
+      HttpResponse.json({
+        content: rows,
+        totalElements: rows.length,
+        totalPages: 1,
+        number: 0,
+        size: 25,
+      })
+    );
+  },
+
+  createBanSuccess(ban: AdminBanRow) {
+    return http.post("*/api/v1/admin/bans", () => HttpResponse.json(ban));
+  },
+
+  liftBanSuccess(ban: AdminBanRow) {
+    return http.post(`*/api/v1/admin/bans/${ban.id}/lift`, () => HttpResponse.json(ban));
+  },
+
+  ban409AlreadyLifted(banId: number) {
+    return http.post(`*/api/v1/admin/bans/${banId}/lift`, () =>
+      HttpResponse.json(
+        { code: "BAN_ALREADY_LIFTED", message: "Ban already lifted", details: {} },
+        { status: 409 }
+      )
+    );
+  },
+
+  ban409TypeFieldMismatch(banId: number) {
+    return http.post(`*/api/v1/admin/bans/${banId}/lift`, () =>
+      HttpResponse.json(
+        { code: "BAN_TYPE_FIELD_MISMATCH", message: "Ban type field mismatch", details: {} },
+        { status: 409 }
+      )
+    );
+  },
+
+  usersSearchSuccess(rows: AdminUserSummary[]) {
+    return http.get("*/api/v1/admin/users", () =>
+      HttpResponse.json({
+        content: rows,
+        totalElements: rows.length,
+        totalPages: 1,
+        number: 0,
+        size: 25,
+      })
+    );
+  },
+
+  userDetailSuccess(detail: AdminUserDetail) {
+    return http.get(`*/api/v1/admin/users/${detail.id}`, () => HttpResponse.json(detail));
+  },
+
+  userIpsSuccess(userId: number, ips: UserIpProjection[]) {
+    return http.get(`*/api/v1/admin/users/${userId}/ips`, () => HttpResponse.json(ips));
+  },
+
+  userListingsSuccess(userId: number, rows: AdminUserModerationRow[]) {
+    return http.get(`*/api/v1/admin/users/${userId}/listings`, () =>
+      HttpResponse.json({
+        content: rows,
+        totalElements: rows.length,
+        totalPages: 1,
+        number: 0,
+        size: 25,
+      })
+    );
+  },
+
+  userBidsSuccess(userId: number, rows: AdminUserModerationRow[]) {
+    return http.get(`*/api/v1/admin/users/${userId}/bids`, () =>
+      HttpResponse.json({
+        content: rows,
+        totalElements: rows.length,
+        totalPages: 1,
+        number: 0,
+        size: 25,
+      })
+    );
+  },
+
+  userCancellationsSuccess(userId: number, rows: AdminUserModerationRow[]) {
+    return http.get(`*/api/v1/admin/users/${userId}/cancellations`, () =>
+      HttpResponse.json({
+        content: rows,
+        totalElements: rows.length,
+        totalPages: 1,
+        number: 0,
+        size: 25,
+      })
+    );
+  },
+
+  userReportsSuccess(userId: number, rows: AdminUserModerationRow[]) {
+    return http.get(`*/api/v1/admin/users/${userId}/reports`, () =>
+      HttpResponse.json({
+        content: rows,
+        totalElements: rows.length,
+        totalPages: 1,
+        number: 0,
+        size: 25,
+      })
+    );
+  },
+
+  userFraudFlagsSuccess(userId: number, rows: AdminUserFraudFlagRow[]) {
+    return http.get(`*/api/v1/admin/users/${userId}/fraud-flags`, () =>
+      HttpResponse.json({
+        content: rows,
+        totalElements: rows.length,
+        totalPages: 1,
+        number: 0,
+        size: 25,
+      })
+    );
+  },
+
+  userModerationSuccess(userId: number, rows: AdminUserModerationRow[]) {
+    return http.get(`*/api/v1/admin/users/${userId}/moderation`, () =>
+      HttpResponse.json({
+        content: rows,
+        totalElements: rows.length,
+        totalPages: 1,
+        number: 0,
+        size: 25,
+      })
+    );
+  },
+
+  promoteUserSuccess(userId: number) {
+    return http.post(`*/api/v1/admin/users/${userId}/promote`, () =>
+      new HttpResponse(null, { status: 200 })
+    );
+  },
+
+  promoteUser409AlreadyAdmin(userId: number) {
+    return http.post(`*/api/v1/admin/users/${userId}/promote`, () =>
+      HttpResponse.json(
+        { code: "ALREADY_ADMIN", message: "User is already an admin", details: {} },
+        { status: 409 }
+      )
+    );
+  },
+
+  demoteUserSuccess(userId: number) {
+    return http.post(`*/api/v1/admin/users/${userId}/demote`, () =>
+      new HttpResponse(null, { status: 200 })
+    );
+  },
+
+  demoteUser409SelfForbidden(userId: number) {
+    return http.post(`*/api/v1/admin/users/${userId}/demote`, () =>
+      HttpResponse.json(
+        { code: "SELF_DEMOTE_FORBIDDEN", message: "Cannot demote yourself", details: {} },
+        { status: 409 }
+      )
+    );
+  },
+
+  demoteUser409NotAdmin(userId: number) {
+    return http.post(`*/api/v1/admin/users/${userId}/demote`, () =>
+      HttpResponse.json(
+        { code: "NOT_ADMIN", message: "User is not an admin", details: {} },
+        { status: 409 }
+      )
+    );
+  },
+
+  resetFrivolousCounterSuccess(userId: number) {
+    return http.post(`*/api/v1/admin/users/${userId}/reset-frivolous-counter`, () =>
+      new HttpResponse(null, { status: 200 })
+    );
+  },
+
+  auditListSuccess(rows: AdminUserModerationRow[]) {
+    return http.get("*/api/v1/admin/audit", () =>
+      HttpResponse.json({
+        content: rows,
+        totalElements: rows.length,
+        totalPages: 1,
+        number: 0,
+        size: 25,
+      })
+    );
+  },
+
+  submitReportSuccess(auctionId: number, response: MyReportResponse) {
+    return http.post(`*/api/v1/auctions/${auctionId}/report`, () =>
+      HttpResponse.json(response)
+    );
+  },
+
+  myReport204(auctionId: number) {
+    return http.get(`*/api/v1/auctions/${auctionId}/my-report`, () =>
+      new HttpResponse(null, { status: 204 })
+    );
+  },
+
+  myReportSuccess(auctionId: number, response: MyReportResponse) {
+    return http.get(`*/api/v1/auctions/${auctionId}/my-report`, () =>
+      HttpResponse.json(response)
     );
   },
 };


### PR DESCRIPTION
## Summary

- `ListingReport` entity + user-facing report endpoints (upsert + my-report)
- Admin reports queue at /admin/reports (listing-grouped + slide-over with 4 actions)
- `Ban` entity + Redis cache + 6-path enforcement (register/login/SL-verify/bid/listing-create/listing-cancel)
- Admin bans page at /admin/bans + create/lift modals + first-seen-IP for AVATAR rows
- Admin user search at /admin/users + user-detail at /admin/users/{id} with 6 tabs + 280px right rail
- `admin_actions` audit table + audit read endpoint (per-user via Moderation tab)
- `AdminAuctionService.reinstate` shared primitive + standalone /admin/auctions/{id}/reinstate
- Sub-spec 1's fraud-flag reinstate refactored to delegate (net behavior unchanged)
- `CancellationService.cancelByAdmin` skips penalty ladder; cause-neutral bidder fanout body
- New notification categories: LISTING_WARNED, LISTING_REMOVED_BY_ADMIN
- Dashboard 4-up needs-attention row (Open reports added)
- Auction detail Report button + modal

## Test plan

- [ ] Backend: `cd backend && ./mvnw test` — all green
- [ ] Frontend: `cd frontend && npx tsc --noEmit && npm test && npm run lint` — all green
- [ ] Manual: user reports a listing → modal flow → button flips to Reported ✓
- [ ] Manual: admin dismisses → button re-enables (re-submit replaces row + resets OPEN)
- [ ] Manual: admin warns seller (different report) → seller gets LISTING_WARNED
- [ ] Manual: admin suspends from reports → seller gets LISTING_SUSPENDED, all open reports → ACTION_TAKEN, DISMISSED reports stay DISMISSED
- [ ] Manual: admin reinstates from user-detail Listings tab → auction → ACTIVE, seller gets LISTING_REINSTATED
- [ ] Manual: admin cancels from reports → seller gets LISTING_REMOVED_BY_ADMIN, bidders get cause-neutral cancel notification, no penalty applied (cancellation_log row has cancelledByAdminId, seller.cancelledWithBids unchanged)
- [ ] Manual: admin creates AVATAR ban on logged-in user → user invalidates on next refresh (tv bump)
- [ ] Manual: banned user attempts bid → 403 USER_BANNED
- [ ] Manual: admin lifts ban → user can act again (after Redis cache flush)
- [ ] Manual: admin self-demote → 409 SELF_DEMOTE_FORBIDDEN

## Out of scope (next sub-specs)

- Bot pool health, escrow dispute resolution, terminal secret rotation → sub-spec 3
- Reminder schedulers, account deletion UI, audit-log viewer page → sub-spec 4
- REPORT_THRESHOLD_REACHED admin-targeted notification — deferred
- Frivolous-reporter automatic revocation — counter only this sub-spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)