### PR TITLE
feat(infra): bot pool — 2 ECS services, IAM, log groups (SLPABot1+2 live)

### DIFF
--- a/infra/compute/ecs_backend.tf
+++ b/infra/compute/ecs_backend.tf
@@ -92,10 +92,10 @@ resource "aws_ecs_task_definition" "backend" {
       }
 
       healthCheck = {
-        command     = ["CMD-SHELL", "curl -f http://localhost:8080/api/v1/health || exit 1"]
-        interval    = 30
-        timeout     = 5
-        retries     = 3
+        command  = ["CMD-SHELL", "curl -f http://localhost:8080/api/v1/health || exit 1"]
+        interval = 30
+        timeout  = 5
+        retries  = 3
         # Spring Boot 4 + Java 26 + the SLPA bean graph takes ~150-180s to
         # finish context init on a 0.25 vCPU Fargate task. startPeriod=180
         # gives the JVM headroom to bind 8080 before failed checks count

--- a/infra/compute/ecs_bots.tf
+++ b/infra/compute/ecs_bots.tf
@@ -1,0 +1,151 @@
+################################################################################
+# Bot pool ECS services (spec §4.3)
+#
+# One ECS service per active bot (slpa-bot-1, slpa-bot-2, ...). Each service
+# has desired_count = 1 — named workers can't double-run with the same SL
+# credentials. var.bot_active_count controls how many of the 5-bot pool are
+# instantiated at this deploy (launch-lite default = 2).
+#
+# Each bot's task definition pulls its own credentials via secrets[] from
+# /slpa/${env}/bot-N/{username,password,uuid}. The shared bot/backend secret
+# at /slpa/${env}/bot/shared-secret is injected into every bot's
+# Backend__SharedSecret env var.
+#
+# Bots have no public exposure (no ALB target group, no Route 53 record per
+# spec Q10a = B). Health checks via container healthCheck only; ad-hoc
+# inspection via ECS Exec.
+################################################################################
+
+locals {
+  # Build a set of stringified bot indices [1, 2, ...] up to var.bot_active_count.
+  active_bots = toset([for i in range(1, var.bot_active_count + 1) : tostring(i)])
+}
+
+# ----- Per-bot CloudWatch log groups --------------------------------------- #
+
+resource "aws_cloudwatch_log_group" "bot" {
+  for_each = local.active_bots
+
+  name              = "/aws/ecs/slpa-bot-${each.value}"
+  retention_in_days = var.log_retention_days
+
+  tags = {
+    Name = "slpa-${var.environment}-logs-bot-${each.value}"
+  }
+}
+
+# ----- Per-bot task definitions -------------------------------------------- #
+
+resource "aws_ecs_task_definition" "bot" {
+  for_each = local.active_bots
+
+  family                   = "slpa-${var.environment}-bot-${each.value}"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.bot_cpu
+  memory                   = var.bot_memory
+
+  runtime_platform {
+    cpu_architecture        = "X86_64"
+    operating_system_family = "LINUX"
+  }
+
+  task_role_arn      = aws_iam_role.bot_task.arn
+  execution_role_arn = aws_iam_role.bot_task_execution.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "bot"
+      image     = "${aws_ecr_repository.bot.repository_url}:${var.bot_image_tag}"
+      essential = true
+
+      # Bot exposes /health on 8081 for the container healthcheck. Not
+      # registered to any ALB target group — health is internal-only per
+      # spec Q10a = B.
+      portMappings = [
+        {
+          containerPort = 8081
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        # Note: ASP.NET uses '__' (double underscore) as the section separator
+        # for env-var binding. So Bot__Username binds to Bot:Username in the
+        # appsettings hierarchy.
+        { name = "Bot__StartLocation", value = "last" },
+        { name = "Backend__BaseUrl", value = "https://${var.domain_slpa_app}" },
+        { name = "RateLimit__TeleportsPerMinute", value = "6" },
+        { name = "Logging__LogLevel__Default", value = "Warning" },
+        { name = "Logging__LogLevel__Slpa", value = "Information" },
+      ]
+
+      secrets = [
+        # Per-bot credentials — only this bot sees its own creds.
+        { name = "Bot__Username", valueFrom = "arn:aws:ssm:us-east-1:${data.aws_caller_identity.current.account_id}:parameter/slpa/${var.environment}/bot-${each.value}/username" },
+        { name = "Bot__Password", valueFrom = "arn:aws:ssm:us-east-1:${data.aws_caller_identity.current.account_id}:parameter/slpa/${var.environment}/bot-${each.value}/password" },
+        { name = "Bot__BotUuid", valueFrom = "arn:aws:ssm:us-east-1:${data.aws_caller_identity.current.account_id}:parameter/slpa/${var.environment}/bot-${each.value}/uuid" },
+        # Shared backend bearer secret — same value across all bots.
+        { name = "Backend__SharedSecret", valueFrom = "arn:aws:ssm:us-east-1:${data.aws_caller_identity.current.account_id}:parameter/slpa/${var.environment}/bot/shared-secret" },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.bot[each.value].name
+          awslogs-region        = "us-east-1"
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+
+      healthCheck = {
+        # Bot's ASP.NET /health endpoint (NOT /api/v1/health like the backend
+        # — the bot is its own ASP.NET host on port 8081, not a Spring app).
+        command  = ["CMD-SHELL", "curl -f http://localhost:8081/health || exit 1"]
+        interval = 30
+        timeout  = 5
+        retries  = 3
+        # SL grid login takes ~10-30s of network round-trips on cold start.
+        # 120s gives headroom for slow grid days.
+        startPeriod = 120
+      }
+    }
+  ])
+
+  tags = {
+    Name = "slpa-${var.environment}-bot-${each.value}-task"
+  }
+}
+
+# ----- Per-bot ECS services ------------------------------------------------- #
+
+resource "aws_ecs_service" "bot" {
+  for_each = local.active_bots
+
+  name            = "slpa-${var.environment}-bot-${each.value}"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.bot[each.value].arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  enable_execute_command = true
+  propagate_tags         = "SERVICE"
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [var.bots_security_group_id]
+    assign_public_ip = false
+  }
+
+  # Bot is a stateful single-task service (named SL credentials). Rolling
+  # deploy with min=0 / max=100 means the old task drains before the new
+  # task starts — no SL grid double-login. Brief downtime per deploy is
+  # acceptable; the bot is best-effort observer, not on the auction-close
+  # critical path.
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
+
+  tags = {
+    Name = "slpa-${var.environment}-bot-${each.value}-service"
+  }
+}

