### PR TITLE
feat(admin): DELETE /admin/terminals/{id}

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/terminals/AdminTerminalsController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/terminals/AdminTerminalsController.java
@@ -1,8 +1,11 @@
 package com.slparcelauctions.backend.admin.infrastructure.terminals;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,5 +22,16 @@ public class AdminTerminalsController {
     @GetMapping
     public List<AdminTerminalRow> list() {
         return service.list();
+    }
+
+    /**
+     * Deactivates a registered terminal (soft delete — flips active=false).
+     * The row stays for forensics; the dispatcher stops routing to it.
+     * Re-registering via POST /sl/terminal/register sets active=true again.
+     */
+    @DeleteMapping("/{terminalId}")
+    public ResponseEntity<Void> deactivate(@PathVariable String terminalId) {
+        service.deactivate(terminalId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/terminals/AdminTerminalsService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/terminals/AdminTerminalsService.java
@@ -1,14 +1,19 @@
 package com.slparcelauctions.backend.admin.infrastructure.terminals;
 
+import com.slparcelauctions.backend.escrow.terminal.Terminal;
 import com.slparcelauctions.backend.escrow.terminal.TerminalRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AdminTerminalsService {
 
     private final TerminalRepository terminalRepo;
@@ -22,5 +27,22 @@ public class AdminTerminalsService {
                 t.getTerminalId(), t.getRegionName(), t.getHttpInUrl(),
                 t.getLastSeenAt(), t.getLastHeartbeatAt(),
                 t.getLastReportedBalance(), currentVersion)).toList();
+    }
+
+    /**
+     * Soft-unregister a terminal: flips {@code active = false} so the
+     * dispatcher's {@code findAnyLive} query no longer returns it. The row
+     * stays for forensics + audit; resetting the in-world script
+     * re-registers it via {@code POST /sl/terminal/register} (which sets
+     * {@code active = true} again).
+     */
+    @Transactional
+    public void deactivate(String terminalId) {
+        Terminal t = terminalRepo.findById(terminalId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "terminal not found: " + terminalId));
+        t.setActive(false);
+        terminalRepo.save(t);
+        log.warn("Admin deactivated terminal: terminalId={}", terminalId);
     }
 }


### PR DESCRIPTION
Soft-unregister a terminal — sets active=false. Useful for taking a stale or re-rezzed terminal out of dispatcher rotation immediately rather than waiting for the lastSeenAt cutoff.