### PR TITLE
chore(infra): gitignore bare `tfplan` filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,6 +215,7 @@ docker-compose.override.yml
 # never live there (they go to Parameter Store via `aws ssm put-parameter`).
 infra/terraform.tfvars
 infra/.terraform/
+infra/tfplan
 infra/*.tfplan
 infra/*.tfstate
 infra/*.tfstate.*


### PR DESCRIPTION
Adds `infra/tfplan` (no extension) to .gitignore. The existing `infra/*.tfplan` rule covers suffixed plan files but not the unsuffixed `tfplan` that `terraform plan -out=tfplan` produces by default (Terraform's own docs use this name). One-line fix so the binary plan blob never sneaks into a commit regardless of naming convention.