### PR TITLE
release: wallet model + LSL terminal rewrite

### DIFF
--- a/lsl-scripts/README.md
+++ b/lsl-scripts/README.md
@@ -32,12 +32,19 @@ A script's README must cover:
 - [`parcel-verifier/`](parcel-verifier/) — Single-use rezzable. Sellers rez it
   on the parcel they want to list; the script reads parcel metadata, prompts
   for the 6-digit PARCEL code, POSTs to the backend, then `llDie()`s.
-  Distributed via Marketplace + given out by the SLPA Terminal.
-- [`slpa-terminal/`](slpa-terminal/) — Unified in-world payment terminal.
-  Touch menu offers Escrow Payment, Listing Fee, Pay Penalty, and Get Parcel
-  Verifier. Also receives HTTP-in commands from the backend for PAYOUT /
-  REFUND / WITHDRAW execution. SLPA-team-deployed; holds shared secret +
-  PERMISSION_DEBIT.
+  Distributed via Marketplace + given out by the SLPA Parcel Verifier Giver.
+- [`slpa-verifier-giver/`](slpa-verifier-giver/) — Touch-to-receive prim that
+  hands out a copy of the SLPA Parcel Verifier inventory item. Free, no L$,
+  no shared secret. Per-avatar 60s rate-limit. Deployed at SLPA HQ + auction
+  venues + Marketplace.
+- [`slpa-terminal/`](slpa-terminal/) — Wallet-model payment terminal. Right-
+  click → Pay credits the user's wallet via `/sl/wallet/deposit` (lockless,
+  fully concurrent). Touch menu offers Deposit-instructions and Withdraw.
+  Withdraw uses per-flow slots dispatched by avatar key on a single shared
+  listen — no terminal-wide lock. Also receives HTTP-in commands from the
+  backend for PAYOUT / WITHDRAW execution (REFUND defensive — refunds are
+  wallet credits, never dispatched). SLPA-team-deployed; holds shared
+  secret + PERMISSION_DEBIT.
 - [`sl-im-dispatcher/`](sl-im-dispatcher/) — Polls SLPA backend for pending
   SL IM notifications and delivers them via `llInstantMessage`. SLPA-team-deployed
   (one instance per environment); not user-deployed.

--- a/lsl-scripts/slpa-terminal/README.md
+++ b/lsl-scripts/slpa-terminal/README.md
@@ -1,25 +1,36 @@
-# SLPA Terminal (unified payments)
+# SLPA Terminal (wallet model)
 
-In-world unified payment kiosk for SLPA. Handles three payment types via a
-4-option touch menu and accepts backend-initiated payouts/refunds/withdrawals
-via HTTP-in.
+In-world wallet kiosk for SLPA. Two touch-menu options (Deposit-instructions,
+Withdraw) plus a lockless `money()` deposit handler. Also accepts
+backend-initiated PAYOUT/WITHDRAW commands via HTTP-in.
 
 ## Architecture summary
 
 - **Trust:** SL-injected `X-SecondLife-Shard` + `X-SecondLife-Owner-Key` headers
-  on outbound, **plus** a `sharedSecret` field in body for register / payment /
-  payout-result requests. Inbound HTTP-in: shared-secret check on every
-  command.
-- **Touch flow:** IDLE → (touch) lock + menu → (selection) AUCTION_ID prompt
-  (Escrow/Listing-Fee) or LOOKUP (Penalty) or GIVE (Verifier) → (after
-  selection) AWAITING_PAYMENT with appropriate `llSetPayPrice` → (money())
-  POST to selected endpoint → release lock; retries run in background.
+  on outbound, plus a `sharedSecret` field in body for register / deposit /
+  withdraw-request / payout-result requests. Inbound HTTP-in: shared-secret
+  check on every command.
+- **Deposit flow (lockless):** Right-click → Pay → enter L$ amount → `money()`
+  fires → POST to `/sl/wallet/deposit` → OK / REFUND / ERROR. On REFUND, the
+  script `llTransferLindenDollars` to bounce; on ERROR, owner-say only (could
+  be an attacker probing). Background retry: 10s / 30s / 90s / 5m / 15m.
+  Multiple users can pay simultaneously — `money()` is naturally reentrant.
+- **Touch flow:** touch → `llDialog` `[Deposit, Withdraw]` (no lock acquired).
+  Deposit selection → `llRegionSayTo` instructions, no state. Withdraw
+  selection → acquire per-flow slot → text-box for amount → confirm dialog →
+  POST to `/sl/wallet/withdraw-request`. On `OK`, the backend queues a
+  `WALLET_WITHDRAWAL` `TerminalCommand` that fires asynchronously; on
+  `REFUND_BLOCKED`, no L$ to bounce — `llRegionSayTo` the reason.
+- **Per-flow withdraw slots:** single `llListen` opened at startup, never
+  closed. Up to 4 concurrent withdraw sessions, one per avatar (per-avatar
+  dedup). Strided list `[avatarKey, amountOrMinusOne, expiresAt, ...]`.
+  Slot dispatched by `id` in the listen handler. 60s session TTL; sweeper
+  runs every 10s.
 - **HTTP-in flow:** parallel to touch; backend POSTs `TerminalCommandBody`
-  with action PAYOUT/REFUND/WITHDRAW; script validates shared secret, fires
+  with action PAYOUT/WITHDRAW; script validates shared secret, fires
   `llTransferLindenDollars`, reports `transaction_result` to `/payout-result`.
-- **Lock:** single-user, 60s TTL. Released eagerly: as soon as the first
-  payment POST fires, the lock releases so a second user can touch while
-  retries run. "Get Parcel Verifier" releases immediately after `llGiveInventory`.
+  REFUND action is defensive — refunds are wallet credits in the new model
+  and shouldn't arrive; if one does, log CRITICAL and fail.
 - **Region restart:** `changed(CHANGED_REGION_START)` triggers `llRequestURL()`
   + re-register. Backend's `terminals.http_in_url` is updated.
 
@@ -31,36 +42,35 @@ Never publish on Marketplace.
 1. Rez a generic prim at SLPA HQ or an auction venue. Land must permit
    outbound HTTP and `llRequestURL`.
 2. Drop `slpa-terminal.lsl` into the prim.
-3. Drop a `SLPA Parcel Verifier` object copy into the prim's contents (so
-   the "Get Parcel Verifier" menu option works).
-4. Drop a copy of `config.notecard.example` renamed to **`config`** (no
-   extension). Edit all six URLs and `SHARED_SECRET`.
-5. Set the prim's owner to the SLPA service avatar (so
+3. Drop a copy of `config.notecard.example` renamed to **`config`** (no
+   extension). Edit all four URLs and `SHARED_SECRET`.
+4. Set the prim's owner to the SLPA service avatar (so
    `X-SecondLife-Owner-Key` matches `slpa.sl.trusted-owner-keys`).
-6. Reset the script. The script will request `PERMISSION_DEBIT` from the
+5. Reset the script. The script will request `PERMISSION_DEBIT` from the
    owner — accept the dialog. Confirm:
    - `SLPA Terminal: registered (terminal_id=..., url=...)` startup ping.
-   - Floating text "SLPA Terminal\nTouch for options" appears.
-7. Smoke-test each menu option once with small amounts.
+   - Floating text "SLPA Terminal\nRight-click → Pay to deposit\nTouch for menu" appears.
+6. Smoke-test:
+   - Right-click the prim → Pay → L$10. Confirm `deposit ok L$10 from <name>`.
+   - Touch → Withdraw → enter L$5 → Yes. Confirm withdrawal arrives in your
+     SL avatar within ~30s.
 
-≥1 active SLPA Terminal must be live for the auction-completion path
-(PAYOUT). Multi-instance is fine; backend dispatcher picks any active
-terminal for any command.
+The new SLPA Parcel Verifier Giver prim (separate; see
+`lsl-scripts/slpa-verifier-giver/`) handles parcel-verifier give-out — it is
+**not** built into this terminal anymore.
 
 ## Configuration
 
 | Key | Description |
 | --- | --- |
 | `REGISTER_URL` | Full URL of `/api/v1/sl/terminal/register`. Required. |
-| `ESCROW_PAYMENT_URL` | Full URL of `/api/v1/sl/escrow/payment`. Required. |
-| `LISTING_FEE_URL` | Full URL of `/api/v1/sl/listing-fee/payment`. Required. |
-| `PENALTY_LOOKUP_URL` | Full URL of `/api/v1/sl/penalty-lookup`. Required. |
-| `PENALTY_PAYMENT_URL` | Full URL of `/api/v1/sl/penalty-payment`. Required. |
+| `DEPOSIT_URL` | Full URL of `/api/v1/sl/wallet/deposit`. Required. |
+| `WITHDRAW_REQUEST_URL` | Full URL of `/api/v1/sl/wallet/withdraw-request`. Required. |
 | `PAYOUT_RESULT_URL` | Full URL of `/api/v1/sl/escrow/payout-result`. Required. |
 | `SHARED_SECRET` | The shared secret. **Required.** Obtain from `slpa.escrow.terminal-shared-secret`. |
-| `TERMINAL_ID` | Optional. Defaults to `(string)llGetKey()`. Use a stable name if you want admin tooling to identify this terminal across restarts. |
+| `TERMINAL_ID` | Optional. Defaults to `(string)llGetKey()`. |
 | `REGION_NAME` | Optional. Defaults to `llGetRegionName()`. |
-| `DEBUG_MODE` | Optional. `true`/`false`, default `true`. When `true`, also surfaces a `DEBUG <flow>: status=N title=… detail=… code=…` line to the toucher on HTTP 4xx/5xx, so an operator at the terminal can diagnose backend errors without grepping CloudWatch. |
+| `DEBUG_MODE` | Optional. `true`/`false`, default `true`. Per-event owner-say. |
 
 ### Rotating the shared secret
 
@@ -69,44 +79,26 @@ terminal for any command.
 3. On every deployed SLPA Terminal: edit the `config` notecard with the new
    `SHARED_SECRET` value. `CHANGED_INVENTORY` auto-resets the script and
    re-registers with the new secret.
