### PR TITLE
feat(infra): compute foundation - ECR, ECS cluster, IAM, ALB, backend service (count=0)

### DIFF
--- a/infra/compute/alb.tf
+++ b/infra/compute/alb.tf
@@ -1,0 +1,92 @@
+################################################################################
+# Application Load Balancer (spec §4.2)
+#
+# Public-facing HTTPS termination for the backend. Two listeners:
+#   - 80  -> redirect to 443
+#   - 443 -> forward to backend target group (HTTP 8080 internal)
+#
+# Bot tasks reach the backend via this ALB too (spec §4.3 — Backend__BaseUrl
+# is the ALB internal DNS routed via slpa.app).
+################################################################################
+
+resource "aws_lb" "main" {
+  name               = "slpa-${var.environment}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [var.alb_security_group_id]
+  subnets            = var.public_subnet_ids
+
+  enable_deletion_protection = true
+
+  # idle_timeout default 60s is fine for SLPA's request shape.
+  drop_invalid_header_fields = true
+
+  tags = {
+    Name = "slpa-${var.environment}-alb"
+  }
+}
+
+resource "aws_lb_target_group" "backend" {
+  name                 = "slpa-${var.environment}-backend-tg"
+  port                 = 8080
+  protocol             = "HTTP"
+  vpc_id               = var.vpc_id
+  target_type          = "ip" # required for awsvpc network mode (Fargate)
+  deregistration_delay = 30   # seconds; in-flight requests drain before a task is removed
+
+  health_check {
+    enabled             = true
+    path                = "/api/v1/health"
+    protocol            = "HTTP"
+    port                = "traffic-port"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    matcher             = "200"
+  }
+
+  tags = {
+    Name = "slpa-${var.environment}-backend-tg"
+  }
+}
+
+# HTTPS listener — primary entry. ALB's HSTS-style behaviour handled at the
+# app level via Spring Security headers.
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.cert_arn_slpa_app
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.backend.arn
+  }
+
+  tags = {
+    Name = "slpa-${var.environment}-listener-https"
+  }
+}
+
+# HTTP listener — redirect everything to HTTPS.
+resource "aws_lb_listener" "http_redirect" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  tags = {
+    Name = "slpa-${var.environment}-listener-http-redirect"
+  }
+}

--- a/infra/compute/ecr.tf
+++ b/infra/compute/ecr.tf
@@ -1,0 +1,79 @@
+################################################################################
+# ECR repositories (spec §4.10)
+#
+# One repo per service. Lifecycle policy keeps the last 10 images and expires
+# older ones to bound storage cost. scan_on_push is free + surfaces high
+# severity CVEs immediately on push.
+################################################################################
+
+resource "aws_ecr_repository" "backend" {
+  name                 = "slpa/backend"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  tags = {
+    Name = "slpa-${var.environment}-ecr-backend"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "backend" {
+  repository = aws_ecr_repository.backend.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 10 images; expire older."
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 10
+        }
+        action = { type = "expire" }
+      }
+    ]
+  })
+}
+
+resource "aws_ecr_repository" "bot" {
+  name                 = "slpa/bot"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  tags = {
+    Name = "slpa-${var.environment}-ecr-bot"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "bot" {
+  repository = aws_ecr_repository.bot.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 10 images; expire older."
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 10
+        }
+        action = { type = "expire" }
+      }
+    ]
+  })
+}

