### PR TITLE
fix(auth): refresh cookie SameSite=None for cross-site SPA

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auth/AuthController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auth/AuthController.java
@@ -82,7 +82,7 @@ public class AuthController {
         ResponseCookie cookie = ResponseCookie.from(REFRESH_COOKIE_NAME, token)
             .httpOnly(true)
             .secure(true)
-            .sameSite("Lax")
+            .sameSite("None")
             .path(REFRESH_COOKIE_PATH)
             .maxAge(lifetime)
             .build();
@@ -93,7 +93,7 @@ public class AuthController {
         ResponseCookie cookie = ResponseCookie.from(REFRESH_COOKIE_NAME, "")
             .httpOnly(true)
             .secure(true)
-            .sameSite("Lax")
+            .sameSite("None")
             .path(REFRESH_COOKIE_PATH)
             .maxAge(0)
             .build();


### PR DESCRIPTION
## Summary
- Refresh cookie was set with `SameSite=Lax`, causing the browser to strip it on cross-site POSTs from `slparcels.com` (frontend) to `slpa.app/api/v1/auth/refresh` (backend).
- Symptom: `/me` works (bearer token, no cookie needed); `/refresh` returns 401 immediately after register/login.
- Worked locally only because `localhost:3000` and `localhost:8080` are same-site.

## Change
- `AuthController.setRefreshCookie` and `clearRefreshCookie`: `SameSite=Lax` → `SameSite=None`.
- Cookie is already `Secure` + `HttpOnly`; CORS already sends specific Origin + `Allow-Credentials: true`.

## Test plan
- [x] `AuthControllerTest` (7) + `AuthFlowIntegrationTest` (5) pass — neither asserts the SameSite attribute.
- [ ] After deploy: register on https://slparcels.com → refresh fires successfully (no 401).