### PR TITLE
fix: backend prod startup blockers (Redis TLS + Fargate sizing + ECS healthcheck timing)

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/config/ratelimit/SearchRateLimitConfig.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/config/ratelimit/SearchRateLimitConfig.java
@@ -44,9 +44,35 @@ public class SearchRateLimitConfig {
     @Value("${spring.data.redis.port:6379}")
     private int redisPort;
 
+    @Value("${spring.data.redis.ssl.enabled:false}")
+    private boolean redisSslEnabled;
+
+    @Value("${spring.data.redis.password:}")
+    private String redisPassword;
+
     @Bean(destroyMethod = "shutdown")
     public RedisClient rateLimitRedisClient() {
-        return RedisClient.create(RedisURI.create(redisHost, redisPort));
+        // Build the URI explicitly rather than using RedisURI.create(host, port)
+        // because that overload skips TLS + auth. ElastiCache requires both
+        // (transit_encryption_enabled = true + auth_token on the replication
+        // group); without them the connection fails at handshake with
+        // "Unable to connect to <host>/<unresolved>:6379" — the <unresolved>
+        // is Lettuce's signal that the TCP connect attempt was rejected before
+        // DNS resolution finished.
+        //
+        // Local dev (docker-compose Redis without TLS or auth) leaves both
+        // properties at their defaults and ends up with a plain TCP URI —
+        // unchanged from the pre-prod-deploy behaviour.
+        RedisURI.Builder builder = RedisURI.builder()
+                .withHost(redisHost)
+                .withPort(redisPort);
+        if (redisSslEnabled) {
+            builder.withSsl(true);
+        }
+        if (!redisPassword.isEmpty()) {
+            builder.withPassword(redisPassword.toCharArray());
+        }
+        return RedisClient.create(builder.build());
     }
 
     @Bean(destroyMethod = "close")

--- a/infra/compute/ecs_backend.tf
+++ b/infra/compute/ecs_backend.tf
@@ -96,7 +96,13 @@ resource "aws_ecs_task_definition" "backend" {
         interval    = 30
         timeout     = 5
         retries     = 3
-        startPeriod = 60
+        # Spring Boot 4 + Java 26 + the SLPA bean graph takes ~150-180s to
+        # finish context init on a 0.25 vCPU Fargate task. startPeriod=180
+        # gives the JVM headroom to bind 8080 before failed checks count
+        # toward the unhealthy threshold. With 0.5 vCPU the real boot is
+        # ~60-90s but the same 180 ceiling is fine — startPeriod is a
+        # MAXIMUM grace window, not a fixed delay.
+        startPeriod = 180
       }
     }
   ])
@@ -133,14 +139,14 @@ resource "aws_ecs_service" "backend" {
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
 
-  # Once GHA wires CodeDeploy blue/green deployments (Step 17 of the deploy
-  # flow), the deployment_controller flips from ECS rolling to CODE_DEPLOY
-  # and Terraform stops being the source of truth for the running task
-  # definition revision. ignore_changes here lets that happen without
-  # Terraform fighting the deployment tool.
-  lifecycle {
-    ignore_changes = [task_definition, desired_count]
-  }
+  # NOTE: ignore_changes on task_definition + desired_count is intentionally
+  # NOT set today. Terraform owns both fields. When GHA wires CodeDeploy
+  # blue/green deploys (Step 17 of the deploy flow), this resource flips
+  # deployment_controller to CODE_DEPLOY and adds the ignore_changes — at
+  # that point Terraform cedes ownership of the running task def revision
+  # to the deployment tool. Until then, Terraform-driven task def updates
+  # work the way you'd expect: bump CPU/memory/env in code -> plan -> apply
+  # rolls a new revision and ECS deploys it.
 
   depends_on = [aws_lb_listener.https]
 


### PR DESCRIPTION
## Summary

Three fixes that all gate the same outcome: backend ECS task goes from crash-looping to healthy on prod. **Already applied to AWS** + **smoke-tested live**:

```
GET https://slpa.app/api/v1/health  ->  200 {"status":"UP"}
POST https://slpa.app/api/v1/auth/register  ->  201 (user created, refresh-token cookie set)
```

## What was failing

1. **`SearchRateLimitConfig.rateLimitRedisClient` bypassed TLS + auth_token.** Used `RedisURI.create(host, port)` which produces a plain TCP URI. ElastiCache with `transit_encryption_enabled = true` rejects plaintext at handshake. Symptom: `Unable to connect to <host>/<unresolved>:6379` during context init. The `<unresolved>` is Lettuce's signal that TCP connect failed before DNS resolution completed — misleading because it looks like a DNS problem but it's actually a TLS handshake failure on a connection Lettuce never managed to open.

2. **ECS task healthcheck `startPeriod` was 60s, Spring needs ~150-180s on 0.25 vCPU.** Fargate marked the task unhealthy at 60s + 30s × 3 retries = 150s and killed it (exit 137 = SIGKILL).

3. **`ignore_changes` on `task_definition` + `desired_count` blocked Terraform from updating CPU/memory/count.** Was premature optimisation for future CodeDeploy compat. Removed for now; will re-add when Step 17 wires the CODE_DEPLOY deployment_controller.

## Code changes

**`SearchRateLimitConfig.java`** — switched from `RedisURI.create(host, port)` to a builder with conditional `.withSsl(true)` + `.withPassword(...)` when the Spring properties are set. Local dev (no TLS, no password) keeps the original plain-TCP behaviour because both flags default to off / empty.

**`infra/compute/ecs_backend.tf`** — `startPeriod = 180`, removed `lifecycle.ignore_changes`.

**`infra/terraform.tfvars`** (gitignored, not in this PR) — bumped `backend_cpu = 512`, `backend_memory = 1024`. Adds ~$8/mo at single-task scale; drops boot from 180s to ~60-90s.

## Test status

`./mvnw test` reports **1588/1589 passing**. The one failure is `BidSchedulerRaceTest.snipeBid_vs_schedulerClose_exactlyOneSucceeds` — a known flaky race test (project FOOTGUNS) that expected `ENDED` and got `SUSPENDED`. Not caused by my changes (the Java change here is a no-op when neither `spring.data.redis.ssl.enabled` nor `spring.data.redis.password` is set, which is true for the dev profile that tests use). Will re-run in CI on this PR.