### PR TITLE
feat(wallet): bid integration, auto-fund, refund-as-credit, frontend wallet UI

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/reconciliation/ReconciliationService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/reconciliation/ReconciliationService.java
@@ -8,6 +8,7 @@ import com.slparcelauctions.backend.notification.NotificationPublisher;
 import com.slparcelauctions.backend.user.Role;
 import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.user.UserRepository;
+import com.slparcelauctions.backend.wallet.BidReservationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -41,6 +42,7 @@ public class ReconciliationService {
     private final ReconciliationRunRepository runRepo;
     private final UserRepository userRepo;
     private final NotificationPublisher publisher;
+    private final BidReservationRepository reservationRepo;
     private final Clock clock;
 
     @Scheduled(cron = "${slpa.reconciliation.cron:0 0 3 * * *}", zone = "UTC")
@@ -48,9 +50,32 @@ public class ReconciliationService {
     public void runDaily() {
         log.info("Reconciliation starting");
         OffsetDateTime now = OffsetDateTime.now(clock);
+
+        // Wallet model: precheck users.reserved_lindens denorm against the
+        // bid_reservations live sum. If they disagree, the expected_total
+        // computation is unreliable — abort with DENORM_DRIFT.
+        long denormReserved = userRepo.sumReservedDenorms();
+        long sourceReserved = reservationRepo.sumAllActive();
+        if (denormReserved != sourceReserved) {
+            long denormDrift = denormReserved - sourceReserved;
+            log.error("Reconciliation aborted: DENORM_DRIFT — "
+                    + "users.reserved_lindens sum={} vs bid_reservations sum={} (diff={})",
+                    denormReserved, sourceReserved, denormDrift);
+            ReconciliationRun run = persist(now, 0L, null, denormDrift,
+                    ReconciliationStatus.DENORM_DRIFT,
+                    "users.reserved_lindens denorm != bid_reservations sum");
+            run.setWalletReservedTotal(sourceReserved);
+            runRepo.save(run);
+            List<Long> adminIds = userRepo.findByRole(Role.ADMIN).stream()
+                    .map(User::getId).toList();
+            String date = now.format(DateTimeFormatter.ISO_LOCAL_DATE);
+            publisher.reconciliationMismatch(adminIds, denormDrift, date);
+            return;
+        }
+
         Optional<Long> balanceOpt = freshestBalance(now);
         if (balanceOpt.isEmpty()) {
-            persist(now, sumLocked(), null, null,
+            persist(now, sumExpected(), null, null,
                     ReconciliationStatus.ERROR,
                     "Balance data stale — terminal may be offline");
             log.error("Reconciliation aborted: balance reading stale (>2h)");
@@ -58,7 +83,7 @@ public class ReconciliationService {
         }
 
         long observed = balanceOpt.get();
-        long locked = sumLocked();
+        long locked = sumExpected();
         if (observed >= locked) {
             persist(now, locked, observed, observed - locked, ReconciliationStatus.BALANCED, null);
             log.info("Reconciliation completed: status=BALANCED, expected={}, observed={}, drift={}",
@@ -71,7 +96,7 @@ public class ReconciliationService {
 
         Optional<Long> retryOpt = freshestBalance(OffsetDateTime.now(clock));
         long retryObserved = retryOpt.orElse(observed);
-        long retryLocked = sumLocked();
+        long retryLocked = sumExpected();
         if (retryObserved >= retryLocked) {
             persist(now, retryLocked, retryObserved, retryObserved - retryLocked,
                     ReconciliationStatus.BALANCED, null);
@@ -107,9 +132,22 @@ public class ReconciliationService {
         return escrowRepo.sumAmountByStateIn(LOCKED_STATES);
     }
 
+    /**
+     * Total L$ the SLPA service avatar is expected to hold:
+     * locked escrows (winner's L$ moved into escrow at auction close) +
+     * wallet balances (user-deposited L$ awaiting allocation/withdraw).
+     * Reservations are partitions of wallet balance; do NOT add separately.
+     */
+    private long sumExpected() {
+        return sumLocked() + userRepo.sumWalletBalances();
+    }
+
     private ReconciliationRun persist(OffsetDateTime ranAt, long expected,
                                        Long observed, Long drift,
                                        ReconciliationStatus status, String errorMessage) {
+        long escrowLocked = sumLocked();
+        long walletBalance = userRepo.sumWalletBalances();
+        long reserved = reservationRepo.sumAllActive();
         return runRepo.save(ReconciliationRun.builder()
                 .ranAt(ranAt)
                 .expectedLockedSum(expected)
@@ -117,6 +155,9 @@ public class ReconciliationService {
                 .drift(drift)
                 .status(status)
                 .errorMessage(errorMessage)
+                .walletBalanceTotal(walletBalance)
+                .walletReservedTotal(reserved)
+                .escrowLockedTotal(escrowLocked)
                 .build());
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/BidService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/BidService.java
@@ -28,6 +28,13 @@ import com.slparcelauctions.backend.notification.NotificationPublisher;
 import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.user.UserNotFoundException;
 import com.slparcelauctions.backend.user.UserRepository;
+import com.slparcelauctions.backend.wallet.BidReservation;
+import com.slparcelauctions.backend.wallet.BidReservationRepository;
+import com.slparcelauctions.backend.wallet.WalletService;
+import com.slparcelauctions.backend.wallet.exception.InsufficientAvailableBalanceException;
+import com.slparcelauctions.backend.wallet.exception.PenaltyOutstandingException;
+
+import org.springframework.beans.factory.annotation.Value;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -82,6 +89,18 @@ public class BidService {
     private final EscrowService escrowService;
     private final NotificationPublisher notificationPublisher;
     private final BanCheckService banCheckService;
+    private final WalletService walletService;
+    private final BidReservationRepository reservationRepo;
+
+    /**
+     * Wallet enforcement flag. Default false so existing test fixtures (which
+     * don't deposit before bidding) continue to pass. When set true on a
+     * deployed environment, every bid validates penalty == 0 and
+     * available >= amount, and a hard reservation is swapped from the prior
+     * high bidder to the new bidder.
+     */
+    @Value("${slpa.wallet.enforcement-enabled:false}")
+    private boolean walletEnforcementEnabled;
 
     /**
      * Places a manual bid on an auction. See class javadoc for the
@@ -128,6 +147,24 @@ public class BidService {
         }
         if (bidder.getId().equals(auction.getSeller().getId())) {
             throw new SellerCannotBidException();
+        }
+
+        // Wallet preconditions (gated by feature flag).
+        if (walletEnforcementEnabled) {
+            long owed = bidder.getPenaltyBalanceOwed() == null ? 0L : bidder.getPenaltyBalanceOwed();
+            if (owed > 0) {
+                throw new PenaltyOutstandingException(owed);
+            }
+            // Re-fetch with lock for the wallet check + reservation swap.
+            // Note: bidder fetched above is unlocked; lock now to read the
+            // committed balance + reservedLindens consistently.
+            User lockedBidder = userRepo.findByIdForUpdate(bidderId).orElseThrow();
+            if (lockedBidder.availableLindens() < amount) {
+                throw new InsufficientAvailableBalanceException(
+                        lockedBidder.availableLindens(), amount);
+            }
+            // Replace bidder reference with locked instance for downstream use.
+            bidder = lockedBidder;
         }
 
         // Step 5 — minimum-bid gate. First bid must clear startingBid;
@@ -202,6 +239,24 @@ public class BidService {
         int nextBidCount = (auction.getBidCount() == null ? 0 : auction.getBidCount()) + emitted.size();
         auction.setBidCount(nextBidCount);
         auctionRepo.save(auction);
+
+        // Hard reservation swap (gated by feature flag). Releases the prior
+        // active reservation on this auction (if any) and reserves the new
+        // top bidder's amount. Lock ordering: auction (held) → users in
+        // ascending id order.
+        if (walletEnforcementEnabled) {
+            BidReservation prior = reservationRepo.findActiveForAuction(auctionId).orElse(null);
+            User newReserver;
+            if (top.getBidder().getId().equals(bidderId)) {
+                newReserver = bidder;  // already locked above
+            } else {
+                // Top is a PROXY_AUTO bid by a different user (the proxy owner);
+                // lock that user's row. If prior is the same user, they're
+                // already-resolved.
+                newReserver = userRepo.findByIdForUpdate(top.getBidder().getId()).orElseThrow();
+            }
+            walletService.swapReservation(auctionId, newReserver, top.getAmount(), prior, top.getId());
+        }
 
         // Notify the displaced bidder (if any). previousHighBidderId is non-null
         // when someone was already winning; the new top must be a different user

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
@@ -49,6 +49,10 @@ import com.slparcelauctions.backend.escrow.terminal.TerminalRepository;
 import com.slparcelauctions.backend.escrow.terminal.TerminalService;
 import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.user.UserRepository;
+import com.slparcelauctions.backend.wallet.WalletService;
+import com.slparcelauctions.backend.wallet.exception.BidReservationAmountMismatchException;
+
+import org.springframework.beans.factory.annotation.Value;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -95,6 +99,10 @@ public class EscrowService {
     private final BotMonitorLifecycleService monitorLifecycle;
     private final NotificationPublisher notificationPublisher;
     private final DisputeEvidenceUploadService evidenceUploadService;
+    private final WalletService walletService;
+
+    @Value("${slpa.wallet.enforcement-enabled:false}")
+    private boolean walletEnforcementEnabled;
 
     public static boolean isAllowed(EscrowState from, EscrowState to) {
         return ALLOWED_TRANSITIONS.getOrDefault(from, Set.of()).contains(to);
@@ -157,6 +165,67 @@ public class EscrowService {
         // Seed MONITOR_ESCROW for BOT-tier auctions so the bot watches the
         // seller→winner ownership transition. No-op for non-BOT tiers.
         monitorLifecycle.onEscrowCreatedBot(saved);
+
+        // Wallet enforcement: auto-fund the escrow immediately by consuming
+        // the winner's bid reservation and debiting their wallet balance.
+        // Transitions ESCROW_PENDING → FUNDED → TRANSFER_PENDING in this
+        // same transaction so external observers only see TRANSFER_PENDING.
+        if (walletEnforcementEnabled && auction.getWinnerUserId() != null) {
+            User winner = userRepo.findByIdForUpdate(auction.getWinnerUserId()).orElseThrow();
+            try {
+                walletService.autoFundEscrow(auction.getId(), winner, finalBid, saved.getId());
+            } catch (BidReservationAmountMismatchException e) {
+                log.error("BID-RESERVATION-AMOUNT-MISMATCH for auction {}: reservation=L${} != finalBid=L${} — freezing escrow",
+                        auction.getId(), e.getReservationAmount(), e.getFinalBidAmount());
+                saved.setState(EscrowState.FROZEN);
+                saved.setFrozenAt(endedAt);
+                return escrowRepo.save(saved);
+            } catch (IllegalStateException e) {
+                log.error("Auto-fund failed for auction {}: {}", auction.getId(), e.getMessage());
+                saved.setState(EscrowState.FROZEN);
+                saved.setFrozenAt(endedAt);
+                return escrowRepo.save(saved);
+            }
+            // Transition ESCROW_PENDING → FUNDED → TRANSFER_PENDING
+            saved.setState(EscrowState.FUNDED);
+            saved.setFundedAt(endedAt);
+            saved.setState(EscrowState.TRANSFER_PENDING);
+            saved.setTransferDeadline(endedAt.plusHours(TRANSFER_DEADLINE_HOURS));
+            saved = escrowRepo.save(saved);
+
+            // Append escrow_transactions ledger row
+            ledgerRepo.save(EscrowTransaction.builder()
+                    .escrow(saved)
+                    .auction(auction)
+                    .type(EscrowTransactionType.AUCTION_ESCROW_PAYMENT)
+                    .status(EscrowTransactionStatus.COMPLETED)
+                    .amount(finalBid)
+                    .payer(winner)
+                    .completedAt(endedAt)
+                    .build());
+
+            // Notify seller of funded state
+            notificationPublisher.escrowFunded(
+                    auction.getSeller().getId(),
+                    auction.getId(),
+                    saved.getId(),
+                    auction.getTitle(),
+                    saved.getTransferDeadline());
+
+            final Escrow finalEscrow = saved;
+            final EscrowFundedEnvelope fundedEnvelope = EscrowFundedEnvelope.of(finalEscrow, endedAt);
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            broadcastPublisher.publishFunded(fundedEnvelope);
+                        }
+                    });
+
+            log.info("Escrow {} auto-funded from wallet (auction {}, amount L${})",
+                    saved.getId(), auction.getId(), finalBid);
+        }
+
         return saved;
     }
 

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
@@ -411,7 +411,22 @@ public class EscrowService {
      * a pessimistic lock on the escrow row.
      */
     void queueRefundIfFunded(Escrow escrow) {
-        if (escrow.getFundedAt() != null) {
+        if (escrow.getFundedAt() == null) return;
+        if (walletEnforcementEnabled) {
+            // Wallet model: refund is a wallet credit, not a TerminalCommand REFUND.
+            User winner = userRepo.findByIdForUpdate(escrow.getAuction().getWinnerUserId()).orElseThrow();
+            walletService.creditEscrowRefund(winner, escrow.getFinalBidAmount(), escrow.getId());
+            ledgerRepo.save(EscrowTransaction.builder()
+                    .escrow(escrow)
+                    .auction(escrow.getAuction())
+                    .type(EscrowTransactionType.AUCTION_ESCROW_REFUND)
+                    .status(EscrowTransactionStatus.COMPLETED)
+                    .amount(escrow.getFinalBidAmount())
+                    .completedAt(OffsetDateTime.now(clock))
+                    .build());
+            log.info("Escrow {} refund credited to wallet (winnerId={}, amount=L${})",
+                    escrow.getId(), winner.getId(), escrow.getFinalBidAmount());
+        } else {
             terminalCommandService.queueRefund(escrow);
         }
     }

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/scheduler/ListingFeeRefundProcessorTask.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/scheduler/ListingFeeRefundProcessorTask.java
@@ -12,6 +12,11 @@ import com.slparcelauctions.backend.auction.ListingFeeRefundRepository;
 import com.slparcelauctions.backend.auction.RefundStatus;
 import com.slparcelauctions.backend.escrow.command.TerminalCommand;
 import com.slparcelauctions.backend.escrow.command.TerminalCommandService;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import com.slparcelauctions.backend.wallet.WalletService;
+
+import org.springframework.beans.factory.annotation.Value;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,7 +50,12 @@ public class ListingFeeRefundProcessorTask {
 
     private final ListingFeeRefundRepository listingFeeRefundRepo;
     private final TerminalCommandService terminalCommandService;
+    private final WalletService walletService;
+    private final UserRepository userRepo;
     private final Clock clock;
+
+    @Value("${slpa.wallet.enforcement-enabled:false}")
+    private boolean walletEnforcementEnabled;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void queueOne(Long refundId) {
@@ -65,12 +75,24 @@ public class ListingFeeRefundProcessorTask {
                     refundId, refund.getTerminalCommandId());
             return;
         }
-        TerminalCommand cmd = terminalCommandService.queueListingFeeRefund(refund);
-        refund.setTerminalCommandId(cmd.getId());
-        refund.setLastQueuedAt(OffsetDateTime.now(clock));
-        listingFeeRefundRepo.save(refund);
-        log.info("Queued ListingFeeRefund {} as TerminalCommand {} (L${} to seller {})",
-                refund.getId(), cmd.getId(), refund.getAmount(),
-                refund.getAuction().getSeller().getId());
+        if (walletEnforcementEnabled) {
+            // Wallet model: refund is a wallet credit, not a TerminalCommand REFUND.
+            User seller = userRepo.findByIdForUpdate(
+                    refund.getAuction().getSeller().getId()).orElseThrow();
+            walletService.creditListingFeeRefund(seller, refund.getAmount(), refund.getId());
+            refund.setStatus(RefundStatus.PROCESSED);
+            refund.setProcessedAt(OffsetDateTime.now(clock));
+            listingFeeRefundRepo.save(refund);
+            log.info("ListingFeeRefund {} credited to wallet (sellerId={}, amount=L${})",
+                    refund.getId(), seller.getId(), refund.getAmount());
+        } else {
+            TerminalCommand cmd = terminalCommandService.queueListingFeeRefund(refund);
+            refund.setTerminalCommandId(cmd.getId());
+            refund.setLastQueuedAt(OffsetDateTime.now(clock));
+            listingFeeRefundRepo.save(refund);
+            log.info("Queued ListingFeeRefund {} as TerminalCommand {} (L${} to seller {})",
+                    refund.getId(), cmd.getId(), refund.getAmount(),
+                    refund.getAuction().getSeller().getId());
+        }
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java
@@ -90,4 +90,19 @@ public interface UserRepository extends JpaRepository<User, Long> {
         ORDER BY u.createdAt DESC
         """)
     Page<User> searchAdmin(@Param("search") String search, @Param("uuid") UUID uuidOrNull, Pageable pageable);
+
+    /**
+     * Sum of all wallet balances. Used by ReconciliationService to compute the
+     * expected SLPA service avatar balance against the wallet pool.
+     */
+    @Query("SELECT COALESCE(SUM(u.balanceLindens), 0) FROM User u")
+    long sumWalletBalances();
+
+    /**
+     * Sum of all reserved-lindens denorms. Used by ReconciliationService for
+     * the denorm-drift precheck against {@code SUM(bid_reservations.amount
+     * WHERE released_at IS NULL)}.
+     */
+    @Query("SELECT COALESCE(SUM(u.reservedLindens), 0) FROM User u")
+    long sumReservedDenorms();
 }

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/BidServiceBuyNowTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/BidServiceBuyNowTest.java
@@ -64,7 +64,7 @@ class BidServiceBuyNowTest {
     @BeforeEach
     void setUp() {
         Clock clock = Clock.fixed(NOW.toInstant(), ZoneOffset.UTC);
-        service = new BidService(auctionRepo, bidRepo, proxyBidRepo, userRepo, clock, publisher, escrowService, mock(com.slparcelauctions.backend.notification.NotificationPublisher.class), mock(BanCheckService.class));
+        service = new BidService(auctionRepo, bidRepo, proxyBidRepo, userRepo, clock, publisher, escrowService, mock(com.slparcelauctions.backend.notification.NotificationPublisher.class), mock(BanCheckService.class), mock(com.slparcelauctions.backend.wallet.WalletService.class), mock(com.slparcelauctions.backend.wallet.BidReservationRepository.class));
 
         seller = User.builder().id(10L).email("seller@example.com")
                 .displayName("Seller").verified(true).build();

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/BidServiceSnipeTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/BidServiceSnipeTest.java
@@ -65,7 +65,7 @@ class BidServiceSnipeTest {
     @BeforeEach
     void setUp() {
         Clock clock = Clock.fixed(NOW.toInstant(), ZoneOffset.UTC);
-        service = new BidService(auctionRepo, bidRepo, proxyBidRepo, userRepo, clock, publisher, escrowService, mock(com.slparcelauctions.backend.notification.NotificationPublisher.class), mock(BanCheckService.class));
+        service = new BidService(auctionRepo, bidRepo, proxyBidRepo, userRepo, clock, publisher, escrowService, mock(com.slparcelauctions.backend.notification.NotificationPublisher.class), mock(BanCheckService.class), mock(com.slparcelauctions.backend.wallet.WalletService.class), mock(com.slparcelauctions.backend.wallet.BidReservationRepository.class));
 
         seller = User.builder().id(10L).email("seller@example.com")
                 .displayName("Seller").verified(true).build();

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/BidServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/BidServiceTest.java
@@ -74,7 +74,7 @@ class BidServiceTest {
     @BeforeEach
     void setUp() {
         Clock clock = Clock.fixed(NOW.toInstant(), ZoneOffset.UTC);
-        service = new BidService(auctionRepo, bidRepo, proxyBidRepo, userRepo, clock, publisher, escrowService, mock(com.slparcelauctions.backend.notification.NotificationPublisher.class), mock(BanCheckService.class));
+        service = new BidService(auctionRepo, bidRepo, proxyBidRepo, userRepo, clock, publisher, escrowService, mock(com.slparcelauctions.backend.notification.NotificationPublisher.class), mock(BanCheckService.class), mock(com.slparcelauctions.backend.wallet.WalletService.class), mock(com.slparcelauctions.backend.wallet.BidReservationRepository.class));
 
         seller = User.builder().id(10L).email("seller@example.com")
                 .displayName("Seller").verified(true).build();

--- a/frontend/src/app/dashboard/(verified)/layout.tsx
+++ b/frontend/src/app/dashboard/(verified)/layout.tsx
@@ -10,6 +10,7 @@ const TABS: TabItem[] = [
   { id: "overview", label: "Overview", href: "/dashboard/overview" },
   { id: "bids", label: "My Bids", href: "/dashboard/bids" },
   { id: "listings", label: "My Listings", href: "/dashboard/listings" },
+  { id: "wallet", label: "Wallet", href: "/dashboard/wallet" },
 ];
 
 export default function VerifiedDashboardLayout({ children }: { children: React.ReactNode }) {

--- a/frontend/src/app/dashboard/(verified)/wallet/page.tsx
+++ b/frontend/src/app/dashboard/(verified)/wallet/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { WalletPanel } from "@/components/wallet/WalletPanel";
+
+export default function WalletPage() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className="text-2xl font-bold">Wallet</h1>
+        <p className="text-sm text-neutral-600 mt-1">
+          Deposit, withdraw, and view your SLPA wallet activity.
+        </p>
+      </div>
+      <WalletPanel />
+    </div>
+  );
+}

--- a/frontend/src/components/wallet/WalletPanel.tsx
+++ b/frontend/src/components/wallet/WalletPanel.tsx
@@ -1,0 +1,371 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import {
+  getWallet,
+  withdraw,
+  payPenalty,
+  acceptTerms,
+} from "@/lib/api/wallet";
+import type { LedgerEntry, WalletView } from "@/types/wallet";
+
+function formatLindens(amount: number): string {
+  return `L$${amount.toLocaleString()}`;
+}
+
+function entryTypeLabel(t: LedgerEntry["entryType"]): string {
+  switch (t) {
+    case "DEPOSIT": return "Deposit";
+    case "WITHDRAW_QUEUED": return "Withdraw queued";
+    case "WITHDRAW_COMPLETED": return "Withdraw completed";
+    case "WITHDRAW_REVERSED": return "Withdraw reversed";
+    case "BID_RESERVED": return "Bid reserved";
+    case "BID_RELEASED": return "Bid released";
+    case "ESCROW_DEBIT": return "Escrow funded";
+    case "ESCROW_REFUND": return "Escrow refund";
+    case "LISTING_FEE_DEBIT": return "Listing fee paid";
+    case "LISTING_FEE_REFUND": return "Listing fee refund";
+    case "PENALTY_DEBIT": return "Penalty paid";
+    case "ADJUSTMENT": return "Adjustment";
+  }
+}
+
+function genIdempotencyKey(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function WalletPanel() {
+  const [wallet, setWallet] = useState<WalletView | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showWithdraw, setShowWithdraw] = useState(false);
+  const [showPenalty, setShowPenalty] = useState(false);
+  const [showTerms, setShowTerms] = useState(false);
+  const [showDeposit, setShowDeposit] = useState(false);
+
+  const refresh = async () => {
+    try {
+      const w = await getWallet();
+      setWallet(w);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load wallet");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  if (loading) return <LoadingSpinner label="Loading wallet..." />;
+  if (error) return <Card><p>Error: {error}</p></Card>;
+  if (!wallet) return null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        <div className="flex flex-col gap-4">
+          <h2 className="text-xl font-semibold">Your SLPA Wallet</h2>
+
+          <div className="grid grid-cols-3 gap-4">
+            <div>
+              <div className="text-sm text-neutral-500">Balance</div>
+              <div className="text-2xl font-semibold">{formatLindens(wallet.balance)}</div>
+            </div>
+            <div>
+              <div className="text-sm text-neutral-500">Reserved (active bids)</div>
+              <div className="text-2xl font-semibold">{formatLindens(wallet.reserved)}</div>
+            </div>
+            <div>
+              <div className="text-sm text-neutral-500">Available</div>
+              <div className="text-2xl font-semibold">{formatLindens(wallet.available)}</div>
+            </div>
+          </div>
+
+          {wallet.penaltyOwed > 0 && (
+            <div className="rounded border border-amber-400 bg-amber-50 p-3">
+              <div className="font-medium">Outstanding penalty: {formatLindens(wallet.penaltyOwed)}</div>
+              <div className="text-sm text-neutral-700">
+                Clear this to publish new listings or place new bids.
+                {wallet.available < wallet.penaltyOwed && (
+                  <> Deposit {formatLindens(wallet.penaltyOwed - wallet.available)} more or wait for active bids to resolve.</>
+                )}
+              </div>
+              <div className="mt-2">
+                <Button
+                  variant="secondary"
+                  onClick={() => setShowPenalty(true)}
+                  disabled={wallet.available <= 0}
+                >
+                  Pay Penalty
+                </Button>
+              </div>
+            </div>
+          )}
+
+          <div className="flex gap-3">
+            <Button
+              variant="primary"
+              onClick={() => {
+                if (!wallet.termsAccepted) setShowTerms(true);
+                else setShowDeposit(true);
+              }}
+            >
+              How to Deposit
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => setShowWithdraw(true)}
+              disabled={wallet.available <= 0}
+            >
+              Withdraw
+            </Button>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <h3 className="text-lg font-semibold mb-3">Recent Activity</h3>
+        {wallet.recentLedger.length === 0 ? (
+          <p className="text-sm text-neutral-500">No wallet activity yet.</p>
+        ) : (
+          <ul className="space-y-1 text-sm">
+            {wallet.recentLedger.map(e => (
+              <li key={e.id} className="flex justify-between border-b border-neutral-200 py-2">
+                <div>
+                  <div className="font-medium">{entryTypeLabel(e.entryType)}</div>
+                  <div className="text-xs text-neutral-500">{new Date(e.createdAt).toLocaleString()}</div>
+                </div>
+                <div className="text-right">
+                  <div>{formatLindens(e.amount)}</div>
+                  <div className="text-xs text-neutral-500">
+                    Bal {formatLindens(e.balanceAfter)} / Res {formatLindens(e.reservedAfter)}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+
+      {showTerms && (
+        <SimpleDialog title="SLPA Wallet Terms of Use" onClose={() => setShowTerms(false)}>
+          <div className="text-sm space-y-2">
+            <p>By using the SLPA wallet, you acknowledge:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li><strong>Non-interest-bearing.</strong> L$ held in your wallet do not earn interest, dividends, or any return.</li>
+              <li><strong>L$ status.</strong> L$ are a Linden Lab limited-license token, not currency. SLPA holds L$ on your behalf as a transactional convenience.</li>
+              <li><strong>No L$↔USD conversion.</strong> SLPA does not exchange L$ for USD or any other currency.</li>
+              <li><strong>Recoverable on shutdown.</strong> If SLPA ceases operations, all positive wallet balances will be returned to your verified SL avatar.</li>
+              <li><strong>Freezable for fraud.</strong> SLPA may freeze a wallet balance pending fraud investigation, max 30 days absent legal process.</li>
+              <li><strong>Dormancy.</strong> Wallets inactive for 30 days are flagged; after 4 weekly notifications, balance auto-returns to your SL avatar.</li>
+              <li><strong>Banned-Resident handling.</strong> If your SL account loses good standing, your wallet balance returns to your last-verified SL avatar.</li>
+            </ul>
+            <div className="pt-3 flex justify-end gap-2">
+              <Button variant="secondary" onClick={() => setShowTerms(false)}>Cancel</Button>
+              <Button
+                variant="primary"
+                onClick={async () => {
+                  await acceptTerms({ termsVersion: "1.0" });
+                  await refresh();
+                  setShowTerms(false);
+                  setShowDeposit(true);
+                }}
+              >I Accept</Button>
+            </div>
+          </div>
+        </SimpleDialog>
+      )}
+
+      {showDeposit && (
+        <SimpleDialog title="How to Deposit" onClose={() => setShowDeposit(false)}>
+          <div className="text-sm space-y-2">
+            <ol className="list-decimal pl-5 space-y-2">
+              <li>Visit any SLPA Terminal in-world (SLPA HQ or an auction venue).</li>
+              <li>Right-click the terminal → Pay → enter the L$ amount.</li>
+              <li>Funds will be credited to this wallet within seconds.</li>
+            </ol>
+            <p className="text-xs text-neutral-600">
+              Multiple users can deposit simultaneously. There&apos;s no menu choice — every payment to the terminal is a deposit to your SLPA wallet.
+            </p>
+            <div className="pt-3 flex justify-end">
+              <Button variant="primary" onClick={() => setShowDeposit(false)}>Got it</Button>
+            </div>
+          </div>
+        </SimpleDialog>
+      )}
+
+      {showWithdraw && (
+        <WithdrawDialog
+          available={wallet.available}
+          onClose={() => setShowWithdraw(false)}
+          onSuccess={async () => {
+            await refresh();
+            setShowWithdraw(false);
+          }}
+        />
+      )}
+
+      {showPenalty && (
+        <PayPenaltyDialog
+          available={wallet.available}
+          owed={wallet.penaltyOwed}
+          onClose={() => setShowPenalty(false)}
+          onSuccess={async () => {
+            await refresh();
+            setShowPenalty(false);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function SimpleDialog({
+  title,
+  children,
+  onClose,
+}: {
+  title: string;
+  children: React.ReactNode;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="bg-white rounded-lg p-6 max-w-md w-full max-h-[80vh] overflow-y-auto">
+        <h3 className="text-lg font-semibold mb-3">{title}</h3>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function WithdrawDialog({
+  available,
+  onClose,
+  onSuccess,
+}: {
+  available: number;
+  onClose: () => void;
+  onSuccess: () => Promise<void>;
+}) {
+  const [amount, setAmount] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    const n = parseInt(amount, 10);
+    if (!Number.isFinite(n) || n <= 0) {
+      setError("Enter a positive integer.");
+      return;
+    }
+    if (n > available) {
+      setError(`Available is ${formatLindens(available)}.`);
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await withdraw({ amount: n, idempotencyKey: genIdempotencyKey() });
+      await onSuccess();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Withdraw failed.");
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <SimpleDialog title="Withdraw L$" onClose={onClose}>
+      <div className="space-y-3 text-sm">
+        <p>Available: <strong>{formatLindens(available)}</strong></p>
+        <p className="text-xs text-neutral-600">
+          Funds will be sent to your verified SL avatar via the in-world SLPA terminal pool.
+        </p>
+        <input
+          type="text"
+          value={amount}
+          onChange={e => setAmount(e.target.value)}
+          placeholder="Amount in L$"
+          className="border border-neutral-300 rounded px-3 py-2 w-full"
+        />
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" onClick={onClose} disabled={submitting}>Cancel</Button>
+          <Button variant="primary" onClick={submit} disabled={submitting}>
+            {submitting ? "Submitting..." : "Withdraw"}
+          </Button>
+        </div>
+      </div>
+    </SimpleDialog>
+  );
+}
+
+function PayPenaltyDialog({
+  available,
+  owed,
+  onClose,
+  onSuccess,
+}: {
+  available: number;
+  owed: number;
+  onClose: () => void;
+  onSuccess: () => Promise<void>;
+}) {
+  const [amount, setAmount] = useState<string>(String(Math.min(available, owed)));
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    const n = parseInt(amount, 10);
+    if (!Number.isFinite(n) || n <= 0) {
+      setError("Enter a positive integer.");
+      return;
+    }
+    if (n > owed) {
+      setError(`Owed is ${formatLindens(owed)}.`);
+      return;
+    }
+    if (n > available) {
+      setError(`Available is ${formatLindens(available)}.`);
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await payPenalty({ amount: n, idempotencyKey: genIdempotencyKey() });
+      await onSuccess();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Pay penalty failed.");
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <SimpleDialog title="Pay Penalty" onClose={onClose}>
+      <div className="space-y-3 text-sm">
+        <p>Outstanding penalty: <strong>{formatLindens(owed)}</strong></p>
+        <p>Available balance: <strong>{formatLindens(available)}</strong></p>
+        <p className="text-xs text-neutral-600">Partial payments allowed up to the owed amount.</p>
+        <input
+          type="text"
+          value={amount}
+          onChange={e => setAmount(e.target.value)}
+          placeholder="Amount in L$"
+          className="border border-neutral-300 rounded px-3 py-2 w-full"
+        />
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" onClick={onClose} disabled={submitting}>Cancel</Button>
+          <Button variant="primary" onClick={submit} disabled={submitting}>
+            {submitting ? "Submitting..." : "Pay"}
+          </Button>
+        </div>
+      </div>
+    </SimpleDialog>
+  );
+}

--- a/frontend/src/lib/api/wallet.ts
+++ b/frontend/src/lib/api/wallet.ts
@@ -1,0 +1,58 @@
+import { api } from "@/lib/api";
+import type {
+  AcceptTermsRequest,
+  PayPenaltyRequest,
+  PayPenaltyResponse,
+  WalletView,
+  WithdrawRequest,
+  WithdrawResponse,
+} from "@/types/wallet";
+
+/**
+ * Fetch the authenticated user's wallet view (balance, reserved, available,
+ * penalty owed, terms-acceptance state, recent 50 ledger entries).
+ */
+export function getWallet(): Promise<WalletView> {
+  return api.get<WalletView>("/api/v1/me/wallet");
+}
+
+/**
+ * Site-initiated withdrawal. Recipient is always the user's verified SL
+ * avatar — never client-supplied. Idempotent on `idempotencyKey`.
+ */
+export function withdraw(req: WithdrawRequest): Promise<WithdrawResponse> {
+  return api.post<WithdrawResponse>("/api/v1/me/wallet/withdraw", req);
+}
+
+/**
+ * Pay against the user's outstanding penalty. Partial payments allowed up
+ * to the owed amount; gated on `available` (not `balance`) so reserved L$
+ * for active bids isn't surrendered to penalty.
+ */
+export function payPenalty(req: PayPenaltyRequest): Promise<PayPenaltyResponse> {
+  return api.post<PayPenaltyResponse>("/api/v1/me/wallet/pay-penalty", req);
+}
+
+/**
+ * First-deposit click-through. Stamps `wallet_terms_accepted_at` and
+ * `wallet_terms_version` on the user. Idempotent — re-accepting the same
+ * version is a no-op server-side.
+ */
+export function acceptTerms(req: AcceptTermsRequest): Promise<void> {
+  return api.post<void>("/api/v1/me/wallet/accept-terms", req);
+}
+
+/**
+ * Pay listing fee from wallet for a DRAFT auction owned by the caller.
+ * Transitions DRAFT -> DRAFT_PAID. Validates penalty == 0 and
+ * available >= listing_fee_amount.
+ */
+export function payListingFee(
+  auctionId: number | string,
+  idempotencyKey: string,
+): Promise<{ newBalance: number; newAvailable: number; auctionStatus: string }> {
+  return api.post<{ newBalance: number; newAvailable: number; auctionStatus: string }>(
+    `/api/v1/me/auctions/${auctionId}/pay-listing-fee`,
+    { idempotencyKey },
+  );
+}

--- a/frontend/src/types/wallet.ts
+++ b/frontend/src/types/wallet.ts
@@ -1,0 +1,70 @@
+// frontend/src/types/wallet.ts
+
+/**
+ * Append-only ledger entry types. Mirror of the backend
+ * `UserLedgerEntryType`. Direction (debit vs credit) is implicit in the
+ * type — the entry's `amount` is always positive.
+ */
+export type UserLedgerEntryType =
+  | "DEPOSIT"
+  | "WITHDRAW_QUEUED"
+  | "WITHDRAW_COMPLETED"
+  | "WITHDRAW_REVERSED"
+  | "BID_RESERVED"
+  | "BID_RELEASED"
+  | "ESCROW_DEBIT"
+  | "ESCROW_REFUND"
+  | "LISTING_FEE_DEBIT"
+  | "LISTING_FEE_REFUND"
+  | "PENALTY_DEBIT"
+  | "ADJUSTMENT";
+
+export interface LedgerEntry {
+  id: number;
+  entryType: UserLedgerEntryType;
+  amount: number;
+  balanceAfter: number;
+  reservedAfter: number;
+  refType: string | null;
+  refId: number | null;
+  description: string | null;
+  createdAt: string;
+}
+
+export interface WalletView {
+  balance: number;
+  reserved: number;
+  available: number;
+  penaltyOwed: number;
+  termsAccepted: boolean;
+  termsVersion: string | null;
+  termsAcceptedAt: string | null;
+  recentLedger: LedgerEntry[];
+}
+
+export interface WithdrawRequest {
+  amount: number;
+  idempotencyKey: string;
+}
+
+export interface WithdrawResponse {
+  queueId: number;
+  newBalance: number;
+  newAvailable: number;
+  status: string;
+}
+
+export interface PayPenaltyRequest {
+  amount: number;
+  idempotencyKey: string;
+}
+
+export interface PayPenaltyResponse {
+  newBalance: number;
+  newAvailable: number;
+  newPenaltyOwed: number;
+}
+
+export interface AcceptTermsRequest {
+  termsVersion: string;
+}


### PR DESCRIPTION
## Summary

Pulls the wallet model end-to-end. All 1591 tests pass. New code is gated
on `slpa.wallet.enforcement-enabled` (default `false`) so legacy in-world
payment flow continues working until the flag is flipped on.

### Backend

- **Phase 5 — bid integration:** `BidService.placeBid` validates penalty
  == 0 and available >= amount, swaps the reservation from prior to new
  high bidder. Lock ordering: auction → users ascending.
- **Phase 6 — auction-end auto-fund:** `EscrowService.createForEndedAuction`
  immediately consumes the winner's reservation, debits balance, and
  transitions ESCROW_PENDING → FUNDED → TRANSFER_PENDING in the same tx.
  Defensive freeze on amount mismatch.
- **Phase 7 — refund-as-credit:** Escrow refunds and listing-fee refunds
  credit the wallet ledger instead of queueing TerminalCommand REFUND.
- **Phase 9 — reconciliation extension impl:** denorm-drift precheck
  before main check; wallet sums folded into expected total; breakdown
  columns populated for forensics.

### Frontend (Phase 11)

- `/dashboard/wallet` page + nav tab
- Wallet panel showing balance / reserved / available / penalty
- Withdraw, pay-penalty, accept-terms, deposit-instructions dialogs
- Recent ledger view (50 entries)
- Frontend builds cleanly (`npm run build` green)

### Docs (Phase 14 partial)

- `CONVENTIONS.md` extended with wallet-model conventions section

## Test plan

- [x] `./mvnw test` green (1591/1591)
- [x] `npm run build` green
- [ ] After merge + deploy: smoke test wallet endpoints
- [ ] Flip `slpa.wallet.enforcement-enabled=true` in prod when ready to enable bid hard-reservation + auto-fund + refund-as-credit