### PR TITLE
feat(backend): tighten application-prod.yml for AWS deployment

### DIFF
--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -8,6 +8,17 @@ spring:
     redis:
       host: ${SPRING_DATA_REDIS_HOST}
       port: ${SPRING_DATA_REDIS_PORT:6379}
+      # ElastiCache auth token (sourced from /slpa/prod/redis/auth-token in
+      # Parameter Store; injected via ECS task definition `secrets[]` block).
+      # Empty default lets local non-AWS prod-profile testing run without auth.
+      password: ${SPRING_DATA_REDIS_PASSWORD:}
+      # ElastiCache encryption-in-transit. The cluster will reject plaintext
+      # connections once `transit_encryption_enabled = true` is set on the
+      # replication group (default in the AWS deployment design §4.6).
+      # Without this flag Spring's Lettuce client opens unencrypted sockets
+      # and the connection is dropped at the TLS handshake.
+      ssl:
+        enabled: true
   flyway:
     baseline-on-migrate: true
 
@@ -17,9 +28,24 @@ cors:
 jwt:
   secret: ${JWT_SECRET}    # required, fail-fast on startup if missing
 
+logging:
+  level:
+    # Prod posture: WARN root + INFO for our own packages keeps CloudWatch
+    # ingestion under ~30 GB/mo at moderate traffic (see AWS_CALCULATION.md
+    # CloudWatch logs section). Crank back up for incident debugging via
+    # env override (LOGGING_LEVEL_<PACKAGE>) — no redeploy required.
+    root: WARN
+    com.slparcelauctions: INFO
+    org.hibernate.SQL: WARN
+    org.flywaydb: INFO
+
 slpa:
   sl:
     trusted-owner-keys: []  # deploy pipeline injects the real UUIDs via env
   storage:
     bucket: ${SLPA_STORAGE_BUCKET}
     region: ${AWS_REGION:us-east-1}
+  web:
+    # Public web origin. Must match the Amplify-served `slparcels.com`. Used
+    # to construct outbound links in SL IM notifications, email subjects, etc.
+    base-url: ${SLPA_WEB_BASE_URL:https://slparcels.com}


### PR DESCRIPTION
## Summary

Pre-launch config tightening for `application-prod.yml`. All changes are env-driven so dev/test profiles are unaffected.

- **Redis TLS enabled** (`spring.data.redis.ssl.enabled: true`) — ElastiCache encryption-in-transit is the load-bearing change here. Without it the cluster will reject plaintext connections once `transit_encryption_enabled = true` is set on the replication group.
- **Redis auth token env hook** (`spring.data.redis.password: \${SPRING_DATA_REDIS_PASSWORD:}`) — sourced from Parameter Store `/slpa/prod/redis/auth-token` and injected via ECS task definition `secrets[]`.
- **Prod logging posture** — `WARN` root + `INFO` for `com.slparcelauctions`, suppress Hibernate SQL noise, keep Flyway migration logs at INFO. Keeps CloudWatch ingestion under ~30 GB/mo at moderate traffic per AWS_CALCULATION.md. Override per-package via env (no redeploy) for incident debugging.
- **`slpa.web.base-url` defaults to `https://slparcels.com`** — used to construct outbound links in SL IM notifications.

## Test plan

- [x] \`./mvnw test\` — 1589 tests, 0 failures (tests use dev profile, prod yaml change doesn't affect them, but the build validates YAML correctness)

## Notes

The Redis TLS change is the only one that's a pure functional change. The others are operational tuning + an env-var hook. None of them affect dev workflow.

Companion to PR #38 (Flyway baseline). Together these complete the backend code changes the AWS deployment design requires before Terraform work begins.