-4. In-flight `terminal_commands` rows dispatched on the old secret will be
-   rejected (terminal returns 403); the dispatcher's existing retry budget
-   (4 attempts with 1m/5m/15m backoff) covers the brief rotation window.
-
-## Updating
-
-**Two-place rule for the parcel verifier.** The "Get Parcel Verifier" menu
-option `llGiveInventory`s a copy of the parcel verifier from the prim's
-contents. When you update `parcel-verifier.lsl`:
-
-1. **Marketplace listing**: republish a new revision with the updated `.lsl`.
-2. **Every deployed SLPA Terminal's inventory**: drag-drop the new
-   `SLPA Parcel Verifier` object into the prim's contents, replacing the old
-   copy. `CHANGED_INVENTORY` auto-resets the SLPA Terminal script
-   (which re-registers — the inventory swap doesn't break anything else).
-
-Forgetting place 2 leaves users with a stale verifier from the give-on-touch
-menu while Marketplace customers get the new version. Track this in the ops
-runbook.
-
-Updating the SLPA Terminal script itself: drag-drop the new `slpa-terminal.lsl`
-into the prim's contents → `CHANGED_INVENTORY` auto-resets → re-register.
-Updating just the notecard: edit values → `CHANGED_INVENTORY` auto-resets →
-re-register.
 
 ## Operations
 
-In steady state, with `DEBUG_MODE=true`:
+In steady state with `DEBUG_MODE=true`:
 
 - `SLPA Terminal: registered (terminal_id=..., url=...)` — startup confirmation.
-- `SLPA Terminal: touch from <name>` — user touched the terminal.
-- `SLPA Terminal: menu choice <option> by <name>` — menu selection.
-- `SLPA Terminal: payment ok <kind> L$<amount> from <payer>` — successful payment POST.
-- `SLPA Terminal: payment retry N/5: <status>` — transient failure, retrying.
-- `SLPA Terminal: PAYOUT to <recipient> L$<amount> ok` — successful debit.
-- `CRITICAL: payment from <payer> L$<amount> key <tx> not acknowledged after 5 retries` — payment recovery failed; manual reconciliation required.
-- `CRITICAL: PERMISSION_DEBIT denied — script halted. Owner must re-grant.` — permissions issue.
-- `CRITICAL: registration failed after 5 attempts.` — backend unreachable; investigate.
+- `SLPA Terminal: deposit ok L$<amount> from <payer>` — successful deposit POST.
+- `SLPA Terminal: deposit refunded (UNKNOWN_PAYER) L$<amount> to <payer>` —
+  bounced an unknown-payer deposit.
+- `SLPA Terminal: deposit retry N/5: status=...` — transient, retrying.
+- `SLPA Terminal: withdraw queued L$<amount> for <payer>` — successful withdraw-request.
+- `SLPA Terminal: HTTP-in WITHDRAW to <recipient> L$<amount> ikey=...` — backend
+  dispatched a wallet-withdrawal fulfillment to this terminal.
+- `SLPA Terminal: payout-result acknowledged.` — backend received our async result.
+- `CRITICAL: SLPA Terminal: deposit ... not acknowledged after 5 retries` —
+  deposit recovery failed; manual reconciliation required.
+- `CRITICAL: unexpected REFUND HTTP-in command` — the backend dispatched a
+  REFUND action; refunds should be wallet credits in the new model. Investigate.
+- `CRITICAL: PERMISSION_DEBIT denied — script halted. Owner must re-grant.` —
+  permissions issue.
 
 ## Troubleshooting
 
@@ -117,28 +109,30 @@ In steady state, with `DEBUG_MODE=true`:
 | `PERMISSION_DEBIT denied` | Owner declined the permission dialog. Reset the script and accept. |
 | `URL_REQUEST_DENIED` | Land doesn't allow scripts to request URLs. Move the prim to a region with permissive land settings. |
 | Periodic `register retry N/5` | Backend unreachable or rejecting registration. Check `slpa.sl.trusted-owner-keys` includes this terminal's owner. |
-| `payment retry N/5` repeatedly | Backend transient or network issue. Self-recovers in most cases. |
-| `CRITICAL: payment from ... not acknowledged` | Backend POST never succeeded after 5 retries. Manual reconciliation required — operator must check `escrow_transactions` ledger and refund or recognize manually. |
-| `Get Parcel Verifier` does nothing | The SLPA Parcel Verifier object is missing from the terminal's inventory. Drag-drop it back in. |
+| `deposit retry N/5` repeatedly | Backend transient or network issue. Self-recovers in most cases. |
+| `CRITICAL: deposit not acknowledged` | Backend POST never succeeded after 5 retries. Manual reconciliation required. |
+| Withdraw text-box says `Terminal busy — try another nearby` | All 4 withdraw slots occupied. Walk to another terminal. (Should be vanishingly rare at SLPA's traffic level.) |
 | Backend command dispatcher logs 403 | Shared secret mismatch. Update notecard, reset. |
-| Terminal stuck `<In Use>` | Lock TTL didn't fire. Reset the script. |
+| `CRITICAL: unexpected REFUND HTTP-in command` | Stale code path or migration issue — refunds should be wallet credits. Investigate. |
 
 ## Limits
 
-- LSL listen cap is 65; the script opens at most 2 listens per touch session
-  (menu + auction-id-input or code-entry) and removes them on every exit path.
+- LSL listen cap is 65; the script opens **exactly one** listen at startup
+  for the entire terminal lifetime. Per-flow withdraw state is stored in the
+  `withdrawSessions` strided list, not per-flow listens. Listen leak class
+  of bug eliminated by construction.
 - HTTP-in URLs change on region restart; re-registration is automatic via
   `changed(CHANGED_REGION_START)`.
 - `llTransferLindenDollars` rate limit: 30 payments per 30 seconds per owner per
   region. Phase 1 traffic is well under this; alert if approached.
-- 60s touch lock means low-volume kiosks rarely hit contention. For high-volume
-  venues, deploy multiple SLPA Terminals — backend's dispatcher picks any
-  active one for commands.
+- 4 concurrent withdraw sessions max per terminal. For high-volume venues,
+  deploy multiple SLPA Terminals — backend's dispatcher picks any active
+  one for commands.
 - Inflight HTTP-in commands cap at 16 concurrent. New commands beyond that
   return 503; backend retry budget handles.
 - Bounded payment retry: 10s / 30s / 90s / 5m / 15m, total ~22 minutes of
   trying. After exhaustion the script logs CRITICAL and stops; daily
-  reconciliation job (deferred — see `DEFERRED_WORK.md`) catches missed POSTs.
+  reconciliation job catches missed POSTs.
 
 ## Security
 
@@ -147,14 +141,12 @@ In steady state, with `DEBUG_MODE=true`:
 - The shared secret in the notecard is visible to anyone with edit-rights on
   the prim — keep ownership and modify permissions SLPA-team-only.
 - A leaked shared secret means an attacker can call `/payout-result` with
-  forged "success" outcomes (debiting the escrow ledger without actually
+  forged "success" outcomes (debiting the wallet ledger without actually
   paying anyone) — rotate immediately if compromise is suspected.
 - HMAC-SHA256 per-request auth is on the deferred list (`DEFERRED_WORK.md`)
   for Phase 2 hardening once the LSL terminal is dogfooded.
-- Penalty endpoints (`/penalty-lookup`, `/penalty-payment`) are
-  header-trust-only on the backend — no shared secret in body. The script
-  still has its shared secret loaded for the other endpoints; it just
-  doesn't include it in penalty bodies.
+- Withdraw recipient UUID is **always** `user.slAvatarUuid` server-side,
+  never client-supplied. The wallet model's central anti-fraud invariant.
 
 ## SL grid Content-Type filter (footgun)
 
@@ -166,12 +158,8 @@ ProblemDetail) gets silently replaced by the SL HTTP layer with a
 synthetic `415` and body `Unsupported or unknown Content-Type.`. The
 script never sees the real status or body.
 
-Backend mitigations live on `/api/v1/sl/**`:
-
-1. `SlProblemDetailContentTypeAdvice` rewrites all 4xx/5xx responses on
-   SL paths to `Content-Type: application/json`.
-2. `/penalty-lookup` always returns 200 (the no-debt case used to be a
-   404 + ProblemDetail, which would be eaten by the grid filter).
+Backend mitigation: `SlProblemDetailContentTypeAdvice` rewrites all 4xx/5xx
+responses on `/api/v1/sl/**` paths to `Content-Type: application/json`.
 
 If you add a new SL-facing endpoint that returns 4xx/5xx, the advice
 covers it automatically by path prefix — no per-endpoint work needed.

--- a/lsl-scripts/slpa-terminal/config.notecard.example
+++ b/lsl-scripts/slpa-terminal/config.notecard.example
@@ -1,13 +1,11 @@
-# config notecard for SLPA Terminal (unified payments)
+# config notecard for SLPA Terminal (wallet model)
 # Place this file (renamed to "config", no extension) in the prim's contents.
 # After editing, the script auto-resets via CHANGED_INVENTORY and re-registers.
 
-# Backend endpoint URLs — all six required.
+# Backend endpoint URLs — all four required.
 REGISTER_URL=https://slpa.app/api/v1/sl/terminal/register
-ESCROW_PAYMENT_URL=https://slpa.app/api/v1/sl/escrow/payment
-LISTING_FEE_URL=https://slpa.app/api/v1/sl/listing-fee/payment
-PENALTY_LOOKUP_URL=https://slpa.app/api/v1/sl/penalty-lookup
-PENALTY_PAYMENT_URL=https://slpa.app/api/v1/sl/penalty-payment
+DEPOSIT_URL=https://slpa.app/api/v1/sl/wallet/deposit
+WITHDRAW_REQUEST_URL=https://slpa.app/api/v1/sl/wallet/withdraw-request
 PAYOUT_RESULT_URL=https://slpa.app/api/v1/sl/escrow/payout-result
 
 # Shared secret for terminal authentication. REQUIRED.

--- a/lsl-scripts/slpa-terminal/slpa-terminal.lsl
+++ b/lsl-scripts/slpa-terminal/slpa-terminal.lsl
@@ -1,12 +1,22 @@
-// SLPA Terminal (unified payments)
+// SLPA Terminal (wallet model)
 //
-// Single-object payment kiosk for SLPA. Handles four touch-menu options:
-//   1. Escrow Payment  — winner pays escrow on a won auction
-//   2. Listing Fee     — seller pays listing fee on a DRAFT auction
-//   3. Pay Penalty     — anyone clears a cancellation-penalty balance
-//   4. Get Parcel Verifier — llGiveInventory of the SLPA Parcel Verifier object
+// Single-object payment kiosk for SLPA. Two touch-menu options:
+//   1. Deposit  — instructs user to right-click and pay any amount
+//   2. Withdraw — touch-confirmed withdrawal from the user's SLPA wallet
 //
-// Also accepts backend-initiated PAYOUT/REFUND/WITHDRAW commands via HTTP-in.
+// The terminal accepts deposits via the natural SL pay flow:
+//   * Right-click → Pay → enter amount → money() event fires
+//   * Lockless, fully concurrent (multiple users can deposit simultaneously)
+//   * Backend POST to /sl/wallet/deposit credits the user's wallet
+//
+// Touch-initiated withdrawals use per-flow slots dispatched by avatar key
+// on a single shared listen — no terminal-wide lock, no per-flow listen
+// handles to leak. Up to 4 concurrent withdraw sessions; per-avatar dedup
+// (a second touch from the same avatar resets their existing slot).
+//
+// Also accepts backend-initiated PAYOUT/WITHDRAW commands via HTTP-in
+// (REFUND defensive — should never arrive in the wallet model since refunds
+// are wallet credits, but logged + failed loudly if it does).
 //
 // Configuration is loaded from a notecard named "config" in the same prim.
 // See README.md for deployment and operations details.
@@ -14,20 +24,16 @@
 // Grid guard note:
 //   llGetEnv("sim_channel") == "Second Life Server"   (in-world env value)
 //   X-SecondLife-Shard: "Production"                  (HTTP header value, checked backend-side)
-// These are DIFFERENT strings. Both are checked: this script checks sim_channel
-// at startup; SlHeaderValidator checks X-SecondLife-Shard on every inbound request.
 
 // === Configuration loaded from notecard ===
-string  REGISTER_URL        = "";
-string  ESCROW_PAYMENT_URL  = "";
-string  LISTING_FEE_URL     = "";
-string  PENALTY_LOOKUP_URL  = "";
-string  PENALTY_PAYMENT_URL = "";
-string  PAYOUT_RESULT_URL   = "";
-string  SHARED_SECRET       = "";
-string  TERMINAL_ID         = "";
-string  REGION_NAME         = "";
-integer DEBUG_MODE          = TRUE;
+string  REGISTER_URL          = "";
+string  DEPOSIT_URL           = "";
+string  WITHDRAW_REQUEST_URL  = "";
+string  PAYOUT_RESULT_URL     = "";
+string  SHARED_SECRET         = "";
+string  TERMINAL_ID           = "";
+string  REGION_NAME           = "";
+integer DEBUG_MODE            = TRUE;
 
 // === Notecard reading state ===
 key     notecardLineRequest = NULL_KEY;
@@ -44,64 +50,51 @@ key     registerReqId     = NULL_KEY;
 integer registerAttempt   = 0;
 integer registerNextRetryAt = 0;
 
-// === Touch session lock ===
-key     lockHolder     = NULL_KEY;
-string  lockHolderName = "";
-integer lockExpiresAt  = 0;
-integer listenHandle   = -1;
+// === Single shared listen (opened at startup, never closed) ===
+integer mainChan       = 0;
+integer mainListenHandle = -1;
 
-// === Touch-state constants ===
-integer STATE_IDLE               = 0;
-integer STATE_MENU_OPEN          = 1;
-integer STATE_AWAITING_AUCTION_ID = 2;
-integer STATE_LOOKUP_INFLIGHT    = 3;
-integer STATE_AWAITING_PAYMENT   = 4;
-integer touchState               = 0;
+// === Per-flow withdraw slots ===
+// Strided 3-wide list: [avatarKey, amountOrMinusOne, expiresAt, ...]
+//   amountOrMinusOne: -1 = awaiting amount; >0 = awaiting confirm
+list    withdrawSessions   = [];
+integer MAX_WITHDRAW_SESSIONS = 4;
+integer SESSION_TTL_SECONDS = 60;
+integer SLOT_STRIDE = 3;
 
-// === Payment-kind constants ===
-integer SELECTED_NONE        = 0;
-integer SELECTED_ESCROW      = 1;
-integer SELECTED_LISTING_FEE = 2;
-integer SELECTED_PENALTY     = 3;
-
-// === Touch payment selection ===
-integer selectedKind         = 0;
-integer selectedAuctionId    = 0;
-integer expectedPenaltyAmount = 0;
-
-// === Async request tracking ===
-key     lookupReqId  = NULL_KEY;
-
-// === Channels (set to random negatives in state_entry) ===
-integer menuChan      = 0;
-integer auctionIdChan = 0;
-
-// === Background payment retry (independent of lock) ===
+// === Background deposit retry (per money() event) ===
 key     paymentReqId       = NULL_KEY;
 key     paymentPayer       = NULL_KEY;
 integer paymentAmount      = 0;
-string  paymentTxKey       = "";    // synthesized once via llGenerateKey(); same across retries
-integer paymentKind        = 0;     // SELECTED_*
-integer paymentAuctionId   = 0;
+string  paymentTxKey       = "";
 integer paymentRetryCount  = 0;
 integer paymentNextRetryAt = 0;
 
-// === HTTP-in inflight command tracking (parallel to touch; lock-independent) ===
+// === Background withdraw-request retry (per touch-confirm) ===
+key     withdrawReqId       = NULL_KEY;
+key     withdrawPayer       = NULL_KEY;
+integer withdrawAmount      = 0;
+string  withdrawTxKey       = "";
+integer withdrawRetryCount  = 0;
+integer withdrawNextRetryAt = 0;
+
+// === HTTP-in inflight command tracking ===
 list    inflightCmdTxKeys         = [];
 list    inflightCmdIdempotencyKeys = [];
 list    inflightCmdRecipients     = [];
-list    inflightCmdAmounts        = [];
+list    inflightCmdAmounts         = [];
 integer MAX_INFLIGHT_CMDS         = 16;
 
 // === Payout-result tracking ===
 key     payoutResultReqId = NULL_KEY;
 
 // === Timer phase ===
-integer TIMER_NONE           = 0;
-integer TIMER_LOCK_TTL       = 1;
-integer TIMER_PAYMENT_RETRY  = 2;
-integer TIMER_REGISTER_RETRY = 3;
-integer timerPhase           = 0;
+integer TIMER_NONE              = 0;
+integer TIMER_SESSION_SWEEP     = 1;
+integer TIMER_PAYMENT_RETRY     = 2;
+integer TIMER_REGISTER_RETRY    = 3;
+integer TIMER_WITHDRAW_RETRY    = 4;
+integer timerPhase              = 0;
 
 // ---------------------------------------------------------------------------
 // Helper functions
@@ -114,7 +107,7 @@ readNotecardLine(integer n) {
 
 parseConfigLine(string line) {
     if (llStringLength(line) == 0) return;
-    if (llSubStringIndex(line, "#") == 0) return;  // comment line
+    if (llSubStringIndex(line, "#") == 0) return;
 
     integer eq = llSubStringIndex(line, "=");
     if (eq < 1) return;
@@ -122,15 +115,13 @@ parseConfigLine(string line) {
     string k = llStringTrim(llGetSubString(line, 0, eq - 1), STRING_TRIM);
     string v = llStringTrim(llGetSubString(line, eq + 1, -1), STRING_TRIM);
 
-    if      (k == "REGISTER_URL")        REGISTER_URL        = v;
-    else if (k == "ESCROW_PAYMENT_URL")  ESCROW_PAYMENT_URL  = v;
-    else if (k == "LISTING_FEE_URL")     LISTING_FEE_URL     = v;
-    else if (k == "PENALTY_LOOKUP_URL")  PENALTY_LOOKUP_URL  = v;
-    else if (k == "PENALTY_PAYMENT_URL") PENALTY_PAYMENT_URL = v;
-    else if (k == "PAYOUT_RESULT_URL")   PAYOUT_RESULT_URL   = v;
-    else if (k == "SHARED_SECRET")       SHARED_SECRET       = v;
-    else if (k == "TERMINAL_ID")         TERMINAL_ID         = v;
-    else if (k == "REGION_NAME")         REGION_NAME         = v;
+    if      (k == "REGISTER_URL")          REGISTER_URL          = v;
+    else if (k == "DEPOSIT_URL")           DEPOSIT_URL           = v;
+    else if (k == "WITHDRAW_REQUEST_URL")  WITHDRAW_REQUEST_URL  = v;
+    else if (k == "PAYOUT_RESULT_URL")     PAYOUT_RESULT_URL     = v;
+    else if (k == "SHARED_SECRET")         SHARED_SECRET         = v;
+    else if (k == "TERMINAL_ID")           TERMINAL_ID           = v;
+    else if (k == "REGION_NAME")           REGION_NAME           = v;
     else if (k == "DEBUG_MODE")
         DEBUG_MODE = (v == "true" || v == "TRUE" || v == "1");
 }
@@ -141,13 +132,6 @@ string escapeJson(string s) {
     return s;
 }
 
-// debugSayUser: when DEBUG_MODE is on, surface the parsed ProblemDetail
-// fields (status, title, detail, code) from a backend error response to
-// both the toucher (`who`, may be NULL_KEY for HTTP-in commands) and
-// owner-chat. The user-visible production message stays generic; this
-// adds a labelled diagnostic line so an operator standing at the
-// terminal can see exactly why a 4xx/5xx came back without grepping
-// CloudWatch.
 debugSayUser(key who, string label, integer status, string body) {
     if (!DEBUG_MODE) return;
     string title  = llJsonGetValue(body, ["title"]);
@@ -158,15 +142,10 @@ debugSayUser(key who, string label, integer status, string body) {
     if (title  != JSON_INVALID && title  != "") { msg += " title=" + title;   haveAny = TRUE; }
     if (detail != JSON_INVALID && detail != "") { msg += " detail=" + detail; haveAny = TRUE; }
     if (code   != JSON_INVALID && code   != "") { msg += " code=" + code;     haveAny = TRUE; }
-    // If the response wasn't a Spring ProblemDetail (no title/detail/code),
-    // surface the raw body excerpt so we can see HTML error pages, plain
-    // text, or empty bodies returned by intermediate proxies / framework
-    // defaults.
     if (!haveAny) {
         integer blen = llStringLength(body);
-        if (blen == 0) {
-            msg += " body=<empty>";
-        } else {
+        if (blen == 0) msg += " body=<empty>";
+        else {
             integer cap = blen;
             if (cap > 200) cap = 200;
             msg += " body[" + (string)blen + "]=" + llGetSubString(body, 0, cap - 1);
@@ -176,49 +155,20 @@ debugSayUser(key who, string label, integer status, string body) {
     llOwnerSay("SLPA Terminal: " + msg);
 }
 
-setBusyChrome() {
-    llSetText("SLPA Terminal\n<In Use>", <1.0, 0.2, 0.2>, 1.0);
-    llSetObjectName("SLPA Terminal <In Use>");
-}
-
 setIdleChrome() {
-    llSetText("SLPA Terminal\nTouch for options", <1.0, 1.0, 1.0>, 1.0);
+    llSetText("SLPA Terminal\nRight-click \xe2\x86\x92 Pay to deposit\nTouch for menu",
+        <1.0, 1.0, 1.0>, 1.0);
     llSetObjectName("SLPA Terminal");
+    llSetPayPrice(PAY_DEFAULT, [100, 500, 1000, 5000]);
 }
 
-releaseLock() {
-    if (listenHandle != -1) {
-        llListenRemove(listenHandle);
-        listenHandle = -1;
-    }
-    lockHolder            = NULL_KEY;
-    lockHolderName        = "";
-    lockExpiresAt         = 0;
-    selectedKind          = SELECTED_NONE;
-    selectedAuctionId     = 0;
-    expectedPenaltyAmount = 0;
-    touchState            = STATE_IDLE;
-    // Restore IDLE pay price — no payment accepted
-    llSetPayPrice(PAY_HIDE, [PAY_HIDE, PAY_HIDE, PAY_HIDE, PAY_HIDE]);
-    // Cancel lock-TTL timer (payment-retry timer lives independently)
-    if (timerPhase == TIMER_LOCK_TTL) {
-        timerPhase = TIMER_NONE;
-        llSetTimerEvent(0);
-    }
-    setIdleChrome();
-}
-
-extendLock(integer seconds) {
-    lockExpiresAt = llGetUnixTime() + seconds;
-    timerPhase    = TIMER_LOCK_TTL;
-    llSetTimerEvent((float)seconds);
-}
-
-acquireLock(key holder, string name) {
-    lockHolder     = holder;
-    lockHolderName = name;
-    setBusyChrome();
-    extendLock(60);
+// retrySchedule: 1-indexed
+integer retryDelay(integer attempt) {
+    list schedule = [10, 30, 90, 300, 900];
+    integer idx = attempt - 1;
+    if (idx < 0)  idx = 0;
+    if (idx > 4)  idx = 4;
+    return llList2Integer(schedule, idx);
 }
 
 postRegister() {
@@ -235,16 +185,6 @@ postRegister() {
         body);
 }
 
-// retrySchedule is 1-indexed: attempt 1 = first retry after initial failure.
-// schedule indices: [10, 30, 90, 300, 900]
-integer retryDelay(integer attempt) {
-    list schedule = [10, 30, 90, 300, 900];
-    integer idx = attempt - 1;
-    if (idx < 0)  idx = 0;
-    if (idx > 4)  idx = 4;
-    return llList2Integer(schedule, idx);
-}
-
 scheduleRegisterRetry() {
     integer delay = retryDelay(registerAttempt);
     registerNextRetryAt = llGetUnixTime() + delay;
@@ -252,42 +192,17 @@ scheduleRegisterRetry() {
     llSetTimerEvent((float)delay);
 }
 
+// ---------------- Deposit (money() handler) ----------------
+
 firePayment() {
-    string url;
-    string body;
-
-    if (paymentKind == SELECTED_ESCROW) {
-        url = ESCROW_PAYMENT_URL;
-        body = "{"
-            + "\"auctionId\":" + (string)paymentAuctionId + ","
-            + "\"payerUuid\":\"" + (string)paymentPayer + "\","
-            + "\"amount\":" + (string)paymentAmount + ","
-            + "\"slTransactionKey\":\"" + paymentTxKey + "\","
-            + "\"terminalId\":\"" + escapeJson(TERMINAL_ID) + "\","
-            + "\"sharedSecret\":\"" + escapeJson(SHARED_SECRET) + "\""
-            + "}";
-    } else if (paymentKind == SELECTED_LISTING_FEE) {
-        url = LISTING_FEE_URL;
-        body = "{"
-            + "\"auctionId\":" + (string)paymentAuctionId + ","
-            + "\"payerUuid\":\"" + (string)paymentPayer + "\","
-            + "\"amount\":" + (string)paymentAmount + ","
-            + "\"slTransactionKey\":\"" + paymentTxKey + "\","
-            + "\"terminalId\":\"" + escapeJson(TERMINAL_ID) + "\","
-            + "\"sharedSecret\":\"" + escapeJson(SHARED_SECRET) + "\""
-            + "}";
-    } else {
-        // SELECTED_PENALTY
-        url = PENALTY_PAYMENT_URL;
-        body = "{"
-            + "\"slAvatarUuid\":\"" + (string)paymentPayer + "\","
-            + "\"slTransactionId\":\"" + paymentTxKey + "\","
-            + "\"amount\":" + (string)paymentAmount + ","
-            + "\"terminalId\":\"" + escapeJson(TERMINAL_ID) + "\""
-            + "}";
-    }
-
-    paymentReqId = llHTTPRequest(url,
+    string body = "{"
+        + "\"payerUuid\":\"" + (string)paymentPayer + "\","
+        + "\"amount\":" + (string)paymentAmount + ","
+        + "\"slTransactionKey\":\"" + paymentTxKey + "\","
+        + "\"terminalId\":\"" + escapeJson(TERMINAL_ID) + "\","
+        + "\"sharedSecret\":\"" + escapeJson(SHARED_SECRET) + "\""
+        + "}";
+    paymentReqId = llHTTPRequest(DEPOSIT_URL,
         [HTTP_METHOD, "POST",
          HTTP_MIMETYPE, "application/json",
          HTTP_BODY_MAXLENGTH, 16384],
@@ -296,23 +211,21 @@ firePayment() {
 
 schedulePaymentRetry() {
     if (paymentRetryCount >= 5) {
-        llOwnerSay("CRITICAL: SLPA Terminal: payment from "
+        llOwnerSay("CRITICAL: SLPA Terminal: deposit from "
             + (string)paymentPayer
             + " L$" + (string)paymentAmount
             + " key " + paymentTxKey
             + " not acknowledged after 5 retries");
-        // Clear payment state — stop retrying
         paymentReqId      = NULL_KEY;
         paymentPayer      = NULL_KEY;
         paymentAmount     = 0;
         paymentTxKey      = "";
-        paymentKind       = SELECTED_NONE;
-        paymentAuctionId  = 0;
         paymentRetryCount = 0;
-        // Only clear timer if not being used for lock TTL
         if (timerPhase == TIMER_PAYMENT_RETRY) {
             timerPhase = TIMER_NONE;
-            llSetTimerEvent(0);
+            // Don't blindly cancel — session sweep also uses the timer.
+            llSetTimerEvent(10.0);
+            timerPhase = TIMER_SESSION_SWEEP;
         }
         return;
     }
@@ -322,8 +235,47 @@ schedulePaymentRetry() {
     llSetTimerEvent((float)delay);
 }
 
-// isPositiveInteger: checks that s is a non-empty string of digits (max 9 digits)
-// representing a value > 0. Used to validate user-typed auction ID.
+// ---------------- Withdraw-request retry ----------------
+
+fireWithdrawRequest() {
+    string body = "{"
+        + "\"payerUuid\":\"" + (string)withdrawPayer + "\","
+        + "\"amount\":" + (string)withdrawAmount + ","
+        + "\"slTransactionKey\":\"" + withdrawTxKey + "\","
+        + "\"terminalId\":\"" + escapeJson(TERMINAL_ID) + "\","
+        + "\"sharedSecret\":\"" + escapeJson(SHARED_SECRET) + "\""
+        + "}";
+    withdrawReqId = llHTTPRequest(WITHDRAW_REQUEST_URL,
+        [HTTP_METHOD, "POST",
+         HTTP_MIMETYPE, "application/json",
+         HTTP_BODY_MAXLENGTH, 16384],
+        body);
+}
+
+scheduleWithdrawRetry() {
+    if (withdrawRetryCount >= 5) {
+        llOwnerSay("CRITICAL: SLPA Terminal: withdraw-request from "
+            + (string)withdrawPayer
+            + " L$" + (string)withdrawAmount
+            + " key " + withdrawTxKey
+            + " not acknowledged after 5 retries");
+        withdrawReqId      = NULL_KEY;
+        withdrawPayer      = NULL_KEY;
+        withdrawAmount     = 0;
+        withdrawTxKey      = "";
+        withdrawRetryCount = 0;
+        if (timerPhase == TIMER_WITHDRAW_RETRY) {
+            timerPhase = TIMER_SESSION_SWEEP;
+            llSetTimerEvent(10.0);
+        }
+        return;
+    }
+    integer delay = retryDelay(withdrawRetryCount);
+    withdrawNextRetryAt = llGetUnixTime() + delay;
+    timerPhase = TIMER_WITHDRAW_RETRY;
+    llSetTimerEvent((float)delay);
+}
+
 integer isPositiveInteger(string s) {
     integer len = llStringLength(s);
     if (len == 0 || len > 9) return FALSE;
@@ -335,10 +287,75 @@ integer isPositiveInteger(string s) {
     return ((integer)s) > 0;
 }
 
+// ---------------- Withdraw slot helpers ----------------
+
+integer findSlot(key avatar) {
+    integer i;
+    integer count = llGetListLength(withdrawSessions) / SLOT_STRIDE;
+    for (i = 0; i < count; ++i) {
+        key k = llList2Key(withdrawSessions, i * SLOT_STRIDE);
+        if (k == avatar) return i;
+    }
+    return -1;
+}
+
+integer slotAmount(integer slotIdx) {
+    return llList2Integer(withdrawSessions, slotIdx * SLOT_STRIDE + 1);
+}
+
+setSlotAmount(integer slotIdx, integer amount) {
+    integer offset = slotIdx * SLOT_STRIDE + 1;
+    withdrawSessions = llListReplaceList(withdrawSessions, [amount], offset, offset);
+}
+
+extendSlot(integer slotIdx) {
+    integer offset = slotIdx * SLOT_STRIDE + 2;
+    withdrawSessions = llListReplaceList(withdrawSessions,
+        [llGetUnixTime() + SESSION_TTL_SECONDS], offset, offset);
+}
+
+// Returns slot index of new/reset slot, or -1 if at capacity (and not own).
+integer acquireOrResetSlot(key avatar) {
+    integer existing = findSlot(avatar);
+    if (existing >= 0) {
+        // Reset existing slot
+        integer offset = existing * SLOT_STRIDE + 1;
+        withdrawSessions = llListReplaceList(withdrawSessions,
+            [-1, llGetUnixTime() + SESSION_TTL_SECONDS], offset, offset + 1);
+        return existing;
+    }
+    integer count = llGetListLength(withdrawSessions) / SLOT_STRIDE;
+    if (count >= MAX_WITHDRAW_SESSIONS) return -1;
+    withdrawSessions += [avatar, -1, llGetUnixTime() + SESSION_TTL_SECONDS];
+    return count;
+}
+
+releaseSlot(key avatar) {
+    integer slotIdx = findSlot(avatar);
+    if (slotIdx < 0) return;
+    integer start = slotIdx * SLOT_STRIDE;
+    withdrawSessions = llDeleteSubList(withdrawSessions, start, start + SLOT_STRIDE - 1);
+}
+
+sweepExpiredSlots() {
+    integer now = llGetUnixTime();
+    integer i = llGetListLength(withdrawSessions) / SLOT_STRIDE - 1;
+    while (i >= 0) {
+        integer expiresAt = llList2Integer(withdrawSessions, i * SLOT_STRIDE + 2);
+        if (expiresAt < now) {
+            withdrawSessions = llDeleteSubList(withdrawSessions,
+                i * SLOT_STRIDE, i * SLOT_STRIDE + SLOT_STRIDE - 1);
+        }
+        --i;
+    }
+}
+
+// ---------------- HTTP-in inflight ----------------
+
 addInflightCommand(key txKey, string idempotencyKey, key recipient, integer amount) {
     if (llGetListLength(inflightCmdTxKeys) >= MAX_INFLIGHT_CMDS) {
         llOwnerSay("SLPA Terminal: inflight command cap (" + (string)MAX_INFLIGHT_CMDS
-            + ") hit — refusing PAYOUT command. Backend retry budget will cover.");
+            + ") hit — refusing command. Backend retry will cover.");
         return;
     }
     inflightCmdTxKeys          = inflightCmdTxKeys          + [txKey];
@@ -347,8 +364,6 @@ addInflightCommand(key txKey, string idempotencyKey, key recipient, integer amou
     inflightCmdAmounts         = inflightCmdAmounts         + [amount];
 }
 
-// Finds and removes entry by txKey. Returns [idempotencyKey, recipientUuid, amount]
-// or [] if not found.
 list removeInflightByTxKey(key txKey) {
     integer idx = llListFindList(inflightCmdTxKeys, [(string)txKey]);
     if (idx < 0) return [];
@@ -363,563 +378,415 @@ list removeInflightByTxKey(key txKey) {
 }
 
 // ---------------------------------------------------------------------------
-// Default state
-// ---------------------------------------------------------------------------
 
 default {
-
     state_entry() {
-        // Reset all globals to sentinel values.
-        REGISTER_URL        = "";
-        ESCROW_PAYMENT_URL  = "";
-        LISTING_FEE_URL     = "";
-        PENALTY_LOOKUP_URL  = "";
-        PENALTY_PAYMENT_URL = "";
-        PAYOUT_RESULT_URL   = "";
-        SHARED_SECRET       = "";
-        TERMINAL_ID         = "";
-        REGION_NAME         = "";
-        DEBUG_MODE          = TRUE;
+        REGISTER_URL          = "";
+        DEPOSIT_URL           = "";
+        WITHDRAW_REQUEST_URL  = "";
+        PAYOUT_RESULT_URL     = "";
+        SHARED_SECRET         = "";
+        TERMINAL_ID           = "";
+        REGION_NAME           = "";
+        DEBUG_MODE            = TRUE;
 
         notecardLineRequest = NULL_KEY;
         notecardLineNum     = 0;
-
         httpInUrl           = "";
         urlRequestId        = NULL_KEY;
-
         debitGranted        = FALSE;
         registered          = FALSE;
         registerReqId       = NULL_KEY;
         registerAttempt     = 0;
         registerNextRetryAt = 0;
-
-        lockHolder          = NULL_KEY;
-        lockHolderName      = "";
-        lockExpiresAt       = 0;
-        listenHandle        = -1;
-        touchState          = STATE_IDLE;
-
-        selectedKind          = SELECTED_NONE;
-        selectedAuctionId     = 0;
-        expectedPenaltyAmount = 0;
-        lookupReqId           = NULL_KEY;
-
-        paymentReqId       = NULL_KEY;
-        paymentPayer       = NULL_KEY;
-        paymentAmount      = 0;
-        paymentTxKey       = "";
-        paymentKind        = SELECTED_NONE;
-        paymentAuctionId   = 0;
-        paymentRetryCount  = 0;
-        paymentNextRetryAt = 0;
-
+        withdrawSessions    = [];
+        paymentReqId        = NULL_KEY;
+        paymentPayer        = NULL_KEY;
+        paymentAmount       = 0;
+        paymentTxKey        = "";
+        paymentRetryCount   = 0;
+        withdrawReqId       = NULL_KEY;
+        withdrawPayer       = NULL_KEY;
+        withdrawAmount      = 0;
+        withdrawTxKey       = "";
+        withdrawRetryCount  = 0;
         inflightCmdTxKeys          = [];
         inflightCmdIdempotencyKeys = [];
         inflightCmdRecipients      = [];
         inflightCmdAmounts         = [];
+        payoutResultReqId   = NULL_KEY;
+        timerPhase          = TIMER_NONE;
 
-        payoutResultReqId = NULL_KEY;
-        timerPhase        = TIMER_NONE;
-
-        // Two distinct channels — use non-adjacent negatives to reduce collision risk.
-        menuChan      = -100000 - (integer)(llFrand(50000.0));
-        auctionIdChan = menuChan - 1;
-
-        // Mainland-only guard.
-        // llGetEnv("sim_channel") == "Second Life Server" on main grid.
-        // This is DISTINCT from X-SecondLife-Shard ("Production") which SlHeaderValidator checks.
+        // Mainland-only grid guard
         if (llGetEnv("sim_channel") != "Second Life Server") {
-            llOwnerSay("CRITICAL: SLPA Terminal must run on the main grid (sim_channel != \"Second Life Server\").");
+            llOwnerSay("CRITICAL: not on Second Life Server grid; halting.");
             return;
         }
 
-        // Idle state: no payment accepted until explicitly set.
-        llSetPayPrice(PAY_HIDE, [PAY_HIDE, PAY_HIDE, PAY_HIDE, PAY_HIDE]);
-        setIdleChrome();
+        if (TERMINAL_ID == "") TERMINAL_ID = (string)llGetKey();
+        if (REGION_NAME == "") REGION_NAME = llGetRegionName();
 
-        // Start reading the config notecard.
+        // Single shared listen on a random negative channel.
+        mainChan = -100000 - (integer)(llFrand(50000.0));
+        mainListenHandle = llListen(mainChan, "", NULL_KEY, "");
+
+        setIdleChrome();
         readNotecardLine(0);
+
+        // Request DEBIT permission from owner so HTTP-in PAYOUT/WITHDRAW
+        // can fire llTransferLindenDollars.
+        llRequestPermissions(llGetOwner(), PERMISSION_DEBIT);
+
+        // 10-second timer for session sweep + retry checks.
+        timerPhase = TIMER_SESSION_SWEEP;
+        llSetTimerEvent(10.0);
     }
 
-    dataserver(key requested, string data) {
-        if (requested != notecardLineRequest) return;
+    on_rez(integer n) {
+        llResetScript();
+    }
 
-        if (data == NAK) {
-            llOwnerSay("SLPA Terminal: notecard 'config' missing or unreadable");
-            return;
+    changed(integer change) {
+        if (change & CHANGED_INVENTORY) {
+            llResetScript();
         }
-
-        if (data == EOF) {
-            // Validate all required keys.
-            if (REGISTER_URL == "" || ESCROW_PAYMENT_URL == "" || LISTING_FEE_URL == ""
-                || PENALTY_LOOKUP_URL == "" || PENALTY_PAYMENT_URL == ""
-                || PAYOUT_RESULT_URL == "" || SHARED_SECRET == "") {
-                llOwnerSay("SLPA Terminal: incomplete config — REGISTER_URL / ESCROW_PAYMENT_URL / LISTING_FEE_URL / PENALTY_LOOKUP_URL / PENALTY_PAYMENT_URL / PAYOUT_RESULT_URL / SHARED_SECRET required");
-                return;
-            }
-            // Apply defaults for optional keys.
-            if (TERMINAL_ID == "") TERMINAL_ID = (string)llGetKey();
-            if (REGION_NAME == "")  REGION_NAME = llGetRegionName();
-
-            // Request PERMISSION_DEBIT from owner before doing anything else.
-            llRequestPermissions(llGetOwner(), PERMISSION_DEBIT);
-            return;
+        if (change & CHANGED_REGION_START) {
+            // Re-request the HTTP-in URL and re-register with backend.
+            urlRequestId = llRequestURL();
         }
-
-        // Normal notecard line.
-        parseConfigLine(data);
-        readNotecardLine(notecardLineNum + 1);
     }
 
     run_time_permissions(integer perm) {
         if (perm & PERMISSION_DEBIT) {
             debitGranted = TRUE;
-            // Request an HTTP-in URL; result arrives in http_request as URL_REQUEST_GRANTED.
+            // Now request HTTP-in URL.
             urlRequestId = llRequestURL();
         } else {
             llOwnerSay("CRITICAL: PERMISSION_DEBIT denied — script halted. Owner must re-grant.");
-            // No further action; script sits idle until reset.
         }
     }
 
-    http_request(key reqId, string method, string body) {
-        // --- URL lifecycle events ---
-        if (method == URL_REQUEST_GRANTED) {
-            httpInUrl = body;
-            postRegister();
-            return;
-        }
-        if (method == URL_REQUEST_DENIED) {
-            llOwnerSay("CRITICAL: HTTP-in URL request denied — region may not allow scripts to request URLs. Halting.");
-            return;
-        }
-
-        // --- Incoming HTTP-in command from backend (POST) ---
-        if (method == "POST") {
-            // Parse TerminalCommandBody fields.
-            string inSecret      = llJsonGetValue(body, ["sharedSecret"]);
-            string action        = llJsonGetValue(body, ["action"]);
-            string recipientUuid = llJsonGetValue(body, ["recipientUuid"]);
-            integer amount       = (integer)llJsonGetValue(body, ["amount"]);
-            string idempotencyKey = llJsonGetValue(body, ["idempotencyKey"]);
-
-            // Shared-secret validation. LSL == is not constant-time, but HTTPS
-            // provides transport security; spec accepts this trade-off.
-            if (inSecret != SHARED_SECRET) {
-                llHTTPResponse(reqId, 403, "{\"error\":\"secret mismatch\"}");
+    dataserver(key requested, string data) {
+        if (requested == notecardLineRequest) {
+            if (data == EOF) {
+                // Check that all required keys parsed
+                if (REGISTER_URL == "" || DEPOSIT_URL == "" || WITHDRAW_REQUEST_URL == ""
+                    || PAYOUT_RESULT_URL == "" || SHARED_SECRET == "" || TERMINAL_ID == "") {
+                    llOwnerSay("CRITICAL: incomplete config notecard.");
+                    return;
+                }
+                if (DEBUG_MODE) llOwnerSay("SLPA Terminal: config loaded.");
                 return;
             }
+            parseConfigLine(data);
+            readNotecardLine(notecardLineNum + 1);
+        }
+    }
 
-            // Inflight cap check.
-            if (llGetListLength(inflightCmdTxKeys) >= MAX_INFLIGHT_CMDS) {
-                llHTTPResponse(reqId, 503, "{\"error\":\"terminal busy\"}");
-                return;
+    http_request(key id, string method, string body) {
+        if (id == urlRequestId) {
+            if (method == URL_REQUEST_GRANTED) {
+                httpInUrl = body;
+                if (DEBUG_MODE) llOwnerSay("SLPA Terminal: HTTP-in URL granted: " + httpInUrl);
+                if (REGISTER_URL != "") {
+                    registerAttempt = 1;
+                    postRegister();
+                }
+            } else if (method == URL_REQUEST_DENIED) {
+                llOwnerSay("CRITICAL: URL_REQUEST_DENIED. Land must allow scripts to request URLs.");
             }
+            return;
+        }
 
-            // Ack receipt immediately; result follows via /payout-result.
-            llHTTPResponse(reqId, 200, "{\"ack\":true}");
+        // Backend-initiated HTTP-in command (PAYOUT / WITHDRAW)
+        if (method != "POST") {
+            llHTTPResponse(id, 405, "{\"error\":\"method not allowed\"}");
+            return;
+        }
+        // Validate shared secret in body
+        string secret = llJsonGetValue(body, ["sharedSecret"]);
+        if (secret == JSON_INVALID || secret != SHARED_SECRET) {
+            llHTTPResponse(id, 403, "{\"error\":\"shared secret mismatch\"}");
+            return;
+        }
+        string action      = llJsonGetValue(body, ["action"]);
+        string ikey        = llJsonGetValue(body, ["idempotencyKey"]);
+        string recipient   = llJsonGetValue(body, ["recipientUuid"]);
+        integer amount     = (integer)llJsonGetValue(body, ["amount"]);
 
-            // Execute the transfer regardless of action enum value
-            // (PAYOUT, REFUND, WITHDRAW all map to llTransferLindenDollars).
-            key txKey = llTransferLindenDollars((key)recipientUuid, amount);
-            addInflightCommand(txKey, idempotencyKey, (key)recipientUuid, amount);
+        if (action == "REFUND") {
+            // Defensive: refunds are wallet credits in the new model and
+            // shouldn't be dispatched to terminals. Log loud and fail.
+            llOwnerSay("CRITICAL: unexpected REFUND HTTP-in command — refunds are now wallet credits. idempotencyKey=" + ikey);
+            llHTTPResponse(id, 200,
+                "{\"status\":\"FAILED\",\"reason\":\"REFUND_NOT_SUPPORTED\"}");
+            return;
+        }
 
-            if (DEBUG_MODE) {
-                llOwnerSay("SLPA Terminal: HTTP-in command action=" + action
-                    + " recipient=" + recipientUuid
-                    + " amount=" + (string)amount
-                    + " idempotencyKey=" + idempotencyKey);
-            }
+        if (recipient == JSON_INVALID || amount <= 0) {
+            llHTTPResponse(id, 400, "{\"error\":\"missing recipient or amount\"}");
+            return;
+        }
+        if (!debitGranted) {
+            llHTTPResponse(id, 503, "{\"error\":\"DEBIT not granted\"}");
+            return;
+        }
+
+        // Ack receipt; transaction_result will follow async.
+        llHTTPResponse(id, 200, "{\"status\":\"ACCEPTED\"}");
+
+        key txKey = llTransferLindenDollars((key)recipient, amount);
+        addInflightCommand(txKey, ikey, (key)recipient, amount);
+        if (DEBUG_MODE) {
+            llOwnerSay("SLPA Terminal: HTTP-in " + action + " to "
+                + recipient + " L$" + (string)amount + " ikey=" + ikey);
         }
     }
 
     transaction_result(key id, integer success, string data) {
-        list found = removeInflightByTxKey(id);
-        if (llGetListLength(found) == 0) {
-            if (DEBUG_MODE)
-                llOwnerSay("SLPA Terminal: transaction_result for unknown txKey=" + (string)id);
-            return;
-        }
+        list inflight = removeInflightByTxKey(id);
+        if (llGetListLength(inflight) == 0) return;
+        string ikey = llList2String(inflight, 0);
+        string recip = llList2String(inflight, 1);
+        integer amount = llList2Integer(inflight, 2);
 
-        string ikey  = llList2String(found, 0);
-        string recip = llList2String(found, 1);
-        integer amt  = llList2Integer(found, 2);
+        // Build payout-result body. success is integer 0/1; JSON requires unquoted true/false.
+        string successStr = "false";
+        if (success) successStr = "true";
 
-        // Build payout-result body. success is an integer (0/1) in LSL;
-        // JSON requires unquoted true/false. slTransactionKey/errorMessage may be null.
-        string successStr;
-        string txKeyField;
-        string errorField;
-
-        if (success) {
-            successStr  = "true";
-            txKeyField  = "\"" + escapeJson(data) + "\"";
-            errorField  = "null";
-        } else {
-            successStr = "false";
-            txKeyField = "null";
-            if (data != "") {
-                errorField = "\"" + escapeJson(data) + "\"";
-            } else {
-                errorField = "null";
-            }
-        }
-
-        string pbody = "{"
+        string body = "{"
             + "\"idempotencyKey\":\"" + escapeJson(ikey) + "\","
             + "\"success\":" + successStr + ","
-            + "\"slTransactionKey\":" + txKeyField + ","
-            + "\"errorMessage\":" + errorField + ","
+            + "\"slTransactionKey\":\"" + (string)id + "\","
             + "\"terminalId\":\"" + escapeJson(TERMINAL_ID) + "\","
             + "\"sharedSecret\":\"" + escapeJson(SHARED_SECRET) + "\""
             + "}";
+        if (!success) {
+            body = "{"
+                + "\"idempotencyKey\":\"" + escapeJson(ikey) + "\","
+                + "\"success\":false,"
+                + "\"slTransactionKey\":\"" + (string)id + "\","
+                + "\"errorMessage\":\"" + escapeJson(data) + "\","
+                + "\"terminalId\":\"" + escapeJson(TERMINAL_ID) + "\","
+                + "\"sharedSecret\":\"" + escapeJson(SHARED_SECRET) + "\""
+                + "}";
+        }
 
         payoutResultReqId = llHTTPRequest(PAYOUT_RESULT_URL,
             [HTTP_METHOD, "POST",
              HTTP_MIMETYPE, "application/json",
              HTTP_BODY_MAXLENGTH, 16384],
-            pbody);
+            body);
 
         if (DEBUG_MODE) {
-            llOwnerSay("SLPA Terminal: payout-result posted: success=" + successStr
-                + " recipient=" + recip + " amount=" + (string)amt);
-        }
-    }
-
-    http_response(key req, integer status, list meta, string body) {
-
-        // --- Registration response ---
-        if (req == registerReqId) {
-            registerReqId = NULL_KEY;
-            if (status == 200) {
-                registered    = TRUE;
-                registerAttempt = 0;
-                if (DEBUG_MODE)
-                    llOwnerSay("SLPA Terminal: registered (terminal_id=" + TERMINAL_ID
-                        + ", url=" + httpInUrl + ")");
-            } else {
-                registerAttempt++;
-                if (registerAttempt > 5) {
-                    llOwnerSay("CRITICAL: SLPA Terminal: registration failed after 5 attempts. Status="
-                        + (string)status);
-                } else {
-                    if (DEBUG_MODE)
-                        llOwnerSay("SLPA Terminal: register retry " + (string)registerAttempt + "/5: status=" + (string)status);
-                    scheduleRegisterRetry();
-                }
-            }
-            return;
-        }
-
-        // --- Penalty-lookup response ---
-        if (req == lookupReqId) {
-            lookupReqId = NULL_KEY;
-            if (status == 200) {
-                // Backend always returns 200 for /penalty-lookup. Branch on
-                // penaltyBalanceOwed: 0 means "no debt" (unknown avatar AND
-                // known-but-zero are byte-identical for privacy); positive
-                // means show the pay prompt. The endpoint used to 404 the
-                // no-debt cases, but the SL HTTP outbound layer rewrites
-                // 4xx responses whose Content-Type is not in HTTP_ACCEPT
-                // into a synthetic 415, so the script never saw the real
-                // 404. See PenaltyTerminalService.lookup javadoc.
-                integer owed = (integer)llJsonGetValue(body, ["penaltyBalanceOwed"]);
-                if (owed <= 0) {
-                    llRegionSayTo(lockHolder, 0, "No penalty on file for your account.");
-                    releaseLock();
-                } else {
-                    selectedKind          = SELECTED_PENALTY;
-                    expectedPenaltyAmount = owed;
-                    llRegionSayTo(lockHolder, 0,
-                        "Penalty owed: L$" + (string)owed
-                        + ". Pay below — full or partial OK.");
-                    // PENALTY pay-price matrix: first arg = default text-field value = owed,
-                    // quick buttons: full / half / quarter / hidden.
-                    llSetPayPrice(owed, [owed, owed / 2, owed / 4, PAY_HIDE]);
-                    touchState = STATE_AWAITING_PAYMENT;
-                    extendLock(60);
-                }
-            } else {
-                // 5xx, 0 (network), or unexpected status (e.g. 400 validation,
-                // 403 SL_INVALID_HEADERS). The user message stays generic;
-                // DEBUG_MODE adds the parsed ProblemDetail so an operator at
-                // the terminal can diagnose without grepping CloudWatch.
-                llRegionSayTo(lockHolder, 0, "Lookup failed — try again.");
-                debugSayUser(lockHolder, "penalty lookup", status, body);
-                releaseLock();
-            }
-            return;
-        }
-
-        // --- Payment response (escrow / listing-fee / penalty) ---
-        if (req == paymentReqId) {
-            paymentReqId = NULL_KEY;
-            if (status == 200) {
-                if (paymentKind == SELECTED_ESCROW || paymentKind == SELECTED_LISTING_FEE) {
-                    string pstatus  = llJsonGetValue(body, ["status"]);
-                    string pmessage = llJsonGetValue(body, ["message"]);
-                    if (pstatus == "OK") {
-                        llRegionSayTo(paymentPayer, 0,
-                            "Payment of L$" + (string)paymentAmount + " accepted.");
-                    } else if (pstatus == "REFUND") {
-                        llRegionSayTo(paymentPayer, 0,
-                            "Payment refused: " + pmessage + ". Refund will be issued.");
-                    } else {
-                        // ERROR
-                        llRegionSayTo(paymentPayer, 0,
-                            "Payment error: " + pmessage);
-                    }
-                } else if (paymentKind == SELECTED_PENALTY) {
-                    integer remaining = (integer)llJsonGetValue(body, ["remainingBalance"]);
-                    if (remaining == 0) {
-                        llRegionSayTo(paymentPayer, 0, "Penalty cleared.");
-                    } else {
-                        llRegionSayTo(paymentPayer, 0,
-                            "L$" + (string)paymentAmount + " applied. L$"
-                            + (string)remaining + " still owed.");
-                    }
-                }
-                // Clear payment state.
-                paymentPayer      = NULL_KEY;
-                paymentAmount     = 0;
-                paymentTxKey      = "";
-                paymentKind       = SELECTED_NONE;
-                paymentAuctionId  = 0;
-                paymentRetryCount = 0;
-                if (timerPhase == TIMER_PAYMENT_RETRY) {
-                    timerPhase = TIMER_NONE;
-                    llSetTimerEvent(0);
-                }
-            } else if (status >= 400 && status < 500) {
-                string title  = llJsonGetValue(body, ["title"]);
-                string detail = llJsonGetValue(body, ["detail"]);
-                if (title == JSON_INVALID || title == "") title = "Error";
-                llOwnerSay("CRITICAL: SLPA Terminal: payment 4xx from "
-                    + (string)paymentPayer
-                    + " L$" + (string)paymentAmount
-                    + " key " + paymentTxKey
-                    + ": " + title + " — " + detail);
-                llRegionSayTo(paymentPayer, 0,
-                    "Payment error (" + (string)status + "): " + title + ". Contact SLPA support.");
-                debugSayUser(paymentPayer, "payment", status, body);
-                // Clear payment state — 4xx is non-retriable.
-                paymentPayer      = NULL_KEY;
-                paymentAmount     = 0;
-                paymentTxKey      = "";
-                paymentKind       = SELECTED_NONE;
-                paymentAuctionId  = 0;
-                paymentRetryCount = 0;
-                if (timerPhase == TIMER_PAYMENT_RETRY) {
-                    timerPhase = TIMER_NONE;
-                    llSetTimerEvent(0);
-                }
-            } else {
-                // 5xx or 0 — schedule retry.
-                paymentRetryCount++;
-                if (DEBUG_MODE)
-                    llOwnerSay("SLPA Terminal: payment retry " + (string)paymentRetryCount
-                        + "/5: status=" + (string)status);
-                debugSayUser(paymentPayer,
-                    "payment retry " + (string)paymentRetryCount + "/5",
-                    status, body);
-                schedulePaymentRetry();
-            }
-            return;
-        }
-
-        // --- Payout-result response ---
-        if (req == payoutResultReqId) {
-            payoutResultReqId = NULL_KEY;
-            if (status == 200) {
-                if (DEBUG_MODE)
-                    llOwnerSay("SLPA Terminal: payout-result acknowledged by backend.");
-            } else {
-                llOwnerSay("CRITICAL: /payout-result POST failed status=" + (string)status
-                    + " — backend will retry from terminal_commands ledger.");
-            }
-            return;
-        }
-    }
-
-    touch_start(integer num_detected) {
-        key    toucher     = llDetectedKey(0);
-        string toucherName = llDetectedName(0);
-
-        // If lock is held and not expired, bounce the toucher.
-        if (lockHolder != NULL_KEY && lockExpiresAt > llGetUnixTime()) {
-            llRegionSayTo(toucher, 0,
-                "Terminal busy with " + lockHolderName + ". Try again in 60s.");
-            return;
-        }
-
-        acquireLock(toucher, toucherName);
-        listenHandle = llListen(menuChan, "", toucher, "");
-        llDialog(toucher, "What do you need?",
-            ["Escrow Payment", "Listing Fee", "Pay Penalty", "Get Parcel Verifier"],
-            menuChan);
-        touchState = STATE_MENU_OPEN;
-    }
-
-    listen(integer channel, string name, key id, string message) {
-
-        // --- Main menu ---
-        if (channel == menuChan && id == lockHolder) {
-            llListenRemove(listenHandle);
-            listenHandle = -1;
-
-            if (message == "Escrow Payment") {
-                selectedKind = SELECTED_ESCROW;
-                listenHandle = llListen(auctionIdChan, "", lockHolder, "");
-                llTextBox(lockHolder, "Enter the Auction ID from your auction page:", auctionIdChan);
-                touchState = STATE_AWAITING_AUCTION_ID;
-                extendLock(60);
-
-            } else if (message == "Listing Fee") {
-                selectedKind = SELECTED_LISTING_FEE;
-                listenHandle = llListen(auctionIdChan, "", lockHolder, "");
-                llTextBox(lockHolder, "Enter the Auction ID from your draft listing:", auctionIdChan);
-                touchState = STATE_AWAITING_AUCTION_ID;
-                extendLock(60);
-
-            } else if (message == "Pay Penalty") {
-                // Fire penalty lookup; lock stays held during inflight.
-                // Manual JSON construction (matches postRegister + firePayment in
-                // this script) instead of llList2Json — the grid's auto-typing in
-                // llList2Json has historically produced bodies that the SL HTTP
-                // layer flags as a non-JSON content shape, surfacing as 415 from
-                // the backend even though HTTP_MIMETYPE is set to application/json.
-                string lbody = "{"
-                    + "\"slAvatarUuid\":\"" + (string)lockHolder + "\","
-                    + "\"terminalId\":\""   + escapeJson(TERMINAL_ID) + "\""
-                    + "}";
-                lookupReqId = llHTTPRequest(PENALTY_LOOKUP_URL,
-                    [HTTP_METHOD, "POST",
-                     HTTP_MIMETYPE, "application/json",
-                     HTTP_BODY_MAXLENGTH, 4096],
-                    lbody);
-                touchState = STATE_LOOKUP_INFLIGHT;
-                extendLock(30);
-
-            } else if (message == "Get Parcel Verifier") {
-                llGiveInventory(lockHolder, "SLPA Parcel Verifier");
-                llRegionSayTo(lockHolder, 0,
-                    "Sent! Rez it on your parcel and enter your 6-digit PARCEL code.");
-                releaseLock();
-            }
-            // If message is anything else (dialog dismissed without selection),
-            // let the 60s lock TTL fire releaseLock() naturally.
-            return;
-        }
-
-        // --- Auction-ID text box ---
-        if (channel == auctionIdChan && id == lockHolder) {
-            llListenRemove(listenHandle);
-            listenHandle = -1;
-
-            if (!isPositiveInteger(message)) {
-                llRegionSayTo(lockHolder, 0,
-                    "Invalid auction ID — must be a positive number.");
-                releaseLock();
-                return;
-            }
-
-            selectedAuctionId = (integer)message;
-
-            if (selectedKind == SELECTED_ESCROW) {
-                llRegionSayTo(lockHolder, 0,
-                    "Pay the L$ escrow amount shown on auction #" + message + ".");
-            } else {
-                llRegionSayTo(lockHolder, 0,
-                    "Pay the L$ listing fee shown on auction #" + message + ".");
-            }
-
-            // ESCROW / LISTING_FEE pay-price matrix:
-            // first arg PAY_DEFAULT = empty text field so user types custom amount;
-            // all four quick buttons hidden.
-            llSetPayPrice(PAY_DEFAULT, [PAY_HIDE, PAY_HIDE, PAY_HIDE, PAY_HIDE]);
-            touchState = STATE_AWAITING_PAYMENT;
-            extendLock(60);
-            return;
+            llOwnerSay("SLPA Terminal: transfer to " + recip + " L$"
+                + (string)amount + " success=" + successStr);
         }
     }
 
     money(key payer, integer amount) {
-        // Defensive: only process payments when we are actively expecting them.
-        // llSetPayPrice(PAY_HIDE,...) in IDLE/other states prevents accidental payments
-        // in normal flow, but record unexpected ones for support.
-        if (touchState != STATE_AWAITING_PAYMENT) {
-            llOwnerSay("SLPA Terminal: unexpected payment from "
-                + (string)payer + " L$" + (string)amount
-                + " — touchState=" + (string)touchState + ". Forwarding to backend.");
-        }
-
-        if (payer != lockHolder && DEBUG_MODE) {
-            llOwnerSay("SLPA Terminal: payment from " + (string)payer
-                + " is not the menu user " + (string)lockHolder);
-        }
-
-        // Capture payment context. paymentTxKey is synthesized ONCE here and
-        // reused across retries for idempotency.
+        // Lockless: every money() event is a deposit.
         paymentPayer      = payer;
         paymentAmount     = amount;
-        paymentKind       = selectedKind;
-        paymentAuctionId  = selectedAuctionId;
         paymentTxKey      = (string)llGenerateKey();
         paymentRetryCount = 0;
-
-        // Fire the first POST attempt.
         firePayment();
+    }
 
-        // Release lock IMMEDIATELY so a second user can touch while retries run.
-        releaseLock();
+    touch_start(integer num) {
+        key toucher = llDetectedKey(0);
+        // Per-toucher dialog filtered by avatar key in the listen handler.
+        llDialog(toucher,
+            "What would you like to do?\n\n"
+            + "Deposit: right-click & pay (any amount)\n"
+            + "Withdraw: pull L$ from your wallet to your avatar",
+            ["Deposit", "Withdraw"], mainChan);
+    }
 
-        // Ensure pay price returns to IDLE (releaseLock does this, but be explicit).
-        llSetPayPrice(PAY_HIDE, [PAY_HIDE, PAY_HIDE, PAY_HIDE, PAY_HIDE]);
+    listen(integer chan, string name, key id, string msg) {
+        if (chan != mainChan) return;
+
+        // Top-level menu responses (Deposit / Withdraw)
+        if (msg == "Deposit") {
+            llRegionSayTo(id, 0,
+                "To deposit: right-click this terminal \xe2\x86\x92 Pay \xe2\x86\x92 enter any L$ amount. "
+                + "Funds will be credited to your SLPA wallet.");
+            return;
+        }
+        if (msg == "Withdraw") {
+            integer slot = acquireOrResetSlot(id);
+            if (slot < 0) {
+                llRegionSayTo(id, 0, "Terminal busy — try another nearby.");
+                return;
+            }
+            llTextBox(id, "Enter L$ amount to withdraw:", mainChan);
+            return;
+        }
+
+        // Dispatch by avatar key against per-flow withdraw slots
+        integer slotIdx = findSlot(id);
+        if (slotIdx < 0) return;
+        integer amt = slotAmount(slotIdx);
+        if (amt == -1) {
+            // Awaiting amount
+            if (!isPositiveInteger(msg)) {
+                llRegionSayTo(id, 0, "Amount must be a positive integer.");
+                releaseSlot(id);
+                return;
+            }
+            integer reqAmt = (integer)msg;
+            setSlotAmount(slotIdx, reqAmt);
+            extendSlot(slotIdx);
+            llDialog(id, "Withdraw L$" + msg + " from your SLPA wallet?",
+                ["Yes", "No"], mainChan);
+            return;
+        }
+        // Awaiting confirm
+        if (msg == "Yes") {
+            withdrawPayer      = id;
+            withdrawAmount     = amt;
+            withdrawTxKey      = (string)llGenerateKey();
+            withdrawRetryCount = 0;
+            fireWithdrawRequest();
+            llRegionSayTo(id, 0, "Withdrawal queued — L$" + (string)amt
+                + " will arrive shortly.");
+        } else {
+            llRegionSayTo(id, 0, "Withdrawal cancelled.");
+        }
+        releaseSlot(id);
+    }
+
+    http_response(key req, integer status, list meta, string body) {
+        // ----- Register response -----
+        if (req == registerReqId) {
+            registerReqId = NULL_KEY;
+            if (status >= 200 && status < 300) {
+                registered = TRUE;
+                registerAttempt = 0;
+                if (DEBUG_MODE)
+                    llOwnerSay("SLPA Terminal: registered (terminal_id="
+                        + TERMINAL_ID + ", url=" + httpInUrl + ")");
+                return;
+            }
+            ++registerAttempt;
+            if (registerAttempt > 5) {
+                llOwnerSay("CRITICAL: registration failed after 5 attempts.");
+                return;
+            }
+            if (DEBUG_MODE)
+                llOwnerSay("SLPA Terminal: register retry "
+                    + (string)registerAttempt + "/5: status=" + (string)status);
+            scheduleRegisterRetry();
+            return;
+        }
+
+        // ----- Deposit response -----
+        if (req == paymentReqId) {
+            paymentReqId = NULL_KEY;
+            if (status >= 200 && status < 300) {
+                string s = llJsonGetValue(body, ["status"]);
+                if (s == "OK") {
+                    if (DEBUG_MODE)
+                        llOwnerSay("SLPA Terminal: deposit ok L$"
+                            + (string)paymentAmount + " from " + (string)paymentPayer);
+                } else if (s == "REFUND") {
+                    string reason = llJsonGetValue(body, ["reason"]);
+                    llTransferLindenDollars(paymentPayer, paymentAmount);
+                    if (DEBUG_MODE)
+                        llOwnerSay("SLPA Terminal: deposit refunded ("
+                            + reason + ") L$" + (string)paymentAmount
+                            + " to " + (string)paymentPayer);
+                } else if (s == "ERROR") {
+                    // ERROR — do NOT refund (could be an attack probe).
+                    string reason = llJsonGetValue(body, ["reason"]);
+                    llOwnerSay("SLPA Terminal: deposit ERROR (" + reason
+                        + ") L$" + (string)paymentAmount + " from " + (string)paymentPayer
+                        + " — NOT refunded.");
+                }
+                paymentPayer = NULL_KEY;
+                paymentAmount = 0;
+                paymentTxKey = "";
+                paymentRetryCount = 0;
+                return;
+            }
+            // Transient: schedule retry
+            ++paymentRetryCount;
+            if (DEBUG_MODE)
+                llOwnerSay("SLPA Terminal: deposit retry "
+                    + (string)paymentRetryCount + "/5: status=" + (string)status);
+            debugSayUser(paymentPayer, "deposit", status, body);
+            schedulePaymentRetry();
+            return;
+        }
+
+        // ----- Withdraw-request response -----
+        if (req == withdrawReqId) {
+            withdrawReqId = NULL_KEY;
+            if (status >= 200 && status < 300) {
+                string s = llJsonGetValue(body, ["status"]);
+                if (s == "OK") {
+                    if (DEBUG_MODE)
+                        llOwnerSay("SLPA Terminal: withdraw queued L$"
+                            + (string)withdrawAmount + " for " + (string)withdrawPayer);
+                } else if (s == "REFUND_BLOCKED") {
+                    string reason = llJsonGetValue(body, ["reason"]);
+                    string message = llJsonGetValue(body, ["message"]);
+                    llRegionSayTo(withdrawPayer, 0,
+                        "Withdrawal declined: " + reason
+                        + (message != JSON_INVALID && message != "" ? " (" + message + ")" : ""));
+                } else if (s == "ERROR") {
+                    string reason = llJsonGetValue(body, ["reason"]);
+                    llOwnerSay("SLPA Terminal: withdraw-request ERROR ("
+                        + reason + ") for " + (string)withdrawPayer);
+                }
+                withdrawPayer = NULL_KEY;
+                withdrawAmount = 0;
+                withdrawTxKey = "";
+                withdrawRetryCount = 0;
+                return;
+            }
+            ++withdrawRetryCount;
+            if (DEBUG_MODE)
+                llOwnerSay("SLPA Terminal: withdraw retry "
+                    + (string)withdrawRetryCount + "/5: status=" + (string)status);
+            debugSayUser(withdrawPayer, "withdraw-request", status, body);
+            scheduleWithdrawRetry();
+            return;
+        }
+
+        // ----- Payout-result ack -----
+        if (req == payoutResultReqId) {
+            payoutResultReqId = NULL_KEY;
+            if (status >= 200 && status < 300) {
+                if (DEBUG_MODE)
+                    llOwnerSay("SLPA Terminal: payout-result acknowledged.");
+            } else {
+                llOwnerSay("CRITICAL: /payout-result POST failed status="
+                    + (string)status);
+            }
+            return;
+        }
     }
 
     timer() {
-        llSetTimerEvent(0);
+        // Multi-purpose 10-second timer: sweeps expired withdraw slots,
+        // checks for due register/deposit/withdraw retries, then continues.
+        integer now = llGetUnixTime();
 
-        if (timerPhase == TIMER_LOCK_TTL) {
-            timerPhase = TIMER_NONE;
-            // Lock TTL expired — release lock in all states.
-            // For STATE_LOOKUP_INFLIGHT: the HTTP response may still arrive after lock
-            // is cleared; the lookupReqId guard in http_response will match, but
-            // lockHolder will be NULL_KEY, so llRegionSayTo(NULL_KEY,...) is harmless
-            // and releaseLock() will be a safe no-op (already cleared).
-            releaseLock();
-
-        } else if (timerPhase == TIMER_PAYMENT_RETRY) {
-            timerPhase = TIMER_NONE;
-            if (DEBUG_MODE)
-                llOwnerSay("SLPA Terminal: payment retry " + (string)paymentRetryCount + "/5");
-            firePayment();
-
-        } else if (timerPhase == TIMER_REGISTER_RETRY) {
-            timerPhase = TIMER_NONE;
-            if (DEBUG_MODE)
-                llOwnerSay("SLPA Terminal: register retry " + (string)registerAttempt + "/5");
+        if (timerPhase == TIMER_REGISTER_RETRY && now >= registerNextRetryAt) {
             postRegister();
         }
-    }
-
-    changed(integer change) {
-        // Notecard edit or parcel-verifier inventory update — full reset.
-        if (change & CHANGED_INVENTORY) {
-            llResetScript();
+        if (timerPhase == TIMER_PAYMENT_RETRY && now >= paymentNextRetryAt) {
+            firePayment();
         }
-        // Region restart: HTTP-in URL is invalidated; re-request and re-register.
-        // Touch state is NOT preserved across region restarts — releaseLock not called
-        // (lockHolder is cleared on reset anyway). The script remains in default state.
-        if (change & CHANGED_REGION_START) {
-            httpInUrl  = "";
-            registered = FALSE;
-            urlRequestId = llRequestURL();
+        if (timerPhase == TIMER_WITHDRAW_RETRY && now >= withdrawNextRetryAt) {
+            fireWithdrawRequest();
         }
-    }
 
-    on_rez(integer start_param) {
-        llResetScript();
-    }
+        sweepExpiredSlots();
 
+        // Always reschedule for the next sweep.
+        timerPhase = TIMER_SESSION_SWEEP;
+        llSetTimerEvent(10.0);
+    }
 }

--- a/lsl-scripts/slpa-verifier-giver/README.md
+++ b/lsl-scripts/slpa-verifier-giver/README.md
@@ -1,0 +1,86 @@
+# SLPA Parcel Verifier Giver
+
+Single-purpose in-world prim that hands out a copy of the SLPA Parcel
+Verifier inventory item on touch. Free, no L$, no backend interaction.
+
+## Architecture summary
+
+- **Trust:** none. Touch-driven, header-trust-equivalent — anyone in-world
+  can touch and receive a verifier.
+- **Touch flow:** IDLE → (touch) per-avatar rate-limit check → if OK,
+  `llGiveInventory(toucher, "SLPA Parcel Verifier")` → owner-say → IDLE.
+- **Rate limit:** 60 seconds per-avatar. A second touch from the same
+  avatar within the window is refused with `Just gave you one — wait a
+  minute before requesting another.`
+
+## Why a separate prim?
+
+Previously the SLPA Terminal had a "Get Parcel Verifier" menu option that
+called `llGiveInventory` from the terminal's own contents. Updating
+`parcel-verifier.lsl` required dragging the new object into every deployed
+SLPA Terminal's inventory — a two-place rule that was easy to forget.
+
+Splitting the verifier-give role into a dedicated prim concentrates that
+update step to just the verifier-giver instances. SLPA Terminal no longer
+carries an SLPA Parcel Verifier in its inventory.
+
+## Deployment
+
+1. Rez a generic prim at SLPA HQ, an auction venue, or Marketplace.
+2. Drop `slpa-verifier-giver.lsl` into the prim.
+3. Drop a `SLPA Parcel Verifier` object copy into the prim's contents.
+4. Drop a copy of `config.notecard.example` renamed to **`config`** (no
+   extension). Edit if you want to change the verifier item name or
+   rate-limit duration.
+5. Reset the script. Confirm the floating text "SLPA Parcel Verifier — Free
+   / Touch to receive" appears.
+6. Smoke-test: touch the prim from a second avatar; confirm the verifier
+   inventory offer arrives.
+
+## Configuration
+
+| Key | Description |
+| --- | --- |
+| `VERIFIER_NAME` | Name of the inventory item to give. Default `SLPA Parcel Verifier`. |
+| `RATE_LIMIT_SECONDS` | Per-avatar rate-limit window. Default 60. |
+| `DEBUG_MODE` | Optional. `true`/`false`, default `true`. Per-event owner-chat. |
+
+## Updating
+
+When `parcel-verifier.lsl` is updated:
+
+1. **Marketplace listing**: republish a new revision with the updated `.lsl`.
+2. **Every deployed verifier-giver prim's inventory**: drag-drop the new
+   `SLPA Parcel Verifier` object into the prim's contents, replacing the
+   old copy. `CHANGED_INVENTORY` auto-resets the giver script.
+
+This is now the only place to update verifiers — SLPA Terminals no longer
+carry a copy.
+
+Updating the giver script itself: drag-drop the new `slpa-verifier-giver.lsl`
+into the prim's contents → `CHANGED_INVENTORY` auto-resets.
+
+## Operations
+
+In steady state with `DEBUG_MODE=true`:
+
+- `SLPA Verifier Giver: config loaded (rate_limit=60s).` — startup.
+- `SLPA Verifier Giver: gave verifier to <name>` — successful touch.
+- `CRITICAL: 'SLPA Parcel Verifier' missing from giver prim inventory.` —
+  the verifier object isn't in the prim's contents. Drag-drop it back in.
+
+## Limits
+
+- LSL listen cap: this script opens zero listens. No leak risk.
+- `llGiveInventory` cap: 16 pending offers per agent. The 60-second
+  rate-limit makes hitting this implausible at SLPA's traffic level.
+
+## Security
+
+- The verifier itself is free; there's nothing to steal.
+- The script holds no secrets. Anyone with edit-rights on the prim sees
+  only the inventory-item name and rate-limit settings.
+- A determined griefer could touch repeatedly with multiple alts to
+  consume verifier copies — but verifier copies are free and unlimited
+  for the prim owner, so the worst-case impact is minor avatar-list
+  noise. Rate-limiting per-avatar handles single-avatar griefing.

--- a/lsl-scripts/slpa-verifier-giver/config.notecard.example
+++ b/lsl-scripts/slpa-verifier-giver/config.notecard.example
@@ -1,0 +1,14 @@
+# config notecard for SLPA Parcel Verifier Giver
+# Place this file (renamed to "config", no extension) in the prim's contents.
+# After editing, the script auto-resets via CHANGED_INVENTORY.
+
+# Inventory item name to give. Must match the name of an SLPA Parcel
+# Verifier object in the prim's contents.
+VERIFIER_NAME=SLPA Parcel Verifier
+
+# Per-avatar rate-limit (seconds). A second touch from the same avatar
+# within this window is refused with a "wait a minute" message. Default 60.
+RATE_LIMIT_SECONDS=60
+
+# Optional: false to silence per-event chat. Recommended true for ops.
+DEBUG_MODE=true

--- a/lsl-scripts/slpa-verifier-giver/slpa-verifier-giver.lsl
+++ b/lsl-scripts/slpa-verifier-giver/slpa-verifier-giver.lsl
@@ -1,0 +1,127 @@
+// SLPA Parcel Verifier Giver
+//
+// Single-purpose touch-to-receive prim. Hands out a copy of the SLPA
+// Parcel Verifier inventory item to anyone who touches it. Free, no L$.
+//
+// Header-trust only — no shared secret, no L$, no backend HTTP. The only
+// runtime concern is per-avatar rate-limiting (60s) so a griefer can't
+// spam the giver and exhaust the 16-pending-give-inventory cap.
+//
+// Replaces the "Get Parcel Verifier" menu option that used to live on the
+// SLPA Terminal. Splitting into a dedicated prim removes the two-place
+// inventory-update rule (previously you had to drag-drop the new verifier
+// into every deployed payment terminal whenever parcel-verifier.lsl was
+// updated). Now the verifier-giver instances are the only place that
+// ships the verifier.
+//
+// Configuration is loaded from a notecard named "config" in the same prim.
+// See README.md for deployment and operations details.
+
+string  VERIFIER_NAME    = "SLPA Parcel Verifier";
+integer DEBUG_MODE       = TRUE;
+integer RATE_LIMIT_SECONDS = 60;
+
+// Notecard reading state
+key     notecardLineRequest = NULL_KEY;
+integer notecardLineNum     = 0;
+
+// Per-avatar rate-limit list: [avatarKey, lastGivenAt, ...]
+list givenSessions = [];
+
+readNotecardLine(integer n) {
+    notecardLineNum     = n;
+    notecardLineRequest = llGetNotecardLine("config", n);
+}
+
+parseConfigLine(string line) {
+    if (llStringLength(line) == 0) return;
+    if (llSubStringIndex(line, "#") == 0) return;
+
+    integer eq = llSubStringIndex(line, "=");
+    if (eq < 1) return;
+
+    string k = llStringTrim(llGetSubString(line, 0, eq - 1), STRING_TRIM);
+    string v = llStringTrim(llGetSubString(line, eq + 1, -1), STRING_TRIM);
+
+    if      (k == "VERIFIER_NAME")         VERIFIER_NAME = v;
+    else if (k == "RATE_LIMIT_SECONDS")    RATE_LIMIT_SECONDS = (integer)v;
+    else if (k == "DEBUG_MODE")
+        DEBUG_MODE = (v == "true" || v == "TRUE" || v == "1");
+}
+
+setIdleChrome() {
+    llSetText("SLPA Parcel Verifier \xe2\x80\x94 Free\nTouch to receive",
+        <0.6, 0.9, 0.6>, 1.0);
+    llSetObjectName("SLPA Parcel Verifier Giver");
+}
+
+default {
+    state_entry() {
+        givenSessions = [];
+
+        // Mainland-only grid guard
+        if (llGetEnv("sim_channel") != "Second Life Server") {
+            llOwnerSay("CRITICAL: not on Second Life Server grid; halting.");
+            return;
+        }
+
+        setIdleChrome();
+        readNotecardLine(0);
+    }
+
+    on_rez(integer n) {
+        llResetScript();
+    }
+
+    changed(integer change) {
+        if (change & CHANGED_INVENTORY) {
+            llResetScript();
+        }
+    }
+
+    dataserver(key requested, string data) {
+        if (requested == notecardLineRequest) {
+            if (data == EOF) {
+                if (DEBUG_MODE)
+                    llOwnerSay("SLPA Verifier Giver: config loaded (rate_limit="
+                        + (string)RATE_LIMIT_SECONDS + "s).");
+                return;
+            }
+            parseConfigLine(data);
+            readNotecardLine(notecardLineNum + 1);
+        }
+    }
+
+    touch_start(integer num) {
+        key toucher = llDetectedKey(0);
+        string toucherName = llDetectedName(0);
+
+        // Per-avatar rate-limit
+        integer slot = llListFindList(givenSessions, [toucher]);
+        integer now = llGetUnixTime();
+        if (slot >= 0) {
+            integer lastAt = llList2Integer(givenSessions, slot + 1);
+            if (now - lastAt < RATE_LIMIT_SECONDS) {
+                llRegionSayTo(toucher, 0,
+                    "Just gave you one — wait a minute before requesting another.");
+                return;
+            }
+            givenSessions = llListReplaceList(givenSessions,
+                [toucher, now], slot, slot + 1);
+        } else {
+            givenSessions += [toucher, now];
+        }
+
+        // Verify the named inventory item exists
+        if (llGetInventoryType(VERIFIER_NAME) == INVENTORY_NONE) {
+            llRegionSayTo(toucher, 0,
+                "Sorry — the verifier object is missing. Please contact SLPA support.");
+            llOwnerSay("CRITICAL: '" + VERIFIER_NAME + "' missing from giver prim inventory.");
+            return;
+        }
+
+        llGiveInventory(toucher, VERIFIER_NAME);
+        if (DEBUG_MODE)
+            llOwnerSay("SLPA Verifier Giver: gave verifier to " + toucherName);
+    }
+}


### PR DESCRIPTION
Combines PR #65 (wallet foundation) and PR #67 (LSL terminal rewrite). 

After this merge, the wallet model is functionally end-to-end on the backend + LSL side:
- /sl/wallet/deposit + /sl/wallet/withdraw-request endpoints live
- /me/wallet/* user-facing endpoints live
- /me/auctions/{id}/pay-listing-fee live
- Updated slpa-terminal.lsl talks to the wallet endpoints
- New slpa-verifier-giver prim ready for deployment

Follow-up work in subsequent PRs:
- Bid + BIN preconditions (penalty + balance) and hard-reservation swap
- Auction-end auto-fund + ESCROW_PENDING retirement
- Refund-as-credit conversion
- Delete retired SL payment endpoints
- Frontend wallet UI + dialogs
- Postman collection rebuild
- Documentation sweep

## Test plan
- [x] ./mvnw test green on dev (1591/1591)
- [ ] Backend deploys cleanly via GHA
- [ ] In-world: deploy new slpa-terminal.lsl + config; smoke deposit + withdraw