### PR TITLE
fix(lsl): `key` keyword + prod URLs in notecard examples

### DIFF
--- a/lsl-scripts/parcel-verifier/README.md
+++ b/lsl-scripts/parcel-verifier/README.md
@@ -48,7 +48,7 @@ To set up the Marketplace listing:
 The script speaks via `llOwnerSay` (visible only to the rezzer). Expected
 chat after rez:
 
-- `✓ Parcel verified — your listing is live on slparcelauctions.com.` (success)
+- `✓ Parcel verified — your listing is live on slparcels.com.` (success)
 - `✗ This parcel isn't yours. Please rez on land you own.` (owner mismatch)
 - `✗ Code must be 6 digits.` (bad input)
 - `✗ <title>: <detail>` (backend rejection — code expired, parcel mismatch, etc.)

--- a/lsl-scripts/parcel-verifier/config.notecard.example
+++ b/lsl-scripts/parcel-verifier/config.notecard.example
@@ -3,7 +3,7 @@
 # BEFORE you rez it on a parcel — once rezzed it self-destructs after one
 # verification attempt.
 
-PARCEL_VERIFY_URL=https://api.slparcelauctions.com/api/v1/sl/parcel/verify
+PARCEL_VERIFY_URL=https://slpa.app/api/v1/sl/parcel/verify
 
 # Optional: set to "false" to silence chat.
 DEBUG_OWNER_SAY=true

--- a/lsl-scripts/parcel-verifier/parcel-verifier.lsl
+++ b/lsl-scripts/parcel-verifier/parcel-verifier.lsl
@@ -60,11 +60,11 @@ parseConfigLine(string line) {
     integer eq = llSubStringIndex(line, "=");
     if (eq < 1) return;
 
-    string key = llStringTrim(llGetSubString(line, 0, eq - 1), STRING_TRIM);
+    string cfgKey = llStringTrim(llGetSubString(line, 0, eq - 1), STRING_TRIM);
     string val = llStringTrim(llGetSubString(line, eq + 1, -1), STRING_TRIM);
 
-    if (key == "PARCEL_VERIFY_URL") PARCEL_VERIFY_URL = val;
-    else if (key == "DEBUG_OWNER_SAY")
+    if (cfgKey == "PARCEL_VERIFY_URL") PARCEL_VERIFY_URL = val;
+    else if (cfgKey == "DEBUG_OWNER_SAY")
         DEBUG_OWNER_SAY = (val == "true" || val == "TRUE" || val == "1");
 }
 
