### PR TITLE
feat(infra): ACM certificates - slpa.app + slparcels.com (DNS-validated)

### DIFF
--- a/infra/dns/acm.tf
+++ b/infra/dns/acm.tf
@@ -1,0 +1,112 @@
+################################################################################
+# ACM certificates (spec §4.9)
+#
+# Two certs issued in this module:
+#   - cert_slpa_app:    apex slpa.app + wildcard *.slpa.app for the ALB
+#   - cert_slparcels:   slparcels.com + www.slparcels.com for Amplify
+#
+# Both use DNS validation against the Route 53 zones created in route53.tf.
+# Validation auto-completes within a few minutes once Namecheap NS delegation
+# has propagated to the AWS resolvers.
+#
+# IMPORTANT region pinning:
+# - cert_slpa_app: issued in the stack's primary region (us-east-1) for use
+#   by the ALB. Will need cross-region issuance if we ever move the stack
+#   off us-east-1.
+# - cert_slparcels: MUST be issued in us-east-1 because Amplify's CloudFront
+#   distribution requires the cert there regardless of where the rest of
+#   the stack lives. Today the stack is already in us-east-1 so they're
+#   the same region, but using the aliased provider explicitly makes the
+#   constraint visible + future-proof.
+#
+# Note: Amplify can also auto-issue + auto-manage its own ACM cert when you
+# connect a custom domain. We're issuing one explicitly here so that the
+# DNS validation (and renewal records) live in our Route 53 zone where we
+# can see them, rather than in Amplify-managed shadow records.
+################################################################################
+
+# ----- slpa.app: apex + wildcard for ALB ----------------------------------- #
+
+resource "aws_acm_certificate" "slpa_app" {
+  domain_name               = var.domain_slpa_app
+  subject_alternative_names = ["*.${var.domain_slpa_app}"]
+  validation_method         = "DNS"
+
+  tags = {
+    Name = "slpa-${var.environment}-cert-slpa-app"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Per-FQDN DNS validation records. ACM emits one CNAME per name on the cert
+# (apex + each SAN). The for_each iterates over those distinct records.
+resource "aws_route53_record" "slpa_app_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.slpa_app.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id         = aws_route53_zone.slpa_app.zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+  ttl             = 60
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "slpa_app" {
+  certificate_arn         = aws_acm_certificate.slpa_app.arn
+  validation_record_fqdns = [for r in aws_route53_record.slpa_app_validation : r.fqdn]
+
+  timeouts {
+    create = "10m"
+  }
+}
+
+# ----- slparcels.com: apex + www for Amplify ------------------------------- #
+
+resource "aws_acm_certificate" "slparcels_com" {
+  domain_name               = var.domain_slparcels
+  subject_alternative_names = ["www.${var.domain_slparcels}"]
+  validation_method         = "DNS"
+
+  tags = {
+    Name = "slpa-${var.environment}-cert-slparcels-com"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "slparcels_com_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.slparcels_com.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id         = aws_route53_zone.slparcels_com.zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+  ttl             = 60
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "slparcels_com" {
+  certificate_arn         = aws_acm_certificate.slparcels_com.arn
+  validation_record_fqdns = [for r in aws_route53_record.slparcels_com_validation : r.fqdn]
+
+  timeouts {
+    create = "10m"
+  }
+}

--- a/infra/dns/outputs.tf
+++ b/infra/dns/outputs.tf
@@ -19,3 +19,15 @@ output "nameservers_slpa_app" {
   description = "AWS-assigned nameservers for slpa.app. Replace Namecheap's NS records with these 4 entries to delegate DNS authority."
   value       = aws_route53_zone.slpa_app.name_servers
 }
+
+# ----- ACM certificate ARNs (consumed by ALB + Amplify) -------------------- #
+
+output "cert_arn_slpa_app" {
+  description = "ACM cert ARN for *.slpa.app + apex slpa.app. Attach to the ALB HTTPS listener."
+  value       = aws_acm_certificate_validation.slpa_app.certificate_arn
+}
+
+output "cert_arn_slparcels_com" {
+  description = "ACM cert ARN for slparcels.com + www.slparcels.com. Attach to Amplify custom domain."
+  value       = aws_acm_certificate_validation.slparcels_com.certificate_arn
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -63,3 +63,11 @@ output "nameservers_slpa_app" {
   description = "Paste these 4 NS records into Namecheap for slpa.app (same path)."
   value       = module.dns.nameservers_slpa_app
 }
+
+output "cert_arn_slpa_app" {
+  value = module.dns.cert_arn_slpa_app
+}
+
+output "cert_arn_slparcels_com" {
+  value = module.dns.cert_arn_slparcels_com
+}


### PR DESCRIPTION
## Summary

Step 6c.5. **Already applied** to account 486208158127. Both certs **ISSUED** via DNS validation against the Route 53 zones from PR #43 — confirms Namecheap NS delegation worked end-to-end.

Cost: **\$0** (non-exportable public certs are free).

## What got created (8 resources)

- `aws_acm_certificate.slpa_app` — apex `slpa.app` + wildcard `*.slpa.app` (covers `bots.slpa.app` and any future subdomain)
- `aws_acm_certificate.slparcels_com` — `slparcels.com` + `www.slparcels.com` (for Amplify)
- 4 `aws_route53_record` validation CNAMEs (one per cert SAN, in the appropriate hosted zone)
- 2 `aws_acm_certificate_validation` resources (block until ACM confirms DNS, with 10m timeout)

## ARNs

- `arn:aws:acm:us-east-1:486208158127:certificate/e5028c23-be6b-429b-a726-9d9cd268adf1` (slpa.app)
- `arn:aws:acm:us-east-1:486208158127:certificate/3badbb77-e498-4688-b94f-05824d2aba01` (slparcels.com)

## Live verification

```
aws acm list-certificates →
  slpa.app       ISSUED
  slparcels.com  ISSUED
```

## What's next

PR #45 (compute foundation) consumes `cert_arn_slpa_app` for the ALB HTTPS listener. The slparcels.com cert is referenced by Amplify's custom domain config in a later PR.