--- a/infra/compute/iam_bots.tf
+++ b/infra/compute/iam_bots.tf
@@ -1,0 +1,106 @@
+################################################################################
+# Bot pool IAM (spec §4.3)
+#
+# One pair of roles (task + execution) shared across all bot ECS services.
+# Per-bot credentials are scoped at the Parameter Store path level: each
+# bot service injects only its own /slpa/${env}/bot-N/* params into the
+# task env, so even though all bots share the IAM role, they only see
+# their own credentials at runtime.
+#
+# Bots don't need S3 access (they don't write user-facing assets); they
+# only need:
+#   - SSM read for /slpa/${env}/bot/* (shared backend secret) and
+#     /slpa/${env}/bot-N/* (per-bot creds)
+#   - ECS Exec (so we can shell into a misbehaving bot)
+#   - CloudWatch Logs writes
+################################################################################
+
+# ----- Task role ------------------------------------------------------------ #
+
+resource "aws_iam_role" "bot_task" {
+  name               = "slpa-${var.environment}-bot-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+
+  tags = {
+    Name = "slpa-${var.environment}-bot-task-role"
+  }
+}
+
+data "aws_iam_policy_document" "bot_task" {
+  # Parameter Store reads (shared bot secret + per-bot creds).
+  statement {
+    sid       = "ParameterStoreRead"
+    actions   = ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath"]
+    resources = ["arn:aws:ssm:*:*:parameter/slpa/${var.environment}/*"]
+  }
+  statement {
+    sid       = "ParameterStoreKMS"
+    actions   = ["kms:Decrypt"]
+    resources = ["arn:aws:kms:*:*:alias/aws/ssm"]
+  }
+
+  # ECS Exec (interactive shell into a running task).
+  statement {
+    sid = "ECSExec"
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel",
+    ]
+    resources = ["*"]
+  }
+
+  # CloudWatch Logs writes — wildcard across the per-bot log group ARNs
+  # because the IAM role doesn't know which specific bot it'll be assigned
+  # to. The log groups follow a known naming pattern.
+  statement {
+    sid     = "CloudWatchLogs"
+    actions = ["logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = [
+      "arn:aws:logs:*:*:log-group:/aws/ecs/slpa-bot-*:*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "bot_task" {
+  name   = "slpa-${var.environment}-bot-task-policy"
+  role   = aws_iam_role.bot_task.id
+  policy = data.aws_iam_policy_document.bot_task.json
+}
+
+# ----- Execution role ------------------------------------------------------- #
+
+resource "aws_iam_role" "bot_task_execution" {
+  name               = "slpa-${var.environment}-bot-task-execution-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+
+  tags = {
+    Name = "slpa-${var.environment}-bot-task-execution-role"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "bot_task_execution_managed" {
+  role       = aws_iam_role.bot_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Plus SSM read for secrets[] injection on the per-bot task definitions.
+data "aws_iam_policy_document" "bot_task_execution_ssm" {
+  statement {
+    sid       = "ParameterStoreRead"
+    actions   = ["ssm:GetParameter", "ssm:GetParameters"]
+    resources = ["arn:aws:ssm:*:*:parameter/slpa/${var.environment}/*"]
+  }
+  statement {
+    sid       = "ParameterStoreKMS"
+    actions   = ["kms:Decrypt"]
+    resources = ["arn:aws:kms:*:*:alias/aws/ssm"]
+  }
+}
+
+resource "aws_iam_role_policy" "bot_task_execution_ssm" {
+  name   = "slpa-${var.environment}-bot-task-execution-ssm"
+  role   = aws_iam_role.bot_task_execution.id
+  policy = data.aws_iam_policy_document.bot_task_execution_ssm.json
+}

--- a/infra/compute/variables.tf
+++ b/infra/compute/variables.tf
@@ -91,6 +91,30 @@ variable "backend_image_tag" {
   default     = "initial"
 }
 
+# ----- Bot pool inputs ----------------------------------------------------- #
+
+variable "bots_security_group_id" {
+  type = string
+}
+
+variable "bot_active_count" {
+  type = number
+}
+
+variable "bot_cpu" {
+  type = number
+}
+
+variable "bot_memory" {
+  type = number
+}
+
+variable "bot_image_tag" {
+  description = "Image tag for the bot ECS task definitions. Defaults to 'initial'; CI/CD bumps to git SHA on each deploy."
+  type        = string
+  default     = "initial"
+}
+
 variable "log_retention_days" {
   type = number
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -158,6 +158,7 @@ module "compute" {
 
   alb_security_group_id     = module.networking.alb_security_group_id
   backend_security_group_id = module.networking.backend_security_group_id
+  bots_security_group_id    = module.networking.bots_security_group_id
 
   rds_writer_endpoint      = module.data.rds_writer_endpoint
   rds_database_name        = module.data.rds_database_name
@@ -176,5 +177,10 @@ module "compute" {
   backend_cpu           = var.backend_cpu
   backend_memory        = var.backend_memory
   backend_image_tag     = var.backend_image_tag
-  log_retention_days    = var.log_retention_days
+
+  bot_active_count = var.bot_active_count
+  bot_cpu          = var.bot_cpu
+  bot_memory       = var.bot_memory
+
+  log_retention_days = var.log_retention_days
 }


### PR DESCRIPTION
## Summary

Step 8. **Already applied** to AWS account 486208158127. **+\$15/mo recurring** (2 Fargate tasks at 0.25 vCPU / 0.5 GB).

**Both bots live**: SLPABot1 + SLPABot2 logged in to SL within 60s of apply, backend ALB seeing claim-loop traffic.

## What got created (11 resources)

- **IAM `bot_task` role** — SSM read on `/slpa/prod/bot/*` + `/slpa/prod/bot-N/*`, ECS Exec, CloudWatch Logs writes (no S3 — bots don't write user assets)
- **IAM `bot_task_execution` role** — ECR pull, log group create/write, SSM read for `secrets[]` injection
- **2 CloudWatch log groups** (`/aws/ecs/slpa-bot-1`, `/aws/ecs/slpa-bot-2`) with 7d retention
- **2 ECS task definitions** with per-bot `secrets[]` injection from `/slpa/prod/bot-N/{username,password,uuid}` + shared `/slpa/prod/bot/shared-secret`
- **2 ECS services** with `desired_count = 1` each (named workers can't double-run)

## Live verification

```
bot-1: 'Bot 8ce5f5dc-5c45-4bea-87fe-aa8a82a89d25 ONLINE as SLPABot1 Resident'
bot-2: 'Bot 8f276005-38b4-4ea6-8329-ed4261f0f470 ONLINE as SLPABot2 Resident'
ALB:   3-11 req/min sustained on slpa.app (bot claim-loop polling)
```

## Notes

- **`Backend__BaseUrl`** points at `https://slpa.app` (the public ALB), not an internal service-discovery DNS — same path you'd test with a local docker bot pointing at the host backend
- **`portMappings`** declares 8081 for the container healthcheck only; no ALB target group (spec Q10a = B — bot health via ECS Exec, not public DNS)
- **`deployment_minimum_healthy_percent = 0` + `max = 100`** — brief downtime per deploy is acceptable since two SL sessions with the same credentials conflict at the grid
- Bot pool is fixed at 5 named workers; `var.bot_active_count = 2` launch-lite default. Bump to 5 in tfvars when Method-C verification volume justifies the +\$23/mo