### PR TITLE
fix(security): permitAll on /sl/wallet endpoints

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
@@ -110,6 +110,13 @@ public class SecurityConfig {
                         // catch-all (first-match-wins).
                         .requestMatchers(HttpMethod.POST, "/api/v1/sl/penalty-lookup").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/sl/penalty-payment").permitAll()
+                        // Wallet model SL-headers-gated endpoints. Same trust posture
+                        // as the older per-obligation payment endpoints above —
+                        // permitAll at the HTTP layer; SlHeaderValidator +
+                        // TerminalService.assertSharedSecret inside the handler are
+                        // the actual security boundary.
+                        .requestMatchers(HttpMethod.POST, "/api/v1/sl/wallet/deposit").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/sl/wallet/withdraw-request").permitAll()
                         // --- New in Epic 02 sub-spec 2a ---
                         // Public avatar proxy. Must come before the /api/v1/** catch-all
                         // and before /api/v1/users/{id} (also public). FOOTGUNS section B.5


### PR DESCRIPTION
Fix for missing SecurityConfig entries on /sl/wallet/deposit + /sl/wallet/withdraw-request. Without this, all calls to those endpoints return 401 instead of being validated by SlHeaderValidator + shared-secret check.