### PR TITLE
feat(infra,cicd): GHA deploy workflows + alarms + dashboard + budgets

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,95 @@
+# Builds the backend Docker image, pushes to ECR with the commit SHA as the
+# tag, registers a new ECS task-definition revision pointing at the new image,
+# and rolls the slpa-prod-backend service over to it. Replaces the manual
+# docker push + aws ecs update-service dance.
+#
+# Triggers on push to main when backend/** or this workflow itself changes.
+# Manual `workflow_dispatch` is also enabled for one-off redeploys (e.g. when
+# only the task-def changed via terraform apply and you want to roll the
+# running tasks without a new image build).
+#
+# IAM role assumed via OIDC. Trust policy is locked to repo + branch.
+# See infra/cicd/iam.tf.
+
+name: deploy backend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/deploy-backend.yml'
+  workflow_dispatch:
+
+permissions:
+  id-token: write   # Required for OIDC
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: slpa/backend
+  ECS_CLUSTER: slpa-prod
+  ECS_SERVICE: slpa-prod-backend
+  CONTAINER_NAME: backend
+  # Update this if you rotate or recreate the role. Read it from
+  # `terraform output gha_deploy_role_arn`.
+  AWS_ROLE_ARN: arn:aws:iam::486208158127:role/slpa-prod-gha-deploy
+
+jobs:
+  deploy:
+    name: Build, push, and deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build image
+        working-directory: backend
+        run: |
+          IMAGE=${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}
+          docker build \
+            --tag "$IMAGE:${{ github.sha }}" \
+            --tag "$IMAGE:latest" \
+            .
+          echo "IMAGE=$IMAGE" >> $GITHUB_ENV
+
+      - name: Push image
+        run: |
+          docker push "$IMAGE:${{ github.sha }}"
+          docker push "$IMAGE:latest"
+
+      - name: Render new task definition
+        id: render
+        run: |
+          # Pull the live task def and strip read-only fields AWS rejects on
+          # re-register. Then point the container at the new image SHA.
+          aws ecs describe-task-definition \
+            --task-definition "${{ env.ECS_SERVICE }}" \
+            --query 'taskDefinition' > task-def-raw.json
+          jq 'del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)' \
+            task-def-raw.json > task-def-clean.json
+          jq --arg img "${IMAGE}:${{ github.sha }}" \
+            '.containerDefinitions[0].image = $img' \
+            task-def-clean.json > task-def-rendered.json
+          echo "task-definition=task-def-rendered.json" >> $GITHUB_OUTPUT
+
+      - name: Deploy
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.render.outputs.task-definition }}
+          service: ${{ env.ECS_SERVICE }}
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true
+          # ALB target health check + ECS grace period (300s) means a fresh
+          # task takes ~3-5 min to become healthy. The deploy action's
+          # default 10-min wait covers that comfortably.

--- a/.github/workflows/deploy-bot.yml
+++ b/.github/workflows/deploy-bot.yml
@@ -1,0 +1,114 @@
+# Builds the bot Docker image, pushes to ECR, then fans out a task-def
+# revision + service update across every active slpa-prod-bot-* service.
+# All bots share the same image; only their per-bot task-def env vars and
+# Parameter Store paths differ (per-bot creds).
+#
+# Triggers on push to main when bot/** or this workflow itself changes, plus
+# manual dispatch.
+#
+# Note: bot ECS services use deployment_minimum_healthy_percent = 0 so the old
+# task drains fully before the new one starts (named SL credentials can't
+# double-login). Brief downtime per deploy is expected and acceptable.
+
+name: deploy bots
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'bot/**'
+      - '.github/workflows/deploy-bot.yml'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: slpa/bot
+  ECS_CLUSTER: slpa-prod
+  AWS_ROLE_ARN: arn:aws:iam::486208158127:role/slpa-prod-gha-deploy
+
+jobs:
+  deploy:
+    name: Build, push, and roll bot pool
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build image
+        working-directory: bot
+        run: |
+          IMAGE=${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}
+          docker build \
+            --tag "$IMAGE:${{ github.sha }}" \
+            --tag "$IMAGE:latest" \
+            .
+          echo "IMAGE=$IMAGE" >> $GITHUB_ENV
+
+      - name: Push image
+        run: |
+          docker push "$IMAGE:${{ github.sha }}"
+          docker push "$IMAGE:latest"
+
+      - name: Discover active bot services
+        id: discover
+        run: |
+          # ListServices on the cluster is paginated; --output text + tr handle that.
+          services=$(aws ecs list-services --cluster "${{ env.ECS_CLUSTER }}" \
+            --query 'serviceArns' --output text \
+            | tr '\t' '\n' \
+            | grep -E '/slpa-prod-bot-[0-9]+$' \
+            | xargs -n1 basename \
+            | sort)
+          if [ -z "$services" ]; then
+            echo "::error::No active bot services found in cluster ${{ env.ECS_CLUSTER }}"
+            exit 1
+          fi
+          echo "Discovered bot services:"
+          echo "$services"
+          # Save as space-separated for the next step.
+          echo "services=$(echo $services | tr '\n' ' ')" >> $GITHUB_OUTPUT
+
+      - name: Register new task definitions and update services
+        run: |
+          for svc in ${{ steps.discover.outputs.services }}; do
+            echo "::group::Updating $svc"
+            aws ecs describe-task-definition \
+              --task-definition "$svc" \
+              --query 'taskDefinition' > "td-raw-$svc.json"
+            jq 'del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)' \
+              "td-raw-$svc.json" > "td-clean-$svc.json"
+            jq --arg img "${IMAGE}:${{ github.sha }}" \
+              '.containerDefinitions[0].image = $img' \
+              "td-clean-$svc.json" > "td-rendered-$svc.json"
+            new_arn=$(aws ecs register-task-definition \
+              --cli-input-json "file://td-rendered-$svc.json" \
+              --query 'taskDefinition.taskDefinitionArn' \
+              --output text)
+            echo "Registered: $new_arn"
+            aws ecs update-service \
+              --cluster "${{ env.ECS_CLUSTER }}" \
+              --service "$svc" \
+              --task-definition "$new_arn" > /dev/null
+            echo "Update kicked off for $svc"
+            echo "::endgroup::"
+          done
+
+      - name: Wait for all bot services to stabilize
+        run: |
+          aws ecs wait services-stable \
+            --cluster "${{ env.ECS_CLUSTER }}" \
+            --services ${{ steps.discover.outputs.services }}

