### PR TITLE
feat(infra): DNS module - Route 53 hosted zones (slparcels.com + slpa.app)

### DIFF
--- a/infra/dns/outputs.tf
+++ b/infra/dns/outputs.tf
@@ -1,0 +1,21 @@
+output "zone_id_slparcels_com" {
+  description = "Route 53 hosted zone ID for slparcels.com. Used in PR-6d for ALIAS records to Amplify + ACM validation records."
+  value       = aws_route53_zone.slparcels_com.zone_id
+}
+
+output "zone_id_slpa_app" {
+  description = "Route 53 hosted zone ID for slpa.app. Used in PR-6d for ALIAS to ALB + ACM validation records."
+  value       = aws_route53_zone.slpa_app.zone_id
+}
+
+# ----- Nameservers (CRITICAL - paste these into Namecheap) ----------------- #
+
+output "nameservers_slparcels_com" {
+  description = "AWS-assigned nameservers for slparcels.com. Replace Namecheap's NS records with these 4 entries to delegate DNS authority."
+  value       = aws_route53_zone.slparcels_com.name_servers
+}
+
+output "nameservers_slpa_app" {
+  description = "AWS-assigned nameservers for slpa.app. Replace Namecheap's NS records with these 4 entries to delegate DNS authority."
+  value       = aws_route53_zone.slpa_app.name_servers
+}

--- a/infra/dns/route53.tf
+++ b/infra/dns/route53.tf
@@ -1,0 +1,34 @@
+################################################################################
+# Route 53 hosted zones (spec §4.9)
+#
+# Two zones created here:
+#   - slparcels.com  (frontend; Amplify target - records added in PR-6d)
+#   - slpa.app       (backend; ALB ALIAS - records added in PR-6d)
+#
+# slparcelauctions.com intentionally NOT here - that domain stays on
+# Namecheap DNS and uses Namecheap's URL Redirect feature (spec Q10b).
+#
+# After this PR applies, the operator MUST update nameservers at Namecheap
+# for both domains to delegate DNS authority to Route 53. The NS records
+# to use are exposed as outputs.
+################################################################################
+
+resource "aws_route53_zone" "slparcels_com" {
+  name = var.domain_slparcels
+
+  comment = "SLPA frontend apex - Amplify-fronted, NS-delegated from Namecheap."
+
+  tags = {
+    Name = "slpa-${var.environment}-zone-slparcels-com"
+  }
+}
+
+resource "aws_route53_zone" "slpa_app" {
+  name = var.domain_slpa_app
+
+  comment = "SLPA backend apex - ALB ALIAS, NS-delegated from Namecheap."
+
+  tags = {
+    Name = "slpa-${var.environment}-zone-slpa-app"
+  }
+}

--- a/infra/dns/variables.tf
+++ b/infra/dns/variables.tf
@@ -1,0 +1,13 @@
+variable "environment" {
+  type = string
+}
+
+variable "domain_slparcels" {
+  description = "Frontend apex (Amplify target). Spec §4.9."
+  type        = string
+}
+
+variable "domain_slpa_app" {
+  description = "Backend apex (ALB ALIAS target). Spec §4.9."
+  type        = string
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -139,3 +139,11 @@ module "data" {
   redis_num_cache_clusters = var.redis_num_cache_clusters
   redis_node_type          = var.redis_node_type
 }
+
+module "dns" {
+  source = "./dns"
+
+  environment      = var.environment
+  domain_slparcels = var.domain_slparcels
+  domain_slpa_app  = var.domain_slpa_app
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -51,3 +51,15 @@ output "redis_primary_endpoint" {
 output "storage_bucket_name" {
   value = module.data.storage_bucket_name
 }
+
+# ----- DNS outputs (the nameservers are what you paste into Namecheap) ------ #
+
+output "nameservers_slparcels_com" {
+  description = "Paste these 4 NS records into Namecheap for slparcels.com (Domain List → Manage → Domain → Nameservers → Custom DNS)."
+  value       = module.dns.nameservers_slparcels_com
+}
+
+output "nameservers_slpa_app" {
+  description = "Paste these 4 NS records into Namecheap for slpa.app (same path)."
+  value       = module.dns.nameservers_slpa_app
+}


### PR DESCRIPTION
## Summary

Step 6c of the deploy flow. **Already applied** to account 486208158127. **+$1/mo recurring** (2 new hosted zones at $0.50/mo each).

Spec: §4.9.

## What got created (2 resources)

- `aws_route53_zone.slparcels_com` — frontend apex (Amplify target)
- `aws_route53_zone.slpa_app` — backend apex (ALB ALIAS target)

`slparcelauctions.com` is intentionally NOT here — stays on Namecheap DNS with their URL Redirect to `slparcels.com` per spec Q10b.

## Manual action required after merge

I cannot touch your registrar. Update Namecheap NS records for both domains:

**For `slparcels.com`** — Namecheap → Domain List → Manage → Domain → Nameservers → **Custom DNS**:

```
ns-1467.awsdns-55.org
ns-1724.awsdns-23.co.uk
ns-491.awsdns-61.com
ns-829.awsdns-39.net
```

**For `slpa.app`** — same path:

```
ns-1283.awsdns-32.org
ns-1648.awsdns-14.co.uk
ns-351.awsdns-43.com
ns-569.awsdns-07.net
```

Verify propagation (5-30 min):

```
dig NS slparcels.com +short
dig NS slpa.app +short
```

Both should return the AWS NS list above. **PR-6d (compute) will block on ACM cert validation until this is done** — the cert can't validate against DNS records that don't yet point at AWS.