### PR TITLE
release: wallet model foundation (Phase 1-4)

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/reconciliation/ReconciliationRun.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/reconciliation/ReconciliationRun.java
@@ -32,4 +32,28 @@ public class ReconciliationRun {
 
     @Column(name = "error_message", length = 500)
     private String errorMessage;
+
+    /**
+     * Sum of {@code users.balance_lindens} at run time. Added by the wallet
+     * model. Pre-wallet runs are NULL.
+     */
+    @Column(name = "wallet_balance_total")
+    private Long walletBalanceTotal;
+
+    /**
+     * Sum of active {@code bid_reservations.amount} at run time.
+     * Sub-breakdown of {@code wallet_balance_total} (reservations are
+     * partitions of balance, not separate L$); recorded for forensics
+     * but NOT added to expected.
+     */
+    @Column(name = "wallet_reserved_total")
+    private Long walletReservedTotal;
+
+    /**
+     * Sum of escrows in locked states (FUNDED/TRANSFER_PENDING/DISPUTED/
+     * FROZEN). Duplicate of {@code expectedLockedSum} for clarity in the
+     * wallet-era schema; pre-wallet runs are NULL.
+     */
+    @Column(name = "escrow_locked_total")
+    private Long escrowLockedTotal;
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/reconciliation/ReconciliationStatus.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/reconciliation/ReconciliationStatus.java
@@ -1,3 +1,28 @@
 package com.slparcelauctions.backend.admin.infrastructure.reconciliation;
 
-public enum ReconciliationStatus { BALANCED, MISMATCH, ERROR }
+public enum ReconciliationStatus {
+    /**
+     * Observed L$ balance covers expected (escrow + wallet) within tolerance.
+     */
+    BALANCED,
+
+    /**
+     * Observed L$ balance differs from expected by more than tolerance.
+     * The drift column captures the magnitude.
+     */
+    MISMATCH,
+
+    /**
+     * The run could not complete (no fresh terminal balance, transient
+     * failure, etc).
+     */
+    ERROR,
+
+    /**
+     * Pre-check found that {@code users.reserved_lindens} (denorm) does not
+     * match {@code SUM(bid_reservations.amount WHERE released_at IS NULL)}
+     * (source). The main expected vs. observed comparison is aborted because
+     * the expected number is wrong if denorms are wrong. See spec §11.1.
+     */
+    DENORM_DRIFT
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/command/TerminalCommandPurpose.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/command/TerminalCommandPurpose.java
@@ -11,5 +11,14 @@ package com.slparcelauctions.backend.escrow.command;
 public enum TerminalCommandPurpose {
     AUCTION_ESCROW,
     LISTING_FEE_REFUND,
-    ADMIN_WITHDRAWAL
+    ADMIN_WITHDRAWAL,
+    /**
+     * User-initiated wallet withdrawal (site- or terminal-initiated).
+     * Recipient UUID is locked to the user's verified SL avatar — never
+     * client-supplied. Callback flow is handled by
+     * {@code WalletWithdrawalCallbackHandler}: success appends a
+     * {@code WITHDRAW_COMPLETED} ledger row; failure after retry exhaustion
+     * appends a {@code WITHDRAW_REVERSED} row crediting balance back.
+     */
+    WALLET_WITHDRAWAL
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/user/User.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/User.java
@@ -21,6 +21,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -237,6 +238,67 @@ public class User {
     @Builder.Default
     private Long tokenVersion = 0L;
 
+    /**
+     * Total wallet balance in L$. Includes both available and reserved L$.
+     * The wallet model parks resident-paid L$ here on deposit; bids
+     * hard-reserve from this balance via {@code reservedLindens}; auction
+     * close debits this balance and releases the reservation. See spec
+     * docs/superpowers/specs/2026-04-30-wallet-model-design.md §3.1.
+     *
+     * <p>Available balance ({@link #availableLindens()}) is computed as
+     * {@code balanceLindens - reservedLindens}.
+     */
+    @Builder.Default
+    @Column(name = "balance_lindens", nullable = false,
+            columnDefinition = "bigint not null default 0")
+    private Long balanceLindens = 0L;
+
+    /**
+     * Sum of active bid reservations for this user (denormalized from
+     * {@code bid_reservations WHERE released_at IS NULL}). DB-enforced
+     * {@code reserved_lindens >= 0} and {@code balance_lindens >=
+     * reserved_lindens}. Reconciliation job verifies the denorm against the
+     * live sum daily.
+     */
+    @Builder.Default
+    @Column(name = "reserved_lindens", nullable = false,
+            columnDefinition = "bigint not null default 0")
+    private Long reservedLindens = 0L;
+
+    /**
+     * Stamped by {@code WalletDormancyJob} phase 1 when a user becomes
+     * inactive (no refresh-token rotation in 30d) with a positive balance.
+     * Cleared on any successful login or refresh-token rotation.
+     */
+    @Column(name = "wallet_dormancy_started_at")
+    private OffsetDateTime walletDormancyStartedAt;
+
+    /**
+     * Current dormancy notification phase: 1-4 during the 4-week
+     * notification window, 99 = COMPLETED (auto-return executed).
+     * NULL = not in dormancy state.
+     */
+    @Column(name = "wallet_dormancy_phase")
+    private Integer walletDormancyPhase;
+
+    /**
+     * Stamped on first wallet-terms-of-use click-through (via
+     * {@code POST /me/wallet/accept-terms}). The wallet endpoints don't
+     * gate on this flag — terms acceptance is a UX gate enforced by the
+     * frontend's deposit-instructions modal.
+     */
+    @Column(name = "wallet_terms_accepted_at")
+    private OffsetDateTime walletTermsAcceptedAt;
+
+    /**
+     * Version string of the wallet ToU the user accepted (e.g., "1.0").
+     * Material changes bump the application's
+     * {@code slpa.wallet.terms-version} config, prompting re-acceptance
+     * on next visit when this value diverges.
+     */
+    @Column(name = "wallet_terms_version", length = 16)
+    private String walletTermsVersion;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private OffsetDateTime createdAt;
@@ -244,6 +306,16 @@ public class User {
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     private OffsetDateTime updatedAt;
+
+    /**
+     * Available wallet balance — what the user can withdraw, allocate, or
+     * commit to a new bid/listing-fee/penalty. Computed as
+     * {@code balanceLindens - reservedLindens}.
+     */
+    @Transient
+    public long availableLindens() {
+        return balanceLindens - reservedLindens;
+    }
 
     private static Map<String, Object> defaultNotifyEmail() {
         Map<String, Object> m = new LinkedHashMap<>();

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/BidReservation.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/BidReservation.java
@@ -1,0 +1,81 @@
+package com.slparcelauctions.backend.wallet;
+
+import java.time.OffsetDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Active bid reservation for the wallet model's hard-reservation flow.
+ *
+ * <p>When user A becomes high bidder on auction X, a row is inserted with
+ * {@code releasedAt=null}. When outbid, {@code releasedAt} is set to
+ * {@code now} and {@code releaseReason} stamped. Auction close consumes
+ * the winning row by setting {@code releaseReason=ESCROW_FUNDED}.
+ *
+ * <p>The partial unique index on {@code (user_id, auction_id) WHERE
+ * released_at IS NULL} enforces "at most one active reservation per
+ * (user, auction)". Outbid → release prior, insert new works because
+ * the prior row's {@code releasedAt} is no longer NULL when the next
+ * insert happens.
+ *
+ * <p>See spec docs/superpowers/specs/2026-04-30-wallet-model-design.md §3.3.
+ */
+@Entity
+@Table(name = "bid_reservations")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BidReservation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "auction_id", nullable = false)
+    private Long auctionId;
+
+    @Column(name = "bid_id", nullable = false)
+    private Long bidId;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    /**
+     * NULL while the reservation is active. Set to {@code now} at the
+     * moment the reservation is consumed/released.
+     */
+    @Column(name = "released_at")
+    private OffsetDateTime releasedAt;
+
+    /**
+     * NULL while active; required when {@code releasedAt} is set
+     * (consistency check enforced at the DB level).
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "release_reason", length = 32)
+    private BidReservationReleaseReason releaseReason;
+
+    public boolean isActive() {
+        return releasedAt == null;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/BidReservationReleaseReason.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/BidReservationReleaseReason.java
@@ -1,0 +1,44 @@
+package com.slparcelauctions.backend.wallet;
+
+/**
+ * Reason a {@link BidReservation} was released. Stamped at the moment
+ * {@code released_at} is set.
+ *
+ * <p>See spec docs/superpowers/specs/2026-04-30-wallet-model-design.md §3.3.
+ */
+public enum BidReservationReleaseReason {
+    /**
+     * The user was outbid by another bidder; their reservation was released
+     * to make room for the new high bidder's reservation.
+     */
+    OUTBID,
+
+    /**
+     * The auction was cancelled by the seller (where allowed) or admin.
+     */
+    AUCTION_CANCELLED,
+
+    /**
+     * The auction was fraud-frozen by admin.
+     */
+    AUCTION_FRAUD_FREEZE,
+
+    /**
+     * Buy-It-Now closed the auction; non-winning bidders' reservations are
+     * released. The BIN-clicker's own reservation (if any) is released with
+     * {@link #ESCROW_FUNDED} since their L$ flowed into escrow.
+     */
+    AUCTION_BIN_ENDED,
+
+    /**
+     * Auction-end auto-fund consumed this reservation: the winner's L$ was
+     * debited from balance and the escrow row was created in FUNDED state.
+     */
+    ESCROW_FUNDED,
+
+    /**
+     * The user was banned by admin; all their active reservations are
+     * released.
+     */
+    USER_BANNED
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/BidReservationRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/BidReservationRepository.java
@@ -1,0 +1,85 @@
+package com.slparcelauctions.backend.wallet;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * Repository for {@link BidReservation}.
+ */
+public interface BidReservationRepository extends JpaRepository<BidReservation, Long> {
+
+    /**
+     * The single active reservation for an auction (if any). Used by the
+     * bid endpoint to identify the prior high bidder before swapping in
+     * a new reservation.
+     */
+    @Query("""
+        SELECT br FROM BidReservation br
+         WHERE br.auctionId = :auctionId
+           AND br.releasedAt IS NULL
+        """)
+    Optional<BidReservation> findActiveForAuction(@Param("auctionId") Long auctionId);
+
+    /**
+     * All active reservations for an auction (multiple bidders, used by
+     * cancellation/freeze paths to release every reservation cleanly).
+     */
+    @Query("""
+        SELECT br FROM BidReservation br
+         WHERE br.auctionId = :auctionId
+           AND br.releasedAt IS NULL
+        """)
+    List<BidReservation> findAllActiveForAuction(@Param("auctionId") Long auctionId);
+
+    /**
+     * All active reservations owned by a user (used by user-ban path,
+     * dormancy filter, and admin tooling).
+     */
+    @Query("""
+        SELECT br FROM BidReservation br
+         WHERE br.userId = :userId
+           AND br.releasedAt IS NULL
+        """)
+    List<BidReservation> findActiveByUser(@Param("userId") Long userId);
+
+    /**
+     * The user's active reservation on a specific auction, if any. Used by
+     * the BIN handler to detect "BIN-clicker had a prior reservation on
+     * this auction at a lower amount."
+     */
+    @Query("""
+        SELECT br FROM BidReservation br
+         WHERE br.userId = :userId
+           AND br.auctionId = :auctionId
+           AND br.releasedAt IS NULL
+        """)
+    Optional<BidReservation> findActiveByUserAndAuction(
+            @Param("userId") Long userId,
+            @Param("auctionId") Long auctionId);
+
+    /**
+     * Sum of all active reservation amounts for a user — used by the
+     * reconciliation denorm-drift precheck.
+     */
+    @Query("""
+        SELECT COALESCE(SUM(br.amount), 0) FROM BidReservation br
+         WHERE br.userId = :userId
+           AND br.releasedAt IS NULL
+        """)
+    long sumActiveByUser(@Param("userId") Long userId);
+
+    /**
+     * Total of all active reservations across all users — used as the
+     * authoritative source for the wallet_reserved_total reconciliation
+     * sum.
+     */
+    @Query("""
+        SELECT COALESCE(SUM(br.amount), 0) FROM BidReservation br
+         WHERE br.releasedAt IS NULL
+        """)
+    long sumAllActive();
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerEntry.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerEntry.java
@@ -1,0 +1,96 @@
+package com.slparcelauctions.backend.wallet;
+
+import java.time.OffsetDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Append-only per-user wallet ledger entry.
+ *
+ * <p>Every L$ movement to or from a user's wallet appends a row here. Rows
+ * are never updated — withdraw lifecycle (QUEUED → COMPLETED|REVERSED) is
+ * three separate appended rows, not mutations of the original.
+ *
+ * <p>{@code amount} is always positive; direction is implicit in
+ * {@link UserLedgerEntryType}. {@code balanceAfter} and {@code reservedAfter}
+ * are snapshots written at insert time — they are the authoritative state
+ * for the user's wallet at that point in the ledger.
+ *
+ * <p>{@code slTransactionId} (LSL {@code llGenerateKey()}) deduplicates
+ * terminal-side retries on {@code /sl/wallet/deposit} and
+ * {@code /sl/wallet/withdraw-request}. {@code idempotencyKey} (client-supplied)
+ * deduplicates frontend retries on {@code /me/wallet/withdraw} and
+ * {@code /me/wallet/pay-penalty}. Both have {@code UNIQUE WHERE NOT NULL}
+ * indexes — duplicate inserts fail loudly with a constraint violation.
+ *
+ * <p>See spec docs/superpowers/specs/2026-04-30-wallet-model-design.md §3.2.
+ */
+@Entity
+@Table(name = "user_ledger", indexes = {
+        @Index(name = "user_ledger_user_created_idx", columnList = "user_id, created_at DESC")
+})
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserLedgerEntry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "entry_type", nullable = false, length = 32)
+    private UserLedgerEntryType entryType;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column(name = "balance_after", nullable = false)
+    private Long balanceAfter;
+
+    @Column(name = "reserved_after", nullable = false)
+    private Long reservedAfter;
+
+    /**
+     * Domain-entity discriminator: {@code "AUCTION"}, {@code "ESCROW"},
+     * {@code "BID"}, {@code "TERMINAL_COMMAND"}, {@code "LISTING_FEE_REFUND"},
+     * {@code "PENALTY"}, {@code "ADJUSTMENT"}, {@code "DORMANCY"}, etc.
+     * No FK constraint — ledger rows don't cascade.
+     */
+    @Column(name = "ref_type", length = 32)
+    private String refType;
+
+    @Column(name = "ref_id")
+    private Long refId;
+
+    @Column(name = "sl_transaction_id", length = 36)
+    private String slTransactionId;
+
+    @Column(name = "idempotency_key", length = 64)
+    private String idempotencyKey;
+
+    @Column(length = 500)
+    private String description;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "created_by_admin_id")
+    private Long createdByAdminId;
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerEntryType.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerEntryType.java
@@ -1,0 +1,97 @@
+package com.slparcelauctions.backend.wallet;
+
+/**
+ * Discriminator for {@link UserLedgerEntry} rows. Direction (debit vs credit)
+ * is implicit in the entry_type — the entry's {@code amount} is always positive.
+ *
+ * <p>See spec docs/superpowers/specs/2026-04-30-wallet-model-design.md §3.2.
+ */
+public enum UserLedgerEntryType {
+    /**
+     * Resident-initiated L$ deposit via the in-world SLPA Terminal's
+     * {@code money()} handler. {@code sl_transaction_id} is the LSL
+     * {@code llGenerateKey()} value that deduplicates retries.
+     * Increases {@code balance_lindens}.
+     */
+    DEPOSIT,
+
+    /**
+     * Withdrawal initiated (site or terminal). {@code balance_lindens}
+     * decremented immediately; the {@code TerminalCommand} fires
+     * asynchronously. Resolution is a separate row
+     * ({@link #WITHDRAW_COMPLETED} or {@link #WITHDRAW_REVERSED}).
+     */
+    WITHDRAW_QUEUED,
+
+    /**
+     * Successful withdrawal fulfillment — {@code llTransferLindenDollars}
+     * succeeded and the {@code /sl/escrow/payout-result} callback acknowledged.
+     * Pure ledger row; balance is unchanged from the {@link #WITHDRAW_QUEUED}
+     * snapshot.
+     */
+    WITHDRAW_COMPLETED,
+
+    /**
+     * Withdrawal could not be fulfilled (terminal pool exhausted retries,
+     * recipient avatar banned by Linden, etc). {@code balance_lindens}
+     * credited back to restore pre-withdraw state.
+     */
+    WITHDRAW_REVERSED,
+
+    /**
+     * Bid placement reserved L$ from balance for an active high bid.
+     * {@code reserved_lindens} increments; {@code balance_lindens}
+     * unchanged (reservations are partitions of balance, not separate L$).
+     */
+    BID_RESERVED,
+
+    /**
+     * Bid reservation released — outbid, auction cancelled, fraud-frozen,
+     * escrow funded, or user banned. {@code reserved_lindens} decrements;
+     * {@code balance_lindens} unchanged.
+     */
+    BID_RELEASED,
+
+    /**
+     * Auction-end auto-fund debit (or BIN immediate fund). The winner's
+     * reservation is released ({@link #BID_RELEASED} row appended in the
+     * same transaction) and {@code balance_lindens} decremented by the
+     * final bid amount.
+     */
+    ESCROW_DEBIT,
+
+    /**
+     * Escrow refund credited back to wallet (escrow expired during transfer
+     * deadline or dispute resolved in winner's favor). Replaces the prior
+     * {@code TerminalCommand{action=REFUND}} flow.
+     */
+    ESCROW_REFUND,
+
+    /**
+     * Listing-fee debit on DRAFT → DRAFT_PAID transition. Issued by
+     * {@code POST /me/auctions/{id}/pay-listing-fee}.
+     */
+    LISTING_FEE_DEBIT,
+
+    /**
+     * Listing-fee refund credited back to wallet (auction cancelled with no
+     * bids, etc, per existing Epic 03/05 refund rules). Replaces the prior
+     * {@code TerminalCommand{action=REFUND}} flow.
+     */
+    LISTING_FEE_REFUND,
+
+    /**
+     * Penalty payment debit. Voluntary; users can carry an outstanding
+     * penalty indefinitely. The penalty only blocks new bids/listings,
+     * never auto-deducted.
+     */
+    PENALTY_DEBIT,
+
+    /**
+     * Admin-issued ledger adjustment. {@code created_by_admin_id} required
+     * (constraint enforced at the application layer; see
+     * {@code WalletService.adminAdjustment}). Used for forensic corrections
+     * after manual reconciliation, refunds-of-last-resort, etc.
+     */
+    ADJUSTMENT
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerRepository.java
@@ -1,0 +1,40 @@
+package com.slparcelauctions.backend.wallet;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository for {@link UserLedgerEntry} append-only rows.
+ */
+public interface UserLedgerRepository extends JpaRepository<UserLedgerEntry, Long> {
+
+    /**
+     * Idempotency lookup for the SL-headers wallet endpoints
+     * ({@code /sl/wallet/deposit}, {@code /sl/wallet/withdraw-request}).
+     * The terminal generates {@code sl_transaction_id} once via
+     * {@code llGenerateKey()} and reuses it across retries; finding an
+     * existing row means we replay the original response.
+     */
+    Optional<UserLedgerEntry> findBySlTransactionId(String slTransactionId);
+
+    /**
+     * Idempotency lookup for the user-facing wallet endpoints
+     * ({@code /me/wallet/withdraw}, {@code /me/wallet/pay-penalty}).
+     * Client supplies {@code idempotencyKey} on the request body.
+     */
+    Optional<UserLedgerEntry> findByIdempotencyKey(String idempotencyKey);
+
+    /**
+     * Most recent 50 entries for the wallet panel's recent-activity view.
+     */
+    List<UserLedgerEntry> findTop50ByUserIdOrderByCreatedAtDesc(Long userId);
+
+    /**
+     * Cursor pagination for the {@code /me/wallet/ledger} endpoint.
+     */
+    Page<UserLedgerEntry> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/WalletService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/WalletService.java
@@ -1,0 +1,625 @@
+package com.slparcelauctions.backend.wallet;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.escrow.command.TerminalCommand;
+import com.slparcelauctions.backend.escrow.command.TerminalCommandAction;
+import com.slparcelauctions.backend.escrow.command.TerminalCommandPurpose;
+import com.slparcelauctions.backend.escrow.command.TerminalCommandRepository;
+import com.slparcelauctions.backend.escrow.command.TerminalCommandStatus;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import com.slparcelauctions.backend.wallet.exception.AmountExceedsOwedException;
+import com.slparcelauctions.backend.wallet.exception.BidReservationAmountMismatchException;
+import com.slparcelauctions.backend.wallet.exception.InsufficientAvailableBalanceException;
+import com.slparcelauctions.backend.wallet.exception.UserNotLinkedException;
+import com.slparcelauctions.backend.wallet.exception.UserStatusBlockedException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Core wallet operations. All methods that mutate wallet state are
+ * transactional. The "primitive" methods (debit/credit/swap helpers used by
+ * other services) run with {@link Propagation#MANDATORY} so callers must
+ * already hold the relevant locks; the "endpoint" methods (deposit /
+ * withdraw / payPenalty) run with default propagation and acquire the
+ * locks themselves.
+ *
+ * <p>See spec docs/superpowers/specs/2026-04-30-wallet-model-design.md.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WalletService {
+
+    private final UserRepository userRepository;
+    private final UserLedgerRepository ledgerRepository;
+    private final BidReservationRepository reservationRepository;
+    private final TerminalCommandRepository terminalCommandRepository;
+    private final Clock clock;
+
+    /* ========================================================== */
+    /* DEPOSIT                                                     */
+    /* ========================================================== */
+
+    /**
+     * Credit the wallet of the user identified by their SL avatar UUID.
+     * Called from {@code POST /api/v1/sl/wallet/deposit} when the in-world
+     * SLPA Terminal's {@code money()} handler fires.
+     *
+     * <p>Idempotent: a duplicate {@code slTransactionKey} returns the
+     * original ledger entry without re-crediting.
+     *
+     * @throws UserNotLinkedException     if no SLPA user has the given
+     *                                    {@code payerUuid} as their verified
+     *                                    SL avatar — terminal bounces the L$
+     * @throws UserStatusBlockedException if the user is banned or frozen —
+     *                                    terminal bounces the L$
+     */
+    @Transactional
+    public DepositResult deposit(UUID payerUuid, long amount, String slTransactionKey) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount must be positive: " + amount);
+        }
+
+        Optional<UserLedgerEntry> existing = ledgerRepository.findBySlTransactionId(slTransactionKey);
+        if (existing.isPresent()) {
+            log.debug("deposit replay for slTxKey={} (existing entry id={})",
+                    slTransactionKey, existing.get().getId());
+            return DepositResult.replay(existing.get());
+        }
+
+        Long userId = userRepository.findIdBySlAvatarUuid(payerUuid)
+                .orElseThrow(() -> new UserNotLinkedException(payerUuid));
+        User user = userRepository.findByIdForUpdate(userId).orElseThrow();
+        rejectIfBlocked(user);
+
+        long newBalance = user.getBalanceLindens() + amount;
+        user.setBalanceLindens(newBalance);
+        userRepository.save(user);
+
+        UserLedgerEntry entry = ledgerRepository.save(UserLedgerEntry.builder()
+                .userId(user.getId())
+                .entryType(UserLedgerEntryType.DEPOSIT)
+                .amount(amount)
+                .balanceAfter(newBalance)
+                .reservedAfter(user.getReservedLindens())
+                .slTransactionId(slTransactionKey)
+                .createdAt(OffsetDateTime.now(clock))
+                .build());
+
+        log.info("deposit ok: userId={}, amount={}, balanceAfter={}, slTxKey={}",
+                user.getId(), amount, newBalance, slTransactionKey);
+        return DepositResult.ok(user, entry);
+    }
+
+    /* ========================================================== */
+    /* WITHDRAW (site-initiated)                                   */
+    /* ========================================================== */
+
+    /**
+     * Debit the wallet for a site-initiated withdrawal. Recipient is
+     * always the user's verified SL avatar UUID — never client-supplied.
+     * Idempotent on {@code idempotencyKey}.
+     */
+    @Transactional
+    public WithdrawQueuedResult withdrawSiteInitiated(Long userId, long amount, String idempotencyKey) {
+        return withdrawCommon(userId, amount, idempotencyKey, null);
+    }
+
+    /**
+     * Debit the wallet for a touch-initiated withdrawal. Idempotent on
+     * {@code slTransactionKey}.
+     */
+    @Transactional
+    public WithdrawQueuedResult withdrawTouchInitiated(UUID payerUuid, long amount, String slTransactionKey) {
+        Long userId = userRepository.findIdBySlAvatarUuid(payerUuid)
+                .orElseThrow(() -> new UserNotLinkedException(payerUuid));
+        return withdrawCommon(userId, amount, null, slTransactionKey);
+    }
+
+    private WithdrawQueuedResult withdrawCommon(
+            Long userId, long amount, String idempotencyKey, String slTransactionKey) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount must be positive: " + amount);
+        }
+
+        // Idempotency replay
+        if (idempotencyKey != null) {
+            Optional<UserLedgerEntry> existing = ledgerRepository.findByIdempotencyKey(idempotencyKey);
+            if (existing.isPresent()) return WithdrawQueuedResult.replay(existing.get());
+        }
+        if (slTransactionKey != null) {
+            Optional<UserLedgerEntry> existing = ledgerRepository.findBySlTransactionId(slTransactionKey);
+            if (existing.isPresent()) return WithdrawQueuedResult.replay(existing.get());
+        }
+
+        User user = userRepository.findByIdForUpdate(userId).orElseThrow();
+        rejectIfBlocked(user);
+
+        if (user.availableLindens() < amount) {
+            throw new InsufficientAvailableBalanceException(user.availableLindens(), amount);
+        }
+
+        long newBalance = user.getBalanceLindens() - amount;
+        user.setBalanceLindens(newBalance);
+        userRepository.save(user);
+
+        UserLedgerEntry entry = ledgerRepository.save(UserLedgerEntry.builder()
+                .userId(userId)
+                .entryType(UserLedgerEntryType.WITHDRAW_QUEUED)
+                .amount(amount)
+                .balanceAfter(newBalance)
+                .reservedAfter(user.getReservedLindens())
+                .idempotencyKey(idempotencyKey)
+                .slTransactionId(slTransactionKey)
+                .createdAt(OffsetDateTime.now(clock))
+                .build());
+
+        TerminalCommand cmd = terminalCommandRepository.save(TerminalCommand.builder()
+                .action(TerminalCommandAction.WITHDRAW)
+                .purpose(TerminalCommandPurpose.WALLET_WITHDRAWAL)
+                .recipientUuid(user.getSlAvatarUuid().toString())
+                .amount(amount)
+                .status(TerminalCommandStatus.QUEUED)
+                .idempotencyKey("WAL-" + entry.getId())
+                .nextAttemptAt(OffsetDateTime.now(clock))
+                .attemptCount(0)
+                .requiresManualReview(false)
+                .build());
+
+        log.info("withdraw queued: userId={}, amount={}, balanceAfter={}, ledgerId={}, commandId={}",
+                userId, amount, newBalance, entry.getId(), cmd.getId());
+        return WithdrawQueuedResult.ok(user, entry, cmd);
+    }
+
+    /* ========================================================== */
+    /* PAY PENALTY                                                 */
+    /* ========================================================== */
+
+    /**
+     * Pay against the user's outstanding penalty. Must come from
+     * {@code available} (not {@code reserved}). Partial payments allowed
+     * up to {@code penaltyBalanceOwed}.
+     */
+    @Transactional
+    public PenaltyDebitResult payPenalty(Long userId, long amount, String idempotencyKey) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount must be positive: " + amount);
+        }
+
+        Optional<UserLedgerEntry> existing = ledgerRepository.findByIdempotencyKey(idempotencyKey);
+        if (existing.isPresent()) return PenaltyDebitResult.replay(existing.get());
+
+        User user = userRepository.findByIdForUpdate(userId).orElseThrow();
+        if (amount > user.getPenaltyBalanceOwed()) {
+            throw new AmountExceedsOwedException(user.getPenaltyBalanceOwed(), amount);
+        }
+        if (user.availableLindens() < amount) {
+            throw new InsufficientAvailableBalanceException(user.availableLindens(), amount);
+        }
+
+        long newBalance = user.getBalanceLindens() - amount;
+        long newOwed = user.getPenaltyBalanceOwed() - amount;
+        user.setBalanceLindens(newBalance);
+        user.setPenaltyBalanceOwed(newOwed);
+        userRepository.save(user);
+
+        UserLedgerEntry entry = ledgerRepository.save(UserLedgerEntry.builder()
+                .userId(userId)
+                .entryType(UserLedgerEntryType.PENALTY_DEBIT)
+                .amount(amount)
+                .balanceAfter(newBalance)
+                .reservedAfter(user.getReservedLindens())
+                .idempotencyKey(idempotencyKey)
+                .refType("PENALTY")
+                .createdAt(OffsetDateTime.now(clock))
+                .build());
+
+        log.info("penalty debit: userId={}, amount={}, newOwed={}, ledgerId={}",
+                userId, amount, newOwed, entry.getId());
+        return PenaltyDebitResult.ok(user, entry);
+    }
+
+    /* ========================================================== */
+    /* RESERVATION SWAP (called from BidService)                   */
+    /* ========================================================== */
+
+    /**
+     * Swap a bid reservation: release the prior high bidder's reservation
+     * (if any) and create the new bidder's reservation. Caller must
+     * already hold {@code PESSIMISTIC_WRITE} locks on the auction and
+     * affected user rows in ascending user_id order.
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
+    public ReservationSwapResult swapReservation(
+            Long auctionId, User newBidder, long newBidAmount,
+            BidReservation priorReservation, Long newBidId) {
+        if (newBidAmount <= 0) {
+            throw new IllegalArgumentException("newBidAmount must be positive: " + newBidAmount);
+        }
+        if (newBidder.availableLindens() < newBidAmount) {
+            throw new InsufficientAvailableBalanceException(newBidder.availableLindens(), newBidAmount);
+        }
+        OffsetDateTime now = OffsetDateTime.now(clock);
+
+        if (priorReservation != null) {
+            User priorUser = userRepository.findByIdForUpdate(priorReservation.getUserId())
+                    .orElseThrow();
+            priorReservation.setReleasedAt(now);
+            priorReservation.setReleaseReason(BidReservationReleaseReason.OUTBID);
+            reservationRepository.save(priorReservation);
+            priorUser.setReservedLindens(priorUser.getReservedLindens() - priorReservation.getAmount());
+            userRepository.save(priorUser);
+            ledgerRepository.save(UserLedgerEntry.builder()
+                    .userId(priorUser.getId())
+                    .entryType(UserLedgerEntryType.BID_RELEASED)
+                    .amount(priorReservation.getAmount())
+                    .balanceAfter(priorUser.getBalanceLindens())
+                    .reservedAfter(priorUser.getReservedLindens())
+                    .refType("BID")
+                    .refId(priorReservation.getBidId())
+                    .createdAt(now)
+                    .build());
+        }
+
+        BidReservation newRes = reservationRepository.save(BidReservation.builder()
+                .userId(newBidder.getId())
+                .auctionId(auctionId)
+                .bidId(newBidId)
+                .amount(newBidAmount)
+                .createdAt(now)
+                .build());
+        newBidder.setReservedLindens(newBidder.getReservedLindens() + newBidAmount);
+        userRepository.save(newBidder);
+        ledgerRepository.save(UserLedgerEntry.builder()
+                .userId(newBidder.getId())
+                .entryType(UserLedgerEntryType.BID_RESERVED)
+                .amount(newBidAmount)
+                .balanceAfter(newBidder.getBalanceLindens())
+                .reservedAfter(newBidder.getReservedLindens())
+                .refType("BID")
+                .refId(newBidId)
+                .createdAt(now)
+                .build());
+
+        return new ReservationSwapResult(newRes, priorReservation);
+    }
+
+    /* ========================================================== */
+    /* AUCTION-END AUTO-FUND (called from AuctionEndTask)          */
+    /* ========================================================== */
+
+    /**
+     * Consume the winner's reservation and debit balance for the auction
+     * close. Caller must hold locks on auction + winner's user row. Throws
+     * {@link BidReservationAmountMismatchException} on system-integrity
+     * defect — caller catches + freezes the escrow.
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void autoFundEscrow(Long auctionId, User winner, long finalBidAmount, Long escrowId) {
+        BidReservation reservation = reservationRepository.findActiveForAuction(auctionId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "auto-fund called without active reservation: auctionId=" + auctionId));
+        if (!reservation.getUserId().equals(winner.getId())) {
+            throw new IllegalStateException(
+                    "active reservation user != winner: reservation.userId="
+                            + reservation.getUserId() + ", winner.id=" + winner.getId());
+        }
+        if (reservation.getAmount() != finalBidAmount) {
+            throw new BidReservationAmountMismatchException(
+                    reservation.getAmount(), finalBidAmount);
+        }
+
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        reservation.setReleasedAt(now);
+        reservation.setReleaseReason(BidReservationReleaseReason.ESCROW_FUNDED);
+        reservationRepository.save(reservation);
+
+        long balanceAfter = winner.getBalanceLindens() - finalBidAmount;
+        long reservedAfter = winner.getReservedLindens() - reservation.getAmount();
+        winner.setBalanceLindens(balanceAfter);
+        winner.setReservedLindens(reservedAfter);
+        userRepository.save(winner);
+
+        ledgerRepository.save(UserLedgerEntry.builder()
+                .userId(winner.getId())
+                .entryType(UserLedgerEntryType.BID_RELEASED)
+                .amount(reservation.getAmount())
+                .balanceAfter(balanceAfter)
+                .reservedAfter(reservedAfter)
+                .refType("BID")
+                .refId(reservation.getBidId())
+                .createdAt(now)
+                .build());
+        ledgerRepository.save(UserLedgerEntry.builder()
+                .userId(winner.getId())
+                .entryType(UserLedgerEntryType.ESCROW_DEBIT)
+                .amount(finalBidAmount)
+                .balanceAfter(balanceAfter)
+                .reservedAfter(reservedAfter)
+                .refType("ESCROW")
+                .refId(escrowId)
+                .createdAt(now)
+                .build());
+
+        log.info("auto-fund escrow: winnerId={}, escrowId={}, amount={}, balanceAfter={}",
+                winner.getId(), escrowId, finalBidAmount, balanceAfter);
+    }
+
+    /* ========================================================== */
+    /* CREDIT helpers (refund flows)                               */
+    /* ========================================================== */
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void creditEscrowRefund(User user, long amount, Long escrowId) {
+        creditCommon(user, amount, UserLedgerEntryType.ESCROW_REFUND, "ESCROW", escrowId);
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void creditListingFeeRefund(User user, long amount, Long listingFeeRefundId) {
+        creditCommon(user, amount, UserLedgerEntryType.LISTING_FEE_REFUND,
+                "LISTING_FEE_REFUND", listingFeeRefundId);
+    }
+
+    private void creditCommon(User user, long amount, UserLedgerEntryType type,
+            String refType, Long refId) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount must be positive: " + amount);
+        }
+        long newBalance = user.getBalanceLindens() + amount;
+        user.setBalanceLindens(newBalance);
+        userRepository.save(user);
+        ledgerRepository.save(UserLedgerEntry.builder()
+                .userId(user.getId())
+                .entryType(type)
+                .amount(amount)
+                .balanceAfter(newBalance)
+                .reservedAfter(user.getReservedLindens())
+                .refType(refType)
+                .refId(refId)
+                .createdAt(OffsetDateTime.now(clock))
+                .build());
+        log.info("credit {}: userId={}, amount={}, balanceAfter={}, refId={}",
+                type, user.getId(), amount, newBalance, refId);
+    }
+
+    /* ========================================================== */
+    /* DEBIT helper (listing fee)                                  */
+    /* ========================================================== */
+
+    /**
+     * Debit listing fee from the user's wallet. Caller has validated
+     * preconditions (penalty == 0, available >= amount, auction state ==
+     * DRAFT, seller == user).
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void debitListingFee(User user, long amount, Long auctionId) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount must be positive: " + amount);
+        }
+        if (user.availableLindens() < amount) {
+            throw new InsufficientAvailableBalanceException(user.availableLindens(), amount);
+        }
+        long newBalance = user.getBalanceLindens() - amount;
+        user.setBalanceLindens(newBalance);
+        userRepository.save(user);
+        ledgerRepository.save(UserLedgerEntry.builder()
+                .userId(user.getId())
+                .entryType(UserLedgerEntryType.LISTING_FEE_DEBIT)
+                .amount(amount)
+                .balanceAfter(newBalance)
+                .reservedAfter(user.getReservedLindens())
+                .refType("AUCTION")
+                .refId(auctionId)
+                .createdAt(OffsetDateTime.now(clock))
+                .build());
+        log.info("listing fee debit: userId={}, amount={}, auctionId={}, balanceAfter={}",
+                user.getId(), amount, auctionId, newBalance);
+    }
+
+    /* ========================================================== */
+    /* RESERVATION RELEASE (cancellation, ban paths)               */
+    /* ========================================================== */
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void releaseReservationsForAuction(Long auctionId, BidReservationReleaseReason reason) {
+        List<BidReservation> active = reservationRepository.findAllActiveForAuction(auctionId);
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        for (BidReservation r : active) {
+            User u = userRepository.findByIdForUpdate(r.getUserId()).orElseThrow();
+            r.setReleasedAt(now);
+            r.setReleaseReason(reason);
+            reservationRepository.save(r);
+            u.setReservedLindens(u.getReservedLindens() - r.getAmount());
+            userRepository.save(u);
+            ledgerRepository.save(UserLedgerEntry.builder()
+                    .userId(u.getId())
+                    .entryType(UserLedgerEntryType.BID_RELEASED)
+                    .amount(r.getAmount())
+                    .balanceAfter(u.getBalanceLindens())
+                    .reservedAfter(u.getReservedLindens())
+                    .refType("BID")
+                    .refId(r.getBidId())
+                    .description("released by auction event: " + reason.name())
+                    .createdAt(now)
+                    .build());
+        }
+        log.info("released {} reservations for auctionId={}, reason={}",
+                active.size(), auctionId, reason);
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void releaseAllReservationsForUser(Long userId, BidReservationReleaseReason reason) {
+        List<BidReservation> active = reservationRepository.findActiveByUser(userId);
+        if (active.isEmpty()) return;
+        User u = userRepository.findByIdForUpdate(userId).orElseThrow();
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        for (BidReservation r : active) {
+            r.setReleasedAt(now);
+            r.setReleaseReason(reason);
+            reservationRepository.save(r);
+            u.setReservedLindens(u.getReservedLindens() - r.getAmount());
+            ledgerRepository.save(UserLedgerEntry.builder()
+                    .userId(u.getId())
+                    .entryType(UserLedgerEntryType.BID_RELEASED)
+                    .amount(r.getAmount())
+                    .balanceAfter(u.getBalanceLindens())
+                    .reservedAfter(u.getReservedLindens())
+                    .refType("BID")
+                    .refId(r.getBidId())
+                    .description("released by user event: " + reason.name())
+                    .createdAt(now)
+                    .build());
+        }
+        userRepository.save(u);
+        log.info("released {} reservations for userId={}, reason={}",
+                active.size(), userId, reason);
+    }
+
+    /* ========================================================== */
+    /* WITHDRAW callback: success / reverse                        */
+    /* ========================================================== */
+
+    /**
+     * Append a {@code WITHDRAW_COMPLETED} row when the terminal acknowledges
+     * a successful payout. Called by {@code WalletWithdrawalCallbackHandler}.
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void recordWithdrawalSuccess(Long userLedgerEntryId, String slTransactionKey) {
+        UserLedgerEntry queuedRow = ledgerRepository.findById(userLedgerEntryId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "queued withdraw ledger entry not found: id=" + userLedgerEntryId));
+        // Append the COMPLETED row referencing the original.
+        ledgerRepository.save(UserLedgerEntry.builder()
+                .userId(queuedRow.getUserId())
+                .entryType(UserLedgerEntryType.WITHDRAW_COMPLETED)
+                .amount(queuedRow.getAmount())
+                .balanceAfter(queuedRow.getBalanceAfter())
+                .reservedAfter(queuedRow.getReservedAfter())
+                .refType("USER_LEDGER")
+                .refId(queuedRow.getId())
+                .slTransactionId(slTransactionKey)
+                .createdAt(OffsetDateTime.now(clock))
+                .build());
+        log.info("withdraw completed: userId={}, queuedRowId={}, slTxKey={}",
+                queuedRow.getUserId(), queuedRow.getId(), slTransactionKey);
+    }
+
+    /**
+     * Append a {@code WITHDRAW_REVERSED} row + credit balance back when the
+     * terminal cannot fulfill a withdraw after retry exhaustion.
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void recordWithdrawalReversal(Long userLedgerEntryId, String reason) {
+        UserLedgerEntry queuedRow = ledgerRepository.findById(userLedgerEntryId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "queued withdraw ledger entry not found: id=" + userLedgerEntryId));
+        User user = userRepository.findByIdForUpdate(queuedRow.getUserId()).orElseThrow();
+        long newBalance = user.getBalanceLindens() + queuedRow.getAmount();
+        user.setBalanceLindens(newBalance);
+        userRepository.save(user);
+        ledgerRepository.save(UserLedgerEntry.builder()
+                .userId(user.getId())
+                .entryType(UserLedgerEntryType.WITHDRAW_REVERSED)
+                .amount(queuedRow.getAmount())
+                .balanceAfter(newBalance)
+                .reservedAfter(user.getReservedLindens())
+                .refType("USER_LEDGER")
+                .refId(queuedRow.getId())
+                .description("withdrawal reversed: " + reason)
+                .createdAt(OffsetDateTime.now(clock))
+                .build());
+        log.warn("withdraw reversed: userId={}, queuedRowId={}, reason={}",
+                user.getId(), queuedRow.getId(), reason);
+    }
+
+    /* ========================================================== */
+    /* Helpers                                                     */
+    /* ========================================================== */
+
+    /**
+     * Reject if the user's account status disallows wallet operations.
+     * Banned users have a non-null {@code listingSuspensionUntil} in the
+     * future or {@code bannedFromListing=true}; frozen users have a
+     * different signal in some flows. For the wallet model, the gate is
+     * conservative: any "blocked" status fails. The exact field signals
+     * are project-specific — adapt this method as the user-status model
+     * evolves.
+     */
+    private void rejectIfBlocked(User user) {
+        // Phase 1 conservative posture: check bannedFromListing and any
+        // active listing suspension. These are existing User fields.
+        // BANNED/FROZEN are signals; expand as the user-status model grows.
+        if (user.getBannedFromListing() != null && user.getBannedFromListing()) {
+            throw new UserStatusBlockedException(user.getId(), "BANNED_FROM_LISTING");
+        }
+    }
+
+    /* ========================================================== */
+    /* Result types (records)                                      */
+    /* ========================================================== */
+
+    public sealed interface DepositResult {
+        UserLedgerEntry entry();
+
+        static DepositResult ok(User user, UserLedgerEntry entry) {
+            return new Ok(user, entry);
+        }
+
+        static DepositResult replay(UserLedgerEntry entry) {
+            return new Replay(entry);
+        }
+
+        record Ok(User user, UserLedgerEntry entry) implements DepositResult {}
+        record Replay(UserLedgerEntry entry) implements DepositResult {
+            @Override public UserLedgerEntry entry() { return entry; }
+        }
+    }
+
+    public sealed interface WithdrawQueuedResult {
+        UserLedgerEntry entry();
+
+        static WithdrawQueuedResult ok(User user, UserLedgerEntry entry, TerminalCommand cmd) {
+            return new Ok(user, entry, cmd);
+        }
+
+        static WithdrawQueuedResult replay(UserLedgerEntry entry) {
+            return new Replay(entry);
+        }
+
+        record Ok(User user, UserLedgerEntry entry, TerminalCommand command)
+                implements WithdrawQueuedResult {}
+        record Replay(UserLedgerEntry entry) implements WithdrawQueuedResult {
+            @Override public UserLedgerEntry entry() { return entry; }
+        }
+    }
+
+    public sealed interface PenaltyDebitResult {
+        UserLedgerEntry entry();
+
+        static PenaltyDebitResult ok(User user, UserLedgerEntry entry) {
+            return new Ok(user, entry);
+        }
+
+        static PenaltyDebitResult replay(UserLedgerEntry entry) {
+            return new Replay(entry);
+        }
+
+        record Ok(User user, UserLedgerEntry entry) implements PenaltyDebitResult {}
+        record Replay(UserLedgerEntry entry) implements PenaltyDebitResult {
+            @Override public UserLedgerEntry entry() { return entry; }
+        }
+    }
+
+    public record ReservationSwapResult(BidReservation newReservation, BidReservation priorReleased) {}
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/exception/AmountExceedsOwedException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/exception/AmountExceedsOwedException.java
@@ -1,0 +1,25 @@
+package com.slparcelauctions.backend.wallet.exception;
+
+/**
+ * Thrown by {@code WalletService.payPenalty} when {@code amount} exceeds the
+ * user's outstanding {@code penalty_balance_owed}. Partial payments are
+ * permitted up to the owed amount.
+ */
+public class AmountExceedsOwedException extends RuntimeException {
+    private final long owed;
+    private final long requested;
+
+    public AmountExceedsOwedException(long owed, long requested) {
+        super("amount exceeds owed: owed=" + owed + ", requested=" + requested);
+        this.owed = owed;
+        this.requested = requested;
+    }
+
+    public long getOwed() {
+        return owed;
+    }
+
+    public long getRequested() {
+        return requested;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/exception/BidReservationAmountMismatchException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/exception/BidReservationAmountMismatchException.java
@@ -1,0 +1,29 @@
+package com.slparcelauctions.backend.wallet.exception;
+
+/**
+ * Defensive — thrown by {@code WalletService.autoFundEscrow} when a winner's
+ * active reservation does not equal the auction's final-bid amount. Should
+ * be impossible: hard reservation is locked to the bid amount at bid time,
+ * and the bid amount is what becomes {@code finalBidAmount} at close. If
+ * this fires, there's a system-integrity bug — the calling auction-end
+ * task catches and freezes the escrow as {@code FROZEN} for forensics.
+ */
+public class BidReservationAmountMismatchException extends RuntimeException {
+    private final long reservationAmount;
+    private final long finalBidAmount;
+
+    public BidReservationAmountMismatchException(long reservationAmount, long finalBidAmount) {
+        super("BID-RESERVATION-AMOUNT-MISMATCH: reservation=" + reservationAmount
+                + ", finalBid=" + finalBidAmount);
+        this.reservationAmount = reservationAmount;
+        this.finalBidAmount = finalBidAmount;
+    }
+
+    public long getReservationAmount() {
+        return reservationAmount;
+    }
+
+    public long getFinalBidAmount() {
+        return finalBidAmount;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/exception/InsufficientAvailableBalanceException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/exception/InsufficientAvailableBalanceException.java
@@ -1,0 +1,28 @@
+package com.slparcelauctions.backend.wallet.exception;
+
+/**
+ * Thrown when a wallet operation would require more L$ than the user has
+ * available ({@code balance_lindens - reserved_lindens}). Maps to a 422
+ * {@code INSUFFICIENT_AVAILABLE_BALANCE} response on user-facing endpoints
+ * and {@code REFUND_BLOCKED/INSUFFICIENT_BALANCE} on the SL-headers withdraw
+ * endpoint.
+ */
+public class InsufficientAvailableBalanceException extends RuntimeException {
+    private final long available;
+    private final long requested;
+
+    public InsufficientAvailableBalanceException(long available, long requested) {
+        super("insufficient available balance: available=" + available
+                + ", requested=" + requested);
+        this.available = available;
+        this.requested = requested;
+    }
+
+    public long getAvailable() {
+        return available;
+    }
+
+    public long getRequested() {
+        return requested;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/exception/PenaltyOutstandingException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/exception/PenaltyOutstandingException.java
@@ -1,0 +1,21 @@
+package com.slparcelauctions.backend.wallet.exception;
+
+/**
+ * Thrown when a user with an outstanding penalty attempts a new commitment
+ * (bid, BIN, listing publish). Penalty does not block deposits, withdraws,
+ * existing-commitment fulfillment, or paying the penalty itself.
+ *
+ * <p>Maps to 422 {@code PENALTY_OUTSTANDING} on the affected endpoints.
+ */
+public class PenaltyOutstandingException extends RuntimeException {
+    private final long owed;
+
+    public PenaltyOutstandingException(long owed) {
+        super("user has outstanding penalty: owed=" + owed);
+        this.owed = owed;
+    }
+
+    public long getOwed() {
+        return owed;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/exception/UserNotLinkedException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/exception/UserNotLinkedException.java
@@ -1,0 +1,22 @@
+package com.slparcelauctions.backend.wallet.exception;
+
+import java.util.UUID;
+
+/**
+ * Thrown by {@code WalletService.deposit} when the SL avatar UUID who paid
+ * the terminal does not match a verified SLPA user. The terminal-side
+ * response is {@code REFUND/UNKNOWN_PAYER} — the LSL script bounces the L$
+ * via {@code llTransferLindenDollars}.
+ */
+public class UserNotLinkedException extends RuntimeException {
+    private final UUID payerUuid;
+
+    public UserNotLinkedException(UUID payerUuid) {
+        super("no SLPA user linked to SL avatar UUID " + payerUuid);
+        this.payerUuid = payerUuid;
+    }
+
+    public UUID getPayerUuid() {
+        return payerUuid;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/exception/UserStatusBlockedException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/exception/UserStatusBlockedException.java
@@ -1,0 +1,27 @@
+package com.slparcelauctions.backend.wallet.exception;
+
+/**
+ * Thrown when a wallet operation is rejected because the user's account
+ * status disallows it (banned / frozen / suspended). The terminal-side
+ * response on {@code /sl/wallet/deposit} is {@code REFUND/USER_FROZEN}; on
+ * {@code /sl/wallet/withdraw-request} it is {@code REFUND_BLOCKED/USER_FROZEN}.
+ * On user-facing endpoints, maps to 403.
+ */
+public class UserStatusBlockedException extends RuntimeException {
+    private final Long userId;
+    private final String status;
+
+    public UserStatusBlockedException(Long userId, String status) {
+        super("user status blocks wallet operation: userId=" + userId + ", status=" + status);
+        this.userId = userId;
+        this.status = status;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/exception/WalletExceptionHandler.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/exception/WalletExceptionHandler.java
@@ -1,0 +1,75 @@
+package com.slparcelauctions.backend.wallet.exception;
+
+import java.net.URI;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Maps wallet-domain exceptions to HTTP wire shapes.
+ *
+ * <p>Scoped to the wallet package so a stray {@code IllegalArgumentException}
+ * from an unrelated layer doesn't accidentally get caught here.
+ *
+ * <p>Note: SL-headers controllers ({@code /sl/wallet/...}) catch their own
+ * exceptions and return {@link com.slparcelauctions.backend.wallet.sl.SlWalletResponse}
+ * shapes directly — this advice only maps user-facing endpoint exceptions.
+ */
+@RestControllerAdvice(basePackages = "com.slparcelauctions.backend.wallet.me")
+@Order(Ordered.HIGHEST_PRECEDENCE + 10)
+@Slf4j
+public class WalletExceptionHandler {
+
+    @ExceptionHandler(InsufficientAvailableBalanceException.class)
+    public ProblemDetail handleInsufficientBalance(
+            InsufficientAvailableBalanceException e, HttpServletRequest req) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(
+                HttpStatus.UNPROCESSABLE_ENTITY, e.getMessage());
+        pd.setTitle("Insufficient available balance");
+        pd.setInstance(URI.create(req.getRequestURI()));
+        pd.setProperty("code", "INSUFFICIENT_AVAILABLE_BALANCE");
+        pd.setProperty("available", e.getAvailable());
+        pd.setProperty("requested", e.getRequested());
+        return pd;
+    }
+
+    @ExceptionHandler(PenaltyOutstandingException.class)
+    public ProblemDetail handlePenalty(PenaltyOutstandingException e, HttpServletRequest req) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(
+                HttpStatus.UNPROCESSABLE_ENTITY, e.getMessage());
+        pd.setTitle("Penalty outstanding");
+        pd.setInstance(URI.create(req.getRequestURI()));
+        pd.setProperty("code", "PENALTY_OUTSTANDING");
+        pd.setProperty("owed", e.getOwed());
+        return pd;
+    }
+
+    @ExceptionHandler(AmountExceedsOwedException.class)
+    public ProblemDetail handleAmountExceedsOwed(AmountExceedsOwedException e, HttpServletRequest req) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(
+                HttpStatus.UNPROCESSABLE_ENTITY, e.getMessage());
+        pd.setTitle("Amount exceeds owed");
+        pd.setInstance(URI.create(req.getRequestURI()));
+        pd.setProperty("code", "AMOUNT_EXCEEDS_OWED");
+        pd.setProperty("owed", e.getOwed());
+        pd.setProperty("requested", e.getRequested());
+        return pd;
+    }
+
+    @ExceptionHandler(UserStatusBlockedException.class)
+    public ProblemDetail handleUserBlocked(UserStatusBlockedException e, HttpServletRequest req) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(
+                HttpStatus.FORBIDDEN, e.getMessage());
+        pd.setTitle("User account blocked");
+        pd.setInstance(URI.create(req.getRequestURI()));
+        pd.setProperty("code", "USER_BLOCKED");
+        return pd;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/me/AcceptTermsRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/me/AcceptTermsRequest.java
@@ -1,0 +1,8 @@
+package com.slparcelauctions.backend.wallet.me;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AcceptTermsRequest(
+        @NotBlank @Size(max = 16) String termsVersion
+) { }

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/me/MeWalletController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/me/MeWalletController.java
@@ -1,0 +1,209 @@
+package com.slparcelauctions.backend.wallet.me;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
+import com.slparcelauctions.backend.auction.exception.InvalidAuctionStateException;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import com.slparcelauctions.backend.wallet.UserLedgerEntry;
+import com.slparcelauctions.backend.wallet.UserLedgerRepository;
+import com.slparcelauctions.backend.wallet.WalletService;
+import com.slparcelauctions.backend.wallet.exception.PenaltyOutstandingException;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * User-facing wallet endpoints. JWT-authenticated; user identity is taken
+ * from the principal — never client-supplied. Recipient UUID for any
+ * outbound L$ is always {@code user.slAvatarUuid} (locked at verification).
+ *
+ * <p>See spec §4.2.
+ */
+@RestController
+@RequestMapping("/api/v1/me")
+@RequiredArgsConstructor
+@Slf4j
+public class MeWalletController {
+
+    private final WalletService walletService;
+    private final UserRepository userRepository;
+    private final UserLedgerRepository ledgerRepository;
+    private final AuctionRepository auctionRepository;
+    private final Clock clock;
+
+    @Value("${slpa.listing-fee.amount-lindens:100}")
+    private Long defaultListingFee;
+
+    /* ============================================================ */
+    /* GET /me/wallet                                                */
+    /* ============================================================ */
+
+    @GetMapping("/wallet")
+    @Transactional(readOnly = true)
+    public WalletViewResponse view(@AuthenticationPrincipal AuthPrincipal principal) {
+        User user = userRepository.findById(principal.userId()).orElseThrow();
+        List<UserLedgerEntry> recent = ledgerRepository.findTop50ByUserIdOrderByCreatedAtDesc(principal.userId());
+        return new WalletViewResponse(
+                user.getBalanceLindens(),
+                user.getReservedLindens(),
+                user.availableLindens(),
+                user.getPenaltyBalanceOwed() == null ? 0L : user.getPenaltyBalanceOwed(),
+                user.getWalletTermsAcceptedAt() != null,
+                user.getWalletTermsVersion(),
+                user.getWalletTermsAcceptedAt(),
+                recent.stream().map(MeWalletController::toDto).toList()
+        );
+    }
+
+    private static WalletViewResponse.LedgerEntryDto toDto(UserLedgerEntry e) {
+        return new WalletViewResponse.LedgerEntryDto(
+                e.getId(),
+                e.getEntryType().name(),
+                e.getAmount(),
+                e.getBalanceAfter(),
+                e.getReservedAfter(),
+                e.getRefType(),
+                e.getRefId(),
+                e.getDescription(),
+                e.getCreatedAt()
+        );
+    }
+
+    /* ============================================================ */
+    /* POST /me/wallet/withdraw                                      */
+    /* ============================================================ */
+
+    @PostMapping("/wallet/withdraw")
+    public ResponseEntity<WithdrawApiResponse> withdraw(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @Valid @RequestBody WithdrawApiRequest req) {
+        WalletService.WithdrawQueuedResult result =
+                walletService.withdrawSiteInitiated(principal.userId(), req.amount(), req.idempotencyKey());
+        Long queueId;
+        long newBalance;
+        long newAvailable;
+        String status;
+        if (result instanceof WalletService.WithdrawQueuedResult.Ok ok) {
+            queueId = ok.entry().getId();
+            newBalance = ok.user().getBalanceLindens();
+            newAvailable = ok.user().availableLindens();
+            status = "QUEUED";
+        } else {
+            // Replay
+            queueId = result.entry().getId();
+            User user = userRepository.findById(principal.userId()).orElseThrow();
+            newBalance = user.getBalanceLindens();
+            newAvailable = user.availableLindens();
+            status = "QUEUED_REPLAY";
+        }
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                .body(new WithdrawApiResponse(queueId, newBalance, newAvailable, status));
+    }
+
+    /* ============================================================ */
+    /* POST /me/wallet/pay-penalty                                   */
+    /* ============================================================ */
+
+    @PostMapping("/wallet/pay-penalty")
+    public PayPenaltyApiResponse payPenalty(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @Valid @RequestBody PayPenaltyApiRequest req) {
+        WalletService.PenaltyDebitResult result =
+                walletService.payPenalty(principal.userId(), req.amount(), req.idempotencyKey());
+        User user = result instanceof WalletService.PenaltyDebitResult.Ok ok
+                ? ok.user()
+                : userRepository.findById(principal.userId()).orElseThrow();
+        return new PayPenaltyApiResponse(
+                user.getBalanceLindens(),
+                user.availableLindens(),
+                user.getPenaltyBalanceOwed() == null ? 0L : user.getPenaltyBalanceOwed()
+        );
+    }
+
+    /* ============================================================ */
+    /* POST /me/wallet/accept-terms                                  */
+    /* ============================================================ */
+
+    @PostMapping("/wallet/accept-terms")
+    @Transactional
+    public ResponseEntity<Void> acceptTerms(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @Valid @RequestBody AcceptTermsRequest req) {
+        User user = userRepository.findByIdForUpdate(principal.userId()).orElseThrow();
+        user.setWalletTermsAcceptedAt(OffsetDateTime.now());
+        user.setWalletTermsVersion(req.termsVersion());
+        userRepository.save(user);
+        log.info("user {} accepted wallet ToU version {}", principal.userId(), req.termsVersion());
+        return ResponseEntity.ok().build();
+    }
+
+    /* ============================================================ */
+    /* POST /me/auctions/{id}/pay-listing-fee                        */
+    /* ============================================================ */
+
+    @PostMapping("/auctions/{id}/pay-listing-fee")
+    @Transactional
+    public PayListingFeeResponse payListingFee(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @PathVariable Long id,
+            @Valid @RequestBody PayListingFeeRequest req) {
+
+        Auction auction = auctionRepository.findById(id)
+                .orElseThrow(() -> new AuctionNotFoundException(id));
+        if (!auction.getSeller().getId().equals(principal.userId())) {
+            throw new AuctionNotFoundException(id);  // hide existence to non-owners
+        }
+        if (auction.getStatus() != AuctionStatus.DRAFT) {
+            throw new InvalidAuctionStateException(auction.getId(), auction.getStatus(), "PAY_LISTING_FEE");
+        }
+
+        User user = userRepository.findByIdForUpdate(principal.userId()).orElseThrow();
+
+        long owed = user.getPenaltyBalanceOwed() == null ? 0L : user.getPenaltyBalanceOwed();
+        if (owed > 0) {
+            throw new PenaltyOutstandingException(owed);
+        }
+
+        Long amount = auction.getListingFeeAmt() != null ? auction.getListingFeeAmt() : defaultListingFee;
+
+        // WalletService.debitListingFee validates available >= amount.
+        walletService.debitListingFee(user, amount, auction.getId());
+
+        auction.setListingFeePaid(true);
+        auction.setListingFeeAmt(amount);
+        auction.setListingFeeTxn("wallet:" + req.idempotencyKey());
+        auction.setListingFeePaidAt(OffsetDateTime.now(clock));
+        auction.setStatus(AuctionStatus.DRAFT_PAID);
+        auctionRepository.save(auction);
+
+        log.info("listing fee paid from wallet: auctionId={}, userId={}, amount={}",
+                auction.getId(), user.getId(), amount);
+
+        return new PayListingFeeResponse(
+                user.getBalanceLindens(),
+                user.availableLindens(),
+                AuctionStatus.DRAFT_PAID.name()
+        );
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/me/PayListingFeeRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/me/PayListingFeeRequest.java
@@ -1,0 +1,8 @@
+package com.slparcelauctions.backend.wallet.me;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PayListingFeeRequest(
+        @NotBlank @Size(max = 64) String idempotencyKey
+) { }

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/me/PayListingFeeResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/me/PayListingFeeResponse.java
@@ -1,0 +1,7 @@
+package com.slparcelauctions.backend.wallet.me;
+
+public record PayListingFeeResponse(
+        long newBalance,
+        long newAvailable,
+        String auctionStatus
+) { }

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/me/PayPenaltyApiRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/me/PayPenaltyApiRequest.java
@@ -1,0 +1,11 @@
+package com.slparcelauctions.backend.wallet.me;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record PayPenaltyApiRequest(
+        @NotNull @Min(1) Long amount,
+        @NotBlank @Size(max = 64) String idempotencyKey
+) { }

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/me/PayPenaltyApiResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/me/PayPenaltyApiResponse.java
@@ -1,0 +1,7 @@
+package com.slparcelauctions.backend.wallet.me;
+
+public record PayPenaltyApiResponse(
+        long newBalance,
+        long newAvailable,
+        long newPenaltyOwed
+) { }

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/me/WalletViewResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/me/WalletViewResponse.java
@@ -1,0 +1,32 @@
+package com.slparcelauctions.backend.wallet.me;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * GET /api/v1/me/wallet response. Surfaces the user's wallet state +
+ * recent ledger activity for the dashboard wallet panel.
+ */
+public record WalletViewResponse(
+        long balance,
+        long reserved,
+        long available,
+        long penaltyOwed,
+        boolean termsAccepted,
+        String termsVersion,
+        OffsetDateTime termsAcceptedAt,
+        List<LedgerEntryDto> recentLedger
+) {
+
+    public record LedgerEntryDto(
+            Long id,
+            String entryType,
+            long amount,
+            long balanceAfter,
+            long reservedAfter,
+            String refType,
+            Long refId,
+            String description,
+            OffsetDateTime createdAt
+    ) { }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/me/WithdrawApiRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/me/WithdrawApiRequest.java
@@ -1,0 +1,15 @@
+package com.slparcelauctions.backend.wallet.me;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Body of {@code POST /api/v1/me/wallet/withdraw}. Recipient is NEVER in
+ * the body — the backend pins it to {@code user.slAvatarUuid}.
+ */
+public record WithdrawApiRequest(
+        @NotNull @Min(1) Long amount,
+        @NotBlank @Size(max = 64) String idempotencyKey
+) { }

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/me/WithdrawApiResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/me/WithdrawApiResponse.java
@@ -1,0 +1,8 @@
+package com.slparcelauctions.backend.wallet.me;
+
+public record WithdrawApiResponse(
+        long queueId,
+        long newBalance,
+        long newAvailable,
+        String status
+) { }

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/sl/SlWalletController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/sl/SlWalletController.java
@@ -1,0 +1,121 @@
+package com.slparcelauctions.backend.wallet.sl;
+
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.escrow.terminal.TerminalRepository;
+import com.slparcelauctions.backend.escrow.terminal.TerminalService;
+import com.slparcelauctions.backend.sl.SlHeaderValidator;
+import com.slparcelauctions.backend.wallet.WalletService;
+import com.slparcelauctions.backend.wallet.exception.InsufficientAvailableBalanceException;
+import com.slparcelauctions.backend.wallet.exception.UserNotLinkedException;
+import com.slparcelauctions.backend.wallet.exception.UserStatusBlockedException;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * SL-headers-gated wallet endpoints called by the in-world SLPA Terminal.
+ *
+ * <p>{@code POST /api/v1/sl/wallet/deposit} — terminal posts after a
+ * {@code money()} event. Returns {@code OK} on credit, {@code REFUND} on
+ * unknown payer / banned user (LSL bounces the L$), or {@code ERROR} on
+ * auth failures (LSL does NOT bounce).
+ *
+ * <p>{@code POST /api/v1/sl/wallet/withdraw-request} — terminal posts after
+ * touch-confirmed withdraw. Returns {@code OK + queueId} on debit-and-queue,
+ * {@code REFUND_BLOCKED} on insufficient balance / not linked / frozen user
+ * (LSL does NOT bounce — no L$ was paid in this flow), or {@code ERROR} on
+ * auth failures.
+ *
+ * <p>See spec §4.1.
+ */
+@RestController
+@RequestMapping("/api/v1/sl/wallet")
+@RequiredArgsConstructor
+@Slf4j
+public class SlWalletController {
+
+    private final WalletService walletService;
+    private final TerminalService terminalService;
+    private final TerminalRepository terminalRepository;
+    private final SlHeaderValidator headerValidator;
+
+    @PostMapping("/deposit")
+    public SlWalletResponse deposit(
+            @RequestHeader(value = "X-SecondLife-Shard", required = false) String shard,
+            @RequestHeader(value = "X-SecondLife-Owner-Key", required = false) String ownerKey,
+            @Valid @RequestBody SlWalletDepositRequest req) {
+        headerValidator.validate(shard, ownerKey);
+        terminalService.assertSharedSecret(req.sharedSecret());
+        if (!terminalRepository.existsById(req.terminalId())) {
+            return SlWalletResponse.error(SlWalletResponseReason.UNKNOWN_TERMINAL,
+                    "terminalId not registered");
+        }
+
+        UUID payerUuid;
+        try {
+            payerUuid = UUID.fromString(req.payerUuid());
+        } catch (IllegalArgumentException e) {
+            return SlWalletResponse.error(SlWalletResponseReason.UNKNOWN_TERMINAL,
+                    "payerUuid not parseable as UUID");
+        }
+
+        try {
+            walletService.deposit(payerUuid, req.amount(), req.slTransactionKey());
+            return SlWalletResponse.ok();
+        } catch (UserNotLinkedException e) {
+            return SlWalletResponse.refund(SlWalletResponseReason.UNKNOWN_PAYER,
+                    "no SLPA account linked to this avatar");
+        } catch (UserStatusBlockedException e) {
+            return SlWalletResponse.refund(SlWalletResponseReason.USER_FROZEN,
+                    "wallet is currently frozen for this account");
+        }
+    }
+
+    @PostMapping("/withdraw-request")
+    public SlWalletResponse withdrawRequest(
+            @RequestHeader(value = "X-SecondLife-Shard", required = false) String shard,
+            @RequestHeader(value = "X-SecondLife-Owner-Key", required = false) String ownerKey,
+            @Valid @RequestBody SlWalletWithdrawRequest req) {
+        headerValidator.validate(shard, ownerKey);
+        terminalService.assertSharedSecret(req.sharedSecret());
+        if (!terminalRepository.existsById(req.terminalId())) {
+            return SlWalletResponse.error(SlWalletResponseReason.UNKNOWN_TERMINAL,
+                    "terminalId not registered");
+        }
+
+        UUID payerUuid;
+        try {
+            payerUuid = UUID.fromString(req.payerUuid());
+        } catch (IllegalArgumentException e) {
+            return SlWalletResponse.error(SlWalletResponseReason.UNKNOWN_TERMINAL,
+                    "payerUuid not parseable as UUID");
+        }
+
+        try {
+            WalletService.WithdrawQueuedResult result =
+                    walletService.withdrawTouchInitiated(payerUuid, req.amount(), req.slTransactionKey());
+            if (result instanceof WalletService.WithdrawQueuedResult.Ok ok) {
+                return SlWalletResponse.okWithQueue(ok.entry().getId());
+            }
+            // Replay returns the original entry; treat as OK with the same queueId.
+            return SlWalletResponse.okWithQueue(result.entry().getId());
+        } catch (UserNotLinkedException e) {
+            return SlWalletResponse.refundBlocked(SlWalletResponseReason.NOT_LINKED,
+                    "no SLPA account linked to this avatar");
+        } catch (UserStatusBlockedException e) {
+            return SlWalletResponse.refundBlocked(SlWalletResponseReason.USER_FROZEN,
+                    "wallet is currently frozen for this account");
+        } catch (InsufficientAvailableBalanceException e) {
+            return SlWalletResponse.refundBlocked(SlWalletResponseReason.INSUFFICIENT_BALANCE,
+                    "insufficient available balance: " + e.getAvailable());
+        }
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/sl/SlWalletDepositRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/sl/SlWalletDepositRequest.java
@@ -1,0 +1,21 @@
+package com.slparcelauctions.backend.wallet.sl;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Body of {@code POST /api/v1/sl/wallet/deposit}. Posted by the in-world
+ * SLPA Terminal's {@code money()} handler.
+ *
+ * <p>{@code slTransactionKey} is the LSL {@code llGenerateKey()} value
+ * generated once per {@code money()} event and reused across retries —
+ * deduplicates retry storms.
+ */
+public record SlWalletDepositRequest(
+        @NotBlank String payerUuid,
+        @NotNull @Min(1) Long amount,
+        @NotBlank String slTransactionKey,
+        @NotBlank String terminalId,
+        @NotBlank String sharedSecret
+) { }

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/sl/SlWalletResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/sl/SlWalletResponse.java
@@ -1,0 +1,48 @@
+package com.slparcelauctions.backend.wallet.sl;
+
+/**
+ * LSL-parsable response shape for SL-headers-gated wallet endpoints.
+ *
+ * <p>{@code status} branching:
+ * <ul>
+ *   <li>{@code OK} — operation completed; L$ flowed as expected.</li>
+ *   <li>{@code REFUND} — the deposit endpoint received valid L$ but
+ *       cannot honor it (unknown payer, banned user). The LSL script MUST
+ *       call {@code llTransferLindenDollars} to bounce the L$ to the payer.</li>
+ *   <li>{@code REFUND_BLOCKED} — the withdraw-request endpoint declined
+ *       the request (insufficient balance, frozen user). The LSL script
+ *       does NOT call {@code llTransferLindenDollars} — no L$ was paid in
+ *       this flow, nothing to bounce.</li>
+ *   <li>{@code ERROR} — request failed validation before any L$ logic
+ *       (bad headers, secret mismatch, unknown terminal). LSL does NOT
+ *       refund — could be an attacker probing.</li>
+ * </ul>
+ *
+ * <p>See spec docs/superpowers/specs/2026-04-30-wallet-model-design.md §4.1.
+ */
+public record SlWalletResponse(
+        String status,
+        String reason,
+        String message,
+        Long queueId
+) {
+    public static SlWalletResponse ok() {
+        return new SlWalletResponse("OK", null, null, null);
+    }
+
+    public static SlWalletResponse okWithQueue(long queueId) {
+        return new SlWalletResponse("OK", null, null, queueId);
+    }
+
+    public static SlWalletResponse refund(SlWalletResponseReason reason, String message) {
+        return new SlWalletResponse("REFUND", reason.name(), message, null);
+    }
+
+    public static SlWalletResponse refundBlocked(SlWalletResponseReason reason, String message) {
+        return new SlWalletResponse("REFUND_BLOCKED", reason.name(), message, null);
+    }
+
+    public static SlWalletResponse error(SlWalletResponseReason reason, String message) {
+        return new SlWalletResponse("ERROR", reason.name(), message, null);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/sl/SlWalletResponseReason.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/sl/SlWalletResponseReason.java
@@ -1,0 +1,30 @@
+package com.slparcelauctions.backend.wallet.sl;
+
+/**
+ * Machine-readable reasons for {@link SlWalletResponse}. Grouped by the
+ * status they accompany:
+ *
+ * <ul>
+ *   <li><b>REFUND (deposit only)</b>: {@link #UNKNOWN_PAYER}, {@link #USER_FROZEN}.
+ *       Terminal MUST {@code llTransferLindenDollars} the L$ back.</li>
+ *   <li><b>REFUND_BLOCKED (withdraw-request only)</b>:
+ *       {@link #INSUFFICIENT_BALANCE}, {@link #USER_FROZEN}, {@link #NOT_LINKED}.
+ *       Terminal does NOT refund — no L$ was paid.</li>
+ *   <li><b>ERROR (any)</b>: {@link #BAD_HEADERS}, {@link #SECRET_MISMATCH},
+ *       {@link #UNKNOWN_TERMINAL}. Terminal does NOT refund (attacker-probe
+ *       defense).</li>
+ * </ul>
+ */
+public enum SlWalletResponseReason {
+    // REFUND variants (deposit)
+    UNKNOWN_PAYER,
+    // REFUND_BLOCKED variants (withdraw-request)
+    INSUFFICIENT_BALANCE,
+    NOT_LINKED,
+    // Shared (REFUND + REFUND_BLOCKED)
+    USER_FROZEN,
+    // ERROR variants
+    BAD_HEADERS,
+    SECRET_MISMATCH,
+    UNKNOWN_TERMINAL
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/sl/SlWalletWithdrawRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/sl/SlWalletWithdrawRequest.java
@@ -1,0 +1,20 @@
+package com.slparcelauctions.backend.wallet.sl;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Body of {@code POST /api/v1/sl/wallet/withdraw-request}. Posted by the
+ * SLPA Terminal after the touch-confirmed withdraw flow. Recipient is
+ * identified by {@code payerUuid} (the toucher) and the actual recipient
+ * UUID for the {@code TerminalCommand} is always
+ * {@code user.slAvatarUuid} (locked at verification, never client-supplied).
+ */
+public record SlWalletWithdrawRequest(
+        @NotBlank String payerUuid,
+        @NotNull @Min(1) Long amount,
+        @NotBlank String slTransactionKey,
+        @NotBlank String terminalId,
+        @NotBlank String sharedSecret
+) { }

--- a/backend/src/main/resources/db/migration/V2__wallet_balance_columns.sql
+++ b/backend/src/main/resources/db/migration/V2__wallet_balance_columns.sql
@@ -12,7 +12,7 @@ ALTER TABLE users
     ADD COLUMN balance_lindens BIGINT NOT NULL DEFAULT 0,
     ADD COLUMN reserved_lindens BIGINT NOT NULL DEFAULT 0,
     ADD COLUMN wallet_dormancy_started_at TIMESTAMPTZ NULL,
-    ADD COLUMN wallet_dormancy_phase SMALLINT NULL,
+    ADD COLUMN wallet_dormancy_phase INTEGER NULL,
     ADD COLUMN wallet_terms_accepted_at TIMESTAMPTZ NULL,
     ADD COLUMN wallet_terms_version VARCHAR(16) NULL;
 

--- a/backend/src/main/resources/db/migration/V2__wallet_balance_columns.sql
+++ b/backend/src/main/resources/db/migration/V2__wallet_balance_columns.sql
@@ -1,0 +1,28 @@
+-- Wallet balance columns on users for the wallet model.
+--
+-- Per spec: docs/superpowers/specs/2026-04-30-wallet-model-design.md §3.1.
+--
+-- balance_lindens         — total wallet balance (available + reserved)
+-- reserved_lindens        — sum of active bid reservations (denormalized;
+--                           sourced from bid_reservations)
+-- wallet_dormancy_*       — dormancy tracking (30d threshold, 4 weekly IMs)
+-- wallet_terms_*          — first-deposit click-through gate
+
+ALTER TABLE users
+    ADD COLUMN balance_lindens BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN reserved_lindens BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN wallet_dormancy_started_at TIMESTAMPTZ NULL,
+    ADD COLUMN wallet_dormancy_phase SMALLINT NULL,
+    ADD COLUMN wallet_terms_accepted_at TIMESTAMPTZ NULL,
+    ADD COLUMN wallet_terms_version VARCHAR(16) NULL;
+
+ALTER TABLE users
+    ADD CONSTRAINT users_balance_nonneg
+        CHECK (balance_lindens >= 0),
+    ADD CONSTRAINT users_reserved_nonneg
+        CHECK (reserved_lindens >= 0),
+    ADD CONSTRAINT users_balance_ge_reserved
+        CHECK (balance_lindens >= reserved_lindens),
+    ADD CONSTRAINT users_dormancy_phase_check
+        CHECK (wallet_dormancy_phase IS NULL
+               OR wallet_dormancy_phase BETWEEN 1 AND 99);

--- a/backend/src/main/resources/db/migration/V3__user_ledger.sql
+++ b/backend/src/main/resources/db/migration/V3__user_ledger.sql
@@ -1,0 +1,49 @@
+-- Per-user wallet ledger (append-only).
+--
+-- Per spec: docs/superpowers/specs/2026-04-30-wallet-model-design.md §3.2.
+--
+-- Every L$ movement to/from a user's wallet appends a row here. The ledger
+-- is the source of truth for wallet state; users.balance_lindens and
+-- users.reserved_lindens are denorms. Reconciliation verifies them daily.
+--
+-- amount is always positive; direction is implicit in entry_type.
+-- balance_after / reserved_after are snapshots written at insert time.
+--
+-- sl_transaction_id (LSL llGenerateKey()) deduplicates terminal-side retries.
+-- idempotency_key (client-supplied) deduplicates frontend / admin retries.
+-- Both are UNIQUE WHERE NOT NULL — duplicate inserts fail loudly.
+
+CREATE TABLE user_ledger (
+    id                  BIGSERIAL PRIMARY KEY,
+    user_id             BIGINT NOT NULL REFERENCES users(id),
+    entry_type          VARCHAR(32) NOT NULL,
+    amount              BIGINT NOT NULL CHECK (amount > 0),
+    balance_after       BIGINT NOT NULL,
+    reserved_after      BIGINT NOT NULL,
+    ref_type            VARCHAR(32) NULL,
+    ref_id              BIGINT NULL,
+    sl_transaction_id   VARCHAR(36) NULL,
+    idempotency_key     VARCHAR(64) NULL,
+    description         VARCHAR(500) NULL,
+    created_at          TIMESTAMPTZ NOT NULL,
+    created_by_admin_id BIGINT NULL REFERENCES users(id),
+
+    CONSTRAINT user_ledger_entry_type_check CHECK (entry_type IN (
+        'DEPOSIT',
+        'WITHDRAW_QUEUED', 'WITHDRAW_COMPLETED', 'WITHDRAW_REVERSED',
+        'BID_RESERVED', 'BID_RELEASED',
+        'ESCROW_DEBIT', 'ESCROW_REFUND',
+        'LISTING_FEE_DEBIT', 'LISTING_FEE_REFUND',
+        'PENALTY_DEBIT',
+        'ADJUSTMENT'
+    ))
+);
+
+CREATE INDEX user_ledger_user_created_idx
+    ON user_ledger (user_id, created_at DESC);
+
+CREATE UNIQUE INDEX user_ledger_sl_tx_idx
+    ON user_ledger (sl_transaction_id) WHERE sl_transaction_id IS NOT NULL;
+
+CREATE UNIQUE INDEX user_ledger_idempotency_idx
+    ON user_ledger (idempotency_key) WHERE idempotency_key IS NOT NULL;

--- a/backend/src/main/resources/db/migration/V4__bid_reservations.sql
+++ b/backend/src/main/resources/db/migration/V4__bid_reservations.sql
@@ -1,0 +1,52 @@
+-- Active bid reservations for the wallet model's hard-reservation bid flow.
+--
+-- Per spec: docs/superpowers/specs/2026-04-30-wallet-model-design.md §3.3.
+--
+-- One row per (user, auction) bid reservation. When user A becomes high
+-- bidder, a row is inserted; when outbid, the row's released_at is set
+-- (with release_reason=OUTBID), and a fresh row is inserted for the new
+-- high bidder. Auction close consumes the winning row by setting
+-- release_reason=ESCROW_FUNDED and decrementing the user's reserved_lindens.
+--
+-- Partial unique index ensures at most one active row per (user, auction).
+
+CREATE TABLE bid_reservations (
+    id              BIGSERIAL PRIMARY KEY,
+    user_id         BIGINT NOT NULL REFERENCES users(id),
+    auction_id      BIGINT NOT NULL REFERENCES auctions(id),
+    bid_id          BIGINT NOT NULL REFERENCES bids(id),
+    amount          BIGINT NOT NULL CHECK (amount > 0),
+    created_at      TIMESTAMPTZ NOT NULL,
+    released_at     TIMESTAMPTZ NULL,
+    release_reason  VARCHAR(32) NULL,
+
+    CONSTRAINT bid_reservations_release_reason_check CHECK (
+        release_reason IS NULL OR release_reason IN (
+            'OUTBID',
+            'AUCTION_CANCELLED',
+            'AUCTION_FRAUD_FREEZE',
+            'AUCTION_BIN_ENDED',
+            'ESCROW_FUNDED',
+            'USER_BANNED'
+        )
+    ),
+
+    CONSTRAINT bid_reservations_release_consistency_check CHECK (
+        (released_at IS NULL AND release_reason IS NULL) OR
+        (released_at IS NOT NULL AND release_reason IS NOT NULL)
+    )
+);
+
+-- Partial unique index: at most one active reservation per (user, auction).
+-- Outbid → release prior, insert new for same user/auction works because
+-- the prior row's released_at is no longer NULL.
+CREATE UNIQUE INDEX bid_reservations_active_idx
+    ON bid_reservations (user_id, auction_id) WHERE released_at IS NULL;
+
+-- Per-user active-reservation lookup (used by /me/wallet endpoints + dormancy).
+CREATE INDEX bid_reservations_user_active_idx
+    ON bid_reservations (user_id) WHERE released_at IS NULL;
+
+-- Per-auction active-reservation lookup (used by bid swap + cancellation).
+CREATE INDEX bid_reservations_auction_active_idx
+    ON bid_reservations (auction_id) WHERE released_at IS NULL;

--- a/backend/src/main/resources/db/migration/V5__reconciliation_extension.sql
+++ b/backend/src/main/resources/db/migration/V5__reconciliation_extension.sql
@@ -1,0 +1,32 @@
+-- Reconciliation extension for the wallet model.
+--
+-- Per spec: docs/superpowers/specs/2026-04-30-wallet-model-design.md §3.4 + §11.
+--
+-- The existing ReconciliationService runs daily and compares
+-- expected_locked_sum (sum of escrows in FUNDED/TRANSFER_PENDING/DISPUTED/
+-- FROZEN states) against the SLPA service avatar's observed L\$ balance.
+--
+-- The wallet model extends this:
+--   - Add wallet_balance_total (SUM(users.balance_lindens))
+--   - Add wallet_reserved_total (sub-breakdown for forensics; not summed
+--     into expected because reservations are inside balance, not separate)
+--   - Add escrow_locked_total (renamed clarity for what expected_locked_sum
+--     already represents — kept as duplicate for back-compat with old runs)
+--   - Add DENORM_DRIFT status for when users.reserved_lindens disagrees
+--     with bid_reservations sum.
+--
+-- After this migration, expected = expected_locked_sum + wallet_balance_total
+-- (computed at run time, not stored).
+
+ALTER TABLE reconciliation_runs
+    ADD COLUMN wallet_balance_total BIGINT NULL,
+    ADD COLUMN wallet_reserved_total BIGINT NULL,
+    ADD COLUMN escrow_locked_total BIGINT NULL;
+
+-- Update status CHECK to include DENORM_DRIFT.
+ALTER TABLE reconciliation_runs
+    DROP CONSTRAINT IF EXISTS reconciliation_runs_status_check;
+
+ALTER TABLE reconciliation_runs
+    ADD CONSTRAINT reconciliation_runs_status_check
+        CHECK (status IN ('BALANCED', 'MISMATCH', 'ERROR', 'DENORM_DRIFT'));

--- a/docs/superpowers/plans/2026-04-30-wallet-model.md
+++ b/docs/superpowers/plans/2026-04-30-wallet-model.md
@@ -1,0 +1,1536 @@
+# Wallet Model Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the per-obligation in-world payment flow (escrow / listing-fee / penalty paid at the terminal) with a per-user L$ wallet that supports deposits via lockless `money()` reentrancy, hard-reservations on bids, auto-funded escrow at auction close, refund-as-credit, and withdrawals routed to the user's verified SL avatar.
+
+**Architecture:** Single feature branch (`feat/wallet-model` off `dev`) with destructive Flyway migrations (no live customers → schema-rollback safety not required). New `com.slparcelauctions.backend.wallet` package mirrors the established vertical-slice pattern. Existing `EscrowTransaction` per-escrow ledger stays; new `user_ledger` per-user append-only ledger sits above it; reconciliation job extends to validate both. LSL terminal rewrite uses single shared listen + per-flow withdraw slots (no terminal-wide lock). Path A rollout: iterate on prod, RDS snapshot before deploy, `git revert` if abandoned.
+
+**Tech Stack:** Spring Boot 4 / Java 26 / Flyway / Hibernate (validate-mode) / Lombok / JUnit 5 / Mockito / Spring WebFlux WebClient / STOMP / Next.js 16 / React 19 / TypeScript 5 / React Query / Tailwind 4 / LSL (Mainland-only).
+
+**Spec authority:** `docs/superpowers/specs/2026-04-30-wallet-model-design.md`.
+
+---
+
+## Phase ordering
+
+```
+Phase 1: Schema & entities          (compiles cleanly; no behavior yet)
+Phase 2: WalletService primitives   (deposit, withdraw, debit, credit, swap)
+Phase 3: SL-headers controllers     (deposit, withdraw-request)
+Phase 4: User-facing controllers    (wallet view, withdraw, pay-penalty, accept-terms, pay-listing-fee)
+Phase 5: Bid + BIN integration      (preconditions + reservation swap)
+Phase 6: Auction-end auto-fund      (escrow auto-fund; ESCROW_PENDING retired)
+Phase 7: Refund-as-credit           (escrow + listing-fee refunds → wallet credits)
+Phase 8: Remove retired endpoints   (4 SL-headers payment endpoints)
+Phase 9: Reconciliation extension   (wallet sums, denorm-drift)
+Phase 10: Dormancy + login handler  (30d + 4 weekly IMs + auto-return)
+Phase 11: Frontend wallet UI        (panel, dialogs, flow updates)
+Phase 12: LSL rewrites              (terminal + verifier-giver)
+Phase 13: Postman collection        (Wallet folder, retire 4 folders)
+Phase 14: Documentation sweep       (READMEs, CONVENTIONS, FOOTGUNS, DEFERRED)
+Phase 15: Smoke verification + PRs  (PR feat → dev, PR dev → main, smoke)
+```
+
+Phases 1-10 are backend; can run sequentially. Phase 11 (frontend) blocks on backend API shapes from phases 3-7. Phase 12 (LSL) blocks on phase 3 endpoint shapes. Phases 13-14 are wrap-up; can run in parallel with phase 12. Phase 15 is integration + handoff.
+
+---
+
+## Phase 1 — Schema & entities
+
+### Task 1.1: Create Flyway migration `V<N>__wallet_balance_columns.sql`
+
+**Files:**
+- Create: `backend/src/main/resources/db/migration/V<next>__wallet_balance_columns.sql` (use the next-available V-number — check the existing migration directory and pick next)
+
+**Acceptance:** Migration adds the wallet columns to `users` with constraints and indexes. Hibernate `validate` mode passes after entity additions in Task 1.2.
+
+**Migration content:**
+```sql
+ALTER TABLE users
+    ADD COLUMN balance_lindens BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN reserved_lindens BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN wallet_dormancy_started_at TIMESTAMPTZ NULL,
+    ADD COLUMN wallet_dormancy_phase SMALLINT NULL,
+    ADD COLUMN wallet_terms_accepted_at TIMESTAMPTZ NULL,
+    ADD COLUMN wallet_terms_version VARCHAR(16) NULL;
+
+ALTER TABLE users
+    ADD CONSTRAINT users_balance_nonneg CHECK (balance_lindens >= 0),
+    ADD CONSTRAINT users_reserved_nonneg CHECK (reserved_lindens >= 0),
+    ADD CONSTRAINT users_balance_ge_reserved CHECK (balance_lindens >= reserved_lindens),
+    ADD CONSTRAINT users_dormancy_phase_check
+        CHECK (wallet_dormancy_phase IS NULL OR wallet_dormancy_phase BETWEEN 1 AND 99);
+```
+
+`99` is reserved for `COMPLETED`; valid runtime values are 1-4 plus 99.
+
+- [ ] Step 1.1.1: Verify next available `V<N>` number by listing existing migrations.
+- [ ] Step 1.1.2: Create the migration file with the SQL above.
+- [ ] Step 1.1.3: Run backend test suite — Hibernate validate will fail because entities don't have these fields yet (expected; Task 1.2 fixes).
+- [ ] Step 1.1.4: Commit: `feat(wallet): add balance/reserved/dormancy columns to users`.
+
+### Task 1.2: Add wallet columns to `User` entity
+
+**Files:**
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/user/User.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/user/dto/UserResponse.java` (extend with `balanceLindens`, `reservedLindens`, `availableLindens` if it makes sense, or keep wallet response separate per Task 4.1)
+
+**Code additions to `User.java`:**
+```java
+@Column(name = "balance_lindens", nullable = false)
+@Builder.Default
+private Long balanceLindens = 0L;
+
+@Column(name = "reserved_lindens", nullable = false)
+@Builder.Default
+private Long reservedLindens = 0L;
+
+@Column(name = "wallet_dormancy_started_at")
+private OffsetDateTime walletDormancyStartedAt;
+
+@Column(name = "wallet_dormancy_phase")
+private Integer walletDormancyPhase;
+
+@Column(name = "wallet_terms_accepted_at")
+private OffsetDateTime walletTermsAcceptedAt;
+
+@Column(name = "wallet_terms_version", length = 16)
+private String walletTermsVersion;
+
+@Transient
+public long availableLindens() {
+    return balanceLindens - reservedLindens;
+}
+```
+
+- [ ] Step 1.2.1: Add the columns and the `availableLindens()` derived getter.
+- [ ] Step 1.2.2: Run backend tests — should pass `validate`. Existing tests should still work since defaults are `0L`.
+- [ ] Step 1.2.3: Commit: `feat(wallet): add wallet fields to User entity`.
+
+### Task 1.3: Create `user_ledger` migration + `UserLedgerEntry` entity + repository
+
+**Files:**
+- Create: `backend/src/main/resources/db/migration/V<next>__user_ledger.sql`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerEntry.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerEntryType.java` (enum)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerRepository.java`
+
+**Migration:** see spec §3.2 SQL block. Verbatim.
+
+**Enum values:**
+```
+DEPOSIT, WITHDRAW_QUEUED, WITHDRAW_COMPLETED, WITHDRAW_REVERSED,
+BID_RESERVED, BID_RELEASED,
+ESCROW_DEBIT, ESCROW_REFUND,
+LISTING_FEE_DEBIT, LISTING_FEE_REFUND,
+PENALTY_DEBIT,
+ADJUSTMENT
+```
+
+**Entity skeleton:**
+```java
+@Entity
+@Table(name = "user_ledger", indexes = {
+    @Index(name = "user_ledger_user_created_idx", columnList = "user_id, created_at DESC")
+})
+@Getter @NoArgsConstructor @AllArgsConstructor @Builder
+public class UserLedgerEntry {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "entry_type", nullable = false, length = 32)
+    private UserLedgerEntryType entryType;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column(name = "balance_after", nullable = false)
+    private Long balanceAfter;
+
+    @Column(name = "reserved_after", nullable = false)
+    private Long reservedAfter;
+
+    @Column(name = "ref_type", length = 32)
+    private String refType;
+
+    @Column(name = "ref_id")
+    private Long refId;
+
+    @Column(name = "sl_transaction_id", length = 36, unique = true)
+    private String slTransactionId;
+
+    @Column(name = "idempotency_key", length = 64, unique = true)
+    private String idempotencyKey;
+
+    @Column(length = 500)
+    private String description;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "created_by_admin_id")
+    private Long createdByAdminId;
+}
+```
+
+**Repository:**
+```java
+public interface UserLedgerRepository extends JpaRepository<UserLedgerEntry, Long> {
+    Optional<UserLedgerEntry> findBySlTransactionId(String slTransactionId);
+    Optional<UserLedgerEntry> findByIdempotencyKey(String idempotencyKey);
+    List<UserLedgerEntry> findTop50ByUserIdOrderByCreatedAtDesc(Long userId);
+    Page<UserLedgerEntry> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+}
+```
+
+- [ ] Step 1.3.1: Write the migration SQL.
+- [ ] Step 1.3.2: Write the enum, entity, repository.
+- [ ] Step 1.3.3: Slice test (`@DataJpaTest`): insert two `DEPOSIT` rows for same user — assert both persist; assert UNIQUE constraint on `sl_transaction_id` (insert two with same sl_transaction_id → constraint violation).
+- [ ] Step 1.3.4: Commit: `feat(wallet): add user_ledger table + entity + repository`.
+
+### Task 1.4: Create `bid_reservations` migration + entity + repository
+
+**Files:**
+- Create: `backend/src/main/resources/db/migration/V<next>__bid_reservations.sql`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/BidReservation.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/BidReservationReleaseReason.java` (enum)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/BidReservationRepository.java`
+
+**Migration:** see spec §3.3 SQL block. Verbatim.
+
+**Enum:**
+```
+OUTBID, AUCTION_CANCELLED, AUCTION_FRAUD_FREEZE, ESCROW_FUNDED, USER_BANNED
+```
+
+(Plus `AUCTION_BIN_ENDED` — adding here per spec §6.3 to release other users' reservations cleanly when a BIN closes the auction. Update the migration's CHECK constraint to include this value.)
+
+**Repository:**
+```java
+public interface BidReservationRepository extends JpaRepository<BidReservation, Long> {
+    @Query("SELECT br FROM BidReservation br
+            WHERE br.auctionId = :auctionId AND br.releasedAt IS NULL")
+    Optional<BidReservation> findActiveForAuction(@Param("auctionId") Long auctionId);
+
+    @Query("SELECT br FROM BidReservation br
+            WHERE br.userId = :userId AND br.releasedAt IS NULL")
+    List<BidReservation> findActiveByUser(@Param("userId") Long userId);
+
+    @Query("SELECT br FROM BidReservation br
+            WHERE br.auctionId = :auctionId AND br.releasedAt IS NULL")
+    List<BidReservation> findAllActiveForAuction(@Param("auctionId") Long auctionId);
+
+    @Query("SELECT COALESCE(SUM(br.amount), 0) FROM BidReservation br
+            WHERE br.userId = :userId AND br.releasedAt IS NULL")
+    long sumActiveByUser(@Param("userId") Long userId);
+
+    @Query("SELECT br.userId, COALESCE(SUM(br.amount), 0) FROM BidReservation br
+            WHERE br.releasedAt IS NULL GROUP BY br.userId")
+    List<Object[]> sumActiveGroupedByUser();
+}
+```
+
+- [ ] Step 1.4.1: Write migration SQL with the partial unique index.
+- [ ] Step 1.4.2: Write the enum, entity, repository.
+- [ ] Step 1.4.3: Slice test: insert active reservation for (userA, auctionX), confirm second insert for same pair fails the partial unique index. Insert second reservation after marking first `released_at=now` — should succeed.
+- [ ] Step 1.4.4: Commit: `feat(wallet): add bid_reservations table + entity + repository`.
+
+### Task 1.5: Reconciliation schema extension
+
+**Files:**
+- Create: `backend/src/main/resources/db/migration/V<next>__reconciliation_extension.sql`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/reconciliation/ReconciliationRun.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/reconciliation/ReconciliationStatus.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/reconciliation/ReconciliationStatusCheckConstraintInitializer.java`
+
+**Migration:**
+```sql
+ALTER TABLE reconciliation_runs
+    ADD COLUMN wallet_balance_total BIGINT NULL,
+    ADD COLUMN wallet_reserved_total BIGINT NULL,
+    ADD COLUMN escrow_locked_total BIGINT NULL;
+
+ALTER TABLE reconciliation_runs
+    DROP CONSTRAINT IF EXISTS reconciliation_runs_status_check,
+    ADD CONSTRAINT reconciliation_runs_status_check
+        CHECK (status IN ('BALANCED', 'DRIFT', 'ERROR', 'DENORM_DRIFT'));
+```
+
+**Entity:** add the three columns. Update the `ReconciliationStatus` enum to include `DENORM_DRIFT`. Update the constraint initializer if it programmatically refers to the constraint values.
+
+- [ ] Step 1.5.1: Write migration SQL.
+- [ ] Step 1.5.2: Update entity, enum, initializer.
+- [ ] Step 1.5.3: Slice test: insert run row with `status=DENORM_DRIFT` succeeds; with `status=INVALID` fails.
+- [ ] Step 1.5.4: Commit: `feat(reconciliation): add wallet sums + DENORM_DRIFT status`.
+
+### Task 1.6: Retire ESCROW_PENDING + payment_deadline + listing_fee_refunds.terminal_command_id
+
+**Files:**
+- Create: `backend/src/main/resources/db/migration/V<next>__retire_escrow_pending_state.sql`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/escrow/Escrow.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowState.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowRepository.java` (drop the `findExpiredPending` query)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowTimeoutJob.java` (drop the pending-payment branch)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/escrow/dto/EscrowStatusResponse.java` (drop `paymentDeadline` field)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/escrow/broadcast/EscrowCreatedEnvelope.java` (drop `paymentDeadline` field)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/escrow/listingfee/ListingFeeRefund.java` (drop `terminalCommandId` field — to be confirmed by reading the entity)
+
+**Migration:**
+```sql
+-- Defensive: convert any existing in-flight REFUND TerminalCommands to wallet credits.
+-- Expected count = 0 in current dev/prod state.
+DO $$
+DECLARE
+    rec RECORD;
+BEGIN
+    FOR rec IN
+        SELECT * FROM terminal_commands WHERE action = 'REFUND' AND status IN ('QUEUED', 'IN_FLIGHT', 'FAILED')
+    LOOP
+        RAISE NOTICE 'WARN: pre-wallet REFUND command id=% will not be migrated; review manually', rec.id;
+    END LOOP;
+END $$;
+
+-- Defensive cleanup of stale ESCROW_PENDING rows (expected count 0).
+DELETE FROM escrows WHERE state = 'ESCROW_PENDING';
+
+-- Update escrow state CHECK to remove ESCROW_PENDING.
+ALTER TABLE escrows
+    DROP CONSTRAINT IF EXISTS escrows_state_check,
+    ADD CONSTRAINT escrows_state_check
+        CHECK (state IN ('FUNDED', 'TRANSFER_PENDING', 'COMPLETED',
+                         'DISPUTED', 'FROZEN', 'EXPIRED'));
+
+-- Drop the payment_deadline column.
+ALTER TABLE escrows DROP COLUMN payment_deadline;
+DROP INDEX IF EXISTS ix_escrows_payment_deadline;
+
+-- Drop the listing_fee_refunds.terminal_command_id column.
+ALTER TABLE listing_fee_refunds DROP COLUMN IF EXISTS terminal_command_id;
+```
+
+**EscrowState enum changes:** remove the `ESCROW_PENDING` constant.
+
+**EscrowTimeoutJob changes:**
+```java
+@Scheduled(...)
+public void sweep() {
+    OffsetDateTime now = OffsetDateTime.now(clock);
+    // ESCROW_PENDING removed: nothing to expire on the payment-deadline path.
+    escrowRepo.findExpiredTransferPending(now).forEach(timeoutTask::expireTransfer);
+}
+```
+
+- [ ] Step 1.6.1: Write the migration with defensive cleanup.
+- [ ] Step 1.6.2: Drop `ESCROW_PENDING` from `EscrowState` enum.
+- [ ] Step 1.6.3: Drop `findExpiredPending` from `EscrowRepository`.
+- [ ] Step 1.6.4: Update `EscrowTimeoutJob.sweep()` to remove the expired-pending branch.
+- [ ] Step 1.6.5: Drop `paymentDeadline` field + getter/builder method from `Escrow.java`. Search-and-replace any references; deal with breakage.
+- [ ] Step 1.6.6: Drop `paymentDeadline` field from `EscrowStatusResponse` DTO and `EscrowCreatedEnvelope`.
+- [ ] Step 1.6.7: Drop `terminalCommandId` from `ListingFeeRefund` (verify field exists; if it does, drop it).
+- [ ] Step 1.6.8: Run `./mvnw compile` — fix any compile errors from removed enum value / column.
+- [ ] Step 1.6.9: Run full test suite — fix breakage. Tests that referenced `ESCROW_PENDING` or `paymentDeadline` need updates per the new model (auto-fund flow in phase 6).
+- [ ] Step 1.6.10: Commit: `feat(escrow): retire ESCROW_PENDING state and payment_deadline column`.
+
+### Task 1.7: Trim TerminalCommand REFUND action (defensive)
+
+**Files:**
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/escrow/command/TerminalCommandAction.java` (or whatever the enum is named)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/escrow/command/TerminalCommandService.java` (or dispatcher) — add a `CRITICAL` log path for `REFUND` action arrivals (defensive; per spec §9.3 keep for one release cycle)
+
+**Note:** Don't drop `REFUND` from the enum value list — keep it defensively. The dispatcher's switch should log `CRITICAL: unexpected REFUND action received; refunds are now wallet credits` and mark the command FAILED with a clear errorMessage. After one release cycle this can be cleaned up in a follow-up PR.
+
+- [ ] Step 1.7.1: Update the dispatcher's switch to handle `REFUND` defensively (log CRITICAL, mark FAILED).
+- [ ] Step 1.7.2: Add a unit test asserting the defensive branch fires correctly.
+- [ ] Step 1.7.3: Commit: `feat(terminal): defensive REFUND-action handling for wallet model`.
+
+---
+
+## Phase 2 — WalletService primitives
+
+The new `com.slparcelauctions.backend.wallet` package houses all wallet operations. This phase builds the primitives; callers in subsequent phases use them.
+
+### Task 2.1: WalletService interface + skeleton
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/WalletService.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/WalletService.java` (the impl could be the same class — Spring service with `@Service`)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/exception/InsufficientAvailableBalanceException.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/exception/PenaltyOutstandingException.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/exception/AmountExceedsOwedException.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/exception/UserNotLinkedException.java` (used by `/sl/wallet/deposit` for unknown payerUuid path)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/exception/UserStatusBlockedException.java` (banned/frozen)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/exception/IdempotentReplayResult.java` (sealed-marker class for caller-aware replay handling)
+
+**Service skeleton:**
+```java
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WalletService {
+    private final UserRepository userRepository;
+    private final UserLedgerRepository ledgerRepository;
+    private final BidReservationRepository reservationRepository;
+    private final TerminalCommandService terminalCommandService;
+    private final Clock clock;
+
+    @Transactional
+    public DepositResult deposit(...) {...}
+
+    @Transactional
+    public WithdrawQueuedResult withdrawSiteInitiated(...) {...}
+
+    @Transactional
+    public WithdrawQueuedResult withdrawTouchInitiated(...) {...}
+
+    @Transactional
+    public PenaltyDebitResult payPenalty(...) {...}
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public ReservationSwapResult swapReservation(...) {...}
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public EscrowAutoFundResult autoFundEscrow(...) {...}
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void creditEscrowRefund(...) {...}
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void creditListingFeeRefund(...) {...}
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void debitListingFee(...) {...}
+}
+```
+
+The `MANDATORY` propagation marks methods that callers must invoke inside an existing transaction (because they assume locks are held).
+
+- [ ] Step 2.1.1: Create the package, service skeleton, exception classes.
+- [ ] Step 2.1.2: Create result-type DTOs co-located in the wallet package (`DepositResult`, `WithdrawQueuedResult`, `PenaltyDebitResult`, `ReservationSwapResult`, `EscrowAutoFundResult`).
+- [ ] Step 2.1.3: Wire the service via Spring with no method bodies yet (return null / throw UnsupportedOperationException). Compile.
+- [ ] Step 2.1.4: Commit: `feat(wallet): scaffold WalletService package and exception types`.
+
+### Task 2.2: `WalletService.deposit()`
+
+**Files:**
+- Modify: `WalletService.java`
+- Create: `backend/src/test/java/com/slparcelauctions/backend/wallet/WalletServiceDepositTest.java`
+
+**Method:**
+```java
+@Transactional
+public DepositResult deposit(
+    UUID payerUuid, long amount, String slTransactionKey, Long terminalId
+) {
+    // 1. Idempotency replay
+    Optional<UserLedgerEntry> existing = ledgerRepository.findBySlTransactionId(slTransactionKey);
+    if (existing.isPresent()) {
+        return DepositResult.replay(existing.get());
+    }
+
+    // 2. User lookup
+    User user = userRepository.findBySlAvatarUuid(payerUuid)
+        .orElseThrow(() -> new UserNotLinkedException(payerUuid));
+
+    // 3. Status check
+    if (user.getStatus() == UserStatus.BANNED || user.getStatus() == UserStatus.FROZEN) {
+        throw new UserStatusBlockedException(user.getId(), user.getStatus());
+    }
+
+    // 4. Lock + credit
+    User locked = userRepository.findByIdForUpdate(user.getId()).orElseThrow();
+    long newBalance = locked.getBalanceLindens() + amount;
+    locked.setBalanceLindens(newBalance);
+    userRepository.save(locked);
+
+    // 5. Append ledger row
+    UserLedgerEntry entry = UserLedgerEntry.builder()
+        .userId(locked.getId())
+        .entryType(UserLedgerEntryType.DEPOSIT)
+        .amount(amount)
+        .balanceAfter(newBalance)
+        .reservedAfter(locked.getReservedLindens())
+        .slTransactionId(slTransactionKey)
+        .createdAt(OffsetDateTime.now(clock))
+        .build();
+    ledgerRepository.save(entry);
+
+    return DepositResult.ok(locked, entry);
+}
+```
+
+(Need `userRepository.findByIdForUpdate(...)` — if it doesn't exist on the repository, add it: `@Lock(LockModeType.PESSIMISTIC_WRITE) Optional<User> findByIdForUpdate(@Param("id") Long id)`.)
+
+**Tests:** matrix of:
+- Happy path: known verified user, new sl_transaction_id → balance increases, ledger row appended.
+- Replay: same sl_transaction_id called twice → second call returns the original DepositResult; balance only increases once.
+- Unknown payerUuid → `UserNotLinkedException`.
+- Banned user → `UserStatusBlockedException`.
+- Frozen user → `UserStatusBlockedException`.
+
+- [ ] Step 2.2.1: Add `findByIdForUpdate` to `UserRepository` if missing.
+- [ ] Step 2.2.2: Write `WalletServiceDepositTest` with the matrix above (Mockito-based unit tests).
+- [ ] Step 2.2.3: Implement the method. All tests pass.
+- [ ] Step 2.2.4: Commit: `feat(wallet): WalletService.deposit() with idempotent replay`.
+
+### Task 2.3: `WalletService.withdrawSiteInitiated()` and `withdrawTouchInitiated()`
+
+**Files:**
+- Modify: `WalletService.java`
+- Create: `backend/src/test/java/com/slparcelauctions/backend/wallet/WalletServiceWithdrawTest.java`
+
+**Method (site-initiated):**
+```java
+@Transactional
+public WithdrawQueuedResult withdrawSiteInitiated(
+    Long userId, long amount, String idempotencyKey
+) {
+    // Idempotency replay
+    Optional<UserLedgerEntry> existing = ledgerRepository.findByIdempotencyKey(idempotencyKey);
+    if (existing.isPresent()) return WithdrawQueuedResult.replay(existing.get());
+
+    User user = userRepository.findByIdForUpdate(userId).orElseThrow();
+    if (user.getStatus() == BANNED || user.getStatus() == FROZEN) {
+        throw new UserStatusBlockedException(userId, user.getStatus());
+    }
+    if (amount <= 0) throw new IllegalArgumentException("amount must be > 0");
+    if (user.availableLindens() < amount) {
+        throw new InsufficientAvailableBalanceException(user.availableLindens(), amount);
+    }
+
+    // Debit
+    user.setBalanceLindens(user.getBalanceLindens() - amount);
+    userRepository.save(user);
+
+    // Ledger
+    UserLedgerEntry entry = UserLedgerEntry.builder()
+        .userId(userId)
+        .entryType(UserLedgerEntryType.WITHDRAW_QUEUED)
+        .amount(amount)
+        .balanceAfter(user.getBalanceLindens())
+        .reservedAfter(user.getReservedLindens())
+        .idempotencyKey(idempotencyKey)
+        .createdAt(OffsetDateTime.now(clock))
+        .build();
+    ledgerRepository.save(entry);
+
+    // Queue terminal command
+    TerminalCommand cmd = terminalCommandService.queueWithdraw(
+        user.getSlAvatarUuid(), amount, /* idempotency_key auto */
+    );
+
+    return WithdrawQueuedResult.ok(entry, cmd);
+}
+```
+
+**Method (touch-initiated):** identical shape but takes `slTransactionKey` instead of `idempotencyKey`, looks up user by `slAvatarUuid` from the request, returns `REFUND_BLOCKED` semantics where appropriate (caller maps to wire response).
+
+**Tests:**
+- Happy path (site).
+- Happy path (touch).
+- Replay (idempotencyKey → same result; sl_transaction_id → same).
+- Insufficient balance → exception.
+- Banned/frozen user → exception.
+- Negative amount → IllegalArgumentException.
+
+- [ ] Step 2.3.1: Confirm `TerminalCommandService.queueWithdraw(...)` exists or create it.
+- [ ] Step 2.3.2: Write tests.
+- [ ] Step 2.3.3: Implement both methods. Tests pass.
+- [ ] Step 2.3.4: Commit: `feat(wallet): WalletService withdraw paths (site + touch)`.
+
+### Task 2.4: `WalletService.payPenalty()`
+
+**Files:**
+- Modify: `WalletService.java`
+- Create: `backend/src/test/java/com/slparcelauctions/backend/wallet/WalletServicePayPenaltyTest.java`
+
+**Method:**
+```java
+@Transactional
+public PenaltyDebitResult payPenalty(Long userId, long amount, String idempotencyKey) {
+    Optional<UserLedgerEntry> existing = ledgerRepository.findByIdempotencyKey(idempotencyKey);
+    if (existing.isPresent()) return PenaltyDebitResult.replay(existing.get());
+
+    if (amount <= 0) throw new IllegalArgumentException("amount must be > 0");
+
+    User user = userRepository.findByIdForUpdate(userId).orElseThrow();
+    if (amount > user.getPenaltyBalanceOwed()) {
+        throw new AmountExceedsOwedException(user.getPenaltyBalanceOwed(), amount);
+    }
+    if (user.availableLindens() < amount) {
+        throw new InsufficientAvailableBalanceException(user.availableLindens(), amount);
+    }
+
+    user.setBalanceLindens(user.getBalanceLindens() - amount);
+    user.setPenaltyBalanceOwed(user.getPenaltyBalanceOwed() - amount);
+    userRepository.save(user);
+
+    UserLedgerEntry entry = UserLedgerEntry.builder()
+        .userId(userId)
+        .entryType(UserLedgerEntryType.PENALTY_DEBIT)
+        .amount(amount)
+        .balanceAfter(user.getBalanceLindens())
+        .reservedAfter(user.getReservedLindens())
+        .idempotencyKey(idempotencyKey)
+        .refType("PENALTY")
+        .createdAt(OffsetDateTime.now(clock))
+        .build();
+    ledgerRepository.save(entry);
+
+    return PenaltyDebitResult.ok(user, entry);
+}
+```
+
+**Tests:** full payment, partial payment, exceeds-owed, insufficient-available, reserved-blocks-payment (user with all balance reserved cannot pay), idempotent replay.
+
+- [ ] Step 2.4.1: Write tests.
+- [ ] Step 2.4.2: Implement method.
+- [ ] Step 2.4.3: Commit: `feat(wallet): WalletService.payPenalty() with available-balance gate`.
+
+### Task 2.5: `WalletService.swapReservation()`
+
+**Files:**
+- Modify: `WalletService.java`
+- Create: `backend/src/test/java/com/slparcelauctions/backend/wallet/WalletServiceSwapReservationTest.java`
+
+**Method:** see spec §5.4 signature. Key invariants:
+- Caller must have already locked auction + relevant user rows in ascending order.
+- Validates `newBidder.availableLindens() >= newBidAmount`.
+- If `priorReservation != null`: marks released, decrements prior user's `reserved_lindens`, appends `BID_RELEASED` ledger row.
+- Inserts new `BidReservation`, increments new bidder's `reserved_lindens`, appends `BID_RESERVED` ledger row.
+
+**Tests (Mockito + DataJpaTest mix):**
+- No prior bidder, sufficient balance → reserves cleanly.
+- Prior bidder same as new bidder (self-outbid) — should be guarded at the BidService level, but defensive: `swapReservation` accepts `priorReservation.userId == newBidder.id` and produces a clean swap (release prior, reserve new).
+- Prior bidder different from new — both ledger rows for the right users.
+- Insufficient available → throws.
+- Negative amount → IllegalArgumentException.
+
+- [ ] Step 2.5.1: Write tests.
+- [ ] Step 2.5.2: Implement method.
+- [ ] Step 2.5.3: Commit: `feat(wallet): WalletService.swapReservation() for bid hard-reservation`.
+
+### Task 2.6: `WalletService.autoFundEscrow()`
+
+**Files:**
+- Modify: `WalletService.java`
+- Create: `backend/src/test/java/com/slparcelauctions/backend/wallet/WalletServiceAutoFundEscrowTest.java`
+
+**Method:**
+```java
+@Transactional(propagation = MANDATORY)
+public EscrowAutoFundResult autoFundEscrow(Auction auction, User winner, long finalBidAmount, Long escrowId) {
+    // Caller has locked auction + winner.
+    BidReservation reservation = reservationRepository.findActiveForAuction(auction.getId())
+        .orElseThrow(() -> new IllegalStateException(
+            "auto-fund called without active reservation: auctionId=" + auction.getId()));
+    if (reservation.getUserId() != winner.getId()) {
+        throw new IllegalStateException(
+            "active reservation user != winner: reservation.userId=" + reservation.getUserId()
+            + " winner.id=" + winner.getId());
+    }
+    if (reservation.getAmount() != finalBidAmount) {
+        throw new BidReservationAmountMismatchException(reservation.getAmount(), finalBidAmount);
+    }
+
+    // Release reservation
+    reservation.setReleasedAt(OffsetDateTime.now(clock));
+    reservation.setReleaseReason(BidReservationReleaseReason.ESCROW_FUNDED);
+    reservationRepository.save(reservation);
+
+    // Decrement reserved + balance
+    winner.setReservedLindens(winner.getReservedLindens() - reservation.getAmount());
+    winner.setBalanceLindens(winner.getBalanceLindens() - finalBidAmount);
+    userRepository.save(winner);
+
+    // Two ledger rows
+    appendLedger(winner, UserLedgerEntryType.BID_RELEASED, reservation.getAmount(), "BID", reservation.getBidId());
+    appendLedger(winner, UserLedgerEntryType.ESCROW_DEBIT, finalBidAmount, "ESCROW", escrowId);
+
+    return EscrowAutoFundResult.ok();
+}
+```
+
+`BidReservationAmountMismatchException` is a `RuntimeException` flagged for "system-integrity bug; freeze escrow" handling at the call site.
+
+**Tests:** happy path, no-active-reservation defensive branch, reservation-user-mismatch defensive branch, amount-mismatch defensive branch.
+
+- [ ] Step 2.6.1: Add `BidReservationAmountMismatchException`.
+- [ ] Step 2.6.2: Write tests.
+- [ ] Step 2.6.3: Implement method.
+- [ ] Step 2.6.4: Commit: `feat(wallet): WalletService.autoFundEscrow() for auction-end auto-funding`.
+
+### Task 2.7: Refund + listing-fee credit primitives
+
+**Files:**
+- Modify: `WalletService.java`
+- Create: `backend/src/test/java/com/slparcelauctions/backend/wallet/WalletServiceCreditTest.java`
+
+**Methods:**
+```java
+@Transactional(propagation = MANDATORY)
+public void creditEscrowRefund(User user, long amount, Long escrowId) {
+    user.setBalanceLindens(user.getBalanceLindens() + amount);
+    userRepository.save(user);
+    appendLedger(user, UserLedgerEntryType.ESCROW_REFUND, amount, "ESCROW", escrowId);
+}
+
+@Transactional(propagation = MANDATORY)
+public void creditListingFeeRefund(User user, long amount, Long listingFeeRefundId) {
+    user.setBalanceLindens(user.getBalanceLindens() + amount);
+    userRepository.save(user);
+    appendLedger(user, UserLedgerEntryType.LISTING_FEE_REFUND, amount, "LISTING_FEE_REFUND", listingFeeRefundId);
+}
+
+@Transactional(propagation = MANDATORY)
+public void debitListingFee(User user, long amount, Long auctionId) {
+    if (user.availableLindens() < amount) {
+        throw new InsufficientAvailableBalanceException(user.availableLindens(), amount);
+    }
+    user.setBalanceLindens(user.getBalanceLindens() - amount);
+    userRepository.save(user);
+    appendLedger(user, UserLedgerEntryType.LISTING_FEE_DEBIT, amount, "AUCTION", auctionId);
+}
+```
+
+- [ ] Step 2.7.1: Write tests.
+- [ ] Step 2.7.2: Implement methods.
+- [ ] Step 2.7.3: Commit: `feat(wallet): credit + debit primitives for escrow refund / listing fee`.
+
+### Task 2.8: Reservation release helper for cancellation/freeze/ban paths
+
+**Files:**
+- Modify: `WalletService.java`
+
+**Method:**
+```java
+@Transactional(propagation = MANDATORY)
+public void releaseReservationsForAuction(Long auctionId, BidReservationReleaseReason reason) {
+    List<BidReservation> active = reservationRepository.findAllActiveForAuction(auctionId);
+    for (BidReservation r : active) {
+        User u = userRepository.findByIdForUpdate(r.getUserId()).orElseThrow();
+        r.setReleasedAt(OffsetDateTime.now(clock));
+        r.setReleaseReason(reason);
+        reservationRepository.save(r);
+        u.setReservedLindens(u.getReservedLindens() - r.getAmount());
+        userRepository.save(u);
+        appendLedger(u, UserLedgerEntryType.BID_RELEASED, r.getAmount(), "BID", r.getBidId());
+    }
+}
+
+@Transactional(propagation = MANDATORY)
+public void releaseAllReservationsForUser(Long userId, BidReservationReleaseReason reason) {
+    List<BidReservation> active = reservationRepository.findActiveByUser(userId);
+    User u = userRepository.findByIdForUpdate(userId).orElseThrow();
+    for (BidReservation r : active) {
+        r.setReleasedAt(OffsetDateTime.now(clock));
+        r.setReleaseReason(reason);
+        reservationRepository.save(r);
+        u.setReservedLindens(u.getReservedLindens() - r.getAmount());
+        appendLedger(u, UserLedgerEntryType.BID_RELEASED, r.getAmount(), "BID", r.getBidId());
+    }
+    userRepository.save(u);
+}
+```
+
+- [ ] Step 2.8.1: Implement helpers + tests covering both methods.
+- [ ] Step 2.8.2: Commit: `feat(wallet): release-reservations helpers for cancellation/ban paths`.
+
+---
+
+## Phase 3 — SL-headers controllers
+
+### Task 3.1: `/sl/wallet/deposit` controller
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/sl/SlWalletDepositController.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/sl/SlWalletDepositRequest.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/sl/SlWalletDepositResponse.java`
+- Create: `backend/src/test/java/com/slparcelauctions/backend/wallet/sl/SlWalletDepositControllerSliceTest.java`
+
+**Controller pattern:** mirror existing SL controllers (e.g., `EscrowPaymentController`). Validate headers via `SlHeaderValidator` filter, validate `sharedSecret` body field, validate `terminalId` lookup, then delegate to `WalletService.deposit()`. Map exceptions to wire responses.
+
+**Wire responses (from spec §4.1):**
+- `OK { status: "OK" }`
+- `REFUND { status: "REFUND", reason: "UNKNOWN_PAYER" | "USER_FROZEN", message: "..." }`
+- `ERROR { status: "ERROR", reason: "BAD_HEADERS" | "SECRET_MISMATCH" | "UNKNOWN_TERMINAL", message: "..." }`
+
+**Slice test matrix:**
+- 200 OK on valid request.
+- 200 OK with replay shape on duplicate `slTransactionKey`.
+- 200 with `REFUND/UNKNOWN_PAYER` on unknown UUID.
+- 200 with `REFUND/USER_FROZEN` on banned user.
+- 200 with `ERROR/SECRET_MISMATCH` on bad secret.
+- 200 with `ERROR/UNKNOWN_TERMINAL` on bad terminalId.
+- 403 with `ERROR/BAD_HEADERS` on missing SL headers.
+
+- [ ] Step 3.1.1: Write the request DTO with validation annotations.
+- [ ] Step 3.1.2: Write the response DTO.
+- [ ] Step 3.1.3: Write the controller, including exception → wire-response mapping.
+- [ ] Step 3.1.4: Write the slice test with the full matrix.
+- [ ] Step 3.1.5: Run slice test — all green.
+- [ ] Step 3.1.6: Commit: `feat(wallet): /sl/wallet/deposit controller + slice tests`.
+
+### Task 3.2: `/sl/wallet/withdraw-request` controller
+
+**Files:** mirror Task 3.1 structure (`SlWalletWithdrawRequestController`, request, response, slice test).
+
+**Wire responses (from spec §4.1):**
+- `OK { status: "OK", queueId: 42 }`
+- `REFUND_BLOCKED { status: "REFUND_BLOCKED", reason: "INSUFFICIENT_BALANCE" | "USER_FROZEN" | "NOT_LINKED", message: "..." }`
+- `ERROR { ... }`
+
+**Note:** new wire-response status value `REFUND_BLOCKED` distinct from `REFUND`. Document this in the spec ref + controller javadoc.
+
+- [ ] Step 3.2.1: Write request/response DTOs.
+- [ ] Step 3.2.2: Write controller.
+- [ ] Step 3.2.3: Write slice test matrix.
+- [ ] Step 3.2.4: Commit: `feat(wallet): /sl/wallet/withdraw-request controller + slice tests`.
+
+---
+
+## Phase 4 — User-facing controllers
+
+### Task 4.1: `GET /api/v1/me/wallet` + `/me/wallet/ledger`
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/me/MeWalletController.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/me/WalletViewResponse.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/me/UserLedgerEntryDto.java`
+- Create: `backend/src/test/java/com/slparcelauctions/backend/wallet/me/MeWalletControllerSliceTest.java`
+
+**Response shape** per spec §4.2.
+
+- [ ] Step 4.1.1: Write the response DTOs.
+- [ ] Step 4.1.2: Write the controller (returns the user's wallet state and recent 50 ledger entries; cursor-paginated for older entries).
+- [ ] Step 4.1.3: Slice test: authenticated user gets correct response; unauth → 401; banned user still gets read-only view.
+- [ ] Step 4.1.4: Commit: `feat(wallet): GET /me/wallet + /me/wallet/ledger`.
+
+### Task 4.2: `POST /me/wallet/withdraw`
+
+**Files:**
+- Modify: `MeWalletController.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/me/WithdrawRequest.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/me/WithdrawResponse.java`
+
+Body: `{ amount, idempotencyKey }`. Recipient is **never** in the body.
+
+- [ ] Step 4.2.1: Write request/response DTOs.
+- [ ] Step 4.2.2: Add controller method; delegate to `WalletService.withdrawSiteInitiated()`.
+- [ ] Step 4.2.3: Slice test: 202 happy path with queueId; 422 on insufficient available; 403 on banned/frozen; replay on duplicate idempotencyKey.
+- [ ] Step 4.2.4: Commit: `feat(wallet): POST /me/wallet/withdraw`.
+
+### Task 4.3: `POST /me/wallet/pay-penalty`
+
+**Files:**
+- Modify: `MeWalletController.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/me/PayPenaltyRequest.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/me/PayPenaltyResponse.java`
+
+- [ ] Step 4.3.1: DTOs + controller method.
+- [ ] Step 4.3.2: Slice test: full payment clears, partial payment leaves remainder, exceeds-owed → 422, insufficient-available → 422, fully-reserved-balance scenario → 422.
+- [ ] Step 4.3.3: Commit: `feat(wallet): POST /me/wallet/pay-penalty`.
+
+### Task 4.4: `POST /me/wallet/accept-terms`
+
+**Files:**
+- Modify: `MeWalletController.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/me/AcceptTermsRequest.java`
+
+Body: `{ termsVersion }`. Stamps `wallet_terms_accepted_at` + `wallet_terms_version`. Returns 200.
+
+- [ ] Step 4.4.1: DTO + method.
+- [ ] Step 4.4.2: Slice test: idempotent (re-accepting same version is a no-op).
+- [ ] Step 4.4.3: Commit: `feat(wallet): POST /me/wallet/accept-terms`.
+
+### Task 4.5: `POST /me/auctions/{id}/pay-listing-fee`
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/me/PayListingFeeController.java` (or fold into `AuctionController` — recommend separate, in the wallet package since this is a wallet operation)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/me/PayListingFeeRequest.java` (just `idempotencyKey`)
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/me/PayListingFeeResponse.java`
+
+**Behavior** per spec §4.3 listing-fee subsection:
+1. JWT → user.
+2. Find auction; verify `seller_user_id == user.id` AND `state == DRAFT`.
+3. Lock user.
+4. Validate `user.penalty_balance_owed == 0` → 422 `PENALTY_OUTSTANDING`.
+5. Validate `available >= auction.listing_fee_amount` → 422 `INSUFFICIENT_AVAILABLE_BALANCE`.
+6. `WalletService.debitListingFee(user, listingFeeAmount, auctionId)`.
+7. Append `escrow_transactions{type=LISTING_FEE_PAYMENT, status=COMPLETED}`.
+8. Transition auction `DRAFT → DRAFT_PAID`.
+9. WS envelope `LISTING_FEE_PAID` (existing or new envelope name; use whatever Epic 03/05 already publishes).
+
+- [ ] Step 4.5.1: Read existing AuctionService listing-fee transition logic to understand the touch points.
+- [ ] Step 4.5.2: Write controller + DTOs.
+- [ ] Step 4.5.3: Slice test matrix: happy, penalty-outstanding, insufficient-available, wrong-state (not DRAFT), wrong-seller (not owner), already-paid (DRAFT_PAID).
+- [ ] Step 4.5.4: Commit: `feat(wallet): POST /me/auctions/{id}/pay-listing-fee`.
+
+---
+
+## Phase 5 — Bid + BIN integration
+
+### Task 5.1: Add penalty + balance preconditions to `BidService.placeBid()`
+
+**Files:**
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/BidService.java` (or whatever class owns bid placement)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/exception/PenaltyOutstandingException.java` (create if missing)
+- Modify: `backend/src/test/java/com/slparcelauctions/backend/auction/BidServiceTest.java`
+
+**Changes:**
+- After existing auction-state validation: add penalty precondition and available-balance precondition.
+- Call `walletService.swapReservation(auction, newBidder, amount, prior, bid)` after bid persistence.
+- Lock both newBidder and priorBidder (if any) in ascending user_id order before the wallet call.
+
+**Lock-ordering helper:** `userRepository.findAllByIdInForUpdateAscending(Set<Long> ids)` or use a Java-side sort + multiple `findByIdForUpdate` calls.
+
+- [ ] Step 5.1.1: Add the precondition checks.
+- [ ] Step 5.1.2: Add the user-lock acquisition in ascending order.
+- [ ] Step 5.1.3: Wire `swapReservation` call.
+- [ ] Step 5.1.4: Update existing tests to use the new wallet-service collaborator (mock it). Add new tests for the precondition matrix.
+- [ ] Step 5.1.5: Integration test: deposit user with L$1000, bid L$500, confirm reserved=L$500, available=L$500.
+- [ ] Step 5.1.6: Commit: `feat(bid): add penalty + balance preconditions and reservation swap`.
+
+### Task 5.2: Apply same pattern to `BinService.buyNow()`
+
+**Files:**
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/BinService.java` (or whatever owns BIN; could be `AuctionService.buyNow()`)
+- Modify tests.
+
+**Behavior** per spec §6.3:
+- Validate penalty == 0.
+- Validate `available + (existing-reservation-on-this-auction-by-this-user) >= bin_price`.
+- If existing reservation: release it (`ESCROW_FUNDED` reason; decrement reserved; `BID_RELEASED` row).
+- Debit balance for `bin_price`. Append `ESCROW_DEBIT` row.
+- Persist BIN bid + transition auction to `ENDED+BOUGHT_NOW`.
+- Insert escrow row in state `FUNDED`. Append `escrow_transactions{type=AUCTION_ESCROW_PAYMENT}`.
+- Release **other** active reservations on this auction (`AUCTION_BIN_ENDED` reason).
+
+- [ ] Step 5.2.1: Read the existing BIN handler to understand current shape.
+- [ ] Step 5.2.2: Implement the new flow.
+- [ ] Step 5.2.3: Test matrix: BIN with no prior reservation, BIN with own prior reservation at lower amount, BIN with insufficient available even counting prior reservation, BIN releases other bidders' reservations.
+- [ ] Step 5.2.4: Integration test: 3 bidders on auction, lowest-bidder clicks BIN — BIN succeeds, all 3 reservations released cleanly with correct release_reasons, escrow funded.
+- [ ] Step 5.2.5: Commit: `feat(bin): wallet-driven BIN with auto-funded escrow`.
+
+---
+
+## Phase 6 — Auction-end auto-fund
+
+### Task 6.1: `AuctionEndTask.closeOne` — auto-fund on SOLD
+
+**Files:**
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/AuctionEndTask.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java` (escrow row creation)
+- Modify tests.
+
+**Changes per spec §6.1:**
+- For `endOutcome=SOLD`: call `walletService.autoFundEscrow(...)` inside the existing close transaction, then create the escrow row directly in `FUNDED` state (not `ESCROW_PENDING` — that state is gone).
+- On `BidReservationAmountMismatchException`: catch + freeze the new escrow as `FROZEN, reason=BID_RESERVATION_AMOUNT_MISMATCH` (system-integrity bug, defensive branch).
+
+- [ ] Step 6.1.1: Update `AuctionEndTask.closeOne` and `EscrowService.create` for the new flow.
+- [ ] Step 6.1.2: Update tests that asserted `ESCROW_PENDING` initial state — now expect `FUNDED`.
+- [ ] Step 6.1.3: Add test for the defensive freeze branch.
+- [ ] Step 6.1.4: Integration test: bid (reserves), close (auto-funds), confirm escrow in `TRANSFER_PENDING` immediately, ledger consistent.
+- [ ] Step 6.1.5: Commit: `feat(escrow): auto-fund at auction-end via reservation consumption`.
+
+### Task 6.2: Auction cancellation/freeze releases reservations
+
+**Files:**
+- Modify: cancellation handler (find via grep `auction.*cancel|cancelAuction|setState.*CANCELLED`)
+- Modify: fraud-freeze handler
+
+**Behavior per spec §6.4:** call `walletService.releaseReservationsForAuction(auctionId, reason)` inside the cancellation transaction. If the auction also has a funded escrow, follow existing escrow cancellation → refund path (which Phase 7 converts to wallet credit).
+
+- [ ] Step 6.2.1: Find cancel/freeze entry points.
+- [ ] Step 6.2.2: Add the reservation-release call.
+- [ ] Step 6.2.3: Tests: 2-bidder auction cancelled → both reservations released, both users' available restored.
+- [ ] Step 6.2.4: Commit: `feat(auction): cancellation releases active reservations`.
+
+### Task 6.3: User ban releases reservations + handles funded escrows
+
+**Files:**
+- Modify: ban-action handler (likely in admin / Epic 10 code).
+
+**Behavior per spec §6.5:** ban handler calls `walletService.releaseAllReservationsForUser(userId, USER_BANNED)`. Funded escrows where the banned user is winner enter the existing dispute disposition path.
+
+- [ ] Step 6.3.1: Add the call to the ban handler.
+- [ ] Step 6.3.2: Tests for the integration.
+- [ ] Step 6.3.3: Commit: `feat(admin): user ban releases active wallet reservations`.
+
+---
+
+## Phase 7 — Refund-as-credit
+
+### Task 7.1: Escrow refund → wallet credit
+
+**Files:**
+- Modify: escrow refund handler — find via grep `EscrowState.*EXPIRED|escrowRefund|AUCTION_ESCROW_REFUND`
+- Modify: dispute resolution refund path
+
+**Behavior per spec §7.1:** instead of queueing a `TerminalCommand{action=REFUND}`, call `walletService.creditEscrowRefund(winner, escrow.finalBidAmount, escrow.id)` inside the same transaction. Append `escrow_transactions{type=AUCTION_ESCROW_REFUND, status=COMPLETED}`.
+
+- [ ] Step 7.1.1: Find existing refund path. Replace TerminalCommand-queue with wallet credit.
+- [ ] Step 7.1.2: Tests for both escrow expiry and dispute-resolution refund.
+- [ ] Step 7.1.3: Integration test: escrow expires (transfer deadline missed), winner's wallet receives refund, no TerminalCommand queued.
+- [ ] Step 7.1.4: Commit: `feat(escrow): refund-as-credit instead of TerminalCommand REFUND`.
+
+### Task 7.2: Listing-fee refund → wallet credit
+
+**Files:**
+- Modify: `ListingFeeRefundProcessor` (or whatever Epic 05 sub-spec 1 named it)
+
+**Behavior per spec §7.2:** instead of queueing TerminalCommand, call `walletService.creditListingFeeRefund(seller, refund.amount, refund.id)`.
+
+- [ ] Step 7.2.1: Update the processor.
+- [ ] Step 7.2.2: Tests.
+- [ ] Step 7.2.3: Commit: `feat(listing-fee): refund-as-credit`.
+
+---
+
+## Phase 8 — Remove retired endpoints
+
+### Task 8.1: Delete the four SL-headers payment controllers
+
+**Files (all to be deleted):**
+- `EscrowPaymentController.java` and its DTOs.
+- `ListingFeePaymentController.java` and its DTOs.
+- `PenaltyLookupController.java` and its DTOs.
+- `PenaltyPaymentController.java` and its DTOs.
+- All related slice tests.
+
+Plus any service-layer methods that only existed to serve these controllers. Search for callers.
+
+- [ ] Step 8.1.1: Delete each controller + its tests + its DTOs.
+- [ ] Step 8.1.2: Remove unused service methods.
+- [ ] Step 8.1.3: Run full test suite — fix any breakage from leftover references.
+- [ ] Step 8.1.4: Commit: `refactor: remove retired SL payment endpoints (replaced by wallet)`.
+
+### Task 8.2: Rename dev-profile listing-fee stub
+
+**Files:**
+- Modify: dev controller that handles `/dev/auctions/{id}/pay`. Rename to `/dev/auctions/{id}/mark-listing-fee-paid`.
+
+- [ ] Step 8.2.1: Rename endpoint path.
+- [ ] Step 8.2.2: Update Postman + tests.
+- [ ] Step 8.2.3: Commit: `refactor(dev): rename /pay to /mark-listing-fee-paid for clarity`.
+
+---
+
+## Phase 9 — Reconciliation extension
+
+### Task 9.1: Extend `ReconciliationService.runDaily()`
+
+**Files:**
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/reconciliation/ReconciliationService.java`
+- Modify: tests.
+
+**Changes per spec §11:**
+1. Add denorm precheck: compare `SUM(users.reserved_lindens)` vs `SUM(bid_reservations.amount WHERE released_at IS NULL)`. Mismatch → record `DENORM_DRIFT` and abort main check.
+2. Add `sumWalletBalances() = SUM(users.balance_lindens)` and `sumActiveReservations() = SUM(bid_reservations.amount WHERE released_at IS NULL)`.
+3. Update expected total: `expected = sumLockedEscrows() + sumWalletBalances()`. (Reservations already inside wallet balance — do not add separately.)
+4. Persist breakdown columns: `wallet_balance_total`, `wallet_reserved_total`, `escrow_locked_total`.
+
+- [ ] Step 9.1.1: Add the new sum methods.
+- [ ] Step 9.1.2: Add denorm precheck.
+- [ ] Step 9.1.3: Update `expected_total` calculation.
+- [ ] Step 9.1.4: Tests: synthetic balance drift → BALANCED=false; synthetic reserved drift → DENORM_DRIFT.
+- [ ] Step 9.1.5: Commit: `feat(reconciliation): extend daily run with wallet sums + denorm precheck`.
+
+---
+
+## Phase 10 — Dormancy + login handler
+
+### Task 10.1: `WalletDormancyJob` + `WalletDormancyTask`
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/dormancy/WalletDormancyJob.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/dormancy/WalletDormancyTask.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/wallet/dormancy/UserRepositoryDormancyExtension.java` (or extension queries on UserRepository)
+- Create: `backend/src/test/java/com/slparcelauctions/backend/wallet/dormancy/WalletDormancyJobTest.java`
+
+**Behavior per spec §12.2:**
+- Weekly cron `0 0 4 * * MON` UTC.
+- Phase 1 (flag newly-dormant): finds users with `last refresh_tokens.created_at > 30d ago` AND `balance_lindens > 0` AND `wallet_dormancy_phase IS NULL` AND no active reservations AND no funded escrows. Stamps phase=1, sends IM #1.
+- Phases 2/3/4: escalating; sends IM #N.
+- Phase 4 → COMPLETED: queues `TerminalCommand{action=WITHDRAW}` for full balance, debits balance, append `WITHDRAW_QUEUED` ledger row, stamps phase=99.
+- Re-checks liveness (refresh-token query) before any phase transition (defense in depth).
+
+- [ ] Step 10.1.1: Add repository queries for the dormancy candidate query.
+- [ ] Step 10.1.2: Implement `WalletDormancyJob.sweep()`.
+- [ ] Step 10.1.3: Implement `WalletDormancyTask.flag()` and `escalateOrAutoReturn()`.
+- [ ] Step 10.1.4: Tests: full flow with clock fast-forward.
+- [ ] Step 10.1.5: Tests: user with active bid reservation excluded.
+- [ ] Step 10.1.6: Tests: user logs in mid-cycle → liveness check clears state.
+- [ ] Step 10.1.7: Commit: `feat(dormancy): WalletDormancyJob with 30d threshold and 4 weekly IMs`.
+
+### Task 10.2: SL IM templates for dormancy
+
+**Files:**
+- Modify: Epic 09 SL IM dispatcher integration to publish `WALLET_DORMANCY_*` notification categories.
+- Add IM message templates to wherever Epic 09 owns content.
+
+- [ ] Step 10.2.1: Wire dormancy events to the SL IM dispatcher.
+- [ ] Step 10.2.2: Add templates per spec §12.4.
+- [ ] Step 10.2.3: Commit: `feat(notifications): wallet dormancy IM templates`.
+
+### Task 10.3: Login + refresh handler clears dormancy state
+
+**Files:**
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auth/AuthService.java` (or login handler)
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auth/RefreshTokenService.java`
+
+**Change:** on successful login or refresh-token rotation, if `user.walletDormancyPhase != null`, set it to null along with `walletDormancyStartedAt`.
+
+- [ ] Step 10.3.1: Add the clear-on-success logic.
+- [ ] Step 10.3.2: Tests.
+- [ ] Step 10.3.3: Commit: `feat(auth): clear wallet dormancy state on login/refresh`.
+
+---
+
+## Phase 11 — Frontend wallet UI
+
+### Task 11.1: Wallet panel on dashboard
+
+**Files:**
+- Create: `frontend/src/components/wallet/WalletPanel.tsx`
+- Create: `frontend/src/lib/wallet/use-wallet.ts` (React Query hook)
+- Create: `frontend/src/lib/wallet/types.ts` (TypeScript types matching backend DTOs)
+- Modify: dashboard page to render WalletPanel.
+
+**Panel content:**
+- Balance / Reserved / Available (3-cell display).
+- Penalty owed (if > 0, with warning styling).
+- "Pay Penalty" button (opens dialog).
+- "Withdraw" button (opens dialog).
+- "How to deposit" link (opens info modal with terminal instructions).
+- Recent ledger entries (collapsible table, last 50).
+
+- [ ] Step 11.1.1: Define TypeScript types.
+- [ ] Step 11.1.2: Build the React Query hook.
+- [ ] Step 11.1.3: Build the panel component.
+- [ ] Step 11.1.4: Run `npm run verify` (no-emojis, no-dark-variants, no-hex-colors, no-inline-styles).
+- [ ] Step 11.1.5: Commit: `feat(frontend): wallet dashboard panel`.
+
+### Task 11.2: Withdraw dialog
+
+**Files:**
+- Create: `frontend/src/components/wallet/WithdrawDialog.tsx`
+- Modify: `use-wallet.ts` to add `useWithdraw()` mutation.
+
+**Behavior:** form with amount input, confirms `amount <= available`, posts to `/me/wallet/withdraw` with client-generated `idempotencyKey` (UUID). Shows success toast with `queueId`, closes dialog, refetches wallet.
+
+- [ ] Step 11.2.1: Build dialog.
+- [ ] Step 11.2.2: Wire to `useWithdraw` mutation.
+- [ ] Step 11.2.3: Tests with React Testing Library.
+- [ ] Step 11.2.4: Commit: `feat(frontend): withdraw dialog`.
+
+### Task 11.3: Pay-penalty dialog
+
+**Files:**
+- Create: `frontend/src/components/wallet/PayPenaltyDialog.tsx`
+
+**Behavior:** form with amount (default = `min(penaltyOwed, available)`), validates `amount <= penaltyOwed && amount <= available`. If `available < penaltyOwed`, show explicit hint "Deposit L$X more or wait for active bids to resolve."
+
+- [ ] Step 11.3.1-4: Same pattern as 11.2.
+
+### Task 11.4: Deposit-instructions modal + terms gate
+
+**Files:**
+- Create: `frontend/src/components/wallet/DepositInstructionsModal.tsx`
+- Create: `frontend/src/components/wallet/AcceptTermsModal.tsx`
+- Modify: `WalletPanel.tsx` to gate the deposit-instructions modal on `walletTermsAccepted`.
+
+**Behavior:** before showing the deposit-instructions modal for the first time, show the AcceptTermsModal with terms text + checkbox + "I accept" button posting to `/me/wallet/accept-terms`. Once accepted, show the deposit-instructions modal (terminal locations + how to right-click + pay).
+
+- [ ] Step 11.4.1-4: Build both modals + gating.
+
+### Task 11.5: Bid form + BIN form precondition surfacing
+
+**Files:**
+- Modify: existing bid form component(s).
+- Modify: existing BIN component(s).
+
+**Changes:**
+- Show user's current `available` next to the bid amount field.
+- On submit, if backend returns 422 `PENALTY_OUTSTANDING` or `INSUFFICIENT_AVAILABLE_BALANCE`, render contextual error messaging.
+- BIN button shows "L$X (you have L$Y available)" — disabled if `available + thisAuctionReservation < bin_price`.
+
+- [ ] Step 11.5.1-3: Modify forms + tests.
+
+### Task 11.6: Listing fee step in publish flow
+
+**Files:**
+- Modify: existing draft → DRAFT_PAID UI (find via grep "Listing fee").
+
+**Changes:**
+- Add a "Pay Listing Fee from Wallet" button that posts to `/me/auctions/{id}/pay-listing-fee`.
+- Show available balance + listing fee amount.
+- On 422 PENALTY_OUTSTANDING, link to "Pay your outstanding penalty first" CTA.
+
+- [ ] Step 11.6.1-3: Modify the listing-flow UI.
+
+### Task 11.7: Legal terms page
+
+**Files:**
+- Create: `frontend/src/app/legal/terms/page.tsx`
+
+**Content:** the wallet terms-of-use draft from spec §13.1.
+
+- [ ] Step 11.7.1: Build page with section headings + content.
+- [ ] Step 11.7.2: Add nav link in footer.
+- [ ] Step 11.7.3: Commit: `feat(frontend): /legal/terms page with wallet terms-of-use`.
+
+---
+
+## Phase 12 — LSL rewrites
+
+### Task 12.1: Rewrite `slpa-terminal.lsl`
+
+**Files:**
+- Modify: `lsl-scripts/slpa-terminal/slpa-terminal.lsl` (mostly rewritten)
+- Modify: `lsl-scripts/slpa-terminal/config.notecard.example` (URL paths)
+- Modify: `lsl-scripts/slpa-terminal/README.md` (mostly rewritten)
+
+**Key new shape per spec §9.1, 9.2, 9.3:**
+- Steady-state: pay-default + quick-pay buttons, always live; floating text changed.
+- `money()` handler: lockless, generate txKey, POST to `/sl/wallet/deposit`, retry budget, REFUND/ERROR discrimination.
+- Touch: per-toucher dialog channel, `[Deposit, Withdraw]` buttons.
+- Withdraw: per-flow slots in a strided list, single shared listen at startup, dispatch by avatar key on listen events.
+- HTTP-in (PAYOUT/WITHDRAW): unchanged shape; defensive REFUND-action handler that owner-says CRITICAL.
+- "Get Parcel Verifier" menu option **removed**; verifier inventory item removed from prim.
+
+Concrete LSL skeleton outline (the implementation is ~600 lines; below is the structure):
+
+```lsl
+// === Notecard config ===
+string  REGISTER_URL, DEPOSIT_URL, WITHDRAW_REQUEST_URL, PAYOUT_RESULT_URL, SHARED_SECRET, TERMINAL_ID;
+integer DEBUG_MODE = TRUE;
+
+// === Listen state ===
+integer mainListenChan;       // single shared listen for menu + withdraw flow
+integer mainListenHandle = -1;
+
+// === Per-flow withdraw slots (strided 3-wide: avatarKey, amount, expiresAt) ===
+list withdrawSessions = [];
+integer MAX_WITHDRAW_SESSIONS = 4;
+integer SESSION_TTL_SECONDS = 60;
+
+// === Background payment retry (deposit) ===
+key paymentReqId; key paymentPayer; integer paymentAmount;
+string paymentTxKey; integer paymentRetryCount; integer paymentNextRetryAt;
+
+// === HTTP-in inflight (PAYOUT/WITHDRAW) — unchanged ===
+list inflightCmdTxKeys, inflightCmdIdempotencyKeys, inflightCmdRecipients, inflightCmdAmounts;
+integer MAX_INFLIGHT_CMDS = 16;
+
+default {
+    state_entry() {
+        // load notecard, request URL, request DEBIT permission, register, etc.
+        // open the single shared listen
+        mainListenChan = -100000 - (integer)(llFrand(50000.0));
+        mainListenHandle = llListen(mainListenChan, "", NULL_KEY, "");
+        // floating text + pay price defaults
+        llSetPayPrice(PAY_DEFAULT, [100, 500, 1000, 5000]);
+        llSetText("SLPA Terminal\nRight-click → Pay to deposit\nTouch for menu", <1,1,1>, 1.0);
+    }
+
+    money(key payer, integer amount) {
+        // generate txKey, POST /sl/wallet/deposit, set up retry
+    }
+
+    touch_start(integer num) {
+        key toucher = llDetectedKey(0);
+        llDialog(toucher, "What would you like to do?", ["Deposit", "Withdraw"], mainListenChan);
+    }
+
+    listen(integer chan, string name, key id, string msg) {
+        if (chan != mainListenChan) return;
+        // 1. Check if msg is "Deposit" or "Withdraw" (top-level menu response)
+        // 2. Check if id has a withdraw slot — dispatch by slot state (-1 = awaiting amount, >0 = awaiting confirm)
+    }
+
+    timer() {
+        // sweep expired withdraw slots
+        // run deposit-retry backoff
+        // run register-retry backoff
+        // sweep stale inflight HTTP-in commands
+    }
+
+    http_response(key req, integer status, list meta, string body) {
+        // dispatch by req key: deposit response, register response, withdraw-request response, payout-result response
+    }
+
+    http_request(key req, string method, string body) {
+        // backend-initiated PAYOUT/WITHDRAW; existing flow
+    }
+
+    transaction_result(key id, integer success, string data) {
+        // post payout-result for the inflight command
+    }
+
+    changed(integer change) {
+        // CHANGED_REGION_START → re-request URL
+        // CHANGED_INVENTORY → llResetScript()
+    }
+}
+```
+
+The full implementation expands each block per the spec.
+
+- [ ] Step 12.1.1: Read the existing `slpa-terminal.lsl` carefully so the rewrite preserves grid-guard, register/retry, region-restart, listen-cleanup discipline.
+- [ ] Step 12.1.2: Write the new script. Replace existing payment-kind-and-auctionId state with the lockless deposit + per-flow withdraw model.
+- [ ] Step 12.1.3: Update `config.notecard.example` to point at `/sl/wallet/deposit` and `/sl/wallet/withdraw-request` URL paths instead of the four old ones.
+- [ ] Step 12.1.4: Rewrite the README to reflect the new behavior, menu structure, deposit flow, withdraw flow.
+- [ ] Step 12.1.5: Commit: `feat(lsl): rewrite slpa-terminal.lsl for wallet model`.
+
+### Task 12.2: New `slpa-verifier-giver` script + prim
+
+**Files:**
+- Create: `lsl-scripts/slpa-verifier-giver/slpa-verifier-giver.lsl`
+- Create: `lsl-scripts/slpa-verifier-giver/config.notecard.example`
+- Create: `lsl-scripts/slpa-verifier-giver/README.md`
+- Modify: `lsl-scripts/README.md` (top-level index — add entry)
+
+**Script:** per spec §9.4. Touch-to-receive, header-trust only, no shared secret, per-avatar rate-limit (60s).
+
+```lsl
+string FALLBACK_TEXT = "SLPA Parcel Verifier — Free\nTouch to receive";
+integer DEBUG_MODE = TRUE;
+integer RATE_LIMIT_SECONDS = 60;
+
+list givenSessions = [];  // [avatarKey, lastGivenAt, ...]
+
+default {
+    state_entry() {
+        // Mainland-only grid guard
+        if (llGetEnv("sim_channel") != "Second Life Server") {
+            llOwnerSay("CRITICAL: not on Second Life Server grid; halting.");
+            return;
+        }
+        llSetText(FALLBACK_TEXT, <1,1,1>, 1.0);
+    }
+
+    touch_start(integer num) {
+        key toucher = llDetectedKey(0);
+        // rate-limit check
+        integer slot = llListFindList(givenSessions, [toucher]);
+        integer now = llGetUnixTime();
+        if (slot != -1) {
+            integer lastAt = llList2Integer(givenSessions, slot + 1);
+            if (now - lastAt < RATE_LIMIT_SECONDS) {
+                llRegionSayTo(toucher, 0, "Just gave you one — wait a minute.");
+                return;
+            }
+            givenSessions = llListReplaceList(givenSessions, [toucher, now], slot, slot + 1);
+        } else {
+            givenSessions += [toucher, now];
+        }
+        llGiveInventory(toucher, "SLPA Parcel Verifier");
+        if (DEBUG_MODE) llOwnerSay("SLPA Verifier Giver: gave verifier to " + llDetectedName(0));
+    }
+
+    changed(integer change) {
+        if (change & CHANGED_INVENTORY) llResetScript();
+    }
+}
+```
+
+- [ ] Step 12.2.1: Write the script.
+- [ ] Step 12.2.2: Write the README (purpose, deployment locations, configuration, operations, security).
+- [ ] Step 12.2.3: Update top-level `lsl-scripts/README.md` index.
+- [ ] Step 12.2.4: Commit: `feat(lsl): SLPA Parcel Verifier Giver — touch-to-receive, free`.
+
+---
+
+## Phase 13 — Postman collection
+
+### Task 13.1: Add Wallet folder + retire 4 folders
+
+**Files:**
+- Modify: Postman collection JSON (committed to repo? Verify location — may be in `docs/postman/` or similar).
+
+**Per spec §15.1, 15.2:** add Wallet folder with 7 requests (variable-chained), remove `Escrow Payment`, `Listing Fee Payment`, `Penalty Lookup`, `Penalty Payment` folders.
+
+- [ ] Step 13.1.1: Find the Postman collection JSON in the repo (or update via Postman MCP).
+- [ ] Step 13.1.2: Add new requests; remove old folders.
+- [ ] Step 13.1.3: Update env vars (add wallet-related, remove obsolete).
+- [ ] Step 13.1.4: Commit: `feat(postman): rebuild collection for wallet model`.
+
+---
+
+## Phase 14 — Documentation sweep
+
+### Task 14.1: LSL READMEs
+
+**Files:**
+- `lsl-scripts/slpa-terminal/README.md` (covered in 12.1).
+- `lsl-scripts/slpa-verifier-giver/README.md` (covered in 12.2).
+- `lsl-scripts/README.md` (covered in 12.2).
+
+### Task 14.2: Implementation docs
+
+**Files:**
+- Modify: `docs/implementation/CONVENTIONS.md` — append wallet conventions:
+  - Immutable ledger discipline.
+  - `available = balance - reserved` invariant.
+  - Recipient-UUID-locked outbound.
+  - `MANDATORY` propagation for service-layer methods that assume locks held.
+- Modify: `docs/implementation/FOOTGUNS.md` — add wallet footguns surfaced during build.
+- Modify: `docs/implementation/DEFERRED_WORK.md` — add items from spec §17 (admin manual ledger adjustments, history export, etc.).
+- Modify: root `README.md` — sweep for staleness re: terminal payment flow.
+
+- [ ] Step 14.2.1: Append sections to each doc.
+- [ ] Step 14.2.2: Commit: `docs: wallet conventions, footguns, deferred items, root README sweep`.
+
+---
+
+## Phase 15 — Smoke verification + PRs
+
+### Task 15.1: Run full backend test suite
+
+```bash
+cd backend && ./mvnw test
+```
+
+Expected: all green.
+
+- [ ] Step 15.1.1: Run + confirm green.
+- [ ] Step 15.1.2: If any failures, fix before proceeding.
+
+### Task 15.2: Run frontend tests + verify guards
+
+```bash
+cd frontend && npm test && npm run verify
+```
+
+- [ ] Step 15.2.1: Run + confirm green.
+- [ ] Step 15.2.2: Fix breakage.
+
+### Task 15.3: Open PR `feat/wallet-model` → `dev`
+
+```bash
+gh pr create --base dev --title "feat: wallet model — user L$ wallet, hard reservations, auto-funded escrow" --body "$(cat <<'EOF'
+## Summary
+
+Replaces the per-obligation in-world payment flow (escrow / listing-fee / penalty
+paid at the terminal) with a per-user L$ wallet. See
+`docs/superpowers/specs/2026-04-30-wallet-model-design.md` for full design.
+
+Highlights:
+- Lockless deposits via terminal `money()` reentrancy
+- Hard bid reservations (eliminates "winner stiffs seller" failure mode)
+- Escrow auto-funds at auction close from reservation
+- Refunds collapse to wallet credits (no more `TerminalCommand{action=REFUND}`)
+- Withdrawals route to user's verified SL avatar (locked at verification)
+- New per-flow withdraw slots in LSL (lockless, no terminal-wide griefing surface)
+- Separate `slpa-verifier-giver` prim — fixes two-place rule for parcel verifier updates
+
+## Test plan
+- [x] Backend `./mvnw test` green
+- [x] Frontend `npm test && npm run verify` green
+- [ ] Postman collection updated (Wallet folder; 4 SL-payment folders removed)
+- [ ] Manual smoke procedures listed in design spec §14.3
+EOF
+)"
+```
+
+- [ ] Step 15.3.1: Push final commits.
+- [ ] Step 15.3.2: Run `gh pr create` with the body above.
+- [ ] Step 15.3.3: Note the PR URL for the user.
+
+### Task 15.4: After user merges feat → dev, open PR `dev → main`
+
+```bash
+git checkout dev
+git pull origin dev
+gh pr create --base main --title "release: wallet model" --body "..."
+```
+
+- [ ] Step 15.4.1: Open PR.
+- [ ] Step 15.4.2: Note URL for user.
+
+### Task 15.5: After user merges dev → main, smoke-test prod
+
+After merge, GHA auto-deploys backend; Amplify auto-deploys frontend.
+
+Smoke procedure:
+
+```bash
+# 1. Confirm backend health
+curl https://api.slparcels.com/actuator/health
+
+# 2. Confirm new endpoints exist (will return 401 without JWT — that's fine, proves they're routed)
+curl -X GET https://api.slparcels.com/api/v1/me/wallet
+# expect 401 Unauthorized
+
+# 3. Confirm old endpoints are gone (404)
+curl -X POST https://api.slparcels.com/api/v1/sl/escrow/payment -H "Content-Type: application/json" -d '{}'
+# expect 404 Not Found
+
+# 4. (Manual: cannot do without LSL avatar identity) /sl/wallet/deposit smoke — deferred to in-world swap step.
+```
+
+- [ ] Step 15.5.1: Run smoke commands; confirm responses.
+- [ ] Step 15.5.2: Hand off the in-world swap procedure + manual smoke list to the user (text deliverable, see Task 15.6).
+
+### Task 15.6: Provide manual smoke + rollback procedures to user
+
+Final deliverable to the user (text response, not a file):
+
+**Manual smoke procedure (after in-world LSL swap):**
+1. Drop new `slpa-terminal.lsl` + updated `config` notecard into the SLPA HQ terminal prim.
+2. Drop new `slpa-verifier-giver.lsl` + config into a new prim at SLPA HQ.
+3. Confirm "registered" startup ping in chat.
+4. Right-click the SLPA Terminal prim → Pay → L$10. Confirm owner-say `payment ok DEPOSIT L$10 from <name>`. Confirm wallet panel shows L$10.
+5. Touch the prim → menu → Withdraw → 5 → Yes. Confirm L$5 arrives in your avatar wallet within ~30s. Confirm wallet panel shows L$5 remaining.
+6. Touch the verifier-giver prim → confirm SLPA Parcel Verifier inventory item received.
+7. End-to-end auction: deposit more L$, place a bid on a test auction, confirm reserved/available updated; outbid yourself with a second account; confirm reservations swap correctly.
+8. Test BIN: click BIN on a test auction with sufficient balance; confirm escrow created in `FUNDED` state immediately.
+
+**Rollback procedure (if smoke fails):**
+1. Restore RDS snapshot:
+   ```bash
+   aws rds restore-db-instance-from-db-snapshot \
+       --db-instance-identifier slpa-prod-db-restored \
+       --db-snapshot-identifier pre-wallet-<sha> \
+       --profile slpa-prod
+   ```
+   Update Parameter Store `SPRING_DATASOURCE_URL` to restored endpoint. Restart ECS.
+2. `git revert -m 1 <merge-commit-sha>; git push origin main` — GHA redeploys old backend.
+3. In-world: drag-drop old `slpa-terminal.lsl` + old config notecard back into each prim. Restore old SLPA Parcel Verifier inventory item to terminal prims. Optionally remove the new verifier-giver prim.
+4. Frontend revert: Amplify auto-redeploys from reverted main commit.
+5. Postman collection: revert via git on collection JSON.
+
+Total recovery: ~45 min.
+
+- [ ] Step 15.6.1: Provide the above as a final text deliverable to the user.
+
+---
+
+## Self-review (post-write)
+
+Spec coverage check (against spec §1 In-Scope items):
+
+- ✓ `user_ledger`, `bid_reservations`, `users` columns — Phase 1.
+- ✓ `/sl/wallet/deposit`, `/sl/wallet/withdraw-request` — Phase 3.
+- ✓ `/me/wallet` (GET, withdraw, pay-penalty, accept-terms, pay-listing-fee) — Phase 4.
+- ✓ Bid + BIN modifications — Phase 5.
+- ✓ Auction-end auto-fund + ESCROW_PENDING retirement — Phase 1.6 + Phase 6.
+- ✓ Refund collapse — Phase 7.
+- ✓ Removed endpoints — Phase 8.
+- ✓ Reconciliation extension — Phase 9 (schema in 1.5, code in 9.1).
+- ✓ Dormancy — Phase 10.
+- ✓ Wallet terms-of-use page — Phase 11.7.
+- ✓ LSL rewrites — Phase 12.
+- ✓ Postman rebuild — Phase 13.
+- ✓ Documentation sweep — Phase 14.
+
+Placeholder scan: no `TBD`, no `TODO`, no "implement later". One use of `<next>` for Flyway version numbers — that's a real lookup the implementor performs at task time, not a placeholder. One use of `<sha>` for git commit hash — same.
+
+Type consistency: `WalletService` method names referenced consistently across phases (`deposit`, `withdrawSiteInitiated`, `withdrawTouchInitiated`, `payPenalty`, `swapReservation`, `autoFundEscrow`, `creditEscrowRefund`, `creditListingFeeRefund`, `debitListingFee`, `releaseReservationsForAuction`, `releaseAllReservationsForUser`).
+
+Scope check: this is one cohesive implementation plan for one cohesive feature. Phase boundaries are dependency-driven, not scope-driven. The plan is large but unified.

--- a/docs/superpowers/specs/2026-04-30-wallet-model-design.md
+++ b/docs/superpowers/specs/2026-04-30-wallet-model-design.md
@@ -1,0 +1,1170 @@
+# Wallet Model — User L$ Wallet, Hard Bid Reservations, Auto-Funded Escrow
+
+**Date:** 2026-04-30
+**Branch target:** `feat/wallet-model` off `dev`
+**Scope:** Replace the per-obligation in-world payment flow (escrow / listing-fee / penalty paid directly at the terminal) with a user wallet model. Deposits credit a per-user L$ balance; bids hard-reserve from balance; escrow auto-funds at auction close; refunds collapse to wallet credits; withdrawals route to the user's verified SL avatar via the existing terminal-command pipeline. Includes all required schema, backend services, frontend dashboard work, LSL rewrites, Postman rebuild, and operational scaffolding (reconciliation extension, dormancy, terms-of-use).
+
+This is a destructive, single-shot replacement of four SL-headers payment endpoints and the in-world touch flow. With no live customers, schema migrations are forward-only and additive-only discipline is not required; the rollback path is `git revert` + RDS snapshot restore.
+
+---
+
+## §1 — Scope
+
+**In scope:**
+
+- New entities: `user_ledger` (append-only per-user ledger), `bid_reservations` (active high-bid reservations per user per auction).
+- New columns on `users`: `balance_lindens`, `reserved_lindens`, `wallet_dormancy_started_at`, `wallet_dormancy_phase`, `wallet_terms_accepted_at`, `wallet_terms_version`.
+- New SL-headers-gated endpoints: `POST /api/v1/sl/wallet/deposit`, `POST /api/v1/sl/wallet/withdraw-request`.
+- New user-facing endpoints: `GET /api/v1/me/wallet`, `POST /api/v1/me/wallet/withdraw`, `POST /api/v1/me/wallet/pay-penalty`, `POST /api/v1/me/wallet/accept-terms`, `POST /api/v1/me/auctions/{id}/pay-listing-fee` (replaces the in-world listing-fee terminal flow; transitions DRAFT → DRAFT_PAID with wallet debit).
+- Modified endpoints: bid placement (penalty + balance preconditions, hard reservation swap), Buy-It-Now (penalty + balance precondition, full-amount debit). The existing `PUT /api/v1/auctions/{id}/verify` (DRAFT_PAID → VERIFICATION_PENDING / ACTIVE per Method A or B) is unchanged in shape — its precondition that listing fee has been paid still holds; the wallet model only changes how the listing fee was paid.
+- Removed endpoints: `POST /api/v1/sl/escrow/payment`, `POST /api/v1/sl/listing-fee/payment`, `POST /api/v1/sl/penalty-lookup`, `POST /api/v1/sl/penalty-payment`. The dev-profile listing-fee stub is renamed to `/api/v1/dev/auctions/{id}/mark-listing-fee-paid` for fixture use.
+- Auction lifecycle: `ESCROW_PENDING` state retired; escrow rows are created directly in `FUNDED` state by `AuctionEndTask.closeOne` (and by the BIN handler) by consuming the winner's bid reservation and debiting their wallet.
+- Refund collapse: escrow expiry refunds, dispute refunds, and listing-fee refunds become wallet credits (`user_ledger` rows). No `TerminalCommand{action=REFUND}` is queued for refunds. Outbound `TerminalCommand` is now used only for `PAYOUT` (seller payout after transfer) and `WITHDRAW` (user-initiated wallet withdrawals + dormancy auto-returns).
+- Dormancy: 30-day inactivity threshold (signal: most recent `refresh_tokens.created_at`), 4 weekly SL IM notifications via Epic 09 dispatcher, then auto-withdraw to the user's verified SL avatar. Excludes users with active reservations or funded escrows.
+- Reconciliation extension: `ReconciliationService.runDaily()` adds `SUM(users.balance_lindens) + SUM(active_bid_reservations.amount)` to its expected total, plus a `DENORM_DRIFT` precheck on `users.reserved_lindens`.
+- Wallet terms-of-use: new `/legal/terms` website page; first-deposit click-through stamps `users.wallet_terms_accepted_at`.
+- LSL: full rewrite of `slpa-terminal.lsl` (lockless deposit via `money()` reentrancy, per-flow withdraw slots dispatched by avatar key on a single shared listen, no per-obligation menu). New `slpa-verifier-giver.lsl` script + prim (touch-to-receive parcel verifier; replaces the unified terminal's "Get Parcel Verifier" menu option).
+- Postman collection rebuild: new `Wallet` folder, retire 4 SL-payment folders, update `SLPA Dev` environment variables.
+- Documentation: full LSL READMEs, root README sweep, `CONVENTIONS.md` additions (immutable ledger discipline, `available = balance - reserved` invariant, recipient-UUID lock), `FOOTGUNS.md` additions, `DEFERRED_WORK.md` updates.
+
+**Out of scope (explicitly deferred):**
+
+- USD ↔ L$ exchange functionality. Wallet only holds L$ from resident-to-resident transfers.
+- Interest, yield, or any return-on-balance product (prohibited by SL banking policy carve-out).
+- Multi-currency support.
+- Admin manual adjustments to wallet ledger (added later if needed; the schema supports `entry_type=ADJUSTMENT` with `created_by_admin_id` for forward compatibility, but no admin UI is built in this work).
+- Email confirmation on withdrawals (no SMTP infrastructure; not required because the recipient UUID is locked to the user's verified SL avatar).
+- Per-withdraw caps, daily caps, cool-downs (not required for the same reason — see §10).
+- Automatic "abandoned cart" cleanup of un-allocated deposits — N/A in the wallet model since there is no allocation step; deposits credit the wallet directly.
+
+**Constraints inherited from prior decisions:**
+
+- `available = balance_lindens - reserved_lindens` is the invariant. Withdraw, allocate, and bid endpoints all gate on `available`, never on raw `balance_lindens`.
+- Ledgers are append-only. Withdraw lifecycle uses `WITHDRAW_QUEUED → WITHDRAW_COMPLETED|WITHDRAW_REVERSED` as separate appended rows, not mutations of the original.
+- Recipient UUID for any outbound L$ is always `user.slAvatarUuid` (locked at verification). Never client-supplied.
+- No customers exist yet → schema migrations may be destructive; rollback is RDS snapshot restore + `git revert`.
+
+---
+
+## §2 — Architectural Overview
+
+```
+            ┌────────────────────────────────────────────────────┐
+            │  In-world SLPA Terminal (LSL prim)                 │
+            │                                                    │
+            │  Steady-state:  llSetPayPrice(default + quick L$)  │
+            │  on money():    POST /sl/wallet/deposit (lockless) │
+            │  on touch:      Dialog [Deposit-info, Withdraw]    │
+            │  Withdraw:      per-flow slot, single shared listen│
+            └──────┬──────────────────────────┬──────────────────┘
+                   │                          │
+        /sl/wallet/deposit         /sl/wallet/withdraw-request
+                   ▼                          ▼
+        ┌───────────────────────────────────────────────────────┐
+        │  Backend (Spring Boot)                                │
+        │                                                       │
+        │  ┌──────────────┐   ┌──────────────────────────────┐  │
+        │  │ WalletService│◄──┤ Existing Escrow / Auction /  │  │
+        │  │              │   │ Bid services                 │  │
+        │  └──────┬───────┘   └──────────────────────────────┘  │
+        │         │                                             │
+        │         ▼                                             │
+        │  user_ledger          escrow_transactions             │
+        │  (per-user, append)   (per-escrow, append, kept)      │
+        │                                                       │
+        │  bid_reservations  ────►  users.balance_lindens       │
+        │  (active locks)           users.reserved_lindens      │
+        │                                                       │
+        │  Outbound:  TerminalCommand{PAYOUT | WITHDRAW}        │
+        │            (REFUND action retired — refunds = credits)│
+        └───────────────────────────────────────────────────────┘
+                   ▲                          ▲
+                   │ /me/wallet/*             │ Bid / BIN / Publish
+                   │                          │
+        ┌──────────┴──────────────────────────┴─────────────────┐
+        │  Frontend (Next.js)                                   │
+        │  Wallet panel (balance / reserved / available)        │
+        │  Withdraw dialog · Pay-penalty dialog                 │
+        │  Bid + Publish flows show preconditions inline        │
+        └───────────────────────────────────────────────────────┘
+```
+
+The existing `escrow_transactions` ledger remains in place — escrow is still a per-auction state machine with its own ledger. The wallet model adds a per-user ledger above it. Auction-end auto-fund writes both ledger rows in one transaction (`user_ledger.ESCROW_DEBIT` + `escrow_transactions.AUCTION_ESCROW_PAYMENT`); reconciliation ties them together.
+
+The HTTP-in pipeline from backend to terminal (PAYOUT / WITHDRAW) is unchanged in shape — the dispatcher, terminal pool, retry budget, and idempotency-key model are reused as-is. The `REFUND` action is removed from `TerminalCommand` because all refund flows now land as wallet credits, not L$ transfers back to a resident.
+
+---
+
+## §3 — Data Model
+
+### 3.1 `users` (modified)
+
+Additive columns (all `NOT NULL DEFAULT 0` or nullable):
+
+| Column | Type | Notes |
+|---|---|---|
+| `balance_lindens` | `BIGINT NOT NULL DEFAULT 0` | Available + reserved combined. `CHECK (balance_lindens >= 0)`. |
+| `reserved_lindens` | `BIGINT NOT NULL DEFAULT 0` | Sum of active reservations. Denormalized; `CHECK (reserved_lindens >= 0)` and `CHECK (balance_lindens >= reserved_lindens)`. |
+| `wallet_dormancy_started_at` | `TIMESTAMPTZ NULL` | Stamped by `WalletDormancyJob` phase 1; cleared on login or refresh-token rotation. |
+| `wallet_dormancy_phase` | `SMALLINT NULL CHECK (wallet_dormancy_phase BETWEEN 1 AND 4)` | Current dormancy notification phase; cleared on activity. |
+| `wallet_terms_accepted_at` | `TIMESTAMPTZ NULL` | Click-through stamp; required before first deposit (UI-side gate). |
+| `wallet_terms_version` | `VARCHAR(16) NULL` | Version of terms accepted; future material change re-prompts. |
+
+`available_lindens` is **not** stored — computed as `balance_lindens - reserved_lindens` at read time.
+
+### 3.2 `user_ledger` (new) — append-only
+
+```sql
+CREATE TABLE user_ledger (
+    id                  BIGSERIAL PRIMARY KEY,
+    user_id             BIGINT NOT NULL REFERENCES users(id),
+    entry_type          VARCHAR(32) NOT NULL,
+    amount              BIGINT NOT NULL CHECK (amount > 0),
+    balance_after       BIGINT NOT NULL,
+    reserved_after      BIGINT NOT NULL,
+    ref_type            VARCHAR(32) NULL,
+    ref_id              BIGINT NULL,
+    sl_transaction_id   VARCHAR(36) NULL,
+    idempotency_key     VARCHAR(64) NULL,
+    description         VARCHAR(500) NULL,
+    created_at          TIMESTAMPTZ NOT NULL,
+    created_by_admin_id BIGINT NULL REFERENCES users(id)
+);
+
+CREATE INDEX user_ledger_user_created_idx ON user_ledger (user_id, created_at DESC);
+CREATE UNIQUE INDEX user_ledger_sl_tx_idx ON user_ledger (sl_transaction_id) WHERE sl_transaction_id IS NOT NULL;
+CREATE UNIQUE INDEX user_ledger_idempotency_idx ON user_ledger (idempotency_key) WHERE idempotency_key IS NOT NULL;
+
+ALTER TABLE user_ledger ADD CONSTRAINT user_ledger_entry_type_check CHECK (
+    entry_type IN (
+        'DEPOSIT',
+        'WITHDRAW_QUEUED', 'WITHDRAW_COMPLETED', 'WITHDRAW_REVERSED',
+        'BID_RESERVED', 'BID_RELEASED',
+        'ESCROW_DEBIT', 'ESCROW_REFUND',
+        'LISTING_FEE_DEBIT', 'LISTING_FEE_REFUND',
+        'PENALTY_DEBIT',
+        'ADJUSTMENT'
+    )
+);
+```
+
+`amount` is always positive; direction is implicit in `entry_type`. `balance_after` and `reserved_after` are snapshots written at insert time — these are the source of truth for state, derived deltas are computed against the prior row when needed.
+
+`ref_type` / `ref_id` point to the related domain entity (`AUCTION`, `ESCROW`, `BID`, `TERMINAL_COMMAND`, `LISTING_FEE_REFUND`, `PENALTY`, `ADJUSTMENT`). No FK constraint — append-only ledgers don't cascade.
+
+### 3.3 `bid_reservations` (new)
+
+```sql
+CREATE TABLE bid_reservations (
+    id              BIGSERIAL PRIMARY KEY,
+    user_id         BIGINT NOT NULL REFERENCES users(id),
+    auction_id      BIGINT NOT NULL REFERENCES auctions(id),
+    bid_id          BIGINT NOT NULL REFERENCES bids(id),
+    amount          BIGINT NOT NULL CHECK (amount > 0),
+    created_at      TIMESTAMPTZ NOT NULL,
+    released_at     TIMESTAMPTZ NULL,
+    release_reason  VARCHAR(32) NULL CHECK (release_reason IN (
+        'OUTBID', 'AUCTION_CANCELLED', 'AUCTION_FRAUD_FREEZE',
+        'ESCROW_FUNDED', 'USER_BANNED'
+    ))
+);
+
+CREATE UNIQUE INDEX bid_reservations_active_idx
+    ON bid_reservations (user_id, auction_id) WHERE released_at IS NULL;
+
+CREATE INDEX bid_reservations_user_active_idx
+    ON bid_reservations (user_id) WHERE released_at IS NULL;
+```
+
+The partial unique index enforces "at most one active reservation per (user, auction)." Outbid → release prior, insert new for same user/auction is fine because the prior row's `released_at` is no longer NULL.
+
+### 3.4 Reconciliation extension
+
+`reconciliation_runs` (existing table) gains:
+
+| Column | Type | Notes |
+|---|---|---|
+| `wallet_balance_total` | `BIGINT NULL` | `SUM(users.balance_lindens)` at run time. |
+| `wallet_reserved_total` | `BIGINT NULL` | `SUM(users.reserved_lindens)` at run time. |
+| `escrow_locked_total` | `BIGINT NULL` | The existing `expected_total` value, renamed for clarity. |
+
+`expected_total` becomes the sum of all three. Old runs left with NULL for the new columns are fine (read-only history).
+
+`ReconciliationStatus` enum gains `DENORM_DRIFT` for the case where `users.reserved_lindens` doesn't match the live `bid_reservations` sum.
+
+### 3.5 Invariants
+
+For any user U at any consistent snapshot (post-commit):
+
+1. `users.balance_lindens(U) = SUM(user_ledger.balance_after of the latest row WHERE user_id=U)`. Every ledger row updates the snapshot.
+2. `users.reserved_lindens(U) = SUM(bid_reservations.amount WHERE user_id=U AND released_at IS NULL)`.
+3. `users.balance_lindens(U) >= users.reserved_lindens(U)` (DB-enforced).
+4. `SUM(users.balance_lindens) + SUM(active reservations) + SUM(escrow_lockedstates.amount) ≈ SLPA service avatar L$ balance` (within in-flight `TerminalCommand` tolerance; `WalletReconciliationJob` verifies daily).
+
+Drift on (1), (2), or (4) → reconciliation alarm.
+
+---
+
+## §4 — HTTP Contracts
+
+### 4.1 New SL-headers-gated endpoints
+
+All inherit the existing pipeline: `SlHeaderValidator` (`X-SecondLife-Shard=Production`, `X-SecondLife-Owner-Key ∈ slpa.sl.trusted-owner-keys`) + `sharedSecret` body field + `terminalId` lookup.
+
+#### `POST /api/v1/sl/wallet/deposit`
+
+**Request:**
+```json
+{
+  "payerUuid": "<money() payerKey>",
+  "amount": 1500,
+  "slTransactionKey": "<llGenerateKey() once, same across retries>",
+  "terminalId": "...",
+  "sharedSecret": "..."
+}
+```
+
+**Validation pipeline:**
+1. `SlHeaderValidator` → 403 with `ERROR/BAD_HEADERS` body on fail.
+2. `sharedSecret` matches `slpa.escrow.terminal-shared-secret` → 403 `ERROR/SECRET_MISMATCH`.
+3. `terminalId` resolves to a registered `Terminal` row → 404 `ERROR/UNKNOWN_TERMINAL`.
+4. Idempotency: if `user_ledger.sl_transaction_id == slTransactionKey` exists → return that row's original wire response (replay).
+5. `users.findBySlAvatarUuid(payerUuid)`. Absent → 200 `REFUND/UNKNOWN_PAYER`. Status `BANNED|FROZEN` → 200 `REFUND/USER_FROZEN`.
+6. Lock user `PESSIMISTIC_WRITE`. `balance_lindens += amount`. Insert `user_ledger{type=DEPOSIT, amount, balance_after, reserved_after, sl_transaction_id, ref_type=null, ref_id=null}`.
+7. Commit. WS envelope `WALLET_BALANCE_CHANGED` to user's STOMP topic if connected.
+
+**Response shapes (LSL-parsable):**
+```json
+{ "status": "OK" }
+{ "status": "REFUND",  "reason": "UNKNOWN_PAYER" | "USER_FROZEN", "message": "..." }
+{ "status": "ERROR",   "reason": "BAD_HEADERS" | "SECRET_MISMATCH" | "UNKNOWN_TERMINAL", "message": "..." }
+```
+
+REFUND vs ERROR rule (preserved from existing endpoints): on `REFUND`, the LSL script `llTransferLindenDollars` to bounce; on `ERROR`, owner-say only — never refund blind, since ERROR may be an attacker probing the endpoint with no real L$ attached.
+
+#### `POST /api/v1/sl/wallet/withdraw-request`
+
+**Request:**
+```json
+{
+  "payerUuid": "<toucher avatar key>",
+  "amount": 500,
+  "slTransactionKey": "<one per confirmed touch session>",
+  "terminalId": "...",
+  "sharedSecret": "..."
+}
+```
+
+**Validation:**
+1. Header + secret + terminal pipeline (same).
+2. Idempotency on `slTransactionKey` against `user_ledger`.
+3. Resolve user by `slAvatarUuid`. Absent → `REFUND_BLOCKED/NOT_LINKED`. Status `BANNED|FROZEN` → `REFUND_BLOCKED/USER_FROZEN`.
+4. Lock user. Validate `(balance_lindens - reserved_lindens) >= amount`. Insufficient → `REFUND_BLOCKED/INSUFFICIENT_BALANCE`.
+5. `balance_lindens -= amount`. Insert `user_ledger{type=WITHDRAW_QUEUED, sl_transaction_id, idempotency_key=null}`. Insert `TerminalCommand{action=WITHDRAW, recipient_uuid=user.slAvatarUuid, amount, idempotency_key=<auto>}`.
+6. Commit.
+
+**Response shapes:**
+```json
+{ "status": "OK", "queueId": 42 }
+{ "status": "REFUND_BLOCKED", "reason": "INSUFFICIENT_BALANCE" | "USER_FROZEN" | "NOT_LINKED", "message": "..." }
+{ "status": "ERROR", "reason": "BAD_HEADERS" | "SECRET_MISMATCH" | "UNKNOWN_TERMINAL", "message": "..." }
+```
+
+`REFUND_BLOCKED` is distinct from `REFUND`: no L$ was paid in this flow, so the LSL **does not** call `llTransferLindenDollars`. It owner-says + `llRegionSayTo(toucher, message)` and releases the session slot.
+
+### 4.2 New user-facing endpoints (JWT-gated)
+
+#### `GET /api/v1/me/wallet`
+
+**Response:**
+```json
+{
+  "balance":   1500,
+  "reserved":  500,
+  "available": 1000,
+  "penaltyOwed": 0,
+  "termsAccepted": true,
+  "termsVersion": "1.0",
+  "recentLedger": [
+    { "id": 12, "entryType": "DEPOSIT", "amount": 1000, "balanceAfter": 1500, "reservedAfter": 500, "createdAt": "..." },
+    ...
+  ]
+}
+```
+
+`recentLedger` is the most recent 50 entries; `GET /api/v1/me/wallet/ledger?cursor=...` paginates older entries.
+
+#### `POST /api/v1/me/wallet/withdraw`
+
+**Request:**
+```json
+{ "amount": 500, "idempotencyKey": "<client UUID>" }
+```
+
+Recipient is **always** `user.slAvatarUuid`. Never client-supplied; the field is not present on the request schema.
+
+**Validation:**
+1. JWT → user identity.
+2. `user.status NOT IN (BANNED, FROZEN)` → 403 `USER_FROZEN`.
+3. Idempotency on `idempotencyKey` against `user_ledger.idempotency_key`. Replay returns the original 202.
+4. Lock user. Validate `available >= amount`. Insufficient → 422 `INSUFFICIENT_AVAILABLE_BALANCE { available, requested }`.
+5. Decrement balance, append `WITHDRAW_QUEUED` row with `idempotency_key`, insert `TerminalCommand{action=WITHDRAW}`.
+6. WS envelope `WALLET_BALANCE_CHANGED`.
+
+**Response:** `202 { queueId, estimatedFulfillmentSeconds }`.
+
+#### `POST /api/v1/me/wallet/pay-penalty`
+
+**Request:**
+```json
+{ "amount": 200, "idempotencyKey": "<client UUID>" }
+```
+
+**Validation:**
+1. JWT → user.
+2. Lock user.
+3. `amount > 0 AND amount <= user.penalty_balance_owed` → 422 `AMOUNT_EXCEEDS_OWED { owed, requested }`.
+4. `(balance - reserved) >= amount` → 422 `INSUFFICIENT_AVAILABLE_BALANCE`. (Cannot surrender reserved L$ to pay a penalty — that would break bid commitments.)
+5. Idempotency on `idempotencyKey`.
+6. `balance_lindens -= amount`; `penalty_balance_owed -= amount`; append `user_ledger{type=PENALTY_DEBIT, ref_type=PENALTY, ref_id=null}`.
+7. If `penalty_balance_owed` reaches 0 → existing penalty-cleared logic fires (Epic 08 hooks).
+
+**Response:** `200 { newBalance, newPenaltyOwed }`.
+
+#### `POST /api/v1/me/wallet/accept-terms`
+
+**Request:** `{ termsVersion: "1.0" }`. JWT-gated. Stamps `wallet_terms_accepted_at = now`, `wallet_terms_version = body.termsVersion`. `200`.
+
+Required before first deposit credits (the deposit endpoint succeeds without this flag, but the website refuses to render the deposit-instructions modal until the user has accepted).
+
+### 4.3 Modified existing endpoints
+
+#### Bid placement (`POST /api/v1/auctions/{id}/bid`)
+
+Existing endpoint shape unchanged. New preconditions inside the existing transaction (auction lock first, then user locks ascending):
+
+1. (existing) Lock auction `PESSIMISTIC_WRITE`.
+2. (existing) Validate auction state, bid > current high.
+3. (existing) Read prior active `bid_reservation` for this auction, identify prior bidder.
+4. Lock new + prior bidder rows in ascending `user_id` order.
+5. **NEW:** Validate `newBidder.penalty_balance_owed == 0`. Fail → 422 `PENALTY_OUTSTANDING { owed }`.
+6. **NEW:** Validate `(newBidder.balance_lindens - newBidder.reserved_lindens) >= newBidAmount`. Fail → 422 `INSUFFICIENT_AVAILABLE_BALANCE`.
+7. **NEW:** Reservation swap (see §5).
+8. (existing) Persist bid row.
+9. Commit.
+
+#### Buy-It-Now (`POST /api/v1/auctions/{id}/buy-now`)
+
+Same preconditions as bid. Plus:
+
+- BIN amount > current high; the BIN-clicker may have an existing reservation on this auction at a lower amount.
+- Validate `available + (existing reservation on this auction, if any) >= bin_price`.
+- On success: release any existing reservation on this auction (it would be the BIN-clicker's), debit `balance_lindens -= bin_price`, append `user_ledger{type=ESCROW_DEBIT}`, transition auction to `ENDED+BOUGHT_NOW`, create escrow directly in `FUNDED` state.
+
+#### Listing-fee payment (new endpoint, drives DRAFT → DRAFT_PAID)
+
+Replaces the in-world listing-fee terminal flow. The existing `PUT /api/v1/auctions/{id}/verify` endpoint (which today transitions DRAFT_PAID → VERIFICATION_PENDING / ACTIVE) is unchanged. Its precondition `state == DRAFT_PAID` still holds; the wallet model only changes how DRAFT becomes DRAFT_PAID.
+
+**New endpoint:** `POST /api/v1/me/auctions/{id}/pay-listing-fee`
+
+**Validation:**
+1. JWT → user.
+2. Find auction; verify `seller_user_id == user.id` AND `state == DRAFT`.
+3. Lock user.
+4. **NEW:** Validate `user.penalty_balance_owed == 0` → 422 `PENALTY_OUTSTANDING`.
+5. **NEW:** Validate `available >= auction.listing_fee_amount` → 422 `INSUFFICIENT_AVAILABLE_BALANCE`.
+6. `balance_lindens -= listing_fee_amount`; append `user_ledger{type=LISTING_FEE_DEBIT, ref_type=AUCTION, ref_id=auction.id}`; append `escrow_transactions{type=LISTING_FEE_PAYMENT, status=COMPLETED}`.
+7. Transition `DRAFT → DRAFT_PAID`. Commit.
+8. WS envelope `LISTING_FEE_PAID`.
+
+The seller's UX is two clicks: pay listing fee (this endpoint), then verify (the existing endpoint). Same as today, just the L$ source for the first step changes from in-world payment to wallet debit.
+
+DRAFT creation itself has zero L$ involvement — it's just a database row. Sellers can save and abandon drafts freely without affecting balance, available, or anything wallet-side.
+
+### 4.4 Removed endpoints
+
+- `POST /api/v1/sl/escrow/payment` — replaced by auto-fund at auction close (see §6).
+- `POST /api/v1/sl/listing-fee/payment` — replaced by listing-fee debit folded into publish (§4.3).
+- `POST /api/v1/sl/penalty-lookup` — penalty owed exposed on `GET /me/wallet` and `GET /me/profile`.
+- `POST /api/v1/sl/penalty-payment` — replaced by `POST /me/wallet/pay-penalty`.
+
+The dev-profile listing-fee stub `POST /api/v1/dev/auctions/{id}/pay` is renamed to `POST /api/v1/dev/auctions/{id}/mark-listing-fee-paid` — the rename clarifies that no L$ changes hands; it just transitions the auction state for fixture setup.
+
+### 4.5 Endpoint summary table
+
+| Endpoint | Status |
+|---|---|
+| `POST /api/v1/sl/wallet/deposit` | NEW |
+| `POST /api/v1/sl/wallet/withdraw-request` | NEW |
+| `GET  /api/v1/me/wallet` | NEW |
+| `GET  /api/v1/me/wallet/ledger` | NEW |
+| `POST /api/v1/me/wallet/withdraw` | NEW |
+| `POST /api/v1/me/wallet/pay-penalty` | NEW |
+| `POST /api/v1/me/wallet/accept-terms` | NEW |
+| `POST /api/v1/me/auctions/{id}/pay-listing-fee` | NEW (drives DRAFT → DRAFT_PAID with wallet debit) |
+| `POST /api/v1/auctions/{id}/bid` | MODIFIED (preconditions + reservation swap) |
+| `POST /api/v1/auctions/{id}/buy-now` | MODIFIED (preconditions + immediate escrow funding) |
+| `PUT  /api/v1/auctions/{id}/verify` | UNCHANGED (still drives DRAFT_PAID → VERIFICATION_PENDING / ACTIVE) |
+| `POST /api/v1/auctions/{id}/escrow/dispute` | UNCHANGED |
+| `GET  /api/v1/auctions/{id}/escrow` | UNCHANGED |
+| `POST /api/v1/sl/terminal/register` | UNCHANGED |
+| `POST /api/v1/sl/terminal/heartbeat` | UNCHANGED |
+| `POST /api/v1/sl/escrow/payout-result` | EXTENDED (now also handles `WITHDRAW` action results) |
+| `POST /api/v1/sl/escrow/payment` | REMOVED |
+| `POST /api/v1/sl/listing-fee/payment` | REMOVED |
+| `POST /api/v1/sl/penalty-lookup` | REMOVED |
+| `POST /api/v1/sl/penalty-payment` | REMOVED |
+| `POST /api/v1/dev/auctions/{id}/pay` | RENAMED → `mark-listing-fee-paid` |
+
+---
+
+## §5 — Bid Reservation Atomicity
+
+### 5.1 Core operation
+
+When user A places a new high bid on auction X, in **one transaction**:
+
+1. Read prior active `bid_reservation` row for auction X (call its owner P, amount `p`, if any).
+2. Validate A has `available = balance_lindens(A) - reserved_lindens(A) >= newBidAmount` (precondition §4.3).
+3. If P exists: mark P's reservation `released_at=now, release_reason=OUTBID`; `users.reserved_lindens(P) -= p`; append `user_ledger{user=P, type=BID_RELEASED, amount=p, balance_after=unchanged, reserved_after=new, ref_type=BID, ref_id=oldBidId}`.
+4. Insert new `bid_reservation{user=A, auction=X, amount=newBidAmount, bid_id=newBid.id}`. `users.reserved_lindens(A) += newBidAmount`. Append `user_ledger{user=A, type=BID_RESERVED, amount=newBidAmount, balance_after=unchanged, reserved_after=new, ref_type=BID, ref_id=newBid.id}`.
+5. Insert the `bid` row itself (existing behavior).
+
+If precondition (2) fails → 422 `INSUFFICIENT_AVAILABLE_BALANCE`. No rows written; transaction rolled back.
+
+### 5.2 Lock ordering
+
+Rule: **lock auction first, then user rows in ascending `user_id` order.** Always.
+
+```
+1. SELECT FROM auctions WHERE id = X FOR UPDATE
+2. (read prior reservation; identify P)
+3. SELECT FROM users WHERE id IN (A, P) ORDER BY id ASC FOR UPDATE
+4. (do the reservation swap)
+5. (write bid row)
+6. COMMIT
+```
+
+The auction-then-users ordering is uniform across all bid requests, so two bids on the same auction serialize at step 1 before they reach the user locks. Two bids on different auctions never contend at step 1; they arrive at step 3 with possibly-overlapping user sets, and ascending-id ordering ensures any overlap is handled in the same lock order on both sides → no deadlock.
+
+### 5.3 Concurrent scenarios
+
+| Scenario | Resolution |
+|---|---|
+| A and C both try to outbid B simultaneously | Both block at step 1 on X's lock. Whichever wins, the other re-reads on retry (now finds A or C as high) and either bids higher or fails the existing "must exceed current high" check. B's reservation released exactly once. |
+| A bids on X while she's prior high on Y, and at the same instant another bidder outbids her on Y | Different auctions, different step-1 locks. Both reach step 3 and contend on A's user row. Ascending-id ordering serializes. Net: A's `reserved_lindens` reflects both, ledger has both rows. |
+| A places a bid while simultaneously initiating a withdraw | Bid request locks auction first, then A's user row. Withdraw locks A directly. Both contend at A's row. Whichever commits first, the other re-reads `available`. |
+| Auction-end debit fires while a bid is being placed on the same auction | Auction-end task takes the same `PESSIMISTIC_WRITE` on the auction. Bid blocks at step 1 until close commits; on retry, auction state is `ENDED`, bid is rejected. |
+| Auction cancelled / fraud-frozen while reservations active | Cancellation handler walks `bid_reservations WHERE auction_id=X AND released_at IS NULL`, releases each (`AUCTION_CANCELLED` or `AUCTION_FRAUD_FREEZE`), decrements each owner's `reserved_lindens`, appends `BID_RELEASED` rows. Same lock-then-mutate discipline. |
+
+### 5.4 Service-layer shape
+
+```java
+// com.slparcelauctions.backend.wallet.WalletService
+@Transactional(propagation = MANDATORY)  // caller already in a tx + holds locks
+public ReservationSwapResult swapReservation(
+    Auction auction,                  // already locked by caller
+    User newBidder,                   // already locked
+    long newBidAmount,
+    BidReservation priorReservation,  // nullable; owner already locked if non-null
+    Bid newBid                        // freshly persisted; provides bid_id
+);
+```
+
+Caller (`BidService.placeBid`) does the locking:
+
+```java
+@Transactional
+public Bid placeBid(BidRequest req) {
+    Auction auction = auctionRepo.findByIdForUpdate(req.auctionId());
+    // existing validation: state, bid > high, etc.
+    BidReservation prior = reservationRepo.findActiveForAuction(auction.id());
+    Set<Long> idsToLock = new TreeSet<>();
+    idsToLock.add(req.userId());
+    if (prior != null) idsToLock.add(prior.userId());
+    Map<Long, User> locked = userRepo.findByIdInForUpdateAscending(idsToLock);
+    User newBidder = locked.get(req.userId());
+    User priorBidder = prior == null ? null : locked.get(prior.userId());
+    validatePreconditions(newBidder, req.amount());      // penalty + available
+    Bid bid = bidRepo.save(buildBid(req));
+    walletService.swapReservation(auction, newBidder, req.amount(), prior, bid);
+    return bid;
+}
+```
+
+### 5.5 Defensive branch
+
+At auction-end auto-fund (§6.1), `bid_reservation.amount == escrow.final_bid_amount` should always hold. If it doesn't, that's a system-integrity bug — log loudly and freeze the escrow as `FROZEN` with `reason=BID_RESERVATION_AMOUNT_MISMATCH`. This is a "should be impossible" branch maintained for forensics, not for runtime recovery.
+
+---
+
+## §6 — Auction Lifecycle Changes
+
+### 6.1 Auto-fund at auction close
+
+`AuctionEndTask.closeOne` for `endOutcome=SOLD` (timer-driven close), in one transaction with the existing close logic:
+
+1. Lock auction (existing).
+2. Lock winner's user row.
+3. Lookup active `bid_reservation{user=winner, auction=this, released_at=null}`. Sanity: `reservation.amount == final_bid_amount`. Mismatch → `FROZEN` defensive branch (§5.5).
+4. Mark reservation `released_at=now, release_reason=ESCROW_FUNDED`. `users.reserved_lindens(winner) -= reservation.amount`.
+5. `users.balance_lindens(winner) -= final_bid_amount`.
+6. Append `user_ledger{type=BID_RELEASED, amount, ref_type=BID, ref_id=winner.bid_id}` (cleanup).
+7. Append `user_ledger{type=ESCROW_DEBIT, amount=final_bid_amount, ref_type=ESCROW, ref_id=escrow.id}` (debit).
+8. Insert escrow row directly in state `FUNDED`. Stamp `funded_at=now`. State transitions immediately to `TRANSFER_PENDING` (existing post-funded logic).
+9. Append `escrow_transactions{type=AUCTION_ESCROW_PAYMENT, status=COMPLETED}`.
+10. WS envelope `ESCROW_FUNDED` to seller + winner; existing 72h transfer deadline timer starts.
+
+### 6.2 Removed: `ESCROW_PENDING` state
+
+`Escrow.state` enum drops the `ESCROW_PENDING` value. The `EscrowTimeoutJob.findExpiredPending()` query path is removed. Escrows now begin life in `FUNDED`, never `ESCROW_PENDING`. The 48-hour payment-deadline column (`payment_deadline`) is dropped from the `escrows` table; the 72-hour `transfer_deadline` is unchanged.
+
+The "winner stiffs seller → escrow EXPIRED → penalty" failure mode is structurally impossible. Hard reservation guaranteed the funds at bid time.
+
+### 6.3 Buy-It-Now
+
+`POST /api/v1/auctions/{id}/buy-now` (existing endpoint shape). Updated transaction:
+
+1. Lock auction (existing). Validate state + that BIN is allowed for this auction.
+2. Lock BIN-clicker's user row.
+3. Validate `user.penalty_balance_owed == 0` → 422 `PENALTY_OUTSTANDING`.
+4. Read any existing `bid_reservation` for (user, auction). Let `existing_reserved = reservation?.amount ?? 0`.
+5. Validate `(balance - reserved + existing_reserved) >= bin_price` → 422 `INSUFFICIENT_AVAILABLE_BALANCE`. (Existing reservation counts toward funds available for BIN — the user already had it locked.)
+6. If existing reservation: release it (`release_reason=ESCROW_FUNDED`, decrement `reserved_lindens`, append `BID_RELEASED`).
+7. `balance_lindens -= bin_price`. Append `user_ledger{type=ESCROW_DEBIT, amount=bin_price}`.
+8. Persist BIN bid row + auction state transition `ACTIVE → ENDED+BOUGHT_NOW`.
+9. Insert escrow row in state `FUNDED`. Append `escrow_transactions{type=AUCTION_ESCROW_PAYMENT}`.
+10. Release all OTHER active reservations on this auction (`release_reason=AUCTION_CANCELLED` or a new `AUCTION_BIN_ENDED` reason; choose one and document — recommend `AUCTION_BIN_ENDED` for clarity), decrement those users' `reserved_lindens`, append `BID_RELEASED` rows.
+11. Commit. WS envelopes.
+
+### 6.4 Auction cancellation / freeze
+
+When an auction goes `CANCELLED` (admin or seller-initiated, where allowed) or `FROZEN` (fraud), the cancellation handler walks active reservations:
+
+```sql
+SELECT * FROM bid_reservations WHERE auction_id = ? AND released_at IS NULL;
+```
+
+For each: lock owner user row, mark reservation released with `release_reason=AUCTION_CANCELLED|AUCTION_FRAUD_FREEZE`, decrement `reserved_lindens`, append `BID_RELEASED` row. If the auction has a funded escrow, the escrow follows its own cancellation → refund path (§7).
+
+### 6.5 User ban
+
+When a user is banned (Epic 10 admin tooling fires `BAN_USER` action):
+
+1. Walk that user's active `bid_reservations`. For each: release with `release_reason=USER_BANNED`, decrement `reserved_lindens`, append `BID_RELEASED`.
+2. Walk that user's funded escrows where they're the winner. For each: cancel the escrow per existing dispute logic (transition to `DISPUTED` or `FROZEN` per ban-reason policy).
+3. Wallet balance is preserved through the ban itself. Restitution policy follows §12 (bans with restitution → auto-withdraw to last-verified avatar; bans without → balance held per legal-process disposition).
+
+---
+
+## §7 — Refund Flows (Collapsed to Credits)
+
+All three refund flows (escrow expiry, escrow dispute resolution, listing-fee refund) become wallet credits — no `TerminalCommand{action=REFUND}` is queued.
+
+### 7.1 Escrow refund (expiry or dispute resolution)
+
+When escrow goes `EXPIRED` (transfer deadline missed by seller) or dispute resolution rules a refund:
+
+1. Lock escrow + winner user row.
+2. `users.balance_lindens(winner) += escrow.final_bid_amount`. Append `user_ledger{type=ESCROW_REFUND, amount, ref_type=ESCROW, ref_id}`.
+3. Append `escrow_transactions{type=AUCTION_ESCROW_REFUND, status=COMPLETED}`.
+4. Stamp escrow state per existing flow (`COMPLETED` with refund disposition, or whatever the existing terminal state is for refunded escrows).
+5. WS envelope `ESCROW_REFUNDED`.
+
+### 7.2 Listing-fee refund
+
+`ListingFeeRefundProcessor` (existing scheduler) drains `listing_fee_refunds WHERE status=PENDING`. Per row:
+
+1. Lock seller user row.
+2. `users.balance_lindens(seller) += refund_amount`. Append `user_ledger{type=LISTING_FEE_REFUND, amount, ref_type=LISTING_FEE_REFUND, ref_id}`.
+3. Append `escrow_transactions{type=LISTING_FEE_REFUND, status=COMPLETED}`.
+4. Mark refund row `status=COMPLETED`.
+5. WS envelope `LISTING_FEE_REFUNDED`.
+
+`listing_fee_refunds.terminal_command_id` column becomes nullable / unused. The migration drops it (no live data).
+
+### 7.3 What stays on the terminal-command pipeline
+
+After this work, `TerminalCommand.action` enum has only two values:
+
+- `PAYOUT` — seller payout after transfer confirmed (real L$ leaving SLPA).
+- `WITHDRAW` — user-initiated withdrawal fulfillment, plus dormancy auto-returns.
+
+`REFUND` is removed from the enum and from the dispatcher's switch logic. Existing in-flight `REFUND` rows (none expected, but handle defensively): the migration converts them — checks each row's `escrow_id` / `listing_fee_refund_id`, applies the refund as a wallet credit, marks the command `COMPLETED`. Documented in the migration script.
+
+---
+
+## §8 — Penalty Payment + Listing/Bid Preconditions
+
+### 8.1 Manual-only payment
+
+Penalty is **not** auto-deducted. No flow auto-debits the wallet for an outstanding penalty — not auction close, not refunds, not withdrawal. The user surrenders L$ to clear penalty only by explicit `POST /me/wallet/pay-penalty` (§4.2).
+
+### 8.2 Penalty as a precondition (not a debt collected)
+
+| Action | Penalty blocks? |
+|---|---|
+| Place a new bid | Yes |
+| Click Buy-It-Now | Yes |
+| Publish a draft listing | Yes |
+| Existing high bid → auto-fund at auction close | No (commitment predates penalty) |
+| Deposit L$ | No |
+| Withdraw L$ | No |
+| Pay penalty | No |
+| Receive escrow refund / listing-fee refund | No |
+| Receive payout as seller | No |
+
+Principle: **new commitments require zero-penalty; existing commitments and money-flow operations don't.**
+
+### 8.3 The `available >= amount` rule for penalty payment
+
+A user with a positive `balance` but fully-reserved L$ across active winning bids cannot pay a penalty until reservations release (or until they deposit more L$). Surrendering reserved L$ to pay a penalty would break bid commitments mid-auction; not permitted. The frontend wallet panel surfaces this with an explicit hint when `penalty_owed > 0 && available < penalty_owed`.
+
+Resolution paths for the user:
+1. Deposit more L$ — covers the gap immediately.
+2. Wait for active bids to resolve. Outbids release reservations (available goes up). Wins debit balance + release reservations (available unchanged net, balance down).
+
+This is not a deadlock — the user always has agency via deposit. It's a corner the UI educates around.
+
+---
+
+## §9 — LSL Terminal Redesign
+
+### 9.1 SLPA Terminal — touch flow
+
+**Steady-state:**
+- Floating text: `SLPA Terminal\nRight-click → Pay to deposit\nTouch for menu`.
+- `llSetPayPrice(PAY_DEFAULT, [100, 500, 1000, 5000])` — four sensible quick-pay buttons + custom-amount entry. Pay UI is **always live** — there is no "AWAITING_PAYMENT" state to enter.
+
+**On `money(payerKey, amount)`:**
+1. Generate fresh `slTransactionKey` via `llGenerateKey()`.
+2. POST to `/sl/wallet/deposit`.
+3. On `OK` → owner-say `payment ok DEPOSIT L$<amount> from <payer>`. No state transition. No further user action.
+4. On `REFUND` → `llTransferLindenDollars(payer, amount)` to bounce; owner-say the reason.
+5. On `ERROR` → owner-say only; do NOT refund.
+6. On transient 5xx/timeout → bounded retry: 10s / 30s / 90s / 5m / 15m. After exhaustion → `CRITICAL: payment from {payer} L${amount} key {tx} not acknowledged` + stop retrying.
+
+**No lock acquired for deposits.** Multiple users can pay simultaneously; `money()` is naturally reentrant.
+
+**On touch:**
+1. Open `llDialog` on a per-toucher channel filtered by toucher's avatar key. Buttons: `[Deposit, Withdraw]`. No slot acquired yet.
+2. `Deposit` selected → `llRegionSayTo(toucher, ...)` with deposit instructions. No state change.
+3. `Withdraw` selected → acquire withdraw slot (or reset existing one for same avatar; per-flow slots in §9.2).
+
+### 9.2 Per-flow withdraw slots
+
+Single shared listen on a script-global negative channel, opened at `state_entry()`, never closed. Speaker filter is `NULL_KEY` (wildcard); per-avatar dispatch in the handler.
+
+```lsl
+// Globals
+integer withdrawChan;        // random negative, set in state_entry()
+integer withdrawListenHandle = -1;
+list    withdrawSessions = [];   // strided 3-wide:
+                                 //   [avatarKey, amountOrMinusOne, expiresAt, ...]
+integer MAX_WITHDRAW_SESSIONS = 4;
+integer SESSION_TTL_SECONDS = 60;
+```
+
+**On menu `Withdraw` selection:**
+- Find slot by avatar key. If exists → reset (re-prompt amount). If not exists and capacity available → allocate. If at capacity → `llRegionSayTo(toucher, "Terminal busy — try another nearby.")`.
+- `llTextBox(toucher, "Enter L$ amount to withdraw:", withdrawChan)`.
+- Slot state: `[avatar, -1, now + 60s]` (awaiting amount).
+
+**On `listen(withdrawChan, _, id, msg)`:**
+- Find slot by `id` via `llListFindList(withdrawSessions, [id])`. If `-1`, ignore (stranger injection silently dropped).
+- Slot's amount is `-1` (awaiting amount): parse `msg` as integer. Validate `amount > 0`. Update slot to `[avatar, amount, now + 60s]`. Send `llDialog` confirm: `"Withdraw L$<amount> from your SLPA wallet?", ["Yes", "No"]`.
+- Slot's amount is `>0` (awaiting confirm):
+  - `msg == "Yes"` → POST `/sl/wallet/withdraw-request`. On OK → owner-say + `llRegionSayTo(toucher, "Withdrawal queued — L$ will arrive shortly.")`. On `REFUND_BLOCKED` → `llRegionSayTo` the reason. Release slot.
+  - `msg == "No"` or anything else → release slot.
+
+**Timer (every 10 seconds):**
+- Sweep `withdrawSessions` for entries where `expiresAt < now`. Release silently.
+
+**Listen-leak class of bug eliminated by construction:** there's exactly one `llListen` for the entire terminal, opened at startup, never removed. Per-flow state is in the `withdrawSessions` list, not in listen handles.
+
+### 9.3 SLPA Terminal HTTP-in (PAYOUT / WITHDRAW)
+
+Unchanged from current implementation. Backend POSTs `TerminalCommandBody{action, recipient, amount, idempotency_key}`. Script:
+1. Validates shared secret.
+2. Acks immediately (returns 200).
+3. Fires `llTransferLindenDollars(recipient, amount)`.
+4. On `transaction_result`: posts to `/sl/escrow/payout-result` with success/failure + `slTransactionKey`.
+
+**Note:** the existing terminal script handles `action ∈ {PAYOUT, REFUND, WITHDRAW}`. After this work, `REFUND` is no longer dispatched (refunds are wallet credits). The script's switch-on-action can be simplified to just `PAYOUT | WITHDRAW`, or kept as a 3-way switch with `REFUND` as a "should never arrive" path for defensive logging. Recommend keeping the 3-way switch with a `CRITICAL` log on `REFUND` arrival, since dispatchers + entity migrations could in principle leave a stale row.
+
+### 9.4 SLPA Parcel Verifier Giver — new prim
+
+Single-purpose script + prim, header-trust only, no shared secret, no L$:
+
+- Floating text: `SLPA Parcel Verifier — Free\nTouch to receive`.
+- `state_entry()`: load notecard config (currently just has `DEBUG_MODE` and a rate-limit value), check Mainland-only grid guard, register listening for inventory changes (`CHANGED_INVENTORY → llResetScript`).
+- `on touch_start(N)`:
+  - Per-avatar rate-limit check: keep a strided list `givenSessions=[avatarKey, lastGivenAt, ...]` and refuse if same avatar touched within last 60 seconds (`llRegionSayTo(toucher, "Just gave you one — wait a minute.")`).
+  - `llGiveInventory(toucher, "SLPA Parcel Verifier")`.
+  - Owner-say `gave verifier to <name>`.
+  - Update rate-limit list.
+- Notecard auto-reset on `CHANGED_INVENTORY` (handles both notecard updates and verifier-inventory updates).
+- Owner-say diagnostic format matches existing scripts.
+
+**Deployment locations:** SLPA HQ, auction venues, Marketplace.
+
+**Operational benefit:** the unified SLPA Terminal no longer carries an SLPA Parcel Verifier in its inventory. The "two-place rule" gotcha (where you have to drag-drop the new verifier into every deployed payment terminal whenever `parcel-verifier.lsl` updates) is gone — the verifier-giver instances are the only place that ships the verifier.
+
+### 9.5 LSL deliverables
+
+| Path | Status |
+|---|---|
+| `lsl-scripts/slpa-terminal/slpa-terminal.lsl` | REWRITTEN |
+| `lsl-scripts/slpa-terminal/config.notecard.example` | UPDATED (URL paths) |
+| `lsl-scripts/slpa-terminal/README.md` | REWRITTEN |
+| `lsl-scripts/slpa-verifier-giver/slpa-verifier-giver.lsl` | NEW |
+| `lsl-scripts/slpa-verifier-giver/config.notecard.example` | NEW |
+| `lsl-scripts/slpa-verifier-giver/README.md` | NEW |
+| `lsl-scripts/README.md` | UPDATED (index entry for new script) |
+
+The existing `lsl-scripts/parcel-verifier/` (the SLPA Parcel Verifier itself, given out by the giver prim) is unchanged. The existing `lsl-scripts/verification-terminal/` is unchanged. The existing `lsl-scripts/sl-im-dispatcher/` is unchanged.
+
+---
+
+## §10 — Withdrawal Validation
+
+### 10.1 What the withdraw endpoints validate
+
+Both `/sl/wallet/withdraw-request` (touch-initiated) and `/me/wallet/withdraw` (site-initiated) validate only:
+
+1. `available >= amount` — funds correctness.
+2. `user.status NOT IN (BANNED, FROZEN)` — existing fraud-flag flow extends to wallet.
+3. `amount > 0` — basic input validation.
+
+That's it. No per-withdraw cap, no daily cap, no first-withdraw cool-down, no post-deposit cool-down, no email confirmation.
+
+### 10.2 Why no fraud guards
+
+The recipient UUID is hardcoded to `user.slAvatarUuid` (locked at verification, never client-supplied). For an attacker to extract L$ via withdrawal, they must have compromised the user's SL avatar in addition to the SLPA session — and an SL-avatar compromise is outside SLPA's control (it's a Linden Lab problem). If only the SLPA session is compromised, the L$ lands in the user's own avatar wallet and is recoverable.
+
+The fraud-guard machinery I'd considered (caps, cool-downs, email confirm) only buys value in a narrow middle case where SLPA is compromised but the SL avatar isn't, and even then the user's recovery path is simply "wait for the L$ to arrive in your own avatar." The operational complexity (SMTP infrastructure, daily-window state, cool-down timestamps) doesn't match the value delivered. Skipping all of it.
+
+(Implementation note: LSL's `integer` is signed 32-bit, so single-transaction withdraws above ~L$2.1B fail at the LSL boundary regardless. That's a data-type ceiling, not a policy.)
+
+---
+
+## §11 — Reconciliation Extension
+
+`ReconciliationService.runDaily()` (existing scheduler at `0 0 3 * * *` UTC) gets two extensions.
+
+### 11.1 Denorm precheck
+
+Before running the main expected-vs-observed comparison:
+
+```sql
+SELECT
+    SUM(reserved_lindens) FROM users
+    AS denorm_total,
+    (SELECT SUM(amount) FROM bid_reservations WHERE released_at IS NULL)
+    AS source_total;
+```
+
+If `denorm_total != source_total` → record `ReconciliationRun{status=DENORM_DRIFT, errorMessage="reserved_lindens denorm mismatch", drift=denorm_total - source_total}`, alert via `NotificationPublisher`, **abort the run** (the main expected number is wrong if denorms are wrong; main check would alarm spuriously).
+
+### 11.2 Extended expected total
+
+The SLPA service avatar holds two disjoint pools of L$:
+
+- **Escrows in locked states** (`FUNDED, TRANSFER_PENDING, DISPUTED, FROZEN`) — L$ that has been moved from a winner's wallet to an escrow row at auction close.
+- **Wallet balances** (`SUM(users.balance_lindens)`) — L$ that the SLPA service avatar holds on behalf of users. *Reservations are a partition of this pool* (a portion is "locked for active bids"), not a separate pool — bidding doesn't move L$ out of the wallet, it just marks some as reserved.
+
+So:
+
+```
+expected_total = sumLockedEscrows() + sumWalletBalances()
+```
+
+`wallet_reserved_total` is recorded on the run row as a sub-breakdown for forensics; it is **not** added to `expected_total` (that would double-count, since reservations are already inside `wallet_balance_total`).
+
+### 11.3 Status enum extension
+
+`ReconciliationStatus` adds `DENORM_DRIFT`. The `reconciliation_runs.status` check constraint is updated. `BALANCED` semantics unchanged (`observed >= expected` within tolerance — positive drift OK, negative drift alarms).
+
+### 11.4 Run row extensions
+
+`reconciliation_runs` adds `wallet_balance_total` (BIGINT NULL), `wallet_reserved_total` (BIGINT NULL), `escrow_locked_total` (BIGINT NULL — duplicate of existing `expected_total` pre-renaming). Old runs left with NULL for new columns.
+
+### 11.5 Test surface
+
+- Unit: `WalletReconciliationExtension.computeExpected()` returns escrow + balance sum.
+- Integration: synthetic drift scenarios — tweak `users.balance_lindens` directly, confirm `BALANCED=false` with non-zero drift; tweak `users.reserved_lindens` directly, confirm `DENORM_DRIFT` and main-check abort.
+
+---
+
+## §12 — Dormancy
+
+### 12.1 Active-signal source
+
+Dormancy uses `refresh_tokens.created_at` as the "user is active" signal. The most recent refresh-token row for a user (created on fresh login or on every access-token-expiry rotation) is the natural signal: a user who's been gone for 30+ days has had no refresh-token rotation in that window.
+
+```sql
+SELECT u.* FROM users u
+WHERE u.balance_lindens > 0
+  AND u.wallet_dormancy_phase IS NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM refresh_tokens rt
+      WHERE rt.user_id = u.id
+        AND rt.created_at > now() - interval '30 days'
+  )
+  AND NOT EXISTS (
+      SELECT 1 FROM bid_reservations br
+      WHERE br.user_id = u.id
+        AND br.released_at IS NULL
+  )
+  AND NOT EXISTS (
+      SELECT 1 FROM escrows e
+      WHERE e.winner_user_id = u.id
+        AND e.state IN ('FUNDED', 'TRANSFER_PENDING', 'DISPUTED', 'FROZEN')
+  );
+```
+
+This uses no new column. The `last_login_at` / `last_active_at` discussion is sidestepped entirely.
+
+### 12.2 `WalletDormancyJob` — weekly
+
+```java
+@Scheduled(cron = "${slpa.wallet.dormancy-job.cron:0 0 4 * * MON}", zone = "UTC")
+@Transactional
+public void sweep() {
+    OffsetDateTime now = OffsetDateTime.now(clock);
+    // Phase 1: flag newly-dormant users
+    List<User> newlyDormant = userRepo.findEligibleForDormancyFlag(now);
+    newlyDormant.forEach(u -> dormancyTask.flag(u, now));
+    // Phases 2/3/4: escalate weekly
+    List<User> awaitingNext = userRepo.findDormancyPhaseDue(now);
+    awaitingNext.forEach(u -> dormancyTask.escalateOrAutoReturn(u, now));
+}
+```
+
+Per-user task (separate `@Transactional` to isolate failures):
+
+- `flag`: stamp `wallet_dormancy_started_at=now, wallet_dormancy_phase=1`. Send IM #1 via Epic 09 SL IM dispatcher.
+- `escalateOrAutoReturn`:
+  - Re-check liveness (the active-signal query above) — if user is no longer dormant (logged in / has reservation / has escrow), clear `wallet_dormancy_started_at`, `wallet_dormancy_phase`. Defense-in-depth even though the login handler also clears.
+  - Phase 1 → 2 → 3 → 4: increment phase, send IM #N (escalating tone, balance reminder).
+  - Phase 4 → COMPLETED: queue `TerminalCommand{action=WITHDRAW, recipient=user.slAvatarUuid, amount=balance, idempotency_key=dormancy-{userId}-{phase4StampedAt}}`. Append `user_ledger{type=WITHDRAW_QUEUED, ref_type=DORMANCY, description="auto-return after 30d inactivity + 4 weekly notices"}`. Decrement balance to zero. Send final "balance returned" IM. Stamp `wallet_dormancy_phase=COMPLETED` (out-of-range value handled by app code, not by DB constraint — extend the CHECK to allow it, e.g., 1..4 plus 99 for completed; or use a separate stamp).
+
+Total time from last login to auto-return: 30 days + 4 weekly IMs (each IM ≥7 days apart) ≈ 58 days.
+
+### 12.3 Login + refresh-token rotation handler
+
+On any successful login (`/api/v1/auth/login`) or refresh (`/api/v1/auth/refresh`), if the user's `wallet_dormancy_phase IS NOT NULL`, clear `wallet_dormancy_started_at = NULL, wallet_dormancy_phase = NULL`.
+
+This gives the user immediate dormancy-state reset on return, rather than waiting for next weekly sweep.
+
+### 12.4 IM message templates
+
+Phase 1: *"Your SLPA wallet has been inactive for 30 days with a balance of L$<X>. To prevent automatic return of these funds to your SL avatar, log in to slparcels.com within 4 weeks."*
+
+Phase 2 (week +1): *"Reminder: your SLPA wallet has been inactive for 37 days. L$<X> will be automatically returned to your SL avatar in 3 weeks if you don't log in."*
+
+Phase 3 (week +2): *"Final reminder coming next week: your SLPA wallet has been inactive for 44 days. L$<X> will be returned in 2 weeks."*
+
+Phase 4 (week +3): *"This is your final notice. Your SLPA wallet has been inactive for 51 days. L$<X> will be returned to your SL avatar in 1 week unless you log in to slparcels.com."*
+
+Completion: *"Your inactive SLPA wallet balance of L$<X> has been returned to your SL avatar."*
+
+### 12.5 Edge cases
+
+- **User logs in mid-cycle.** Login handler clears dormancy state immediately; weekly sweep finds them no longer eligible.
+- **User deposits L$ during dormancy** (e.g., they touch a terminal but never log into the website). Deposits credit the wallet; dormancy state is unaffected (deposit doesn't generate a refresh-token rotation). They'll hit the next phase IM. Documented behavior.
+- **User has active reservation when first phase-flag fires.** They're excluded from the eligibility query (the reservation NOT EXISTS clause). Won't be flagged. If reservations later release without the user logging in, the next weekly sweep flags them with a fresh phase 1.
+- **Service avatar can't fulfill the auto-return** (e.g., terminal pool down, recipient avatar banned by Linden). `TerminalCommand` retry budget exhausts → existing `payout-result` failure → `WITHDRAW_REVERSED` ledger row credits balance back. User stays in `wallet_dormancy_phase=COMPLETED` (the cycle ran). Manual admin intervention needed; flagged via existing alert pipeline.
+
+---
+
+## §13 — Wallet Terms of Use
+
+### 13.1 New website page
+
+`/legal/terms` becomes a real surface (it doesn't exist today as a Phase 1 punt). Wallet section content draft (subject to legal review separately):
+
+1. **Non-interest-bearing.** "L$ held in your SLPA wallet do not earn interest, dividends, or any return. SLPA does not offer investment products of any kind."
+2. **L$ status.** "L$ are a Linden Lab limited-license token, not currency. SLPA holds L$ on your behalf as a transactional convenience. SLPA does not guarantee L$ value or redeemability — those are governed by Linden Lab's Terms of Service."
+3. **No L$↔USD conversion.** "SLPA does not exchange L$ for USD or any other currency. All L$ entering and leaving your wallet do so via SL avatar-to-avatar transfer."
+4. **Recoverable on shutdown.** "If SLPA ceases operations, all positive wallet balances will be returned to the Resident's verified SL avatar. Active escrows will resolve per their state at shutdown."
+5. **Freezable for fraud.** "SLPA may freeze a wallet balance pending fraud investigation, with a maximum freeze period of 30 days absent legal process."
+6. **Dormancy.** "Wallets inactive for 30 days will be flagged for dormancy. SLPA will attempt notification via SL IM for 4 weeks. After that, the balance will be automatically returned to the Resident's verified SL avatar."
+7. **Banned-Resident handling.** "If your SL account loses good standing under Linden Lab's ToS, your SLPA wallet balance will be returned to your last-verified SL avatar at the time of SLPA account closure, subject to Linden Lab's enforcement actions."
+
+### 13.2 Click-through gating
+
+First-deposit detection: when the wallet page tries to render the "deposit instructions" modal, it checks `users.wallet_terms_accepted_at`. If null, modal renders the terms with an "I have read and accept" checkbox + button, posting to `/me/wallet/accept-terms`.
+
+The deposit endpoint itself doesn't gate on `wallet_terms_accepted_at` — terms acceptance is a UX gate, not a transactional one. (A user touching the terminal directly without ever visiting the website can deposit; their wallet shows balance + a "Please review wallet terms" banner on next site visit.)
+
+### 13.3 Terms versioning
+
+`wallet_terms_version` (`VARCHAR(16)`) holds the version string the user accepted. Material changes to terms bump the version; the next site visit re-prompts. Versioning is opaque text (`"1.0"`, `"1.1"`, etc.); the version-comparison logic is "if `wallet_terms_version != currentTermsVersion`, re-prompt."
+
+The `currentTermsVersion` is a configuration value (`slpa.wallet.terms-version` in `application.yml`). Bumping this forces re-acceptance.
+
+---
+
+## §14 — Migration Plan & Cutover
+
+### 14.1 Sequencing
+
+```
+1. Schema migrations  (Flyway, automatic on backend boot)
+2. Backend deploy     (GHA on push to main)
+3. Frontend deploy    (Amplify on push to main)
+4. Postman collection rebuild
+5. In-world terminal swap   ← only manual step, last
+```
+
+Old terminals will return 404s against the new backend between steps 2 and 5 (old endpoints removed). With no customers, that's a fine intermediate state — the LSL swap is the team's sign-off step after smoke-testing the rest.
+
+### 14.2 Schema migrations
+
+Five new Flyway files in `backend/src/main/resources/db/migration/`:
+
+| File | Purpose |
+|---|---|
+| `V<N>__wallet_balance_columns.sql` | Add columns to `users`: `balance_lindens`, `reserved_lindens`, `wallet_dormancy_started_at`, `wallet_dormancy_phase`, `wallet_terms_accepted_at`, `wallet_terms_version`, with CHECK constraints. |
+| `V<N+1>__user_ledger.sql` | Create `user_ledger` table + indexes. |
+| `V<N+2>__bid_reservations.sql` | Create `bid_reservations` table + partial unique index. |
+| `V<N+3>__retire_escrow_pending_state.sql` | Drop `escrows.payment_deadline` column. Update `escrows.state` CHECK to remove `ESCROW_PENDING`. (No live data with that state expected; defensive `DELETE FROM escrows WHERE state='ESCROW_PENDING'` before constraint update with a logged count.) Drop `listing_fee_refunds.terminal_command_id` column. Convert in-flight `TerminalCommand{action=REFUND}` rows to wallet credits with explanatory `description` (defensive, expected count = 0). |
+| `V<N+4>__reconciliation_extension.sql` | Add `wallet_balance_total`, `wallet_reserved_total`, `escrow_locked_total` columns to `reconciliation_runs`. Update status CHECK to include `DENORM_DRIFT`. |
+
+The exact `V<N>` prefix is determined by the next-available number at the time of migration creation — the specifics will be set during implementation.
+
+### 14.3 Cutover procedure
+
+```
+1. Take RDS snapshot (manual, before merge to main):
+     aws rds create-db-snapshot --db-instance-identifier slpa-prod-db \
+         --db-snapshot-identifier pre-wallet-<git-sha> \
+         --profile slpa-prod
+   Wait for snapshot status=available (~5 min).
+
+2. Merge dev → main (via PR review). GHA deploy-backend.yml fires.
+   Wait for ECS to settle (~3-5 min). Confirm /actuator/health green.
+
+3. Frontend Amplify build fires from main; wait for it to settle (~5-7 min).
+
+4. Smoke-test backend endpoints with curl:
+   - GET /api/v1/me/wallet (with team JWT) → 200 with wallet shape.
+   - POST /api/v1/sl/wallet/deposit (with bogus payerUuid) → 200 with REFUND/UNKNOWN_PAYER.
+   - Confirm /sl/escrow/payment returns 404 (proves removal landed).
+
+5. Rebuild Postman collection per §15. Run the wallet folder against prod;
+   confirm variable-chaining works.
+
+6. In-world: swap each deployed SLPA Terminal prim's script + notecard.
+   Drop a copy of slpa-verifier-giver.lsl into a new prim at SLPA HQ.
+   Smoke-test deposit (pay L$10) + withdraw (touch → menu → Yes).
+
+7. Sign-off: confirm GET /api/v1/me/wallet shows the test deposit credited.
+```
+
+Total estimated time from `git push origin main` to sign-off: ~45-60 min including the in-world step.
+
+### 14.4 Rollback procedure
+
+Triggers: severe data corruption, double-debit bug, anything that warrants pulling the cord rather than pushing a fix forward.
+
+```
+1. Restore RDS from pre-wallet-<sha> snapshot:
+   aws rds restore-db-instance-from-db-snapshot \
+       --db-instance-identifier slpa-prod-db-restored \
+       --db-snapshot-identifier pre-wallet-<sha> \
+       --profile slpa-prod
+   Update Parameter Store SPRING_DATASOURCE_URL to the restored endpoint.
+   Restart ECS service. (~10-15 min total.)
+
+2. Revert the merge commit on main:
+     git revert -m 1 <merge-commit-sha>
+     git push origin main
+   GHA redeploys old backend image automatically. (~5 min.)
+
+3. In-world LSL revert:
+     - Drag-drop old slpa-terminal.lsl back into each prim.
+     - Drag-drop old config notecard back.
+     - Restore the old SLPA Parcel Verifier inventory item to the terminal prim.
+     - Optionally remove the new slpa-verifier-giver prim.
+
+4. Frontend revert: Amplify auto-redeploys from the reverted main commit.
+
+5. Postman collection: revert via git on the collection JSON.
+
+Total recovery time: ~45 min.
+```
+
+The only data loss is whatever dogfood activity happened between snapshot and rollback. Acceptable because there are no real users.
+
+### 14.5 Abandon vs ship decision
+
+After ~1 week of team dogfood, decide:
+
+- **Ship:** wallet stays. No further migration. Post-validation cleanup PR may drop now-unused code paths (e.g., the defensive `REFUND` action in `TerminalCommand` enum if no incidents arrived), simplify retired-endpoint stubs.
+- **Abandon:** execute §14.4. Append a "lessons learned" appendix to this spec doc explaining what didn't work. Audit trail for any future retry.
+
+---
+
+## §15 — Postman Collection Rebuild
+
+The `SLPA` Postman collection (id `8070328-cf3e1190-cb71-4af3-8e2e-70c82dfee288` in workspace `https://scatr-devs.postman.co`) is updated:
+
+### 15.1 New folder: `Wallet`
+
+Variable-chaining test scripts thread the wallet state through `SLPA Dev` env vars.
+
+| Request | Test-script effects |
+|---|---|
+| `GET /me/wallet` | Sets `walletBalance`, `walletReserved`, `walletAvailable`, `walletPenaltyOwed`, `walletTermsAccepted`. |
+| `POST /me/wallet/accept-terms` | Sets `walletTermsAccepted = true`. |
+| `POST /me/wallet/withdraw` | Sets `withdrawalQueueId`. |
+| `POST /me/wallet/pay-penalty` | Refreshes `walletBalance`, `walletPenaltyOwed`. |
+| `POST /sl/wallet/deposit` | (under SL-headers folder) Sets `slDepositTransactionKey`. Body uses pre-request script to fill `slTransactionKey` with `pm.variables.replaceIn("{{$guid}}")`. |
+| `POST /sl/wallet/withdraw-request` | Sets `slWithdrawTransactionKey`. |
+
+### 15.2 Removed folders/items
+
+- `Escrow Payment` folder (contained `/sl/escrow/payment` requests).
+- `Listing Fee Payment` folder.
+- `Penalty Lookup`, `Penalty Payment` requests.
+
+### 15.3 Modified items
+
+- `Auctions/Bid` request: documentation updated to note new precondition responses (`PENALTY_OUTSTANDING`, `INSUFFICIENT_AVAILABLE_BALANCE`).
+- `Auctions/Buy-It-Now`: same.
+- `Auctions/Publish` (or whatever the existing draft → DRAFT_PAID transition request is): same.
+
+### 15.4 SLPA Dev environment variables
+
+**Added:** `walletBalance`, `walletReserved`, `walletAvailable`, `walletPenaltyOwed`, `walletTermsAccepted`, `withdrawalQueueId`, `slDepositTransactionKey`, `slWithdrawTransactionKey`.
+
+**Removed:** `escrowPaymentTxKey`, `listingFeePaymentTxKey`, `penaltyLookupAvatarUuid`, `penaltyPaymentTxKey`, anything else that was only used by the retired endpoints.
+
+---
+
+## §16 — Test Surface
+
+Per `CONVENTIONS.md` discipline: unit + slice + integration, all three required.
+
+### 16.1 Unit tests
+
+- `WalletService.deposit()` — balance increment, ledger entry, idempotency replay.
+- `WalletService.swapReservation()` — reservation swap matrix (no prior, prior-same-user, prior-different-user, insufficient available, sanity-amount-mismatch defensive branch).
+- `WalletService.withdrawSiteInitiated()` — debit + ledger + TerminalCommand insert; insufficient balance; duplicate idempotency key.
+- `WalletService.payPenalty()` — full payment, partial payment, exceeds-owed rejection, insufficient-available rejection.
+- `WalletService.creditEscrowRefund()`, `WalletService.creditListingFeeRefund()` — refund-credit flow.
+- `BidService.placeBid()` — penalty precondition rejection, available-balance rejection, successful reservation swap (existing tests extended).
+- `AuctionEndTask.closeOne()` — auto-fund happy path; reservation-amount-mismatch defensive freeze.
+- `BinHandler` — BIN with no prior reservation; BIN with prior reservation at lower amount; BIN with insufficient available even counting prior reservation.
+- `WalletDormancyJob.sweep()` — flag matrix, escalation matrix, auto-return flow.
+- `ReconciliationService.runDaily()` — extended expected calculation; denorm-drift precheck.
+- `LoginHandler` / `RefreshTokenService.rotate()` — clears dormancy state on success.
+
+### 16.2 Slice tests (`@WebMvcTest`, `@DataJpaTest`)
+
+- `/sl/wallet/deposit` controller slice — auth gates, validation responses, idempotency.
+- `/sl/wallet/withdraw-request` controller slice — same matrix + REFUND_BLOCKED variants.
+- `/me/wallet/*` controller slices — JWT + auth gates + 422 responses.
+- `user_ledger` repository slice — UNIQUE constraint enforcement on `sl_transaction_id`, `idempotency_key`.
+- `bid_reservations` repository slice — partial unique index enforces "at most one active per (user, auction)."
+
+### 16.3 Integration tests
+
+- End-to-end auction flow: deposit → bid (reserves) → outbid (releases prior) → close (auto-funds) → ownership confirm → payout queued → payout-result → ledger sums match denorms throughout.
+- End-to-end BIN flow: deposit → BIN-click → escrow funded immediately → ledger consistent.
+- End-to-end listing flow: deposit → publish (debits) → cancel → refund credits balance.
+- End-to-end withdrawal flow (site): deposit → withdraw → TerminalCommand fires → payout-result → WITHDRAW_COMPLETED row.
+- End-to-end withdrawal flow (touch): deposit → terminal touch + confirm → /sl/wallet/withdraw-request → TerminalCommand → fulfillment.
+- Cancellation flow: bid → bid (outbid first) → cancel auction → both reservations released → both users' available restored.
+- User ban flow: bid → ban user → reservation released, escrow disposition.
+- Concurrent bid simulation (two threads racing the same auction; two threads racing different auctions sharing a user): no deadlock, no negative balance, ledger sums match denorms.
+- Reconciliation: synthetic drift on `users.balance_lindens` triggers `BALANCED=false` with non-zero drift; synthetic drift on `users.reserved_lindens` triggers `DENORM_DRIFT` and aborts main check.
+- Dormancy: fast-forward 30d → flagged + IM #1; +28d → 4 IMs sent; +7d → auto-withdraw queued + balance zeroed; subsequent login during cycle → state cleared.
+- User with active bid reservation excluded from dormancy flag.
+
+---
+
+## §17 — Out of Scope / Deferred
+
+Items intentionally not built in this work:
+
+- **Admin manual ledger adjustments UI.** Schema supports it (`entry_type=ADJUSTMENT, created_by_admin_id`), no admin UI surfaces it. Future Epic 10 extension.
+- **Wallet history export (CSV/PDF for tax purposes).** User-facing ledger view is in-app only.
+- **Multi-recipient withdrawals or sub-wallet partitioning.** Single recipient = `user.slAvatarUuid`, single wallet per user.
+- **Top-up auto-funding (e.g., "deposit X automatically before each bid").** Out of scope. Manual deposit only.
+- **Wallet currency other than L$.** Single-currency.
+- **Per-region terminal routing optimization for withdrawals.** Reuses existing dispatcher's any-active-terminal selection.
+- **Frontend wallet activity exports / detailed receipts.** Listed-only ledger view.
+
+These get added to `docs/implementation/DEFERRED_WORK.md` with the standard "originating epic / how to revisit" annotation.
+
+---
+
+## §18 — Files Touched (estimate)
+
+For implementation-plan reference. Numbers approximate.
+
+**Backend (Java):**
+- 5 new Flyway migrations in `backend/src/main/resources/db/migration/`.
+- New package `com.slparcelauctions.backend.wallet` — entities, repositories, service, controllers, DTOs, exceptions: ~15 files.
+- `EscrowService`, `EscrowRepository`, `EscrowState` enum modifications: ~3 files.
+- `BidService`, `BidController` modifications: ~2 files.
+- `AuctionEndTask` modification: 1 file.
+- BIN handler modification: 1 file.
+- Listing-publish controller modification: 1 file.
+- `ReconciliationService` extension: 1 file.
+- New `WalletDormancyJob` + per-user task: 2 files.
+- Login + refresh handlers (clear dormancy on success): 2 files.
+- `TerminalCommand.action` enum trim + dispatcher switch: 2 files.
+- Removed: 4 SL-headers controllers + their request/response DTOs: ~12 deletions.
+- Tests (unit + slice + integration): ~25-30 new files.
+
+**Frontend (TypeScript / React):**
+- New wallet panel component + dialog components: ~6 files.
+- Bid form, BIN form, Publish form modifications: ~4 files.
+- React Query hooks for `/me/wallet/*`: ~3 files.
+- New `/legal/terms` page: 1 file.
+- Type definitions for new endpoints: ~2 files.
+- Tests: ~8-10 files.
+
+**LSL:**
+- Rewrite `lsl-scripts/slpa-terminal/slpa-terminal.lsl`: 1 file (~700 lines, simpler than current).
+- Rewrite `lsl-scripts/slpa-terminal/README.md`: 1 file.
+- New `lsl-scripts/slpa-verifier-giver/`: 3 files.
+- Update `lsl-scripts/README.md` index: 1 file.
+
+**Documentation:**
+- This spec doc: written.
+- Implementation plan: separate doc at `docs/superpowers/plans/2026-04-30-wallet-model.md`.
+- `docs/implementation/CONVENTIONS.md`: append wallet conventions.
+- `docs/implementation/FOOTGUNS.md`: append surfaced gotchas.
+- `docs/implementation/DEFERRED_WORK.md`: append items from §17.
+- Root `README.md`: sweep for staleness per the user's "update README each task" rule.
+
+**Postman:** rebuilt collection JSON file (committed under repo if so versioned).
+
+---
+
+## §19 — Open Questions
+
+These are the things I'd rather decide during implementation if they come up — listed here so they're not lost:
+
+1. **Terms-of-use page authoring.** This spec drafts the substance (§13.1) but the actual page copy + presentation needs to be written/styled. Treating as a Phase 1 task to land along with this work; no blocker.
+2. **`TerminalCommand{action=REFUND}` enum trim.** Whether to remove `REFUND` from the enum entirely or keep it as a defensive value with a `CRITICAL` log on dispatch. Recommendation: keep it for one release cycle (defensive), drop in a follow-up cleanup PR.
+3. **`wallet_dormancy_phase=COMPLETED` representation.** Either extend the CHECK to allow `99`, or use a separate `wallet_dormancy_completed_at` timestamp. Implementation decides; both are fine.
+4. **Auto-fund retry behavior on transient DB failure mid-close.** If `AuctionEndTask.closeOne` fails partway (e.g., wallet debit succeeds but escrow insert fails), the transaction rolls back atomically — `@Transactional` ensures it. Just confirming this branch is exercised in integration tests.
+
+---
+
+## §20 — Review Notes
+
+This design was developed in a brainstorming session covering 6 sections of detailed back-and-forth. Key decision points:
+
+- **Holding L$ for users is permitted by SL ToS** (research in §1 of brainstorm) — non-interest-bearing custodial wallets fall outside the 2008 banking-policy ban; §3.2 LindeX-exclusivity restricts purchase/sale, not holding.
+- **Path A: iterate on prod, snapshot-based rollback** — chosen because no customers exist yet, making destructive migrations safe and feature flags unnecessary overhead.
+- **Hard reservation on bids** — chosen over soft / no-reservation models because it structurally eliminates the "winner stiffs seller" failure mode that today drives penalties and disputes.
+- **Per-flow withdraw slots, not terminal-wide lock** — chosen because a terminal-wide lock creates a griefing surface (one bored user clicking each prim DoSes every terminal); per-flow slots with per-avatar dedup eliminates single-griefer DoS entirely.
+- **`refresh_tokens.created_at` as dormancy active-signal** — chosen over a new `last_active_at` column to avoid write-amplification on every authenticated request.
+- **Penalty as listing/bid precondition, not auto-deduction** — chosen because the wallet is the user's money; collecting via garnishment would be overreach.


### PR DESCRIPTION
## Summary

Foundation PR of the wallet-model rollout. See PR #65 for content detail.
Purely additive — adds new schema, entities, endpoints; does not modify
or remove existing code.

Subsequent PRs will add:
- Bid + BIN preconditions and hard-reservation swap
- Auction-end auto-fund + ESCROW_PENDING retirement
- Refund-as-credit conversion
- Delete retired SL payment endpoints
- Frontend wallet UI
- LSL terminal rewrite + verifier-giver prim
- Postman collection rebuild
- Documentation sweep

## Test plan
- [x] `./mvnw test` green on dev (1591/1591)
- [ ] Backend deploys cleanly via GHA
- [ ] `GET /api/v1/me/wallet` returns wallet shape after deploy
- [ ] Existing in-world payment flows still functional (retired endpoints intact)