--- a/README.md
+++ b/README.md
@@ -243,22 +243,54 @@ cd frontend && npm run verify         # grep-based rules: no dark: variants, no 
 
 ## Production deployment
 
-Production deployment is **not covered in Phase 1**. This stack is wired for local development only. Before any non-local deployment:
+Production runs on AWS in `us-east-1`. Architecture and decisions are documented in [`docs/superpowers/specs/2026-04-29-aws-deployment-design.md`](docs/superpowers/specs/2026-04-29-aws-deployment-design.md). All infrastructure is Terraform-managed under `infra/` (the lone exception is the Amplify app, deliberately console-managed — `infra/main.tf` documents the reason and reproduction steps).
 
-- Rotate every value in `.env.example` tagged `# DEV ONLY` — `POSTGRES_PASSWORD`, `CORS_ALLOWED_ORIGIN`, `NEXT_PUBLIC_API_URL`, plus any future `*_SECRET` / `*_TOKEN` introduced by later tasks (JWT signing key in Task 01-07, etc.).
-- Set `SPRING_PROFILES_ACTIVE=prod` and review `application-prod.yml` before shipping. Global `ddl-auto: update` is the dev/source-of-truth mode while the schema stabilizes in Phase 1; the prod profile must override this (and the eventual production migration strategy will replace the disabled Flyway).
-- Add a reverse proxy / TLS terminator (nginx, Caddy, cloud load balancer) in front of the backend; the dev stack ships HTTP only.
-- Lock down the CORS allow-list to the real frontend origin instead of `localhost:3000`.
-- Replace `Dockerfile.dev` with a multi-stage production Dockerfile that builds a layered Spring Boot fat-jar and runs on a JRE base image, not a JDK.
-- Decide on a database backup / point-in-time-recovery strategy — the named `postgres-data` volume is fine for local dev, not for production.
+### Live endpoints
 
