### PR TITLE
feat(infra): networking module — VPC, subnets, NAT instance, security groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,9 +215,10 @@ docker-compose.override.yml
 # never live there (they go to Parameter Store via `aws ssm put-parameter`).
 infra/terraform.tfvars
 infra/.terraform/
-infra/.terraform.lock.hcl
 infra/*.tfplan
 infra/*.tfstate
 infra/*.tfstate.*
 infra/crash.log
 infra/crash.*.log
+# .terraform.lock.hcl IS committed — Terraform's recommendation. Pins provider
+# versions so every machine + CI run resolves the same provider versions.

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,65 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.42.0"
+  constraints = ">= 6.0.0, ~> 6.0"
+  hashes = [
+    "h1:1BwCxrsTa7u4igMUUel+v0ZKuHtW/LfHV6H8L5v7bYo=",
+    "zh:0dd774a97eaa4371a60e13b5dc56800d4fb1c48d50e79049f75fc4fe26705ff5",
+    "zh:237d652d8ec028f7bedce1ce056ffe42e2e120d2a4a47fe45b97263cc5948e7e",
+    "zh:367d9e4b816e5f857956887b8f0770aaa5bec47c4b1e2c7bf924e39192d580d6",
+    "zh:4194addb5b34bb803fab031a80d84e9d16cac2308df9a498d51e2214c7893900",
+    "zh:5bcc36226fa5d8a3c37e41ac8cfd2b1eb73e7ae96f8418f6776dcaa16a987198",
+    "zh:61d0632d4cc7973b779b90c1d3bb2d05a1cd4d7030bb4645831e67cf735ecaa0",
+    "zh:7c7efaf9e4bb662ba3e8a714abafe7107bdcd1bf2cd0867510ea32762debc11d",
+    "zh:7d7f8ffe00d4a90184efa454a107bcc46d81f21245baea9678dcfa2fa77ac1be",
+    "zh:7e534c454cdeafe9cc225bea53397883bb96c54da6ea3421fd53dbc9dfc1bb90",
+    "zh:99564c99a0672b2a8b666ab2040f36a7c6f372fa79ac43a6657a54734e46fff8",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6b1bb6178798882508f5512222a9433fc21e63cdae83a755650c938e6141d32",
+    "zh:a87592d6ff3d46ee83756f4f84503b2fe4ffc9c1d5dc9f8d4afccb5e126ae538",
+    "zh:daa56fb74c5c9d26b327c40b486beac71cdb9a932c7c4e4561f4401cd0d16a4a",
+    "zh:f35ab043d7121f3a194f42f5b0e0d59fe62d94488acea07e3783405fa5838785",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version     = "2.3.7"
+  constraints = "~> 2.3"
+  hashes = [
+    "h1:h1Pr6uNwq+iDEGrnQJEHzOTz+yVTW0AJgZrGXuoO4Qs=",
+    "zh:06f1c54e919425c3139f8aeb8fcf9bceca7e560d48c9f0c1e3bb0a8ad9d9da1e",
+    "zh:0e1e4cf6fd98b019e764c28586a386dc136129fef50af8c7165a067e7e4a31d5",
+    "zh:1871f4337c7c57287d4d67396f633d224b8938708b772abfc664d1f80bd67edd",
+    "zh:2b9269d91b742a71b2248439d5e9824f0447e6d261bfb86a8a88528609b136d1",
+    "zh:3d8ae039af21426072c66d6a59a467d51f2d9189b8198616888c1b7fc42addc7",
+    "zh:3ef4e2db5bcf3e2d915921adced43929214e0946a6fb11793085d9a48995ae01",
+    "zh:42ae54381147437c83cbb8790cc68935d71b6357728a154109d3220b1beb4dc9",
+    "zh:4496b362605ae4cbc9ef7995d102351e2fe311897586ffc7a4a262ccca0c782a",
+    "zh:652a2401257a12706d32842f66dac05a735693abcb3e6517d6b5e2573729ba13",
+    "zh:7406c30806f5979eaed5f50c548eced2ea18ea121e01801d2f0d4d87a04f6a14",
+    "zh:7848429fd5a5bcf35f6fee8487df0fb64b09ec071330f3ff240c0343fe2a5224",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:osH3aBqEARwOz3VBJKdpFKJJCNIdgRC6k8vPojkLmlY=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
+  ]
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -25,11 +25,18 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.70"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.6"
+    }
+    # fck-nat module pulls in cloudinit for the user-data rendering on the
+    # NAT instance. Declared explicitly here so `terraform providers lock`
+    # picks it up.
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = "~> 2.3"
     }
   }
 
@@ -99,3 +106,16 @@ provider "aws" {
 data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}
+
+################################################################################
+# Module wiring
+################################################################################
+
+module "networking" {
+  source = "./networking"
+
+  environment        = var.environment
+  vpc_cidr           = var.vpc_cidr
+  availability_zones = var.availability_zones
+  nat_type           = var.nat_type
+}

--- a/infra/networking/endpoints.tf
+++ b/infra/networking/endpoints.tf
@@ -1,0 +1,24 @@
+################################################################################
+# VPC endpoints
+#
+# S3 gateway endpoint is free + always-on. Routes Fargate→S3 traffic without
+# traversing NAT, saving NAT egress cost on photo/avatar/dispute-evidence
+# read+write paths (the highest-volume internal traffic).
+#
+# Interface endpoints (ECR, Secrets Manager, CloudWatch) are paid (~$7/mo
+# each per AZ) and gated behind a future variable when NAT egress costs
+# justify them. Not in this PR.
+################################################################################
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [aws_route_table.private.id]
+
+  tags = {
+    Name = "slpa-${var.environment}-vpce-s3"
+  }
+}
+
+data "aws_region" "current" {}

--- a/infra/networking/nat.tf
+++ b/infra/networking/nat.tf
@@ -1,0 +1,92 @@
+################################################################################
+# NAT egress
+#
+# nat_type = "instance"  → fck-nat on t4g.nano in single AZ (~$5/mo).
+# nat_type = "gateway"   → managed NAT Gateways (~$32/mo each, ×2 for HA).
+#
+# Launch-lite default is "instance" — see spec §4.1 / §5 (upgrade lever).
+#
+# fck-nat (https://fck-nat.dev) is a community-maintained NAT instance AMI
+# that auto-discovers its route table, attaches the default route, and
+# self-heals via ASG. We use the official Terraform module for it because
+# it abstracts the IAM role, security group, launch template, and ASG
+# scaffolding into ~10 lines of caller config.
+################################################################################
+
+# ----- nat_type = "instance" (fck-nat) -------------------------------------- #
+
+module "fck_nat" {
+  count = var.nat_type == "instance" ? 1 : 0
+
+  source  = "RaJiska/fck-nat/aws"
+  version = "~> 1.3"
+
+  name          = "slpa-${var.environment}-nat"
+  vpc_id        = aws_vpc.main.id
+  subnet_id     = aws_subnet.public[0].id # NAT lives in AZ a public subnet
+  instance_type = "t4g.nano"              # ARM, ~$3/mo (NAT instance is the one place ARM is safe — no JNI/native deps in the NAT routing path)
+
+  # Have the module add a default route from a single private RT through the
+  # NAT instance. update_route_tables = true wires that automatically.
+  update_route_tables = true
+  route_tables_ids = {
+    private = aws_route_table.private.id
+  }
+
+  tags = {
+    Name = "slpa-${var.environment}-nat-instance"
+  }
+}
+
+# ----- nat_type = "gateway" (managed NAT GW × 2 for HA) --------------------- #
+
+resource "aws_eip" "nat" {
+  count = var.nat_type == "gateway" ? length(var.availability_zones) : 0
+
+  domain = "vpc"
+
+  tags = {
+    Name = "slpa-${var.environment}-nat-eip-${var.availability_zones[count.index]}"
+  }
+}
+
+resource "aws_nat_gateway" "main" {
+  count = var.nat_type == "gateway" ? length(var.availability_zones) : 0
+
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = {
+    Name = "slpa-${var.environment}-nat-gw-${var.availability_zones[count.index]}"
+  }
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# When using managed NAT GWs, the single private route table approach above
+# breaks the AZ-affinity benefit (a private subnet in AZ b would still route
+# through the NAT GW in AZ a). For "gateway" mode we add per-AZ private
+# route tables and reassociate. This is a no-op when nat_type = "instance".
+#
+# At launch-lite this branch is dormant; activated via .tfvars flip.
+resource "aws_route_table" "private_per_az" {
+  count = var.nat_type == "gateway" ? length(var.availability_zones) : 0
+
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main[count.index].id
+  }
+
+  tags = {
+    Name = "slpa-${var.environment}-rt-private-${var.availability_zones[count.index]}"
+  }
+}
+
+# Note: when flipping to nat_type = "gateway", the operator must also
+# manually disassociate the original aws_route_table.private from the
+# private subnets and associate the per-AZ route tables instead. Terraform
+# handles this in a follow-up plan because aws_route_table_association is
+# already declared in vpc.tf bound to aws_route_table.private — the upgrade
+# task should rewrite that association block to switch on nat_type.

--- a/infra/networking/outputs.tf
+++ b/infra/networking/outputs.tf
@@ -1,0 +1,51 @@
+output "vpc_id" {
+  value       = aws_vpc.main.id
+  description = "VPC ID for downstream modules (data, compute)."
+}
+
+output "vpc_cidr_block" {
+  value       = aws_vpc.main.cidr_block
+  description = "VPC CIDR block."
+}
+
+output "public_subnet_ids" {
+  value       = aws_subnet.public[*].id
+  description = "Public subnet IDs (ALB, NAT)."
+}
+
+output "private_subnet_ids" {
+  value       = aws_subnet.private[*].id
+  description = "Private subnet IDs (Fargate tasks, RDS, Redis)."
+}
+
+output "private_route_table_id" {
+  value       = aws_route_table.private.id
+  description = "Single private route table (launch-lite). Per-AZ tables when nat_type=gateway."
+}
+
+# ----- Security group IDs (consumed by data + compute modules) -------------- #
+
+output "alb_security_group_id" {
+  value       = aws_security_group.alb.id
+  description = "ALB SG — for ALB resource itself in compute module."
+}
+
+output "backend_security_group_id" {
+  value       = aws_security_group.backend.id
+  description = "Backend Fargate SG — assigned to backend ECS service tasks."
+}
+
+output "bots_security_group_id" {
+  value       = aws_security_group.bots.id
+  description = "Bots Fargate SG — assigned to each bot ECS service's tasks."
+}
+
+output "rds_security_group_id" {
+  value       = aws_security_group.rds.id
+  description = "RDS SG — assigned to the RDS instance in data module."
+}
+
+output "redis_security_group_id" {
+  value       = aws_security_group.redis.id
+  description = "Redis SG — assigned to the ElastiCache replication group in data module."
+}

--- a/infra/networking/security_groups.tf
+++ b/infra/networking/security_groups.tf
@@ -1,0 +1,195 @@
+################################################################################
+# Security groups (spec §4.1)
+#
+# Five SGs — alb, backend, bots, rds, redis. The NAT SG is created by the
+# fck-nat module (when nat_type = "instance") so we don't redefine it here.
+#
+# Ingress rules use security_group_id references rather than CIDR blocks —
+# AWS-native pattern, easier to reason about than IP ranges.
+################################################################################
+
+# ----- ALB: public-facing HTTPS ingress ------------------------------------ #
+
+resource "aws_security_group" "alb" {
+  name        = "slpa-${var.environment}-alb"
+  description = "Public ingress to the SLPA ALB (80/443 from world). Egress to backend tasks only."
+  vpc_id      = aws_vpc.main.id
+
+  tags = {
+    Name = "slpa-${var.environment}-alb"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "alb_https_from_world" {
+  security_group_id = aws_security_group.alb.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "HTTPS from anywhere"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "alb_http_from_world" {
+  security_group_id = aws_security_group.alb.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+  description       = "HTTP from anywhere (redirect to 443 at the ALB listener)"
+}
+
+resource "aws_vpc_security_group_egress_rule" "alb_to_backend" {
+  security_group_id            = aws_security_group.alb.id
+  referenced_security_group_id = aws_security_group.backend.id
+  from_port                    = 8080
+  to_port                      = 8080
+  ip_protocol                  = "tcp"
+  description                  = "ALB to backend tasks on port 8080"
+}
+
+# ----- Backend: receives only from ALB -------------------------------------- #
+
+resource "aws_security_group" "backend" {
+  name        = "slpa-${var.environment}-backend"
+  description = "Backend Fargate tasks. Ingress from ALB only; egress to RDS, Redis, internet (via NAT)."
+  vpc_id      = aws_vpc.main.id
+
+  tags = {
+    Name = "slpa-${var.environment}-backend"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "backend_from_alb" {
+  security_group_id            = aws_security_group.backend.id
+  referenced_security_group_id = aws_security_group.alb.id
+  from_port                    = 8080
+  to_port                      = 8080
+  ip_protocol                  = "tcp"
+  description                  = "From ALB on application port"
+}
+
+resource "aws_vpc_security_group_egress_rule" "backend_to_rds" {
+  security_group_id            = aws_security_group.backend.id
+  referenced_security_group_id = aws_security_group.rds.id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+  description                  = "Backend to RDS Postgres"
+}
+
+resource "aws_vpc_security_group_egress_rule" "backend_to_redis" {
+  security_group_id            = aws_security_group.backend.id
+  referenced_security_group_id = aws_security_group.redis.id
+  from_port                    = 6379
+  to_port                      = 6379
+  ip_protocol                  = "tcp"
+  description                  = "Backend to Redis"
+}
+
+resource "aws_vpc_security_group_egress_rule" "backend_to_internet_https" {
+  security_group_id = aws_security_group.backend.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Backend to SL World API + AWS APIs (Parameter Store, S3) via NAT"
+}
+
+resource "aws_vpc_security_group_egress_rule" "backend_to_internet_http" {
+  security_group_id = aws_security_group.backend.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+  description       = "Backend egress on port 80 for SL World API HTTP redirect handling during retries"
+}
+
+# ----- Bots: no inbound; egress to backend (ALB-fronted) + internet --------- #
+
+resource "aws_security_group" "bots" {
+  name        = "slpa-${var.environment}-bots"
+  description = "Bot Fargate tasks. No inbound. Egress to ALB (backend calls) + internet (SL grid via NAT)."
+  vpc_id      = aws_vpc.main.id
+
+  tags = {
+    Name = "slpa-${var.environment}-bots"
+  }
+}
+
+resource "aws_vpc_security_group_egress_rule" "bots_to_alb_https" {
+  security_group_id            = aws_security_group.bots.id
+  referenced_security_group_id = aws_security_group.alb.id
+  from_port                    = 443
+  to_port                      = 443
+  ip_protocol                  = "tcp"
+  description                  = "Bots to backend via ALB (claim/verify/monitor callbacks)"
+}
+
+resource "aws_vpc_security_group_egress_rule" "bots_to_internet_all" {
+  security_group_id = aws_security_group.bots.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 0
+  to_port           = 65535
+  ip_protocol       = "tcp"
+  description       = "Bots to SL grid (LibreMetaverse uses arbitrary high TCP ports for sim connections) + AWS APIs"
+}
+
+resource "aws_vpc_security_group_egress_rule" "bots_to_internet_udp" {
+  security_group_id = aws_security_group.bots.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 0
+  to_port           = 65535
+  ip_protocol       = "udp"
+  description       = "Bots to SL grid UDP (LibreMetaverse uses UDP for sim message channel)"
+}
+
+# ----- RDS: only from backend + bots ---------------------------------------- #
+
+resource "aws_security_group" "rds" {
+  name        = "slpa-${var.environment}-rds"
+  description = "RDS Postgres. Inbound 5432 from backend + bots only."
+  vpc_id      = aws_vpc.main.id
+
+  tags = {
+    Name = "slpa-${var.environment}-rds"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "rds_from_backend" {
+  security_group_id            = aws_security_group.rds.id
+  referenced_security_group_id = aws_security_group.backend.id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+  description                  = "From backend tasks"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "rds_from_bots" {
+  security_group_id            = aws_security_group.rds.id
+  referenced_security_group_id = aws_security_group.bots.id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+  description                  = "From bots (RDS direct read; bot direct DB access is not used today but reserved for future BOT-tier monitor optimisations)"
+}
+
+# ----- Redis: only from backend --------------------------------------------- #
+
+resource "aws_security_group" "redis" {
+  name        = "slpa-${var.environment}-redis"
+  description = "ElastiCache Redis. Inbound 6379 from backend only."
+  vpc_id      = aws_vpc.main.id
+
+  tags = {
+    Name = "slpa-${var.environment}-redis"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "redis_from_backend" {
+  security_group_id            = aws_security_group.redis.id
+  referenced_security_group_id = aws_security_group.backend.id
+  from_port                    = 6379
+  to_port                      = 6379
+  ip_protocol                  = "tcp"
+  description                  = "From backend tasks"
+}

--- a/infra/networking/variables.tf
+++ b/infra/networking/variables.tf
@@ -1,0 +1,29 @@
+variable "environment" {
+  description = "Environment name (used in resource naming + tags)."
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR block (/16 recommended)."
+  type        = string
+}
+
+variable "availability_zones" {
+  description = "AZs for subnet placement (length must be exactly 2 — one public + one private subnet per AZ)."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.availability_zones) == 2
+    error_message = "Networking module is wired for exactly 2 AZs (RDS subnet group requires >=2 even at launch-lite single-AZ)."
+  }
+}
+
+variable "nat_type" {
+  description = "NAT shape — 'instance' (fck-nat single AZ, ~$5/mo) or 'gateway' (×2 NAT GWs, ~$64/mo)."
+  type        = string
+
+  validation {
+    condition     = contains(["instance", "gateway"], var.nat_type)
+    error_message = "nat_type must be 'instance' or 'gateway'."
+  }
+}

--- a/infra/networking/vpc.tf
+++ b/infra/networking/vpc.tf
@@ -1,0 +1,103 @@
+################################################################################
+# VPC + subnets + IGW + route tables
+#
+# Layout (spec §4.1):
+#   10.0.0.0/16 VPC
+#     Public subnets:  10.0.0.0/24 (AZ a)  + 10.0.1.0/24 (AZ b)
+#     Private subnets: 10.0.10.0/24 (AZ a) + 10.0.11.0/24 (AZ b)
+#
+# Both AZs get private subnets even at launch-lite (single-AZ data tier)
+# because RDS subnet groups require ≥2 AZs for any future Multi-AZ flip
+# without re-provisioning.
+################################################################################
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "slpa-${var.environment}-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "slpa-${var.environment}-igw"
+  }
+}
+
+# ----- Public subnets ------------------------------------------------------- #
+
+resource "aws_subnet" "public" {
+  count = length(var.availability_zones)
+
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index) # 10.0.0.0/24, 10.0.1.0/24
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "slpa-${var.environment}-public-${var.availability_zones[count.index]}"
+    Tier = "public"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "slpa-${var.environment}-rt-public"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count = length(aws_subnet.public)
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# ----- Private subnets ------------------------------------------------------ #
+
+resource "aws_subnet" "private" {
+  count = length(var.availability_zones)
+
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + 10) # 10.0.10.0/24, 10.0.11.0/24
+  availability_zone = var.availability_zones[count.index]
+
+  tags = {
+    Name = "slpa-${var.environment}-private-${var.availability_zones[count.index]}"
+    Tier = "private"
+  }
+}
+
+# Single private route table at launch-lite — both private subnets route
+# through the same NAT instance in AZ a. Upgrade to per-AZ NAT Gateways
+# means flipping nat_type = "gateway", which adds a second route table +
+# AZ-affined NAT GW per subnet.
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  # NAT route is added via aws_route in nat.tf to keep this resource clean
+  # and let nat_type swap (instance vs. gateway) without rewriting the RT.
+
+  tags = {
+    Name = "slpa-${var.environment}-rt-private"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count = length(aws_subnet.private)
+
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -21,5 +21,19 @@ output "aws_account_id" {
 
 output "aws_region" {
   description = "Primary region for the stack."
-  value       = data.aws_region.current.name
+  value       = data.aws_region.current.region
+}
+
+# ----- Networking outputs (re-exported from the module) --------------------- #
+
+output "vpc_id" {
+  value = module.networking.vpc_id
+}
+
+output "public_subnet_ids" {
+  value = module.networking.public_subnet_ids
+}
+
+output "private_subnet_ids" {
+  value = module.networking.private_subnet_ids
 }


### PR DESCRIPTION
## Summary

Step 6a of the deploy flow — first infra PR creating real AWS resources. **Already applied** to account 486208158127 (~$5/mo recurring for the NAT instance + EBS).

Spec: `docs/superpowers/specs/2026-04-29-aws-deployment-design.md` §4.1.

## What got created

41 resources, all in `us-east-1`:

- **VPC** `10.0.0.0/16` + Internet Gateway
- **4 subnets** — 2 public (`10.0.0.0/24`, `10.0.1.0/24`) + 2 private (`10.0.10.0/24`, `10.0.11.0/24`) across `us-east-1a` + `us-east-1b`
- **2 route tables** + 4 associations (single private RT at launch-lite; per-AZ RTs activated when `nat_type = "gateway"`)
- **S3 gateway VPC endpoint** — free, routes Fargate to S3 traffic off NAT (saves egress on the highest-volume internal traffic — photo/avatar/dispute-evidence)
- **5 security groups** — `alb`, `backend`, `bots`, `rds`, `redis` with inter-SG ingress rules (backend reachable from ALB only, RDS reachable from backend+bots only, etc.)
- **fck-nat NAT instance** via `RaJiska/fck-nat/aws` module — `t4g.nano` ARM, ~$3/mo. Self-healing via ASG. Plus its EIP, IAM role, launch template, security group.

## Provider changes

- AWS provider `5.70` → `~> 6.0` (fck-nat module requires `>= 6.0`)
- Added `cloudinit` provider (fck-nat dep)
- Switched `data.aws_region.current.name` → `.region` (deprecated in provider 6.x)
- `.terraform.lock.hcl` now tracked in git (Terraform recommendation; `.gitignore` updated)

## AWS-side verification (live, not just plan)

\`\`\`
=== VPC ===
+--------------+-------------------------+------------+
|     Cidr     |           Id            |   State    |
+--------------+-------------------------+------------+
|  10.0.0.0/16 |  vpc-05fb83968492b0236  |  available |
+--------------+-------------------------+------------+

=== NAT instance ===
+----------------------+--------------------------+-----------+
|          Id          |          Name            |   Type    |
+----------------------+--------------------------+-----------+
|  i-0db134ea2450155f4 |  slpa-prod-nat-instance  |  t4g.nano |
+----------------------+--------------------------+-----------+

=== Security group count ===  6  (5 mine + 1 from fck-nat)
\`\`\`

## Footguns hit during apply

1. **AWS rejects unicode arrows (`→`) AND the ASCII `>` char in security group descriptions.** Allowed charset is `a-zA-Z0-9. _-:/()#,@[]+=&;{}!$*` — no greater-than. All inter-SG flow descriptions use `to` instead of `->`.
2. **fck-nat module needs AWS provider 6.x, cloudinit provider** — required upgrading from 5.70.

## Notes

- `nat_type = "gateway"` branch (managed NAT GWs ×2 for HA) is wired but dormant; flip via tfvars when traffic justifies the +$60/mo.
- ALB stays out of this PR — created with target groups in the compute module (Step 6c).
- DynamoDB lock table from PREP §9.e is now confirmed unused (`use_lockfile = true` in main.tf). Safe to delete via \`aws dynamodb delete-table --table-name slpa-prod-tfstate-lock\` whenever convenient.