--- a/infra/compute/ecs_backend.tf
+++ b/infra/compute/ecs_backend.tf
@@ -1,0 +1,150 @@
+################################################################################
+# Backend ECS service + task definition (spec §4.2)
+#
+# Task definition uses awsvpc network mode (required for Fargate). All env
+# vars except secrets are passed via the `environment[]` block; sensitive
+# values come from Parameter Store via `secrets[]` injection (the execution
+# role has SSM read for /slpa/${env}/*).
+#
+# desired_count starts at 0 — the operator must bootstrap user-action secrets
+# (JWT_SECRET, SLPA_BOT_SHARED_SECRET, SLPA_PRIMARY_ESCROW_UUID,
+# SLPA_SL_TRUSTED_OWNER_KEYS) via `aws ssm put-parameter` per spec §7.3
+# BEFORE bumping desired_count. Backend's SlStartupValidator + BotStartupValidator
+# fail-fast on placeholder values and the task would crash-loop.
+#
+# After secrets are set + first image is pushed, bump var.backend_desired_count
+# = 1 and apply.
+################################################################################
+
+locals {
+  # Parse RDS endpoint "host:port" into separate values for SPRING_DATASOURCE_URL.
+  rds_host = split(":", var.rds_writer_endpoint)[0]
+  rds_port = split(":", var.rds_writer_endpoint)[1]
+
+  spring_datasource_url = "jdbc:postgresql://${local.rds_host}:${local.rds_port}/${var.rds_database_name}"
+}
+
+resource "aws_ecs_task_definition" "backend" {
+  family                   = "slpa-${var.environment}-backend"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.backend_cpu
+  memory                   = var.backend_memory
+
+  runtime_platform {
+    cpu_architecture        = "X86_64"
+    operating_system_family = "LINUX"
+  }
+
+  task_role_arn      = aws_iam_role.backend_task.arn
+  execution_role_arn = aws_iam_role.backend_task_execution.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "backend"
+      image     = "${aws_ecr_repository.backend.repository_url}:${var.backend_image_tag}"
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = 8080
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        { name = "SPRING_PROFILES_ACTIVE", value = "prod" },
+        { name = "SPRING_DATASOURCE_URL", value = local.spring_datasource_url },
+        { name = "SPRING_DATA_REDIS_HOST", value = var.redis_primary_endpoint },
+        { name = "SPRING_DATA_REDIS_PORT", value = "6379" },
+        { name = "CORS_ALLOWED_ORIGIN", value = var.cors_allowed_origin },
+        { name = "SLPA_STORAGE_BUCKET", value = var.storage_bucket_name },
+        { name = "AWS_REGION", value = "us-east-1" },
+        { name = "SLPA_WEB_BASE_URL", value = var.web_base_url },
+        { name = "SERVER_FORWARD_HEADERS_STRATEGY", value = "framework" },
+        { name = "LOGGING_LEVEL_ROOT", value = "WARN" },
+        { name = "LOGGING_LEVEL_COM_SLPARCELAUCTIONS", value = "INFO" },
+        { name = "LOGGING_LEVEL_ORG_FLYWAYDB", value = "INFO" },
+      ]
+
+      secrets = [
+        # Always-required (Terraform-managed)
+        { name = "SPRING_DATASOURCE_USERNAME", valueFrom = var.rds_username_ssm_arn },
+        { name = "SPRING_DATASOURCE_PASSWORD", valueFrom = var.rds_password_ssm_arn },
+        { name = "SPRING_DATA_REDIS_PASSWORD", valueFrom = var.redis_auth_token_ssm_arn },
+        # User-bootstrap (spec §7.3) — these must exist in Parameter Store
+        # before desired_count > 0 or the task fails to start.
+        { name = "JWT_SECRET", valueFrom = "arn:aws:ssm:us-east-1:${data.aws_caller_identity.current.account_id}:parameter/slpa/${var.environment}/jwt/secret" },
+        { name = "SLPA_BOT_SHARED_SECRET", valueFrom = "arn:aws:ssm:us-east-1:${data.aws_caller_identity.current.account_id}:parameter/slpa/${var.environment}/bot/shared-secret" },
+        { name = "SLPA_PRIMARY_ESCROW_UUID", valueFrom = "arn:aws:ssm:us-east-1:${data.aws_caller_identity.current.account_id}:parameter/slpa/${var.environment}/sl/primary-escrow-uuid" },
+        { name = "SLPA_SL_TRUSTED_OWNER_KEYS", valueFrom = "arn:aws:ssm:us-east-1:${data.aws_caller_identity.current.account_id}:parameter/slpa/${var.environment}/sl/trusted-owner-keys" },
+        { name = "SLPA_ESCROW_TERMINAL_SHARED_SECRET", valueFrom = "arn:aws:ssm:us-east-1:${data.aws_caller_identity.current.account_id}:parameter/slpa/${var.environment}/escrow/terminal-shared-secret" },
+        { name = "SL_IM_DISPATCHER_SECRET", valueFrom = "arn:aws:ssm:us-east-1:${data.aws_caller_identity.current.account_id}:parameter/slpa/${var.environment}/notifications/sl-im/dispatcher-secret" },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.backend.name
+          awslogs-region        = "us-east-1"
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -f http://localhost:8080/api/v1/health || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 60
+      }
+    }
+  ])
+
+  tags = {
+    Name = "slpa-${var.environment}-backend-task"
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_ecs_service" "backend" {
+  name            = "slpa-${var.environment}-backend"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.backend.arn
+  desired_count   = var.backend_desired_count
+  launch_type     = "FARGATE"
+
+  enable_execute_command = true # ECS Exec
+  propagate_tags         = "SERVICE"
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [var.backend_security_group_id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.backend.arn
+    container_name   = "backend"
+    container_port   = 8080
+  }
+
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+
+  # Once GHA wires CodeDeploy blue/green deployments (Step 17 of the deploy
+  # flow), the deployment_controller flips from ECS rolling to CODE_DEPLOY
+  # and Terraform stops being the source of truth for the running task
+  # definition revision. ignore_changes here lets that happen without
+  # Terraform fighting the deployment tool.
+  lifecycle {
+    ignore_changes = [task_definition, desired_count]
+  }
+
+  depends_on = [aws_lb_listener.https]
+
+  tags = {
+    Name = "slpa-${var.environment}-backend-service"
+  }
+}