@@ -223,7 +223,7 @@ default {
         llSetTimerEvent(0);
 
         if (status == 204) {
-            dieWithMessage("✓ Parcel verified — your listing is live on slparcelauctions.com.");
+            dieWithMessage("✓ Parcel verified — your listing is live on slparcels.com.");
         } else if (status >= 400 && status < 500) {
             string title  = llJsonGetValue(body, ["title"]);
             string detail = llJsonGetValue(body, ["detail"]);

--- a/lsl-scripts/sl-im-dispatcher/config.notecard.example
+++ b/lsl-scripts/sl-im-dispatcher/config.notecard.example
@@ -2,7 +2,7 @@
 # Copy this file to a notecard named "config" in the same prim, then edit
 # values for your environment.
 
-POLL_URL=https://slpa.example.com/api/v1/internal/sl-im/pending
-CONFIRM_URL_BASE=https://slpa.example.com/api/v1/internal/sl-im/
+POLL_URL=https://slpa.app/api/v1/internal/sl-im/pending
+CONFIRM_URL_BASE=https://slpa.app/api/v1/internal/sl-im/
 SHARED_SECRET=<obtain from server config: slpa.notifications.sl-im.dispatcher.shared-secret>
 DEBUG_OWNER_SAY=true

--- a/lsl-scripts/sl-im-dispatcher/dispatcher.lsl
+++ b/lsl-scripts/sl-im-dispatcher/dispatcher.lsl
@@ -44,13 +44,13 @@ parseConfigLine(string line) {
     integer eq = llSubStringIndex(line, "=");
     if (eq < 1) return;
 
-    string key = llStringTrim(llGetSubString(line, 0, eq - 1), STRING_TRIM);
+    string cfgKey = llStringTrim(llGetSubString(line, 0, eq - 1), STRING_TRIM);
     string val = llStringTrim(llGetSubString(line, eq + 1, -1), STRING_TRIM);
 
-    if (key == "POLL_URL") POLL_URL = val;
-    else if (key == "CONFIRM_URL_BASE") CONFIRM_URL_BASE = val;
-    else if (key == "SHARED_SECRET") SHARED_SECRET = val;
-    else if (key == "DEBUG_OWNER_SAY") DEBUG_OWNER_SAY = (val == "true" || val == "TRUE" || val == "1");
+    if (cfgKey == "POLL_URL") POLL_URL = val;
+    else if (cfgKey == "CONFIRM_URL_BASE") CONFIRM_URL_BASE = val;
+    else if (cfgKey == "SHARED_SECRET") SHARED_SECRET = val;
+    else if (cfgKey == "DEBUG_OWNER_SAY") DEBUG_OWNER_SAY = (val == "true" || val == "TRUE" || val == "1");
 }
 
 deliverNextInBatch() {

--- a/lsl-scripts/slpa-terminal/config.notecard.example
+++ b/lsl-scripts/slpa-terminal/config.notecard.example
@@ -3,12 +3,12 @@
 # After editing, the script auto-resets via CHANGED_INVENTORY and re-registers.
 
 # Backend endpoint URLs — all six required.
-REGISTER_URL=https://api.slparcelauctions.com/api/v1/sl/terminal/register
-ESCROW_PAYMENT_URL=https://api.slparcelauctions.com/api/v1/sl/escrow/payment
-LISTING_FEE_URL=https://api.slparcelauctions.com/api/v1/sl/listing-fee/payment
-PENALTY_LOOKUP_URL=https://api.slparcelauctions.com/api/v1/sl/penalty-lookup
-PENALTY_PAYMENT_URL=https://api.slparcelauctions.com/api/v1/sl/penalty-payment
-PAYOUT_RESULT_URL=https://api.slparcelauctions.com/api/v1/sl/escrow/payout-result
+REGISTER_URL=https://slpa.app/api/v1/sl/terminal/register
+ESCROW_PAYMENT_URL=https://slpa.app/api/v1/sl/escrow/payment
+LISTING_FEE_URL=https://slpa.app/api/v1/sl/listing-fee/payment
+PENALTY_LOOKUP_URL=https://slpa.app/api/v1/sl/penalty-lookup
+PENALTY_PAYMENT_URL=https://slpa.app/api/v1/sl/penalty-payment
+PAYOUT_RESULT_URL=https://slpa.app/api/v1/sl/escrow/payout-result
 
 # Shared secret for terminal authentication. REQUIRED.
 # Obtain from the backend's slpa.escrow.terminal-shared-secret config.

--- a/lsl-scripts/verification-terminal/config.notecard.example
+++ b/lsl-scripts/verification-terminal/config.notecard.example
@@ -2,7 +2,7 @@
 # Place this file (renamed to "config", no extension) in the prim's contents.
 # After editing, the script auto-resets via CHANGED_INVENTORY.
 
-VERIFY_URL=https://api.slparcelauctions.com/api/v1/sl/verify
+VERIFY_URL=https://slpa.app/api/v1/sl/verify
 
 # Optional: set to "false" in prod to silence per-touch chat.
 DEBUG_OWNER_SAY=true

--- a/lsl-scripts/verification-terminal/verification-terminal.lsl
+++ b/lsl-scripts/verification-terminal/verification-terminal.lsl
@@ -68,11 +68,11 @@ parseConfigLine(string line) {
     integer eq = llSubStringIndex(line, "=");
     if (eq < 1) return;
 
-    string key = llStringTrim(llGetSubString(line, 0, eq - 1), STRING_TRIM);
+    string cfgKey = llStringTrim(llGetSubString(line, 0, eq - 1), STRING_TRIM);
     string val = llStringTrim(llGetSubString(line, eq + 1, -1), STRING_TRIM);
 
-    if (key == "VERIFY_URL")     VERIFY_URL = val;
-    else if (key == "DEBUG_OWNER_SAY")
+    if (cfgKey == "VERIFY_URL")     VERIFY_URL = val;
+    else if (cfgKey == "DEBUG_OWNER_SAY")
         DEBUG_OWNER_SAY = (val == "true" || val == "TRUE" || val == "1");
 }
 
@@ -296,7 +296,7 @@ default {
                     llOwnerSay("SLPA Verification Terminal: verify ok: userId=" + userId);
             } else {
                 llRegionSayTo(lockHolder, 0,
-                    "✗ Verification failed. Code may be expired — generate a new one on slparcelauctions.com.");
+                    "✗ Verification failed. Code may be expired — generate a new one on slparcels.com.");
                 if (DEBUG_OWNER_SAY)
                     llOwnerSay("SLPA Verification Terminal: verify denied: not verified");
             }


### PR DESCRIPTION
## Summary
Three bugs caught while deploying LSL terminals to prod:

1. **\`key\` is a reserved LSL type keyword.** Three scripts (\`verification-terminal\`, \`sl-im-dispatcher\`, \`parcel-verifier\`) used \`string key\` as the local in their notecard parser; the SL Mono compiler rejects with "Syntax error" at the declaration. Renamed to \`cfgKey\`. The fourth script (\`slpa-terminal\`) was already using \`string k\` and was unaffected.
2. **Wrong backend host.** Config notecard examples used \`api.slparcelauctions.com\` (or \`slpa.example.com\` placeholder) for backend URLs. Real prod backend is \`slpa.app\`. Updated 8 URLs across 4 config examples.
3. **Wrong website host in user-facing strings.** Two LSL chat messages + one README line referenced \`slparcelauctions.com\` for the website; actual frontend domain is \`slparcels.com\`.

## Test plan
- [ ] Drop the updated \`verification-terminal.lsl\` into a prim with the updated config notecard — script compiles cleanly and terminal links accounts against \`https://slpa.app\`.
- [ ] Same for \`parcel-verifier.lsl\` (rezzable).
- [ ] Same for \`dispatcher.lsl\` (background poller).