-Track these as part of the pre-launch checklist; do not ship without each one signed off.
+- Frontend: `https://slparcels.com` (Amplify Hosting, Next.js SSR on WEB_COMPUTE)
+- Backend API: `https://slpa.app` (ALB → ECS Fargate)
+- Bots: 5-named-worker pool, currently 2 active (ECS Fargate, no public exposure)
+
+### Auto-deploy (GitHub Actions)
+
+Push to `main` triggers the relevant deploy workflow via OIDC-assumed role (no long-lived AWS keys in repo secrets):
+
+- `backend/**` changed → `.github/workflows/deploy-backend.yml` builds + pushes to ECR + registers a new task-def revision + rolls `slpa-prod-backend` (waits for service stability).
+- `bot/**` changed → `.github/workflows/deploy-bot.yml` does the same and fans out across every active `slpa-prod-bot-*` service.
+- `frontend/**` changed → Amplify auto-builds from `main`.
+- `infra/**` changed → operator runs `terraform plan` / `apply` locally. CI for Terraform is deferred.
+
+Manual one-off deploys via `Actions → deploy backend → Run workflow` (uses the same OIDC role).
+
+### Observability
+
+- **CloudWatch alarms** (11 spec'd, 1 deferred): backend 5xx rate, p95 latency, unhealthy hosts, ECS task failures, RDS CPU / free storage / connections, Redis CPU / memory pressure, per-bot running task count. All publish to the `slpa-prod-alerts` SNS topic; operator email subscription must be confirmed via the AWS-sent email link before alerts arrive.
+- **CloudWatch dashboard** at `slpa-prod-overview` — backend traffic + latency, RDS, Redis, ECS task counts.
+- **AWS Budgets**: soft $200/mo (actual), hard $400/mo (actual + 80% forecast).
+- **Logs**: 7-day retention on every ECS log group; `awslogs-stream-prefix=ecs` for IDE jump-to-stream.
+
+### Cost guardrails
+
+Running cost at launch-lite defaults: ~$78/mo. Upgrade levers in `infra/variables.tf` (Multi-AZ RDS, replicated Redis, larger task sizes, NAT Gateway HA) — each one is a `.tfvars` flip + `terraform apply`.
+
+### Teardown
+
+```bash
+# 1. Empty data buckets so destroy can drop them
+aws s3 rm s3://<storage-bucket-name> --recursive --profile slpa-prod
+# 2. Empty ECR repos
+aws ecr batch-delete-image --repository-name slpa/backend --image-ids "$(aws ecr list-images --repository-name slpa/backend --query 'imageIds[*]' --output json)" --profile slpa-prod
+aws ecr batch-delete-image --repository-name slpa/bot --image-ids "$(aws ecr list-images --repository-name slpa/bot --query 'imageIds[*]' --output json)" --profile slpa-prod
+# 3. Destroy everything Terraform owns
+cd infra && terraform destroy
+# 4. Delete the Amplify app from the console (not Terraform-managed)
+```
 
 ## Conventions
 
 Read [`docs/implementation/CONVENTIONS.md`](docs/implementation/CONVENTIONS.md) before contributing. Highlights:
 
 - Lombok is required for entities, services, and controllers — no hand-written getters/setters/loggers.
-- New schema changes go through JPA entities (`ddl-auto: update` in dev), not new Flyway migrations.
+- Schema changes go through Flyway migrations in `backend/src/main/resources/db/migration/V<N>__description.sql`. Hibernate runs in `ddl-auto: validate` in every profile; a missing migration for an entity change fails fast on boot.
 - Each task ships as one vertical slice (entity → repo → service → controller → tests).
 - Feature-based packages (`user/`, `parcel/`, `auction/`, …), not layer-based.

--- a/docs/implementation/DEFERRED_WORK.md
+++ b/docs/implementation/DEFERRED_WORK.md
@@ -279,6 +279,12 @@ When finishing a sub-spec that completes a deferred item, remove the entry.
 - **When:** Indefinite — pull in when proxy bidding ships and operational data shows proxy-bidder notification gaps.
 - **Notes:** `NotificationPublisher.listingCancelledBySellerFanout` is the current fan-out method. Body strings are cause-neutral per FOOTGUNS §F.104.
 
+### NAT instance CPU CloudWatch alarm
+- **From:** AWS deployment design §4.12 (12 spec'd alarms; 11 shipped in `infra/observability/alarms.tf`)
+- **Why:** The fck-nat module's output schema for the underlying EC2 instance ID was not verified at the time observability was wired. Adding the alarm without the right `module.fck_nat[0].<output>` reference would have either failed `terraform plan` or pointed at a wrong resource. Lower priority than the 11 alarms shipped (NAT egress failure first manifests as backend external-call timeouts, which the 5xx-rate alarm catches).
+- **When:** Next infra touch — verify `module.fck_nat[0]` outputs (likely `instance_id` per the RaJiska/fck-nat module contract), add `aws_cloudwatch_metric_alarm.nat_instance_cpu` keyed on namespace=`AWS/EC2`, dimension `InstanceId`. Conditional on `var.nat_type == "instance"` to no-op when NAT Gateway is in use.
+- **Notes:** Spec table row `slpa-nat-instance-cpu` > 80% over 5 min, alert-only.
+
 ---
 
 ## Removal Criteria

--- a/infra/cicd/iam.tf
+++ b/infra/cicd/iam.tf
@@ -1,0 +1,136 @@
+################################################################################
+# GitHub Actions deploy role (OIDC-trusted)
+################################################################################
+
+# OIDC provider was created out-of-band (PREP.md §10). Reference, don't create.
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+data "aws_iam_policy_document" "gha_assume_role" {
+  statement {
+    sid     = "GitHubOIDC"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github.arn]
+    }
+
+    # Standard GitHub OIDC audience claim.
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    # Repo + branch scoping. Only workflows running on the configured branch
+    # of the configured repo can assume this role.
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${var.github_repo}:ref:refs/heads/${var.github_branch_for_deploy}"]
+    }
+  }
+}
+
+resource "aws_iam_role" "gha_deploy" {
+  name               = "slpa-${var.environment}-gha-deploy"
+  description        = "Assumed by GitHub Actions on push to ${var.github_branch_for_deploy} to deploy backend + bots."
+  assume_role_policy = data.aws_iam_policy_document.gha_assume_role.json
+
+  tags = {
+    Name = "slpa-${var.environment}-gha-deploy"
+  }
+}
+
+# ----- Permissions ---------------------------------------------------------- #
+
+data "aws_iam_policy_document" "gha_deploy" {
+  # ECR auth is account-wide (the GetAuthorizationToken API doesn't accept a
+  # resource ARN); push/pull are scoped to our two repos.
+  statement {
+    sid       = "EcrAuth"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+  statement {
+    sid = "EcrPushPull"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:DescribeImages",
+      "ecr:DescribeRepositories",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:InitiateLayerUpload",
+      "ecr:ListImages",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
+    ]
+    resources = [
+      var.ecr_backend_repo_arn,
+      var.ecr_bot_repo_arn,
+    ]
+  }
+
+  # Register a new task definition revision pointing at the just-pushed image.
+  # RegisterTaskDefinition + DescribeTaskDefinition do not support resource-
+  # level permissions, so they're scoped to "*" — this is the documented AWS
+  # constraint, not a permission gap.
+  statement {
+    sid = "EcsTaskDefinition"
+    actions = [
+      "ecs:DescribeTaskDefinition",
+      "ecs:RegisterTaskDefinition",
+    ]
+    resources = ["*"]
+  }
+
+  # Update the live service to use the new task def revision. Scoped to the
+  # cluster's services. UpdateService accepts service ARNs but the cluster ARN
+  # is sufficient: AWS treats cluster ARN as the parent resource.
+  statement {
+    sid = "EcsServiceUpdate"
+    actions = [
+      "ecs:DescribeServices",
+      "ecs:UpdateService",
+    ]
+    resources = [
+      "arn:aws:ecs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:service/slpa-${var.environment}/*",
+    ]
+  }
+
+  # ECS RegisterTaskDefinition needs to attach the existing task + execution
+  # roles to the new revision. iam:PassRole is the gate.
+  statement {
+    sid     = "PassEcsRoles"
+    actions = ["iam:PassRole"]
+    resources = [
+      var.backend_task_role_arn,
+      var.backend_task_execution_role_arn,
+      var.bot_task_role_arn,
+      var.bot_task_execution_role_arn,
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+
+  # CodeDeploy hooks call ListServices on the cluster to discover targets.
+  # Cheap to grant; needed for `aws ecs describe-services --cluster <arn>` from
+  # workflows when iterating bot services.
+  statement {
+    sid       = "EcsListServices"
+    actions   = ["ecs:ListServices"]
+    resources = [var.ecs_cluster_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "gha_deploy" {
+  name   = "slpa-${var.environment}-gha-deploy-policy"
+  role   = aws_iam_role.gha_deploy.id
+  policy = data.aws_iam_policy_document.gha_deploy.json
+}

--- a/infra/cicd/main.tf
+++ b/infra/cicd/main.tf
@@ -1,0 +1,20 @@
+################################################################################
+# SLPA — CI/CD module (spec §4.10)
+#
+# Owns the IAM role GitHub Actions assumes via OIDC to deploy backend + bots.
+# The OIDC provider itself is created out-of-band (PREP.md §10) — this module
+# just creates the role that trusts it.
+#
+# Trust scope: only the configured repo's main branch can assume the role.
+# Permission scope: ECR push for slpa/backend + slpa/bot, ECS describe +
+# register-task-definition + update-service for the slpa-${env} cluster, and
+# iam:PassRole on the existing task + execution roles.
+#
+# What this module deliberately does NOT include:
+# - CodeDeploy app/deployment-group (deferred per spec — ECSAllAtOnce rolling
+#   is fine at launch).
+# - Workflow YAML files. Those live in `.github/workflows/` (git-managed).
+################################################################################
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}

--- a/infra/cicd/outputs.tf
+++ b/infra/cicd/outputs.tf
@@ -1,0 +1,8 @@
+output "gha_deploy_role_arn" {
+  description = "ARN of the IAM role GitHub Actions assumes via OIDC. Reference this from .github/workflows/*.yml in the role-to-assume input of aws-actions/configure-aws-credentials."
+  value       = aws_iam_role.gha_deploy.arn
+}
+
+output "gha_deploy_role_name" {
+  value = aws_iam_role.gha_deploy.name
+}

--- a/infra/cicd/variables.tf
+++ b/infra/cicd/variables.tf
@@ -1,0 +1,50 @@
+variable "environment" {
+  description = "Environment name applied to role + policy names. Single-env launch (prod)."
+  type        = string
+}
+
+variable "github_repo" {
+  description = "GitHub repo (owner/name) the OIDC role is scoped to. Only workflows in this repo can assume the role."
+  type        = string
+}
+
+variable "github_branch_for_deploy" {
+  description = "The single branch from which deploys are allowed (per spec, only main)."
+  type        = string
+  default     = "main"
+}
+
+variable "ecr_backend_repo_arn" {
+  description = "ARN of the slpa/backend ECR repo. Used to scope ECR push permissions."
+  type        = string
+}
+
+variable "ecr_bot_repo_arn" {
+  description = "ARN of the slpa/bot ECR repo."
+  type        = string
+}
+
+variable "ecs_cluster_arn" {
+  description = "ARN of the ECS cluster the deploy role can update services on."
+  type        = string
+}
+
+variable "backend_task_role_arn" {
+  description = "Task role assumed by the backend container. iam:PassRole is granted only on this + the execution role."
+  type        = string
+}
+
+variable "backend_task_execution_role_arn" {
+  description = "Backend execution role (ECR pull, log writes, secrets[] injection)."
+  type        = string
+}
+
+variable "bot_task_role_arn" {
+  description = "Bot task role."
+  type        = string
+}
+
+variable "bot_task_execution_role_arn" {
+  description = "Bot execution role."
+  type        = string
+}

--- a/infra/compute/outputs.tf
+++ b/infra/compute/outputs.tf
@@ -11,9 +11,19 @@ output "ecr_backend_repo_url" {
   value       = aws_ecr_repository.backend.repository_url
 }
 
+output "ecr_backend_repo_arn" {
+  description = "ECR ARN for the backend image. Used by the GHA deploy role to scope ECR push permissions."
+  value       = aws_ecr_repository.backend.arn
+}
+
 output "ecr_bot_repo_url" {
   description = "ECR URL for the bot image."
   value       = aws_ecr_repository.bot.repository_url
+}
+
+output "ecr_bot_repo_arn" {
+  description = "ECR ARN for the bot image."
+  value       = aws_ecr_repository.bot.arn
 }
 
 output "alb_dns_name" {
@@ -32,4 +42,31 @@ output "backend_task_role_arn" {
 
 output "backend_task_execution_role_arn" {
   value = aws_iam_role.backend_task_execution.arn
+}
+
+output "bot_task_role_arn" {
+  value = aws_iam_role.bot_task.arn
+}
+
+output "bot_task_execution_role_arn" {
+  value = aws_iam_role.bot_task_execution.arn
+}
+
+output "alb_arn_suffix" {
+  description = "ALB ARN suffix for CloudWatch metric dimensions (RequestCount, TargetResponseTime, etc.)."
+  value       = aws_lb.main.arn_suffix
+}
+
+output "backend_target_group_arn_suffix" {
+  description = "Backend ALB target-group ARN suffix for CloudWatch metric dimensions (UnHealthyHostCount, HTTPCode_Target_5XX_Count)."
+  value       = aws_lb_target_group.backend.arn_suffix
+}
+
+output "backend_service_name" {
+  value = aws_ecs_service.backend.name
+}
+
+output "bot_service_names" {
+  description = "List of active bot ECS service names. Used by GHA bot-deploy workflow to fan out updates."
+  value       = [for s in aws_ecs_service.bot : s.name]
 }

--- a/infra/data/outputs.tf
+++ b/infra/data/outputs.tf
@@ -3,6 +3,16 @@ output "rds_writer_endpoint" {
   value       = aws_db_instance.main.endpoint
 }
 
+output "rds_instance_id" {
+  description = "RDS instance identifier (DBInstanceIdentifier). CloudWatch metric dimension key."
+  value       = aws_db_instance.main.id
+}
+
+output "rds_max_connections" {
+  description = "Approximate max_connections setting on the RDS instance (Postgres default formula yields ~83 for db.t4g.micro). Used to set the connections-high alarm threshold dynamically."
+  value       = 83
+}
+
 output "rds_database_name" {
   description = "Postgres database name. Currently 'slpa'."
   value       = aws_db_instance.main.db_name
@@ -21,6 +31,11 @@ output "rds_username_ssm_arn" {
 output "redis_primary_endpoint" {
   description = "ElastiCache Redis primary endpoint. Used by the backend ECS task definition to construct SPRING_DATA_REDIS_HOST."
   value       = aws_elasticache_replication_group.main.primary_endpoint_address
+}
+
+output "redis_replication_group_id" {
+  description = "ElastiCache replication group ID. CloudWatch metric dimension key."
+  value       = aws_elasticache_replication_group.main.id
 }
 
 output "redis_auth_token_ssm_arn" {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -208,3 +208,39 @@ module "compute" {
 
   log_retention_days = var.log_retention_days
 }
+
+module "cicd" {
+  source = "./cicd"
+
+  environment              = var.environment
+  github_repo              = var.github_repo
+  github_branch_for_deploy = var.github_branch_for_deploy
+
+  ecr_backend_repo_arn = module.compute.ecr_backend_repo_arn
+  ecr_bot_repo_arn     = module.compute.ecr_bot_repo_arn
+  ecs_cluster_arn      = module.compute.ecs_cluster_arn
+
+  backend_task_role_arn           = module.compute.backend_task_role_arn
+  backend_task_execution_role_arn = module.compute.backend_task_execution_role_arn
+  bot_task_role_arn               = module.compute.bot_task_role_arn
+  bot_task_execution_role_arn     = module.compute.bot_task_execution_role_arn
+}
+
+module "observability" {
+  source = "./observability"
+
+  environment = var.environment
+  alarm_email = var.alarm_email
+
+  ecs_cluster_name                = module.compute.ecs_cluster_name
+  backend_service_name            = module.compute.backend_service_name
+  bot_service_names               = module.compute.bot_service_names
+  alb_arn_suffix                  = module.compute.alb_arn_suffix
+  backend_target_group_arn_suffix = module.compute.backend_target_group_arn_suffix
+  rds_instance_id                 = module.data.rds_instance_id
+  rds_max_connections             = module.data.rds_max_connections
+  redis_replication_group_id      = module.data.redis_replication_group_id
+
+  budget_soft_threshold_usd = var.budget_soft_threshold_usd
+  budget_hard_threshold_usd = var.budget_hard_threshold_usd
+}

--- a/infra/observability/alarms.tf
+++ b/infra/observability/alarms.tf
@@ -1,0 +1,297 @@
+################################################################################
+# CloudWatch alarms (spec §4.12)
+#
+# 11 alarms covering backend (4), RDS (3), Redis (2), bots (1), budgets (handled
+# in budgets.tf as separate AWS Budgets resources, not CloudWatch alarms).
+#
+# All publish to the same SNS topic. Thresholds match the spec table; tune via
+# `aws cloudwatch put-metric-alarm --alarm-name <name>` overrides if real prod
+# traffic shifts the noise floor.
+#
+# CodeDeploy-relevant alarms (5xx-rate, p95-latency, unhealthy-hosts) are tagged
+# `CodeDeployRollback = true` so a future Step-0 wiring can grep them.
+################################################################################
+
+# ----- Backend (ALB-derived) ------------------------------------------------ #
+
+# 5xx rate as a percentage of total requests over a 1-min window. Math expression:
+# (5xx / requests) * 100. Treats divide-by-zero as 0% (no traffic = healthy).
+resource "aws_cloudwatch_metric_alarm" "backend_5xx_rate" {
+  alarm_name          = "slpa-${var.environment}-backend-5xx-rate"
+  alarm_description   = "Backend 5xx rate exceeded 5% over 1 min. Likely deploy regression or downstream failure."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  threshold           = 5
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  metric_query {
+    id          = "rate"
+    expression  = "IF(reqs > 0, (errors / reqs) * 100, 0)"
+    label       = "5xx rate (%)"
+    return_data = true
+  }
+
+  metric_query {
+    id = "errors"
+    metric {
+      metric_name = "HTTPCode_Target_5XX_Count"
+      namespace   = "AWS/ApplicationELB"
+      period      = 60
+      stat        = "Sum"
+      dimensions = {
+        LoadBalancer = var.alb_arn_suffix
+        TargetGroup  = var.backend_target_group_arn_suffix
+      }
+    }
+  }
+
+  metric_query {
+    id = "reqs"
+    metric {
+      metric_name = "RequestCount"
+      namespace   = "AWS/ApplicationELB"
+      period      = 60
+      stat        = "Sum"
+      dimensions = {
+        LoadBalancer = var.alb_arn_suffix
+        TargetGroup  = var.backend_target_group_arn_suffix
+      }
+    }
+  }
+
+  tags = {
+    CodeDeployRollback = "true"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "backend_p95_latency" {
+  alarm_name          = "slpa-${var.environment}-backend-p95-latency"
+  alarm_description   = "Backend p95 response time exceeded 2s over 5 min. Likely DB pool exhaustion or N+1 query regression."
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "TargetResponseTime"
+  extended_statistic  = "p95"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  period              = 300
+  threshold           = 2
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+    TargetGroup  = var.backend_target_group_arn_suffix
+  }
+
+  tags = {
+    CodeDeployRollback = "true"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "backend_unhealthy_hosts" {
+  alarm_name          = "slpa-${var.environment}-backend-unhealthy-hosts"
+  alarm_description   = "Backend has at least one unhealthy ALB target. With desired_count=1 this means total outage."
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "UnHealthyHostCount"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  period              = 60
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+    TargetGroup  = var.backend_target_group_arn_suffix
+  }
+
+  tags = {
+    CodeDeployRollback = "true"
+  }
+}
+
+# ----- Backend ECS task failures (alert-only, no rollback) ----------------- #
+
+# `ServiceTaskCount` minus `DesiredTaskCount` would be ideal but ECS doesn't
+# expose that as a single metric. RunningTaskCount < DesiredTaskCount = at
+# least one task failure or in-progress restart.
+resource "aws_cloudwatch_metric_alarm" "backend_task_failures" {
+  alarm_name          = "slpa-${var.environment}-backend-ecs-task-failures"
+  alarm_description   = "Backend has fewer running tasks than desired. At least one task crashed or is restarting."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 5
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  metric_query {
+    id          = "diff"
+    expression  = "desired - running"
+    label       = "Tasks below desired"
+    return_data = true
+  }
+
+  metric_query {
+    id = "desired"
+    metric {
+      metric_name = "DesiredTaskCount"
+      namespace   = "ECS/ContainerInsights"
+      period      = 60
+      stat        = "Average"
+      dimensions = {
+        ClusterName = var.ecs_cluster_name
+        ServiceName = var.backend_service_name
+      }
+    }
+  }
+
+  metric_query {
+    id = "running"
+    metric {
+      metric_name = "RunningTaskCount"
+      namespace   = "ECS/ContainerInsights"
+      period      = 60
+      stat        = "Average"
+      dimensions = {
+        ClusterName = var.ecs_cluster_name
+        ServiceName = var.backend_service_name
+      }
+    }
+  }
+}
+
+# ----- RDS ------------------------------------------------------------------ #
+
+resource "aws_cloudwatch_metric_alarm" "rds_cpu" {
+  alarm_name          = "slpa-${var.environment}-rds-cpu"
+  alarm_description   = "RDS CPU > 80% over 5 min. Investigate slow queries via Performance Insights."
+  namespace           = "AWS/RDS"
+  metric_name         = "CPUUtilization"
+  statistic           = "Average"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  period              = 300
+  threshold           = 80
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    DBInstanceIdentifier = var.rds_instance_id
+  }
+}
+
+# Free storage low. Threshold = 20% of allocated storage. Allocated storage is
+# baked into the RDS instance config and exposed via FreeStorageSpace
+# (bytes-free) — we compare against an absolute floor of 4 GB which is 20% of
+# the 20 GB launch-lite allocation. If allocated storage grows via
+# rds_allocated_storage, bump this.
+resource "aws_cloudwatch_metric_alarm" "rds_free_storage_low" {
+  alarm_name          = "slpa-${var.environment}-rds-free-storage-low"
+  alarm_description   = "RDS free storage below 4 GB (20% of 20 GB launch allocation). Storage autoscaling should kick in but worth a heads-up."
+  namespace           = "AWS/RDS"
+  metric_name         = "FreeStorageSpace"
+  statistic           = "Minimum"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  period              = 300
+  threshold           = 4 * 1024 * 1024 * 1024 # 4 GB in bytes
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    DBInstanceIdentifier = var.rds_instance_id
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_connections_high" {
+  alarm_name          = "slpa-${var.environment}-rds-connections-high"
+  alarm_description   = "RDS connection count above 80% of max_connections. Investigate connection pool sizing."
+  namespace           = "AWS/RDS"
+  metric_name         = "DatabaseConnections"
+  statistic           = "Average"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  period              = 300
+  threshold           = ceil(var.rds_max_connections * 0.8)
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    DBInstanceIdentifier = var.rds_instance_id
+  }
+}
+
+# ----- Redis ---------------------------------------------------------------- #
+
+resource "aws_cloudwatch_metric_alarm" "redis_cpu" {
+  alarm_name          = "slpa-${var.environment}-redis-cpu"
+  alarm_description   = "Redis EngineCPUUtilization > 80% over 5 min. Investigate hot keys or connection storms."
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "EngineCPUUtilization"
+  statistic           = "Average"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  period              = 300
+  threshold           = 80
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    ReplicationGroupId = var.redis_replication_group_id
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "redis_memory_pressure" {
+  alarm_name          = "slpa-${var.environment}-redis-memory-pressure"
+  alarm_description   = "Redis DatabaseMemoryUsagePercentage > 90% (less than 10% free). Risk of evictions."
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "DatabaseMemoryUsagePercentage"
+  statistic           = "Average"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  period              = 300
+  threshold           = 90
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    ReplicationGroupId = var.redis_replication_group_id
+  }
+}
+
+# ----- Bot pool ------------------------------------------------------------- #
+
+# One alarm per active bot service: running task count != desired (which is
+# always 1 for bots). If a bot's task count drops to 0, the bot is either
+# restarting or stuck — operator should investigate. The alarm de-registers
+# itself when bot_active_count shrinks (for_each tied to var.bot_service_names).
+resource "aws_cloudwatch_metric_alarm" "bot_task_running" {
+  for_each = toset(var.bot_service_names)
+
+  alarm_name          = "slpa-${var.environment}-${each.value}-task-running"
+  alarm_description   = "Bot ${each.value} has fewer than 1 running task. Bot is offline or restarting."
+  namespace           = "ECS/ContainerInsights"
+  metric_name         = "RunningTaskCount"
+  statistic           = "Average"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 3
+  period              = 60
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    ClusterName = var.ecs_cluster_name
+    ServiceName = each.value
+  }
+}

--- a/infra/observability/budgets.tf
+++ b/infra/observability/budgets.tf
@@ -1,0 +1,51 @@
+################################################################################
+# AWS Budgets (spec §4.13)
+#
+# Two cost-monitoring budgets. Both publish to the same SNS topic the alarms
+# use (operator gets one email, regardless of which budget tripped).
+#
+# These are AWS Budgets resources (not CloudWatch alarms) because Budgets has
+# its own evaluation engine optimised for cost data with daily granularity.
+################################################################################
+
+resource "aws_budgets_budget" "soft" {
+  name              = "slpa-${var.environment}-soft-budget"
+  budget_type       = "COST"
+  limit_amount      = tostring(var.budget_soft_threshold_usd)
+  limit_unit        = "USD"
+  time_unit         = "MONTHLY"
+  time_period_start = "2026-01-01_00:00"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.alarm_email]
+  }
+}
+
+resource "aws_budgets_budget" "hard" {
+  name              = "slpa-${var.environment}-hard-budget"
+  budget_type       = "COST"
+  limit_amount      = tostring(var.budget_hard_threshold_usd)
+  limit_unit        = "USD"
+  time_unit         = "MONTHLY"
+  time_period_start = "2026-01-01_00:00"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.alarm_email]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = [var.alarm_email]
+  }
+}

--- a/infra/observability/dashboard.tf
+++ b/infra/observability/dashboard.tf
@@ -1,0 +1,98 @@
+################################################################################
+# CloudWatch dashboard (spec §4.12)
+#
+# Single overview dashboard. Six widgets covering the surfaces an operator
+# wants to see in one glance after a deploy or page:
+#   1. Backend request rate + 5xx count + latency p50/p95/p99
+#   2. RDS CPU + connections + free storage
+#   3. ElastiCache CPU + memory pressure
+#   4. ECS task counts (backend + bots) — shows desired vs. running
+#
+# JSON shape is the standard CloudWatch dashboard body schema; the
+# `aws_cloudwatch_dashboard` resource takes it as a string.
+################################################################################
+
+resource "aws_cloudwatch_dashboard" "overview" {
+  dashboard_name = "slpa-${var.environment}-overview"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "metric"
+        x      = 0
+        y      = 0
+        width  = 12
+        height = 6
+        properties = {
+          title  = "Backend — request rate + 5xx + latency"
+          region = data.aws_region.current.region
+          view   = "timeSeries"
+          stat   = "Sum"
+          period = 60
+          metrics = [
+            ["AWS/ApplicationELB", "RequestCount", "LoadBalancer", var.alb_arn_suffix, "TargetGroup", var.backend_target_group_arn_suffix, { "label" : "Requests" }],
+            [".", "HTTPCode_Target_5XX_Count", ".", ".", ".", ".", { "label" : "5xx", "color" : "#d62728" }],
+            [".", "TargetResponseTime", ".", ".", ".", ".", { "stat" : "p50", "label" : "p50 latency", "yAxis" : "right" }],
+            ["...", { "stat" : "p95", "label" : "p95 latency", "yAxis" : "right", "color" : "#ff7f0e" }],
+            ["...", { "stat" : "p99", "label" : "p99 latency", "yAxis" : "right", "color" : "#9467bd" }],
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 0
+        width  = 12
+        height = 6
+        properties = {
+          title  = "RDS — CPU + connections + free storage"
+          region = data.aws_region.current.region
+          view   = "timeSeries"
+          period = 300
+          metrics = [
+            ["AWS/RDS", "CPUUtilization", "DBInstanceIdentifier", var.rds_instance_id, { "stat" : "Average", "label" : "CPU %" }],
+            [".", "DatabaseConnections", ".", ".", { "stat" : "Average", "label" : "Connections", "yAxis" : "right" }],
+            [".", "FreeStorageSpace", ".", ".", { "stat" : "Minimum", "label" : "Free GB", "yAxis" : "right" }],
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 6
+        width  = 12
+        height = 6
+        properties = {
+          title  = "Redis — CPU + memory"
+          region = data.aws_region.current.region
+          view   = "timeSeries"
+          period = 300
+          metrics = [
+            ["AWS/ElastiCache", "EngineCPUUtilization", "ReplicationGroupId", var.redis_replication_group_id, { "stat" : "Average", "label" : "Engine CPU %" }],
+            [".", "DatabaseMemoryUsagePercentage", ".", ".", { "stat" : "Average", "label" : "Memory used %", "yAxis" : "right" }],
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 6
+        width  = 12
+        height = 6
+        properties = {
+          title  = "ECS — backend + bot task counts"
+          region = data.aws_region.current.region
+          view   = "timeSeries"
+          period = 60
+          stat   = "Average"
+          metrics = concat(
+            [
+              ["ECS/ContainerInsights", "RunningTaskCount", "ClusterName", var.ecs_cluster_name, "ServiceName", var.backend_service_name, { "label" : "backend" }],
+            ],
+            [for name in var.bot_service_names : ["ECS/ContainerInsights", "RunningTaskCount", "ClusterName", var.ecs_cluster_name, "ServiceName", name, { "label" : name }]]
+          )
+        }
+      },
+    ]
+  })
+}

--- a/infra/observability/main.tf
+++ b/infra/observability/main.tf
@@ -1,0 +1,18 @@
+################################################################################
+# SLPA — Observability module (spec §4.12 + §4.13)
+#
+# Owns:
+#   - SNS topic + email subscription (slpa-${env}-alerts)
+#   - 11 of the 12 spec'd CloudWatch alarms (NAT instance CPU deferred —
+#     fck-nat module output schema not verified here; tracked in DEFERRED_WORK)
+#   - CloudWatch dashboard (slpa-${env}-overview)
+#   - AWS Budgets (soft + hard)
+#
+# All alarms publish to the SNS topic; the operator email subscription must be
+# *confirmed* via the AWS-sent confirmation link before alerts arrive. The
+# subscription resource creates the pending subscription; confirmation is a
+# user action.
+################################################################################
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}

--- a/infra/observability/outputs.tf
+++ b/infra/observability/outputs.tf
@@ -1,0 +1,8 @@
+output "alerts_topic_arn" {
+  description = "SNS topic ARN where all alarms publish. Subscribe additional endpoints (Slack, PagerDuty) here later."
+  value       = aws_sns_topic.alerts.arn
+}
+
+output "dashboard_name" {
+  value = aws_cloudwatch_dashboard.overview.dashboard_name
+}

--- a/infra/observability/sns.tf
+++ b/infra/observability/sns.tf
@@ -1,0 +1,22 @@
+################################################################################
+# SNS topic + email subscription
+#
+# All alarms publish here. The email subscription is created in 'pending' state
+# — the operator MUST click the confirmation link in the email AWS sends or
+# alerts will silently drop. Terraform's `aws_sns_topic_subscription` resource
+# does not block on confirmation; it returns immediately with the pending ARN.
+################################################################################
+
+resource "aws_sns_topic" "alerts" {
+  name = "slpa-${var.environment}-alerts"
+
+  tags = {
+    Name = "slpa-${var.environment}-alerts"
+  }
+}
+
+resource "aws_sns_topic_subscription" "alerts_email" {
+  topic_arn = aws_sns_topic.alerts.arn
+  protocol  = "email"
+  endpoint  = var.alarm_email
+}

--- a/infra/observability/variables.tf
+++ b/infra/observability/variables.tf
@@ -1,0 +1,61 @@
+variable "environment" {
+  description = "Environment name applied to alarm + topic names."
+  type        = string
+}
+
+variable "alarm_email" {
+  description = "Operator email subscribed to the SNS alerts topic."
+  type        = string
+}
+
+# Resource references for alarm dimensions
+variable "ecs_cluster_name" {
+  description = "ECS cluster name (CloudWatch dimension)."
+  type        = string
+}
+
+variable "backend_service_name" {
+  description = "Backend ECS service name."
+  type        = string
+}
+
+variable "bot_service_names" {
+  description = "List of active bot ECS service names."
+  type        = list(string)
+}
+
+variable "alb_arn_suffix" {
+  description = "ALB ARN suffix for ALB-level metrics (RequestCount, TargetResponseTime, HTTPCode_Target_*)."
+  type        = string
+}
+
+variable "backend_target_group_arn_suffix" {
+  description = "Backend ALB target-group ARN suffix for UnHealthyHostCount / HealthyHostCount."
+  type        = string
+}
+
+variable "rds_instance_id" {
+  description = "RDS instance identifier (DBInstanceIdentifier)."
+  type        = string
+}
+
+variable "rds_max_connections" {
+  description = "Approximate Postgres max_connections; used to compute the connections-high threshold (80% of this)."
+  type        = number
+}
+
+variable "redis_replication_group_id" {
+  description = "ElastiCache replication group ID."
+  type        = string
+}
+
+# Cost guardrails (spec §4.13)
+variable "budget_soft_threshold_usd" {
+  description = "Soft budget alert in USD."
+  type        = number
+}
+
+variable "budget_hard_threshold_usd" {
+  description = "Hard budget alert in USD."
+  type        = number
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -92,3 +92,22 @@ output "alb_dns_name" {
 
 # Amplify outputs removed — frontend is managed via Amplify Console rather
 # than Terraform (see comment in main.tf for context).
+
+# ----- CI/CD outputs -------------------------------------------------------- #
+
+output "gha_deploy_role_arn" {
+  description = "Paste this into .github/workflows/*.yml as the role-to-assume input. Already wired in deploy-backend.yml + deploy-bot.yml."
+  value       = module.cicd.gha_deploy_role_arn
+}
+
+# ----- Observability outputs ------------------------------------------------ #
+
+output "alerts_topic_arn" {
+  description = "SNS topic for all alarm notifications. Confirm the email subscription in your inbox."
+  value       = module.observability.alerts_topic_arn
+}
+
+output "dashboard_name" {
+  description = "CloudWatch dashboard name. Open via https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=<this>."
+  value       = module.observability.dashboard_name
+}


### PR DESCRIPTION
Closes the last two implementation steps of the AWS deployment plan (spec §4.10 + §4.12 + §4.13). After this lands the operator should not need to manually \`docker push\` / \`aws ecs update-service\` again.

## Scope
**CI/CD**
- New \`infra/cicd/\` module: OIDC-trusted IAM role \`slpa-prod-gha-deploy\`, repo+branch-scoped trust, per-resource permissions (ECR push limited to slpa/{backend,bot}; ECS UpdateService limited to slpa-prod cluster's services; \`iam:PassRole\` limited to the four task/exec roles).
- \`.github/workflows/deploy-backend.yml\` — push to \`main\` + \`backend/**\` -> OIDC -> ECR build/push -> register new task-def revision -> deploy with \`wait-for-service-stability\`.
- \`.github/workflows/deploy-bot.yml\` — same shape, then discovers active \`slpa-prod-bot-*\` services via \`aws ecs list-services\` and fans out the update.

**Observability** (\`infra/observability/\`)
- SNS topic \`slpa-prod-alerts\` + email subscription (operator must confirm the AWS-sent link).
- 11 CloudWatch alarms: backend 5xx-rate, p95 latency, unhealthy hosts, ECS task failures, RDS CPU/free-storage/connections, Redis CPU/memory pressure, per-bot running task count.
- AWS Budgets: \$200/mo soft, \$400/mo hard (actual + 80% forecast).
- CloudWatch dashboard \`slpa-prod-overview\`.

**Deferred** (tracked in DEFERRED_WORK.md): NAT instance CPU alarm — fck-nat module output schema not verified at write time.

**Docs**: rewrote \`README.md\` "Production deployment" (was still claiming Phase 1 was non-deployable) + corrected the \`ddl-auto\` line in Conventions (Flyway is on, was wrong).

## Operator post-merge steps
1. \`cd infra && terraform plan\` (review), then \`apply\` — creates the IAM role, alarms, budgets, dashboard, SNS topic.
2. Confirm the SNS email subscription via the AWS-sent confirmation email.
3. Next push to \`main\` with \`backend/**\` changes will exercise the workflow end-to-end. Watch \`Actions\` tab.

## Test plan
- [ ] \`terraform plan\` shows additions only (the new modules + outputs); no destroys.
- [ ] After apply, AWS Console -> CloudWatch -> Alarms shows 11 alarms in \`OK\` state with \`SNS:slpa-prod-alerts\` action.
- [ ] After confirming the email, an alarm test (briefly drop a backend health check) emails the operator.
- [ ] Trigger a no-op backend redeploy via Actions -> deploy backend -> Run workflow; confirm new task-def revision and successful service stability.