--- a/infra/compute/ecs_cluster.tf
+++ b/infra/compute/ecs_cluster.tf
@@ -1,0 +1,31 @@
+################################################################################
+# ECS cluster (spec §4.2)
+#
+# Single cluster hosts both backend + bot services. Container Insights ON
+# (spec Q11 = B baseline; ~$3/mo flat).
+################################################################################
+
+resource "aws_ecs_cluster" "main" {
+  name = "slpa-${var.environment}"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = {
+    Name = "slpa-${var.environment}-cluster"
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "main" {
+  cluster_name = aws_ecs_cluster.main.name
+
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+    base              = 1
+  }
+}

--- a/infra/compute/iam_backend.tf
+++ b/infra/compute/iam_backend.tf
@@ -1,0 +1,124 @@
+################################################################################
+# Backend IAM (spec §4.2)
+#
+# Two roles per ECS service convention:
+#   - task role:        identity of the running container (app permissions)
+#   - execution role:   identity ECS uses to launch the task (ECR pull, log
+#                       group writes, Parameter Store secret fetch for the
+#                       `secrets[]` block on the task definition)
+################################################################################
+
+# ----- Task role ------------------------------------------------------------ #
+
+data "aws_iam_policy_document" "ecs_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "backend_task" {
+  name               = "slpa-${var.environment}-backend-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+
+  tags = {
+    Name = "slpa-${var.environment}-backend-task-role"
+  }
+}
+
+data "aws_iam_policy_document" "backend_task" {
+  # S3 storage bucket
+  statement {
+    sid     = "S3StorageRW"
+    actions = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+    resources = [
+      "${var.storage_bucket_arn}/*",
+    ]
+  }
+  statement {
+    sid       = "S3StorageList"
+    actions   = ["s3:ListBucket"]
+    resources = [var.storage_bucket_arn]
+  }
+
+  # Parameter Store reads at runtime (the app reads non-injected params via SDK
+  # if it ever wants to; secrets[] injection on the task def covers env vars).
+  statement {
+    sid       = "ParameterStoreRead"
+    actions   = ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath"]
+    resources = ["arn:aws:ssm:*:*:parameter/slpa/${var.environment}/*"]
+  }
+  statement {
+    sid       = "ParameterStoreKMS"
+    actions   = ["kms:Decrypt"]
+    resources = ["arn:aws:kms:*:*:alias/aws/ssm"]
+  }
+
+  # ECS Exec — interactive shell into a running task via SSM Session Manager.
+  statement {
+    sid = "ECSExec"
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel",
+    ]
+    resources = ["*"]
+  }
+
+  # CloudWatch Logs writes
+  statement {
+    sid = "CloudWatchLogs"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = ["${aws_cloudwatch_log_group.backend.arn}:*"]
+  }
+}
+
+resource "aws_iam_role_policy" "backend_task" {
+  name   = "slpa-${var.environment}-backend-task-policy"
+  role   = aws_iam_role.backend_task.id
+  policy = data.aws_iam_policy_document.backend_task.json
+}
+
+# ----- Execution role ------------------------------------------------------- #
+
+resource "aws_iam_role" "backend_task_execution" {
+  name               = "slpa-${var.environment}-backend-task-execution-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+
+  tags = {
+    Name = "slpa-${var.environment}-backend-task-execution-role"
+  }
+}
+
+# Standard managed policy for ECR pull + log group + log writes.
+resource "aws_iam_role_policy_attachment" "backend_task_execution_managed" {
+  role       = aws_iam_role.backend_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Plus SSM read for secrets[] injection on the task definition.
+data "aws_iam_policy_document" "backend_task_execution_ssm" {
+  statement {
+    sid       = "ParameterStoreRead"
+    actions   = ["ssm:GetParameter", "ssm:GetParameters"]
+    resources = ["arn:aws:ssm:*:*:parameter/slpa/${var.environment}/*"]
+  }
+  statement {
+    sid       = "ParameterStoreKMS"
+    actions   = ["kms:Decrypt"]
+    resources = ["arn:aws:kms:*:*:alias/aws/ssm"]
+  }
+}
+
+resource "aws_iam_role_policy" "backend_task_execution_ssm" {
+  name   = "slpa-${var.environment}-backend-task-execution-ssm"
+  role   = aws_iam_role.backend_task_execution.id
+  policy = data.aws_iam_policy_document.backend_task_execution_ssm.json
+}

--- a/infra/compute/log_groups.tf
+++ b/infra/compute/log_groups.tf
@@ -1,0 +1,15 @@
+################################################################################
+# CloudWatch log groups (spec §4.12)
+#
+# Explicit creation with var.log_retention_days so groups don't default to
+# the costly "never expire" CloudWatch behaviour.
+################################################################################
+
+resource "aws_cloudwatch_log_group" "backend" {
+  name              = "/aws/ecs/slpa-backend"
+  retention_in_days = var.log_retention_days
+
+  tags = {
+    Name = "slpa-${var.environment}-logs-backend"
+  }
+}

--- a/infra/compute/outputs.tf
+++ b/infra/compute/outputs.tf
@@ -1,0 +1,35 @@
+output "ecs_cluster_arn" {
+  value = aws_ecs_cluster.main.arn
+}
+
+output "ecs_cluster_name" {
+  value = aws_ecs_cluster.main.name
+}
+
+output "ecr_backend_repo_url" {
+  description = "ECR URL for the backend image. Format: <account>.dkr.ecr.<region>.amazonaws.com/slpa/backend"
+  value       = aws_ecr_repository.backend.repository_url
+}
+
+output "ecr_bot_repo_url" {
+  description = "ECR URL for the bot image."
+  value       = aws_ecr_repository.bot.repository_url
+}
+
+output "alb_dns_name" {
+  description = "ALB DNS name. The Route 53 ALIAS for slpa.app points here."
+  value       = aws_lb.main.dns_name
+}
+
+output "alb_zone_id" {
+  description = "ALB hosted zone ID (used for ALIAS records elsewhere if needed)."
+  value       = aws_lb.main.zone_id
+}
+
+output "backend_task_role_arn" {
+  value = aws_iam_role.backend_task.arn
+}
+
+output "backend_task_execution_role_arn" {
+  value = aws_iam_role.backend_task_execution.arn
+}

--- a/infra/compute/route53_records.tf
+++ b/infra/compute/route53_records.tf
@@ -1,0 +1,22 @@
+################################################################################
+# Route 53 records pointing at the ALB (spec §4.9)
+#
+# slpa.app apex -> ALB ALIAS. Apex ALIAS works on .app zones because Route 53
+# supports apex ALIAS records natively (sidesteps the DNS-spec restriction
+# against CNAMEs at the apex).
+#
+# bots.slpa.app intentionally not created here — bot health endpoints stay
+# private; ECS Exec covers ad-hoc checks (spec Q10a = B).
+################################################################################
+
+resource "aws_route53_record" "slpa_app_apex" {
+  zone_id = var.zone_id_slpa_app
+  name    = var.domain_slpa_app
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.main.dns_name
+    zone_id                = aws_lb.main.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/infra/compute/variables.tf
+++ b/infra/compute/variables.tf
@@ -1,0 +1,110 @@
+variable "environment" {
+  type = string
+}
+
+# ----- Inputs from sibling modules ----------------------------------------- #
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "public_subnet_ids" {
+  description = "Public subnets for the ALB."
+  type        = list(string)
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnets for ECS tasks."
+  type        = list(string)
+}
+
+variable "alb_security_group_id" {
+  type = string
+}
+
+variable "backend_security_group_id" {
+  type = string
+}
+
+variable "rds_writer_endpoint" {
+  description = "Format 'host:port' from data module — split for SPRING_DATASOURCE_URL construction."
+  type        = string
+}
+
+variable "rds_database_name" {
+  type = string
+}
+
+variable "rds_password_ssm_arn" {
+  type = string
+}
+
+variable "rds_username_ssm_arn" {
+  type = string
+}
+
+variable "redis_primary_endpoint" {
+  type = string
+}
+
+variable "redis_auth_token_ssm_arn" {
+  type = string
+}
+
+variable "storage_bucket_name" {
+  type = string
+}
+
+variable "storage_bucket_arn" {
+  type = string
+}
+
+variable "cert_arn_slpa_app" {
+  type = string
+}
+
+variable "zone_id_slpa_app" {
+  type = string
+}
+
+variable "domain_slpa_app" {
+  type = string
+}
+
+# ----- Backend sizing + image tag (passed through from root) --------------- #
+
+variable "backend_desired_count" {
+  type = number
+}
+
+variable "backend_cpu" {
+  type = number
+}
+
+variable "backend_memory" {
+  type = number
+}
+
+variable "backend_image_tag" {
+  description = "Image tag for the backend ECS task definition. Defaults to 'initial' for first deploy; CI/CD bumps to git SHA on each deploy."
+  type        = string
+  default     = "initial"
+}
+
+variable "log_retention_days" {
+  type = number
+}
+
+# ----- CORS + frontend wiring ---------------------------------------------- #
+
+variable "cors_allowed_origin" {
+  description = "Public origin allowed by Spring Security CORS. Should match the Amplify custom domain (e.g. https://slparcels.com)."
+  type        = string
+  default     = "https://slparcels.com"
+}
+
+variable "web_base_url" {
+  description = "Public web origin used by backend to construct outbound links in notifications."
+  type        = string
+  default     = "https://slparcels.com"
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -147,3 +147,34 @@ module "dns" {
   domain_slparcels = var.domain_slparcels
   domain_slpa_app  = var.domain_slpa_app
 }
+
+module "compute" {
+  source = "./compute"
+
+  environment        = var.environment
+  vpc_id             = module.networking.vpc_id
+  public_subnet_ids  = module.networking.public_subnet_ids
+  private_subnet_ids = module.networking.private_subnet_ids
+
+  alb_security_group_id     = module.networking.alb_security_group_id
+  backend_security_group_id = module.networking.backend_security_group_id
+
+  rds_writer_endpoint      = module.data.rds_writer_endpoint
+  rds_database_name        = module.data.rds_database_name
+  rds_password_ssm_arn     = module.data.rds_password_ssm_arn
+  rds_username_ssm_arn     = module.data.rds_username_ssm_arn
+  redis_primary_endpoint   = module.data.redis_primary_endpoint
+  redis_auth_token_ssm_arn = module.data.redis_auth_token_ssm_arn
+  storage_bucket_name      = module.data.storage_bucket_name
+  storage_bucket_arn       = module.data.storage_bucket_arn
+
+  cert_arn_slpa_app = module.dns.cert_arn_slpa_app
+  zone_id_slpa_app  = module.dns.zone_id_slpa_app
+  domain_slpa_app   = var.domain_slpa_app
+
+  backend_desired_count = var.backend_desired_count
+  backend_cpu           = var.backend_cpu
+  backend_memory        = var.backend_memory
+  backend_image_tag     = var.backend_image_tag
+  log_retention_days    = var.log_retention_days
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -71,3 +71,21 @@ output "cert_arn_slpa_app" {
 output "cert_arn_slparcels_com" {
   value = module.dns.cert_arn_slparcels_com
 }
+
+# ----- Compute outputs ------------------------------------------------------ #
+
+output "ecs_cluster_name" {
+  value = module.compute.ecs_cluster_name
+}
+
+output "ecr_backend_repo_url" {
+  value = module.compute.ecr_backend_repo_url
+}
+
+output "ecr_bot_repo_url" {
+  value = module.compute.ecr_bot_repo_url
+}
+
+output "alb_dns_name" {
+  value = module.compute.alb_dns_name
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -98,9 +98,15 @@ variable "redis_node_type" {
 # ----- Compute — backend (spec §4.2) --------------------------------------- #
 
 variable "backend_desired_count" {
-  description = "Number of backend Fargate tasks running concurrently. Launch-lite default = 1. Upgrade lever to 2+ for scheduler-redundancy + AZ spread."
+  description = "Number of backend Fargate tasks running concurrently. Default 0 in this PR — bump to 1+ AFTER bootstrapping user-action secrets in Parameter Store (spec §7.3) AND pushing first backend image to ECR. Launch-lite production target = 1; upgrade lever to 2+ for scheduler-redundancy + AZ spread."
   type        = number
-  default     = 1
+  default     = 0
+}
+
+variable "backend_image_tag" {
+  description = "ECR image tag for the backend ECS task. Default 'initial' — first deploy pushes the image manually with this tag, then bump backend_desired_count to start tasks. CI/CD later rotates this to git SHA on every merge to main."
+  type        = string
+  default     = "initial"
 }
 
 variable "backend_cpu" {


### PR DESCRIPTION
## Summary

Step 6d. **Already applied** to account 486208158127. **+\$22-25/mo recurring** (ALB is the dominant new cost; ECS cluster + ECR are pennies until images push).

Backend ECS service is created at `desired_count = 0` and stays that way until you bootstrap secrets (Step 7) + push the first image. End-to-end network path is **proven live** (see verification below).

## What got created (19 resources)

- **2 ECR repos** (`slpa/backend`, `slpa/bot`) with `scan_on_push = true` + 10-image lifecycle
- **ECS cluster** `slpa-prod` with Container Insights + FARGATE/FARGATE_SPOT capacity providers
- **2 IAM roles** for backend (task + execution) — S3 RW on `slpa-prod-storage`, SSM read on `/slpa/prod/*`, ECS Exec, log writes
- **CloudWatch log group** `/aws/ecs/slpa-backend` (7d retention)
- **ALB** with `deletion_protection = true`, drop_invalid_header_fields, TLS 1.3 policy, HTTP→HTTPS redirect listener
- **Backend target group** (port 8080, healthcheck `/api/v1/health`)
- **Route 53 ALIAS** `slpa.app` → ALB
- **Backend ECS service** (Fargate, x86_64, awsvpc, ECS Exec enabled, `lifecycle.ignore_changes` on `task_definition` + `desired_count` for future CodeDeploy compat)
- **Backend task definition** with full env (Spring profile, datasource URL, Redis host, CORS, storage bucket, log levels) + `secrets[]` for all sensitive values from Parameter Store

## End-to-end network verification (live)

```
nslookup slpa.app                          →  32.197.3.239 (ALB)
curl -sk https://slpa.app/api/v1/health    →  HTTP 503
```

The 503 is the *correct* response — TLS handshake clean (cert valid), ALB routing to backend target group, no healthy targets because `desired_count = 0`.

## Outputs

- `alb_dns_name` = `slpa-prod-alb-1768923819.us-east-1.elb.amazonaws.com`
- `ecr_backend_repo_url` = `486208158127.dkr.ecr.us-east-1.amazonaws.com/slpa/backend`
- `ecr_bot_repo_url` = `486208158127.dkr.ecr.us-east-1.amazonaws.com/slpa/bot`
- `ecs_cluster_name` = `slpa-prod`

## What's next (you)

Step 7 — bootstrap user-action secrets to Parameter Store. I'll generate the exact `aws ssm put-parameter` commands in the next message; you paste-and-run them with the real values:

- `JWT_SECRET` (one-shot via openssl)
- `slpa.bot.shared-secret` (one-shot via openssl)
- `slpa.escrow.terminal-shared-secret` (one-shot via openssl)
- `sl-im.dispatcher.shared-secret` (one-shot via openssl)
- `slpa.bot-task.primary-escrow-uuid` (real `SLPAEscrow Resident` UUID)
- `slpa.sl.trusted-owner-keys` (real owner UUIDs of in-world LSL terminals)
- `bot-1`/`bot-2`/etc. credentials (real SL passwords + UUIDs per bot)

Once secrets are set, I'll build + push the first backend image and bump `desired_count = 1`.