### PR TITLE
feat(infra): Terraform skeleton — provider, S3 backend, variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,15 @@ bot/**/obj/
 # compose file.
 compose.override.yml
 docker-compose.override.yml
+
+# Terraform — per-deployment overrides + local provider/state cache.
+# terraform.tfvars contains the operator email at minimum; sensitive values
+# never live there (they go to Parameter Store via `aws ssm put-parameter`).
+infra/terraform.tfvars
+infra/.terraform/
+infra/.terraform.lock.hcl
+infra/*.tfplan
+infra/*.tfstate
+infra/*.tfstate.*
+infra/crash.log
+infra/crash.*.log

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,101 @@
+################################################################################
+# SLPA — Terraform root module
+#
+# Deploys the SLPA production stack on AWS. See:
+#   docs/superpowers/specs/2026-04-29-aws-deployment-design.md  (architecture)
+#   AWS_CALCULATION.md                                           (cost estimates)
+#   PREP.md                                                      (one-time setup)
+#
+# This file owns the provider + backend wiring only. Resources live in topic
+# subdirectories (networking/, data/, compute/, etc.) added as later PRs land.
+#
+# Apply via:
+#   cd infra
+#   terraform init       # configures the S3 backend (one-time per workstation)
+#   terraform plan -out=tfplan
+#   terraform apply tfplan
+#
+# State backend (S3 bucket + DynamoDB lock) is bootstrapped manually per
+# PREP.md §9 — Terraform cannot create its own backend.
+################################################################################
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.70"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+
+  # State backend — must match the bootstrap created in PREP.md §9.
+  # Bucket name is NOT parameterised because Terraform's `backend` block
+  # doesn't support variables (chicken-and-egg with init).
+  #
+  # `use_lockfile = true` (Terraform 1.10+) uses S3 conditional writes for
+  # state locking instead of a separate DynamoDB table. The table created
+  # in PREP.md §9.e is unused going forward — safe to delete with
+  # `aws dynamodb delete-table --table-name slpa-prod-tfstate-lock` whenever
+  # convenient (no rush, costs are negligible at PAY_PER_REQUEST idle).
+  backend "s3" {
+    bucket       = "slpa-prod-tfstate"
+    key          = "prod/terraform.tfstate"
+    region       = "us-east-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+}
+
+################################################################################
+# AWS provider
+#
+# Default tags are applied to every taggable resource — covers cost allocation
+# (Project, Environment) and operator clarity (ManagedBy = Terraform). Override
+# per-resource if a specific resource needs additional tags; default_tags
+# merges, doesn't replace.
+################################################################################
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = "slpa"
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Repo        = "TheCodeLlama/slparcelauctions"
+    }
+  }
+}
+
+# Second AWS provider aliased to us-east-1 for resources that MUST live
+# there regardless of the stack's primary region (CloudFront ACM certs,
+# Amplify-managed certs). Today the stack is in us-east-1 already so this
+# is functionally identical to the default provider — keeping the alias
+# defined now means a future region migration doesn't have to touch ACM.
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  default_tags {
+    tags = {
+      Project     = "slpa"
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Repo        = "TheCodeLlama/slparcelauctions"
+    }
+  }
+}
+
+################################################################################
+# Data sources used at root scope
+################################################################################
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,25 @@
+################################################################################
+# SLPA — Terraform outputs
+#
+# Outputs are added as resources land in subsequent PRs. Expected outputs from
+# the design (added incrementally):
+#
+#   networking:    vpc_id, public_subnet_ids, private_subnet_ids, alb_dns_name
+#   data:          rds_writer_endpoint, redis_primary_endpoint, s3_storage_bucket
+#   compute:       ecs_cluster_arn, ecr_backend_repo_url, ecr_bot_repo_url
+#   secrets:       (none — Parameter Store paths are conventional)
+#   dns:           route53_zone_ns_slparcels, route53_zone_ns_slpa_app
+#   cicd:          github_actions_role_arn, codedeploy_app_name
+#
+# This file stays empty at the skeleton stage — Terraform requires no outputs.
+################################################################################
+
+output "aws_account_id" {
+  description = "AWS account this stack is deployed into. Sanity check that init is wired to the right account."
+  value       = data.aws_caller_identity.current.account_id
+}
+
+output "aws_region" {
+  description = "Primary region for the stack."
+  value       = data.aws_region.current.name
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,0 +1,39 @@
+################################################################################
+# SLPA — Terraform variable overrides (example)
+#
+# Copy to terraform.tfvars (gitignored) and fill in non-default values for your
+# deployment. Most variables have sane launch-lite defaults in variables.tf;
+# only the ones below typically need per-deployment overrides.
+#
+# Sensitive secrets (RDS password, JWT key, bot credentials, etc.) are NOT in
+# this file — they're set out-of-band via `aws ssm put-parameter`. See PREP.md
+# §7.3 / spec §7.3.
+################################################################################
+
+# Required: operator email for AWS Budgets + SNS alarm subscriptions.
+alarm_email = "your-email@example.com"
+
+# Defaults are launch-lite ($125-195/mo). Uncomment + override individual
+# levers as traffic / load justifies. See spec §5 for the full upgrade-lever
+# table.
+
+# --- Production-tier examples (uncomment when ready) -----------------------
+
+# rds_multi_az          = true
+# rds_instance_class    = "db.t4g.small"
+# rds_allocated_storage = 50
+
+# redis_num_cache_clusters = 2
+# redis_node_type          = "cache.t4g.small"
+
+# backend_desired_count = 2
+# backend_cpu           = 512
+# backend_memory        = 1024
+
+# bot_active_count = 5
+
+# nat_type                  = "gateway"
+# enable_interface_endpoints = true
+
+# log_retention_days = 30
+# enable_waf         = true

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,222 @@
+################################################################################
+# SLPA — Terraform variables
+#
+# Every variable is annotated with whether it's a launch-lite default or an
+# upgrade lever. Spec reference: §5 (Launch-lite vs. production-tier upgrade
+# levers) of docs/superpowers/specs/2026-04-29-aws-deployment-design.md.
+#
+# Sensitive values are NOT defaulted here — they're set in terraform.tfvars
+# (gitignored) or sourced from Parameter Store (set out-of-band via
+# `aws ssm put-parameter` per PREP.md / spec §7.3).
+################################################################################
+
+# ----- Identity + global ---------------------------------------------------- #
+
+variable "aws_region" {
+  description = "Primary AWS region for the SLPA stack. Spec §4.1 + Q12."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Environment name applied to default tags + resource names. Single-env launch (spec Q3 = prod-only)."
+  type        = string
+  default     = "prod"
+}
+
+variable "alarm_email" {
+  description = "Operator email subscribed to the SNS alerts topic. Required."
+  type        = string
+}
+
+# ----- Domains -------------------------------------------------------------- #
+
+variable "domain_slparcels" {
+  description = "Frontend apex (Amplify). Spec §4.9."
+  type        = string
+  default     = "slparcels.com"
+}
+
+variable "domain_slpa_app" {
+  description = "Backend apex (ALB ALIAS target). Spec §4.9."
+  type        = string
+  default     = "slpa.app"
+}
+
+# ----- RDS Postgres (spec §4.5) -------------------------------------------- #
+
+variable "rds_multi_az" {
+  description = "Multi-AZ RDS deployment. Launch-lite default = false; flip to true once production traffic justifies the +$30/mo for AZ failover. Upgrade lever."
+  type        = bool
+  default     = false
+}
+
+variable "rds_instance_class" {
+  description = "RDS instance class. Launch-lite default = db.t4g.micro. Upgrade path: db.t4g.small → db.t4g.medium → db.m6g.large."
+  type        = string
+  default     = "db.t4g.micro"
+}
+
+variable "rds_allocated_storage" {
+  description = "RDS storage (GB). Launch-lite default = 20. Autoscaling enabled to a 100 GB ceiling regardless of this initial value."
+  type        = number
+  default     = 20
+}
+
+variable "rds_database_insights_enabled" {
+  description = "Enable RDS Database Insights (CloudWatch). Launch-lite default = false. Upgrade lever for moderate+ tier."
+  type        = bool
+  default     = false
+}
+
+variable "rds_pi_retention_days" {
+  description = "Performance Insights retention. 7 = free tier. Upgrade lever to 731 (24mo) at moderate+ tier."
+  type        = number
+  default     = 7
+}
+
+variable "rds_enable_proxy" {
+  description = "Enable RDS Proxy. Launch-lite default = false. Upgrade lever for heavy-tier connection-spike mitigation."
+  type        = bool
+  default     = false
+}
+
+# ----- ElastiCache Redis (spec §4.6) --------------------------------------- #
+
+variable "redis_num_cache_clusters" {
+  description = "Number of Redis cache nodes. Launch-lite default = 1 (single node). Upgrade lever to 2 (primary + replica with Multi-AZ failover)."
+  type        = number
+  default     = 1
+}
+
+variable "redis_node_type" {
+  description = "ElastiCache node type. Launch-lite default = cache.t4g.micro. Upgrade lever: cache.t4g.small → cache.t4g.medium."
+  type        = string
+  default     = "cache.t4g.micro"
+}
+
+# ----- Compute — backend (spec §4.2) --------------------------------------- #
+
+variable "backend_desired_count" {
+  description = "Number of backend Fargate tasks running concurrently. Launch-lite default = 1. Upgrade lever to 2+ for scheduler-redundancy + AZ spread."
+  type        = number
+  default     = 1
+}
+
+variable "backend_cpu" {
+  description = "Backend Fargate task CPU units (256 = 0.25 vCPU, 512 = 0.5 vCPU, 1024 = 1 vCPU, etc.). Launch-lite default = 256."
+  type        = number
+  default     = 256
+}
+
+variable "backend_memory" {
+  description = "Backend Fargate task memory (MiB). Must satisfy Fargate's vCPU/memory ratio. Launch-lite default = 512 (matches 256 CPU)."
+  type        = number
+  default     = 512
+}
+
+# ----- Compute — bot pool (spec §4.3) -------------------------------------- #
+
+variable "bot_active_count" {
+  description = "Number of bot ECS services to provision (1-5). Launch-lite default = 2 (bot-1 + bot-2). Increase as Method-C verification + ownership-monitoring volume justifies."
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.bot_active_count >= 1 && var.bot_active_count <= 5
+    error_message = "Bot pool is fixed at 5 named workers (SLPABot1-5). Set between 1 and 5."
+  }
+}
+
+variable "bot_cpu" {
+  description = "Per-bot Fargate task CPU units. Launch-lite default = 256 (0.25 vCPU). Upgrade lever to 512 at heavy tier."
+  type        = number
+  default     = 256
+}
+
+variable "bot_memory" {
+  description = "Per-bot Fargate task memory (MiB). Launch-lite default = 512."
+  type        = number
+  default     = 512
+}
+
+# ----- Networking (spec §4.1) ---------------------------------------------- #
+
+variable "vpc_cidr" {
+  description = "VPC CIDR block. /16 gives plenty of room for future subnets."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  description = "AZs for subnet placement. Two required even at launch-lite (RDS subnet group constraint)."
+  type        = list(string)
+  default     = ["us-east-1a", "us-east-1b"]
+}
+
+variable "nat_type" {
+  description = "NAT shape. Launch-lite default = 'instance' (fck-nat on t4g.nano, ~$5/mo). Upgrade lever to 'gateway' (×2 for HA, ~$64/mo)."
+  type        = string
+  default     = "instance"
+
+  validation {
+    condition     = contains(["instance", "gateway"], var.nat_type)
+    error_message = "nat_type must be 'instance' or 'gateway'."
+  }
+}
+
+variable "enable_interface_endpoints" {
+  description = "Enable VPC interface endpoints for ECR/Secrets/CloudWatch. Launch-lite default = false (S3 gateway endpoint is always on, free). Upgrade lever (~$42-56/mo) once NAT egress costs justify."
+  type        = bool
+  default     = false
+}
+
+# ----- Observability (spec §4.12) ------------------------------------------ #
+
+variable "log_retention_days" {
+  description = "CloudWatch Logs retention for ECS task log groups. Launch-lite default = 7. Upgrade lever to 30 / 90 days as compliance or debugging window grows."
+  type        = number
+  default     = 7
+}
+
+variable "enable_xray" {
+  description = "Enable AWS X-Ray distributed tracing on the backend. Launch-lite default = false. Upgrade lever (~$1-10/mo)."
+  type        = bool
+  default     = false
+}
+
+# ----- Security (spec §4.13 / §9 deferred) --------------------------------- #
+
+variable "enable_waf" {
+  description = "Enable AWS WAF on the ALB. Launch-lite default = false. Upgrade lever ($5+/mo + per-request) once traffic justifies."
+  type        = bool
+  default     = false
+}
+
+# ----- Cost guardrails (spec §4.13) ---------------------------------------- #
+
+variable "budget_soft_threshold_usd" {
+  description = "AWS Budgets soft alert (email). Launch-lite default = $200/mo (1.5x estimate)."
+  type        = number
+  default     = 200
+}
+
+variable "budget_hard_threshold_usd" {
+  description = "AWS Budgets hard alert. Launch-lite default = $400/mo (2.6x estimate; signal of something very wrong)."
+  type        = number
+  default     = 400
+}
+
+# ----- CI/CD (spec §4.10) -------------------------------------------------- #
+
+variable "github_repo" {
+  description = "GitHub repo (owner/name) for OIDC trust. Used to scope the deploy role to this specific repo + branch."
+  type        = string
+  default     = "TheCodeLlama/slparcelauctions"
+}
+
+variable "github_branch_for_deploy" {
+  description = "Git branch GitHub Actions can assume the deploy role from. Per the spec, only main."
+  type        = string
+  default     = "main"
+}


### PR DESCRIPTION
## Summary

Bootstraps the SLPA Terraform module structure. **No AWS resources created** — just provider config, S3 backend wiring, all upgrade-lever variables with launch-lite defaults, and outputs for sanity-checking the account/region.

Step 5 of the implementation flow per `docs/superpowers/specs/2026-04-29-aws-deployment-design.md` §6. Resource definitions land in subsequent PRs (networking → data → compute → DNS → CI/CD).

## What's in here

- `infra/main.tf` — AWS provider (us-east-1) + aliased `us_east_1` provider for CloudFront/Amplify ACM, S3 backend with `use_lockfile = true` (Terraform 1.10+ S3 conditional-write locking, supersedes the DynamoDB lock table from PREP §9.e), default tags for cost allocation.
- `infra/variables.tf` — every upgrade-lever variable from spec §5 with launch-lite defaults. RDS Multi-AZ, instance class, storage; ElastiCache node type/count; Fargate task sizing; bot pool active count (1-5, validated); NAT type; observability flags; cost guardrail thresholds ($200 soft / $400 hard); CI/CD scope (repo + branch).
- `infra/outputs.tf` — `aws_account_id` + `aws_region` for init sanity check. More outputs added per subsequent PR.
- `infra/terraform.tfvars.example` — committed template. Sensitive values never go here (Parameter Store at runtime).
- `.gitignore` — `infra/terraform.tfvars`, `.terraform/`, `*.tfplan`, `*.tfstate`.

## DynamoDB note

The DynamoDB lock table (`slpa-prod-tfstate-lock`) created in PREP §9.e is now unused — `use_lockfile = true` uses S3 conditional writes for state locking instead. Safe to delete via `aws dynamodb delete-table --table-name slpa-prod-tfstate-lock` whenever convenient. Costs are negligible at PAY_PER_REQUEST idle, no rush.

## Verification (run against AWS account 486208158127)

- [x] \`terraform init\` — connected to \`s3://slpa-prod-tfstate\` cleanly
- [x] \`terraform validate\` — Success
- [x] \`terraform fmt -check -recursive\` — clean
- [x] \`terraform plan\` — 0 resources, only output additions
- [x] \`terraform apply -auto-approve\` — 0 added/changed/destroyed; state file initialised in S3