### PR TITLE
release: SL ProblemDetail Content-Type + penalty-lookup 200-always + LSL DEBUG_MODE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,6 +215,7 @@ docker-compose.override.yml
 # never live there (they go to Parameter Store via `aws ssm put-parameter`).
 infra/terraform.tfvars
 infra/.terraform/
+infra/tfplan
 infra/*.tfplan
 infra/*.tfstate
 infra/*.tfstate.*

--- a/backend/src/main/java/com/slparcelauctions/backend/sl/PenaltyTerminalService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/sl/PenaltyTerminalService.java
@@ -69,19 +69,28 @@ public class PenaltyTerminalService {
 
     @Transactional(readOnly = true)
     public PenaltyLookupResponse lookup(UUID slAvatarUuid) {
-        User u = userRepo.findBySlAvatarUuid(slAvatarUuid)
-                .orElseThrow(() -> new UserNotFoundException(
-                        "No SLPA user found for avatar " + slAvatarUuid));
-
+        // Always 200. The original spec returned 404 for both "unknown
+        // avatar" and "zero balance" so the terminal could render a
+        // single "no debt" branch without inspecting the body, but the
+        // SL HTTP outbound layer rewrites any 4xx/5xx whose response
+        // Content-Type is not in HTTP_ACCEPT (default: text/plain) into
+        // a synthetic 415 with body "Unsupported or unknown Content-Type."
+        // Spring's ProblemDetail serialises as application/problem+json,
+        // which the grid rejects — so the terminal never saw the real
+        // 404 and surfaced "Lookup failed - try again" for users with
+        // no penalty. Returning 200 sidesteps the grid filter entirely.
+        //
+        // Privacy is preserved by returning the same payload shape
+        // (userId=null, displayName=null, penaltyBalanceOwed=0) for
+        // both unknown avatars AND known users with zero balance, so an
+        // attacker probing the user table cannot distinguish the two.
+        User u = userRepo.findBySlAvatarUuid(slAvatarUuid).orElse(null);
+        if (u == null) {
+            return new PenaltyLookupResponse(null, null, 0L);
+        }
         long balance = currentBalance(u);
         if (balance == 0L) {
-            // Spec §7.5: zero-balance lookups are 404 so the terminal can
-            // render a single "no debt" branch without inspecting the
-            // numeric body. Distinguishing "unknown avatar" from "user
-            // exists but owes nothing" would only be useful to an
-            // attacker probing the user table.
-            throw new UserNotFoundException(
-                    "No outstanding penalty balance for avatar " + slAvatarUuid);
+            return new PenaltyLookupResponse(null, null, 0L);
         }
         return new PenaltyLookupResponse(u.getId(), u.getDisplayName(), balance);
     }

--- a/backend/src/main/java/com/slparcelauctions/backend/sl/SlProblemDetailContentTypeAdvice.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/sl/SlProblemDetailContentTypeAdvice.java
@@ -1,0 +1,64 @@
+package com.slparcelauctions.backend.sl;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+/**
+ * Rewrites the {@code Content-Type} of {@link ProblemDetail} responses
+ * served from any {@code /api/v1/sl/**} endpoint to
+ * {@code application/json} instead of the RFC 9457 default
+ * {@code application/problem+json}.
+ *
+ * <p><strong>Why:</strong> the in-world LSL HTTP layer
+ * ({@code llHTTPRequest}) filters response Content-Types against its
+ * {@code HTTP_ACCEPT} option. The default accepts only
+ * {@code text/plain;charset=utf-8}; in practice the grid also passes
+ * {@code application/json} through, but it does <em>not</em> recognise
+ * the {@code +json} structured-syntax suffix. When a backend response
+ * carries Content-Type {@code application/problem+json}, the SL grid
+ * silently replaces the entire response with a synthetic {@code 415} +
+ * body {@code "Unsupported or unknown Content-Type."} — the script
+ * never sees the real status code or ProblemDetail body.
+ *
+ * <p>This advice runs after Spring's exception handlers serialise their
+ * {@link ProblemDetail} but before the response is written, so we can
+ * downgrade the Content-Type on the way out. Web clients (frontend,
+ * Postman, anything not behind the SL grid) hit non-{@code /api/v1/sl}
+ * paths and continue to receive RFC-compliant
+ * {@code application/problem+json}.
+ *
+ * <p>The body itself is unchanged — clients reading the documented
+ * ProblemDetail fields ({@code type}, {@code title}, {@code status},
+ * {@code detail}, {@code instance}, plus our {@code code} extension)
+ * continue to work regardless of the Content-Type header.
+ */
+@RestControllerAdvice
+public class SlProblemDetailContentTypeAdvice implements ResponseBodyAdvice<ProblemDetail> {
+
+    private static final String SL_PATH_PREFIX = "/api/v1/sl/";
+
+    @Override
+    public boolean supports(MethodParameter returnType,
+                            Class<? extends HttpMessageConverter<?>> converterType) {
+        return ProblemDetail.class.isAssignableFrom(returnType.getParameterType());
+    }
+
+    @Override
+    public ProblemDetail beforeBodyWrite(ProblemDetail body,
+                                         MethodParameter returnType,
+                                         MediaType selectedContentType,
+                                         Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                         ServerHttpRequest request,
+                                         ServerHttpResponse response) {
+        if (request.getURI().getPath().startsWith(SL_PATH_PREFIX)) {
+            response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+        }
+        return body;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/sl/dto/PenaltyLookupResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/sl/dto/PenaltyLookupResponse.java
@@ -1,11 +1,22 @@
 package com.slparcelauctions.backend.sl.dto;
 
 /**
- * Body of a successful {@code POST /api/v1/sl/penalty-lookup} response.
- * Spec §7.5: returned only when an SLPA user with this avatar UUID has a
- * non-zero {@code penaltyBalanceOwed}; otherwise the controller returns
- * 404 (no debt found / unknown avatar) so the terminal can render a clean
- * "no penalty" message without branching on the body shape.
+ * Body of a {@code POST /api/v1/sl/penalty-lookup} response.
+ *
+ * <p>The endpoint always returns {@code 200}. The terminal branches on
+ * {@code penaltyBalanceOwed}: {@code 0} means "no debt" (render the
+ * clean "no penalty" message); non-zero means "show pay prompt for this
+ * amount". The original spec returned 404 for the no-debt cases, but
+ * the SL HTTP outbound layer rewrites 4xx responses whose Content-Type
+ * is not in {@code HTTP_ACCEPT} (default {@code text/plain}) into a
+ * synthetic 415 — and Spring serialises ProblemDetail as
+ * {@code application/problem+json}, which the grid filter rejects. See
+ * {@code PenaltyTerminalService.lookup} for the privacy rationale.
+ *
+ * <p>For the no-debt case (unknown avatar OR known user with zero
+ * balance), {@code userId} and {@code displayName} are {@code null}
+ * so the two cases are indistinguishable from the wire. Only the
+ * non-zero-balance case populates them.
  */
 public record PenaltyLookupResponse(
         Long userId,

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/PenaltyTerminalControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/PenaltyTerminalControllerSliceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -45,7 +46,8 @@ import com.slparcelauctions.backend.user.UserNotFoundException;
  */
 @WebMvcTest(PenaltyTerminalController.class)
 @Import({SlImInternalConfig.class, SecurityConfig.class, JwtAuthenticationFilter.class,
-        JwtAuthenticationEntryPoint.class, SlExceptionHandler.class})
+        JwtAuthenticationEntryPoint.class, SlExceptionHandler.class,
+        SlProblemDetailContentTypeAdvice.class})
 @TestPropertySource(properties = {
         "auth.cleanup.enabled=false",
         "jwt.secret=dGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdA==",
@@ -109,35 +111,41 @@ class PenaltyTerminalControllerSliceTest {
     }
 
     @Test
-    void lookup_returns404_whenAvatarUnknown() throws Exception {
+    void lookup_returns200WithZeroBalanceAndNullIdentifiers_whenAvatarUnknown() throws Exception {
+        // Endpoint always returns 200 — see PenaltyTerminalService.lookup
+        // for the SL-grid Content-Type filter rationale. Privacy: the
+        // unknown-avatar body is byte-identical to the known-user-with-
+        // zero-balance body so the wire cannot distinguish them.
         doNothing().when(headerValidator).validate(SHARD, OWNER_KEY);
         when(service.lookup(any(UUID.class)))
-                .thenThrow(new UserNotFoundException(
-                        "No SLPA user found for avatar " + AVATAR_UUID));
+                .thenReturn(new PenaltyLookupResponse(null, null, 0L));
 
         mockMvc.perform(post("/api/v1/sl/penalty-lookup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("X-SecondLife-Shard", SHARD)
                         .header("X-SecondLife-Owner-Key", OWNER_KEY)
                         .content(lookupBody(AVATAR_UUID, TERMINAL_ID)))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.displayName").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.penaltyBalanceOwed").value(0));
     }
 
     @Test
-    void lookup_returns404_whenBalanceIsZero() throws Exception {
+    void lookup_returns200WithZeroBalance_whenUserOwesNothing() throws Exception {
         doNothing().when(headerValidator).validate(SHARD, OWNER_KEY);
         when(service.lookup(any(UUID.class)))
-                .thenThrow(new UserNotFoundException(
-                        "No outstanding penalty balance for avatar " + AVATAR_UUID));
+                .thenReturn(new PenaltyLookupResponse(null, null, 0L));
 
         mockMvc.perform(post("/api/v1/sl/penalty-lookup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("X-SecondLife-Shard", SHARD)
                         .header("X-SecondLife-Owner-Key", OWNER_KEY)
                         .content(lookupBody(AVATAR_UUID, TERMINAL_ID)))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.displayName").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.penaltyBalanceOwed").value(0));
     }
 
     @Test
@@ -205,7 +213,11 @@ class PenaltyTerminalControllerSliceTest {
     }
 
     @Test
-    void payment_overpayment_returns422() throws Exception {
+    void payment_overpayment_returns422_asApplicationJson() throws Exception {
+        // The Content-Type assertion guards SlProblemDetailContentTypeAdvice
+        // for /api/v1/sl/** — without it, this 422 would ship as
+        // application/problem+json and the SL grid would replace it with
+        // a synthetic 415 (see advice Javadoc for the full chain).
         doNothing().when(headerValidator).validate(SHARD, OWNER_KEY);
         when(service.pay(any(PenaltyPaymentRequest.class)))
                 .thenThrow(new PenaltyOverpaymentException(1000L, 500L));
@@ -216,6 +228,7 @@ class PenaltyTerminalControllerSliceTest {
                         .header("X-SecondLife-Owner-Key", OWNER_KEY)
                         .content(paymentBody(AVATAR_UUID, SL_TXN, 1000L, TERMINAL_ID)))
                 .andExpect(status().isUnprocessableEntity())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.code").value("SL_PENALTY_OVERPAYMENT"))
                 .andExpect(jsonPath("$.requested").value(1000))
                 .andExpect(jsonPath("$.available").value(500));

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/PenaltyTerminalServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/PenaltyTerminalServiceTest.java
@@ -89,20 +89,29 @@ class PenaltyTerminalServiceTest {
     }
 
     @Test
-    void lookup_throwsUserNotFound_whenAvatarUnknown() {
+    void lookup_returnsZeroBalanceWithNullIdentifiers_whenAvatarUnknown() {
+        // Privacy: unknown-avatar response is byte-identical to the
+        // known-user-with-zero-balance response so an attacker probing
+        // the user table cannot distinguish the two from the wire.
         when(userRepo.findBySlAvatarUuid(AVATAR)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.lookup(AVATAR))
-                .isInstanceOf(UserNotFoundException.class);
+        PenaltyLookupResponse resp = service.lookup(AVATAR);
+
+        assertThat(resp.userId()).isNull();
+        assertThat(resp.displayName()).isNull();
+        assertThat(resp.penaltyBalanceOwed()).isEqualTo(0L);
     }
 
     @Test
-    void lookup_throwsUserNotFound_whenBalanceIsZero() {
+    void lookup_returnsZeroBalanceWithNullIdentifiers_whenUserOwesNothing() {
         User u = userWithBalance(7L, "Alice", 0L);
         when(userRepo.findBySlAvatarUuid(AVATAR)).thenReturn(Optional.of(u));
 
-        assertThatThrownBy(() -> service.lookup(AVATAR))
-                .isInstanceOf(UserNotFoundException.class);
+        PenaltyLookupResponse resp = service.lookup(AVATAR);
+
+        assertThat(resp.userId()).isNull();
+        assertThat(resp.displayName()).isNull();
+        assertThat(resp.penaltyBalanceOwed()).isEqualTo(0L);
     }
 
     @Test
@@ -110,8 +119,11 @@ class PenaltyTerminalServiceTest {
         User u = userWithBalance(7L, "Alice", null);
         when(userRepo.findBySlAvatarUuid(AVATAR)).thenReturn(Optional.of(u));
 
-        assertThatThrownBy(() -> service.lookup(AVATAR))
-                .isInstanceOf(UserNotFoundException.class);
+        PenaltyLookupResponse resp = service.lookup(AVATAR);
+
+        assertThat(resp.userId()).isNull();
+        assertThat(resp.displayName()).isNull();
+        assertThat(resp.penaltyBalanceOwed()).isEqualTo(0L);
     }
 
     // -----------------------------------------------------------------

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/SlProblemDetailContentTypeAdviceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/SlProblemDetailContentTypeAdviceTest.java
@@ -1,0 +1,114 @@
+package com.slparcelauctions.backend.sl;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.web.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.slparcelauctions.backend.auth.JwtAuthenticationEntryPoint;
+import com.slparcelauctions.backend.auth.JwtAuthenticationFilter;
+import com.slparcelauctions.backend.config.SecurityConfig;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Verifies that {@link SlProblemDetailContentTypeAdvice} downgrades the
+ * {@code application/problem+json} default Content-Type to
+ * {@code application/json} on {@code /api/v1/sl/**} paths only. Web
+ * frontends (and every other client) hitting any other path continue to
+ * see the RFC 9457 default.
+ *
+ * <p>Uses two minimal stub controllers (one SL-pathed, one not) instead
+ * of a real domain controller so the test isolates the advice's path
+ * check from any specific endpoint's behaviour.
+ */
+@WebMvcTest(
+        controllers = {
+                SlProblemDetailContentTypeAdviceTest.SlPathStubController.class,
+                SlProblemDetailContentTypeAdviceTest.NonSlPathStubController.class
+        },
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                SecurityFilterAutoConfiguration.class,
+                UserDetailsServiceAutoConfiguration.class
+        },
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = {SecurityConfig.class,
+                           JwtAuthenticationFilter.class,
+                           JwtAuthenticationEntryPoint.class}))
+@AutoConfigureMockMvc(addFilters = false)
+@Import({SlProblemDetailContentTypeAdvice.class,
+        SlProblemDetailContentTypeAdviceTest.SlPathStubController.class,
+        SlProblemDetailContentTypeAdviceTest.NonSlPathStubController.class})
+class SlProblemDetailContentTypeAdviceTest {
+
+    @Autowired MockMvc mockMvc;
+
+    @Test
+    void slPath_problemDetail_servedAsApplicationJson() throws Exception {
+        mockMvc.perform(get("/api/v1/sl/stub-throw"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.title").value("Stub failure"));
+    }
+
+    @Test
+    void nonSlPath_problemDetail_servedAsProblemJson() throws Exception {
+        mockMvc.perform(get("/api/v1/elsewhere/stub-throw"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("$.title").value("Stub failure"));
+    }
+
+    // -----------------------------------------------------------------
+    // Stub fixtures: two endpoints (SL-pathed and not) returning a
+    // ProblemDetail directly. The advice runs after the handler-method
+    // return value is materialised, so this exercises the same code
+    // path as a real @ExceptionHandler producing a ProblemDetail.
+    // -----------------------------------------------------------------
+
+    private static ProblemDetail stubProblemDetail() {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST, "stub detail");
+        pd.setTitle("Stub failure");
+        return pd;
+    }
+
+    @RestController
+    @RequestMapping("/api/v1/sl")
+    static class SlPathStubController {
+        @GetMapping("/stub-throw")
+        @ResponseStatus(HttpStatus.BAD_REQUEST)
+        ProblemDetail stub() {
+            return stubProblemDetail();
+        }
+    }
+
+    @RestController
+    @RequestMapping("/api/v1/elsewhere")
+    static class NonSlPathStubController {
+        @GetMapping("/stub-throw")
+        @ResponseStatus(HttpStatus.BAD_REQUEST)
+        ProblemDetail stub() {
+            return stubProblemDetail();
+        }
+    }
+}

--- a/lsl-scripts/parcel-verifier/README.md
+++ b/lsl-scripts/parcel-verifier/README.md
@@ -41,7 +41,7 @@ To set up the Marketplace listing:
 | Key | Description |
 | --- | --- |
 | `PARCEL_VERIFY_URL` | Full URL of `/api/v1/sl/parcel/verify`. |
-| `DEBUG_OWNER_SAY` | `true`/`false`, default `true`. |
+| `DEBUG_MODE` | `true`/`false`, default `true`. |
 
 ## Operations
 

--- a/lsl-scripts/parcel-verifier/config.notecard.example
+++ b/lsl-scripts/parcel-verifier/config.notecard.example
@@ -6,4 +6,4 @@
 PARCEL_VERIFY_URL=https://slpa.app/api/v1/sl/parcel/verify
 
 # Optional: set to "false" to silence chat.
-DEBUG_OWNER_SAY=true
+DEBUG_MODE=true

--- a/lsl-scripts/parcel-verifier/parcel-verifier.lsl
+++ b/lsl-scripts/parcel-verifier/parcel-verifier.lsl
@@ -15,7 +15,7 @@
 
 // === Configuration loaded from notecard ===
 string  PARCEL_VERIFY_URL = "";
-integer DEBUG_OWNER_SAY   = TRUE;
+integer DEBUG_MODE   = TRUE;
 
 // === Notecard reading state ===
 key     notecardLineRequest = NULL_KEY;
@@ -64,8 +64,8 @@ parseConfigLine(string line) {
     string val = llStringTrim(llGetSubString(line, eq + 1, -1), STRING_TRIM);
 
     if (cfgKey == "PARCEL_VERIFY_URL") PARCEL_VERIFY_URL = val;
-    else if (cfgKey == "DEBUG_OWNER_SAY")
-        DEBUG_OWNER_SAY = (val == "true" || val == "TRUE" || val == "1");
+    else if (cfgKey == "DEBUG_MODE")
+        DEBUG_MODE = (val == "true" || val == "TRUE" || val == "1");
 }
 
 integer isSixDigitCode(string s) {
@@ -97,7 +97,7 @@ default {
     state_entry() {
         // Initialize all globals to sentinel values.
         PARCEL_VERIFY_URL = "";
-        DEBUG_OWNER_SAY   = TRUE;
+        DEBUG_MODE   = TRUE;
         parcelUuid        = NULL_KEY;
         ownerUuid         = NULL_KEY;
         groupUuid         = NULL_KEY;

--- a/lsl-scripts/sl-im-dispatcher/README.md
+++ b/lsl-scripts/sl-im-dispatcher/README.md
@@ -40,7 +40,7 @@ with `#` are comments. Whitespace is trimmed. Required keys:
 | `POLL_URL` | Full URL of the backend's pending-messages endpoint. |
 | `CONFIRM_URL_BASE` | URL prefix for delivery-confirmation posts. The script appends `{id}/delivered` to this base. |
 | `SHARED_SECRET` | The bearer-token secret. Obtain from the server's `slpa.notifications.sl-im.dispatcher.shared-secret` configuration property. |
-| `DEBUG_OWNER_SAY` | `true` to enable per-poll owner chat (default); `false` to silence. Recommended `true` in prod for observability. |
+| `DEBUG_MODE` | `true` to enable per-poll owner chat (default); `false` to silence. Recommended `true` in prod for observability. |
 
 ### Rotating the shared secret
 
@@ -54,7 +54,7 @@ In-flight pending rows are unaffected; the next poll uses the new secret.
 
 ## Operations
 
-In steady state, with `DEBUG_OWNER_SAY=true`, you'll see one of these every
+In steady state, with `DEBUG_MODE=true`, you'll see one of these every
 60 seconds:
 
 - `SL IM poll: 0 messages` — nothing pending; healthy.

--- a/lsl-scripts/sl-im-dispatcher/config.notecard.example
+++ b/lsl-scripts/sl-im-dispatcher/config.notecard.example
@@ -5,4 +5,4 @@
 POLL_URL=https://slpa.app/api/v1/internal/sl-im/pending
 CONFIRM_URL_BASE=https://slpa.app/api/v1/internal/sl-im/
 SHARED_SECRET=<obtain from server config: slpa.notifications.sl-im.dispatcher.shared-secret>
-DEBUG_OWNER_SAY=true
+DEBUG_MODE=true

--- a/lsl-scripts/sl-im-dispatcher/dispatcher.lsl
+++ b/lsl-scripts/sl-im-dispatcher/dispatcher.lsl
@@ -12,7 +12,7 @@
 string POLL_URL = "";
 string CONFIRM_URL_BASE = "";
 string SHARED_SECRET = "";
-integer DEBUG_OWNER_SAY = TRUE;
+integer DEBUG_MODE = TRUE;
 
 // === Cadences ===
 float POLL_INTERVAL = 60.0;
@@ -50,7 +50,7 @@ parseConfigLine(string line) {
     if (cfgKey == "POLL_URL") POLL_URL = val;
     else if (cfgKey == "CONFIRM_URL_BASE") CONFIRM_URL_BASE = val;
     else if (cfgKey == "SHARED_SECRET") SHARED_SECRET = val;
-    else if (cfgKey == "DEBUG_OWNER_SAY") DEBUG_OWNER_SAY = (val == "true" || val == "TRUE" || val == "1");
+    else if (cfgKey == "DEBUG_MODE") DEBUG_MODE = (val == "true" || val == "TRUE" || val == "1");
 }
 
 deliverNextInBatch() {
@@ -121,7 +121,7 @@ default {
                 llOwnerSay("SL IM dispatcher: incomplete config — POLL_URL / CONFIRM_URL_BASE / SHARED_SECRET required");
                 return;
             }
-            if (DEBUG_OWNER_SAY) llOwnerSay("SL IM dispatcher: ready (poll=" + POLL_URL + ")");
+            if (DEBUG_MODE) llOwnerSay("SL IM dispatcher: ready (poll=" + POLL_URL + ")");
             llSetTimerEvent(POLL_INTERVAL);
             return;
         }
@@ -148,18 +148,18 @@ default {
         if (requestId == pollRequestId) {
             pollRequestId = NULL_KEY;
             if (status != 200) {
-                if (DEBUG_OWNER_SAY) llOwnerSay("SL IM poll failed: " + (string)status);
+                if (DEBUG_MODE) llOwnerSay("SL IM poll failed: " + (string)status);
                 return;
             }
             integer count = parseAndStoreBatch(body);
             if (count > 0) {
-                if (DEBUG_OWNER_SAY) llOwnerSay("SL IM batch=" + (string)count);
+                if (DEBUG_MODE) llOwnerSay("SL IM batch=" + (string)count);
                 deliveringBatch = TRUE;
                 batchIndex = 0;
                 llSetTimerEvent(IM_INTERVAL);
                 deliverNextInBatch();  // immediately fire the first IM
             } else {
-                if (DEBUG_OWNER_SAY) llOwnerSay("SL IM poll: 0 messages");
+                if (DEBUG_MODE) llOwnerSay("SL IM poll: 0 messages");
             }
             return;
         }

--- a/lsl-scripts/slpa-terminal/README.md
+++ b/lsl-scripts/slpa-terminal/README.md
@@ -60,7 +60,7 @@ terminal for any command.
 | `SHARED_SECRET` | The shared secret. **Required.** Obtain from `slpa.escrow.terminal-shared-secret`. |
 | `TERMINAL_ID` | Optional. Defaults to `(string)llGetKey()`. Use a stable name if you want admin tooling to identify this terminal across restarts. |
 | `REGION_NAME` | Optional. Defaults to `llGetRegionName()`. |
-| `DEBUG_OWNER_SAY` | Optional. `true`/`false`, default `true`. |
+| `DEBUG_MODE` | Optional. `true`/`false`, default `true`. When `true`, also surfaces a `DEBUG <flow>: status=N title=… detail=… code=…` line to the toucher on HTTP 4xx/5xx, so an operator at the terminal can diagnose backend errors without grepping CloudWatch. |
 
 ### Rotating the shared secret
 
@@ -96,7 +96,7 @@ re-register.
 
 ## Operations
 
-In steady state, with `DEBUG_OWNER_SAY=true`:
+In steady state, with `DEBUG_MODE=true`:
 
 - `SLPA Terminal: registered (terminal_id=..., url=...)` — startup confirmation.
 - `SLPA Terminal: touch from <name>` — user touched the terminal.
@@ -155,3 +155,23 @@ In steady state, with `DEBUG_OWNER_SAY=true`:
   header-trust-only on the backend — no shared secret in body. The script
   still has its shared secret loaded for the other endpoints; it just
   doesn't include it in penalty bodies.
+
+## SL grid Content-Type filter (footgun)
+
+`llHTTPRequest` filters response Content-Type against `HTTP_ACCEPT`.
+The grid passes `application/json` through, but it does NOT recognise
+the `+json` structured-syntax suffix — so a backend response with
+`Content-Type: application/problem+json` (Spring's RFC 9457 default for
+ProblemDetail) gets silently replaced by the SL HTTP layer with a
+synthetic `415` and body `Unsupported or unknown Content-Type.`. The
+script never sees the real status or body.
+
+Backend mitigations live on `/api/v1/sl/**`:
+
+1. `SlProblemDetailContentTypeAdvice` rewrites all 4xx/5xx responses on
+   SL paths to `Content-Type: application/json`.
+2. `/penalty-lookup` always returns 200 (the no-debt case used to be a
+   404 + ProblemDetail, which would be eaten by the grid filter).
+
+If you add a new SL-facing endpoint that returns 4xx/5xx, the advice
+covers it automatically by path prefix — no per-endpoint work needed.

--- a/lsl-scripts/slpa-terminal/config.notecard.example
+++ b/lsl-scripts/slpa-terminal/config.notecard.example
@@ -20,5 +20,6 @@ TERMINAL_ID=
 # Optional: defaults to llGetRegionName() if empty.
 REGION_NAME=
 
-# Optional: false to silence per-event chat. Recommended true in prod.
-DEBUG_OWNER_SAY=true
+# Optional: false to silence per-event chat AND user-facing diagnostic
+# lines on HTTP errors. Recommended true in prod for observability.
+DEBUG_MODE=true

--- a/lsl-scripts/slpa-terminal/slpa-terminal.lsl
+++ b/lsl-scripts/slpa-terminal/slpa-terminal.lsl
@@ -27,7 +27,7 @@ string  PAYOUT_RESULT_URL   = "";
 string  SHARED_SECRET       = "";
 string  TERMINAL_ID         = "";
 string  REGION_NAME         = "";
-integer DEBUG_OWNER_SAY     = TRUE;
+integer DEBUG_MODE          = TRUE;
 
 // === Notecard reading state ===
 key     notecardLineRequest = NULL_KEY;
@@ -131,14 +131,49 @@ parseConfigLine(string line) {
     else if (k == "SHARED_SECRET")       SHARED_SECRET       = v;
     else if (k == "TERMINAL_ID")         TERMINAL_ID         = v;
     else if (k == "REGION_NAME")         REGION_NAME         = v;
-    else if (k == "DEBUG_OWNER_SAY")
-        DEBUG_OWNER_SAY = (v == "true" || v == "TRUE" || v == "1");
+    else if (k == "DEBUG_MODE")
+        DEBUG_MODE = (v == "true" || v == "TRUE" || v == "1");
 }
 
 string escapeJson(string s) {
     s = llReplaceSubString(s, "\\", "\\\\", 0);
     s = llReplaceSubString(s, "\"", "\\\"", 0);
     return s;
+}
+
+// debugSayUser: when DEBUG_MODE is on, surface the parsed ProblemDetail
+// fields (status, title, detail, code) from a backend error response to
+// both the toucher (`who`, may be NULL_KEY for HTTP-in commands) and
+// owner-chat. The user-visible production message stays generic; this
+// adds a labelled diagnostic line so an operator standing at the
+// terminal can see exactly why a 4xx/5xx came back without grepping
+// CloudWatch.
+debugSayUser(key who, string label, integer status, string body) {
+    if (!DEBUG_MODE) return;
+    string title  = llJsonGetValue(body, ["title"]);
+    string detail = llJsonGetValue(body, ["detail"]);
+    string code   = llJsonGetValue(body, ["code"]);
+    string msg = "DEBUG " + label + ": status=" + (string)status;
+    integer haveAny = FALSE;
+    if (title  != JSON_INVALID && title  != "") { msg += " title=" + title;   haveAny = TRUE; }
+    if (detail != JSON_INVALID && detail != "") { msg += " detail=" + detail; haveAny = TRUE; }
+    if (code   != JSON_INVALID && code   != "") { msg += " code=" + code;     haveAny = TRUE; }
+    // If the response wasn't a Spring ProblemDetail (no title/detail/code),
+    // surface the raw body excerpt so we can see HTML error pages, plain
+    // text, or empty bodies returned by intermediate proxies / framework
+    // defaults.
+    if (!haveAny) {
+        integer blen = llStringLength(body);
+        if (blen == 0) {
+            msg += " body=<empty>";
+        } else {
+            integer cap = blen;
+            if (cap > 200) cap = 200;
+            msg += " body[" + (string)blen + "]=" + llGetSubString(body, 0, cap - 1);
+        }
+    }
+    if (who != NULL_KEY) llRegionSayTo(who, 0, msg);
+    llOwnerSay("SLPA Terminal: " + msg);
 }
 
 setBusyChrome() {
@@ -344,7 +379,7 @@ default {
         SHARED_SECRET       = "";
         TERMINAL_ID         = "";
         REGION_NAME         = "";
-        DEBUG_OWNER_SAY     = TRUE;
+        DEBUG_MODE          = TRUE;
 
         notecardLineRequest = NULL_KEY;
         notecardLineNum     = 0;
@@ -489,7 +524,7 @@ default {
             key txKey = llTransferLindenDollars((key)recipientUuid, amount);
             addInflightCommand(txKey, idempotencyKey, (key)recipientUuid, amount);
 
-            if (DEBUG_OWNER_SAY) {
+            if (DEBUG_MODE) {
                 llOwnerSay("SLPA Terminal: HTTP-in command action=" + action
                     + " recipient=" + recipientUuid
                     + " amount=" + (string)amount
@@ -501,7 +536,7 @@ default {
     transaction_result(key id, integer success, string data) {
         list found = removeInflightByTxKey(id);
         if (llGetListLength(found) == 0) {
-            if (DEBUG_OWNER_SAY)
+            if (DEBUG_MODE)
                 llOwnerSay("SLPA Terminal: transaction_result for unknown txKey=" + (string)id);
             return;
         }
@@ -545,7 +580,7 @@ default {
              HTTP_BODY_MAXLENGTH, 16384],
             pbody);
 
-        if (DEBUG_OWNER_SAY) {
+        if (DEBUG_MODE) {
             llOwnerSay("SLPA Terminal: payout-result posted: success=" + successStr
                 + " recipient=" + recip + " amount=" + (string)amt);
         }
@@ -559,7 +594,7 @@ default {
             if (status == 200) {
                 registered    = TRUE;
                 registerAttempt = 0;
-                if (DEBUG_OWNER_SAY)
+                if (DEBUG_MODE)
                     llOwnerSay("SLPA Terminal: registered (terminal_id=" + TERMINAL_ID
                         + ", url=" + httpInUrl + ")");
             } else {
@@ -568,7 +603,7 @@ default {
                     llOwnerSay("CRITICAL: SLPA Terminal: registration failed after 5 attempts. Status="
                         + (string)status);
                 } else {
-                    if (DEBUG_OWNER_SAY)
+                    if (DEBUG_MODE)
                         llOwnerSay("SLPA Terminal: register retry " + (string)registerAttempt + "/5: status=" + (string)status);
                     scheduleRegisterRetry();
                 }
@@ -579,10 +614,15 @@ default {
         // --- Penalty-lookup response ---
         if (req == lookupReqId) {
             lookupReqId = NULL_KEY;
-            if (status == 404) {
-                llRegionSayTo(lockHolder, 0, "No penalty on file for your account.");
-                releaseLock();
-            } else if (status == 200) {
+            if (status == 200) {
+                // Backend always returns 200 for /penalty-lookup. Branch on
+                // penaltyBalanceOwed: 0 means "no debt" (unknown avatar AND
+                // known-but-zero are byte-identical for privacy); positive
+                // means show the pay prompt. The endpoint used to 404 the
+                // no-debt cases, but the SL HTTP outbound layer rewrites
+                // 4xx responses whose Content-Type is not in HTTP_ACCEPT
+                // into a synthetic 415, so the script never saw the real
+                // 404. See PenaltyTerminalService.lookup javadoc.
                 integer owed = (integer)llJsonGetValue(body, ["penaltyBalanceOwed"]);
                 if (owed <= 0) {
                     llRegionSayTo(lockHolder, 0, "No penalty on file for your account.");
@@ -600,8 +640,12 @@ default {
                     extendLock(60);
                 }
             } else {
-                // 5xx, 0 or unexpected
+                // 5xx, 0 (network), or unexpected status (e.g. 400 validation,
+                // 403 SL_INVALID_HEADERS). The user message stays generic;
+                // DEBUG_MODE adds the parsed ProblemDetail so an operator at
+                // the terminal can diagnose without grepping CloudWatch.
                 llRegionSayTo(lockHolder, 0, "Lookup failed — try again.");
+                debugSayUser(lockHolder, "penalty lookup", status, body);
                 releaseLock();
             }
             return;
@@ -657,6 +701,7 @@ default {
                     + ": " + title + " — " + detail);
                 llRegionSayTo(paymentPayer, 0,
                     "Payment error (" + (string)status + "): " + title + ". Contact SLPA support.");
+                debugSayUser(paymentPayer, "payment", status, body);
                 // Clear payment state — 4xx is non-retriable.
                 paymentPayer      = NULL_KEY;
                 paymentAmount     = 0;
@@ -671,9 +716,12 @@ default {
             } else {
                 // 5xx or 0 — schedule retry.
                 paymentRetryCount++;
-                if (DEBUG_OWNER_SAY)
+                if (DEBUG_MODE)
                     llOwnerSay("SLPA Terminal: payment retry " + (string)paymentRetryCount
                         + "/5: status=" + (string)status);
+                debugSayUser(paymentPayer,
+                    "payment retry " + (string)paymentRetryCount + "/5",
+                    status, body);
                 schedulePaymentRetry();
             }
             return;
@@ -683,7 +731,7 @@ default {
         if (req == payoutResultReqId) {
             payoutResultReqId = NULL_KEY;
             if (status == 200) {
-                if (DEBUG_OWNER_SAY)
+                if (DEBUG_MODE)
                     llOwnerSay("SLPA Terminal: payout-result acknowledged by backend.");
             } else {
                 llOwnerSay("CRITICAL: /payout-result POST failed status=" + (string)status
@@ -735,9 +783,15 @@ default {
 
             } else if (message == "Pay Penalty") {
                 // Fire penalty lookup; lock stays held during inflight.
-                string lbody = llList2Json(JSON_OBJECT,
-                    ["slAvatarUuid", (string)lockHolder,
-                     "terminalId",  TERMINAL_ID]);
+                // Manual JSON construction (matches postRegister + firePayment in
+                // this script) instead of llList2Json — the grid's auto-typing in
+                // llList2Json has historically produced bodies that the SL HTTP
+                // layer flags as a non-JSON content shape, surfacing as 415 from
+                // the backend even though HTTP_MIMETYPE is set to application/json.
+                string lbody = "{"
+                    + "\"slAvatarUuid\":\"" + (string)lockHolder + "\","
+                    + "\"terminalId\":\""   + escapeJson(TERMINAL_ID) + "\""
+                    + "}";
                 lookupReqId = llHTTPRequest(PENALTY_LOOKUP_URL,
                     [HTTP_METHOD, "POST",
                      HTTP_MIMETYPE, "application/json",
@@ -799,7 +853,7 @@ default {
                 + " — touchState=" + (string)touchState + ". Forwarding to backend.");
         }
 
-        if (payer != lockHolder && DEBUG_OWNER_SAY) {
+        if (payer != lockHolder && DEBUG_MODE) {
             llOwnerSay("SLPA Terminal: payment from " + (string)payer
                 + " is not the menu user " + (string)lockHolder);
         }
@@ -837,13 +891,13 @@ default {
 
         } else if (timerPhase == TIMER_PAYMENT_RETRY) {
             timerPhase = TIMER_NONE;
-            if (DEBUG_OWNER_SAY)
+            if (DEBUG_MODE)
                 llOwnerSay("SLPA Terminal: payment retry " + (string)paymentRetryCount + "/5");
             firePayment();
 
         } else if (timerPhase == TIMER_REGISTER_RETRY) {
             timerPhase = TIMER_NONE;
-            if (DEBUG_OWNER_SAY)
+            if (DEBUG_MODE)
                 llOwnerSay("SLPA Terminal: register retry " + (string)registerAttempt + "/5");
             postRegister();
         }

--- a/lsl-scripts/verification-terminal/README.md
+++ b/lsl-scripts/verification-terminal/README.md
@@ -38,7 +38,7 @@ User-facing kiosk distributed via Marketplace + SLPA HQ + allied venues.
 | Key | Description |
 | --- | --- |
 | `VERIFY_URL` | Full URL of the backend's `/api/v1/sl/verify` endpoint. |
-| `DEBUG_OWNER_SAY` | `true`/`false`, default `true`. Recommended `true` in prod. |
+| `DEBUG_MODE` | `true`/`false`, default `true`. Recommended `true` in prod. |
 
 Editing the notecard auto-resets the script via `CHANGED_INVENTORY`.
 

--- a/lsl-scripts/verification-terminal/config.notecard.example
+++ b/lsl-scripts/verification-terminal/config.notecard.example
@@ -5,4 +5,4 @@
 VERIFY_URL=https://slpa.app/api/v1/sl/verify
 
 # Optional: set to "false" in prod to silence per-touch chat.
-DEBUG_OWNER_SAY=true
+DEBUG_MODE=true

--- a/lsl-scripts/verification-terminal/verification-terminal.lsl
+++ b/lsl-scripts/verification-terminal/verification-terminal.lsl
@@ -15,7 +15,7 @@
 
 // === Configuration loaded from notecard ===
 string  VERIFY_URL    = "";
-integer DEBUG_OWNER_SAY = TRUE;
+integer DEBUG_MODE = TRUE;
 
 // === Notecard reading state ===
 key     notecardLineRequest = NULL_KEY;
@@ -72,8 +72,8 @@ parseConfigLine(string line) {
     string val = llStringTrim(llGetSubString(line, eq + 1, -1), STRING_TRIM);
 
     if (cfgKey == "VERIFY_URL")     VERIFY_URL = val;
-    else if (cfgKey == "DEBUG_OWNER_SAY")
-        DEBUG_OWNER_SAY = (val == "true" || val == "TRUE" || val == "1");
+    else if (cfgKey == "DEBUG_MODE")
+        DEBUG_MODE = (val == "true" || val == "TRUE" || val == "1");
 }
 
 setBusyChrome() {
@@ -145,7 +145,7 @@ default {
     state_entry() {
         // Initialize all globals to sentinel values.
         VERIFY_URL       = "";
-        DEBUG_OWNER_SAY  = TRUE;
+        DEBUG_MODE  = TRUE;
         lockHolder       = NULL_KEY;
         lockHolderName   = "";
         lockExpiresAt    = 0;
@@ -192,7 +192,7 @@ default {
                     llOwnerSay("SLPA Verification Terminal: incomplete config — VERIFY_URL required");
                     return;
                 }
-                if (DEBUG_OWNER_SAY)
+                if (DEBUG_MODE)
                     llOwnerSay("SLPA Verification Terminal: ready (verify=" + VERIFY_URL + ")");
                 return;
             }
@@ -242,7 +242,7 @@ default {
 
         setBusyChrome();
 
-        if (DEBUG_OWNER_SAY)
+        if (DEBUG_MODE)
             llOwnerSay("SLPA Verification Terminal: touch from " + toucherName);
 
         listenHandle = llListen(menuChan, "", lockHolder, "");
@@ -292,12 +292,12 @@ default {
             if (verified == "true") {
                 llRegionSayTo(lockHolder, 0,
                     "✓ Linked SLPA #" + userId + " to " + slAvatarName + ".");
-                if (DEBUG_OWNER_SAY)
+                if (DEBUG_MODE)
                     llOwnerSay("SLPA Verification Terminal: verify ok: userId=" + userId);
             } else {
                 llRegionSayTo(lockHolder, 0,
                     "✗ Verification failed. Code may be expired — generate a new one on slparcels.com.");
-                if (DEBUG_OWNER_SAY)
+                if (DEBUG_MODE)
                     llOwnerSay("SLPA Verification Terminal: verify denied: not verified");
             }
         } else if (status >= 400 && status < 500) {
@@ -306,13 +306,13 @@ default {
             if (title == JSON_INVALID || title == "") title = "Error";
             if (detail == JSON_INVALID || detail == "") detail = "status " + (string)status;
             llRegionSayTo(lockHolder, 0, "✗ " + title + ": " + detail);
-            if (DEBUG_OWNER_SAY)
+            if (DEBUG_MODE)
                 llOwnerSay("SLPA Verification Terminal: verify denied: " + title);
         } else {
             // 5xx or 0 (HTTP timeout / network failure)
             llRegionSayTo(lockHolder, 0,
                 "✗ Backend unreachable. Try again in a moment.");
-            if (DEBUG_OWNER_SAY)
+            if (DEBUG_MODE)
                 llOwnerSay("SLPA Verification Terminal: http error: status=" + (string)status);
         }
 


### PR DESCRIPTION
## Summary

Releases two PRs already merged to dev:

- **#63** — fixes the in-world Pay Penalty 415 by overriding ProblemDetail Content-Type on `/api/v1/sl/**` to `application/json` (the SL HTTP outbound layer doesn't recognise the `+json` suffix and was synthesising a fake 415). Also makes `/api/v1/sl/penalty-lookup` always return 200 (zero balance for the no-debt case, byte-identical for unknown vs. known users for privacy). LSL slpa-terminal updated to drop the dead 404 branch. Renames `DEBUG_OWNER_SAY` → `DEBUG_MODE` across all 4 LSL scripts and adds in-region diagnostic surfacing on HTTP errors. Postman collection: adds the missing `Penalty lookup (terminal)` and `Penalty payment (terminal)` requests.
- **#62** — `.gitignore` the bare `tfplan` filename so `terraform plan -out tfplan` doesn't show in `git status`.

## Test plan
- [ ] Backend deploys cleanly via GHA.
- [ ] In-world: drop new `slpa-terminal.lsl` into the prim, `CHANGED_INVENTORY` resets it.
- [ ] Touch SLPA Terminal -> Pay Penalty as a user with no debt -> should now show "No penalty on file for your account." (instead of "Lookup failed - try again").
- [ ] Touch SLPA Terminal -> Pay Penalty as a user with debt -> should show "Penalty owed: L\$N. Pay below..." and pay buttons.
- [ ] Verify other SL endpoints still return their expected 4xx error messages with parsed `title`/`detail` (Content-Type override doesn't change body shape, just the header).
- [ ] Web frontend regressions: none expected — frontend doesn't call `/api/v1/sl/**` (grep-confirmed) and other paths still return RFC `application/problem+json`.