### PR TITLE
chore(infra): Amplify managed via Console (not Terraform)

### DIFF
--- a/frontend/amplify.yml
+++ b/frontend/amplify.yml
@@ -1,0 +1,19 @@
+version: 1
+applications:
+  - appRoot: frontend
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - npm ci
+        build:
+          commands:
+            - npm run build
+      artifacts:
+        baseDirectory: .next
+        files:
+          - '**/*'
+      cache:
+        paths:
+          - node_modules/**/*
+          - .next/cache/**/*

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -148,6 +148,30 @@ module "dns" {
   domain_slpa_app  = var.domain_slpa_app
 }
 
+# module "frontend" — removed 2026-04-29.
+#
+# Amplify Hosting for the Next.js frontend is managed via the Amplify Console
+# rather than Terraform because the WEB_COMPUTE platform's IAM role wiring
+# repeatedly defeated `aws_amplify_app` in our hands (9 build attempts, none
+# succeeded — Amplify's build environment kept rejecting any custom service
+# role with the misleading "Unable to assume specified IAM Role" error).
+#
+# What lives in the console (slpa-frontend app):
+#   - GitHub source via CodeStar Connection (049dbcb6-...)
+#   - main branch with auto-build on push
+#   - WEB_COMPUTE platform (Next.js SSR)
+#   - Custom domain slparcels.com + www
+#   - Build spec: frontend/amplify.yml (committed in repo)
+#   - env: NEXT_PUBLIC_API_URL = https://slpa.app
+#
+# What stays in Terraform:
+#   - Route 53 zone for slparcels.com (in dns module — required for the
+#     CodeStar Connection-based custom domain validation that Amplify drives)
+#   - GitHub PAT in tfvars (kept; used by GHA deploy role too)
+#
+# Reproducing on a fresh AWS account: see the Amplify Console steps in the
+# AWS deployment design doc + the post-PR-49 README addendum.
+
 module "compute" {
   source = "./compute"
 

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -89,3 +89,6 @@ output "ecr_bot_repo_url" {
 output "alb_dns_name" {
   value = module.compute.alb_dns_name
 }
+
+# Amplify outputs removed — frontend is managed via Amplify Console rather
+# than Terraform (see comment in main.tf for context).


### PR DESCRIPTION
## Summary

Removes the `infra/frontend/` Terraform module after 9 failed build attempts trying to make `aws_amplify_app` cooperate with the WEB_COMPUTE platform's role requirements. The Amplify build environment kept rejecting any custom service role with the misleading **"Unable to assume specified IAM Role"** error, even with:

- The AWS-managed `AdministratorAccess-Amplify` policy attached
- Both `amplify.amazonaws.com` and `codebuild.amazonaws.com` in the trust policy
- `sts:TagSession` added alongside `sts:AssumeRole`
- Confused-deputy prevention conditions (SourceAccount + SourceArn)
- A separate Compute role with explicit `iam:PassRole` from the Service role

The Amplify Console flow handles all of this correctly internally because AWS's UI has setup logic that isn't exposed via the `CreateApp` API.

## What's in this PR

- Deleted `infra/frontend/{amplify.tf,outputs.tf,variables.tf}`
- Removed the `module "frontend"` block from `infra/main.tf` (replaced with a long comment explaining why)
- Removed Amplify outputs from `infra/outputs.tf`
- Kept `frontend/amplify.yml` (Amplify Console picks this up for the build spec)
- Kept the `github_pat`, `codestar_connection_arn`, `github_repo_url` variables in `infra/variables.tf` — they're referenced from tfvars (gitignored) and removing them would cascade

## What lives in the Amplify Console now

App `slpa-frontend` (or whatever ID the console creates), manually configured:

- GitHub source via CodeStar Connection (`049dbcb6-...`)
- main branch, auto-build on push
- WEB_COMPUTE platform (Next.js SSR)
- Custom domain `slparcels.com` + `www`
- Build spec: `frontend/amplify.yml`
- env: `NEXT_PUBLIC_API_URL = https://slpa.app`

Reproducible per the AWS deployment design doc's Amplify Console steps.

## Verification

```
terraform validate  -> Success
terraform plan      -> No changes
```