### PR TITLE
feat(admin): terminal unregister UI

### DIFF
--- a/frontend/src/app/admin/infrastructure/TerminalsSection.tsx
+++ b/frontend/src/app/admin/infrastructure/TerminalsSection.tsx
@@ -1,12 +1,24 @@
 "use client";
 import { useState } from "react";
-import { useTerminalsAdmin } from "@/lib/admin/infrastructureHooks";
+import {
+  useTerminalsAdmin,
+  useDeactivateTerminal,
+} from "@/lib/admin/infrastructureHooks";
 import { RotateSecretModal } from "./RotateSecretModal";
 
 export function TerminalsSection() {
   const { data: rows = [] } = useTerminalsAdmin();
+  const deactivate = useDeactivateTerminal();
   const [rotateOpen, setRotateOpen] = useState(false);
+  const [confirmId, setConfirmId] = useState<string | null>(null);
   const active = rows.filter((r) => r.lastHeartbeatAt !== null).length;
+
+  const handleConfirmDeactivate = () => {
+    if (!confirmId) return;
+    deactivate.mutate(confirmId, {
+      onSettled: () => setConfirmId(null),
+    });
+  };
 
   return (
     <section className="bg-surface-container rounded p-4">
@@ -24,7 +36,14 @@ export function TerminalsSection() {
       ) : (
         <table className="w-full text-xs mb-3">
           <thead className="text-[10px] uppercase opacity-55 text-left">
-            <tr><th>Region</th><th>Terminal</th><th>Last cmd</th><th>Balance</th><th>Secret v.</th></tr>
+            <tr>
+              <th>Region</th>
+              <th>Terminal</th>
+              <th>Last cmd</th>
+              <th>Balance</th>
+              <th>Secret v.</th>
+              <th></th>
+            </tr>
           </thead>
           <tbody>
             {rows.map((t) => (
@@ -34,6 +53,16 @@ export function TerminalsSection() {
                 <td className="py-2 opacity-80">{t.lastSeenAt ? new Date(t.lastSeenAt).toLocaleString() : "—"}</td>
                 <td className="py-2">{t.lastReportedBalance !== null ? `L$ ${t.lastReportedBalance}` : "—"}</td>
                 <td className="py-2">v{t.currentSecretVersion ?? "—"}</td>
+                <td className="py-2 text-right">
+                  <button
+                    type="button"
+                    onClick={() => setConfirmId(t.terminalId)}
+                    className="px-2 py-1 text-[10px] text-error border border-error/40 rounded hover:bg-error/10"
+                    aria-label={`Unregister terminal ${t.terminalId}`}
+                  >
+                    Unregister
+                  </button>
+                </td>
               </tr>
             ))}
           </tbody>
@@ -45,6 +74,45 @@ export function TerminalsSection() {
         className="px-3 py-1.5 border border-outline rounded text-xs text-tertiary"
       >⟳ Rotate shared secret →</button>
       {rotateOpen && <RotateSecretModal onClose={() => setRotateOpen(false)} />}
+      {confirmId && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-surface-container max-w-md w-full rounded-lg p-5">
+            <h3 className="text-sm font-semibold mb-2">Unregister terminal</h3>
+            <p className="text-xs opacity-80 mb-3">
+              This soft-deletes the terminal — sets <code>active=false</code> so the
+              dispatcher stops routing commands to it. The row stays in the database
+              for forensics. If the in-world script later re-registers, it will become
+              active again.
+            </p>
+            <p className="text-xs mb-4">
+              Terminal: <code className="font-mono">{confirmId}</code>
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirmId(null)}
+                disabled={deactivate.isPending}
+                className="px-3 py-1.5 border border-outline rounded text-xs"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirmDeactivate}
+                disabled={deactivate.isPending}
+                className="px-3 py-1.5 bg-error text-on-error rounded text-xs"
+              >
+                {deactivate.isPending ? "Unregistering…" : "Unregister"}
+              </button>
+            </div>
+            {deactivate.isError && (
+              <p className="mt-2 text-xs text-error">
+                Failed to unregister. Try again or use the API directly.
+              </p>
+            )}
+          </div>
+        </div>
+      )}
     </section>
   );
 }

--- a/frontend/src/lib/admin/api.ts
+++ b/frontend/src/lib/admin/api.ts
@@ -249,6 +249,9 @@ export const adminApi = {
     rotateSecret(): Promise<TerminalRotationResponse> {
       return api.post("/api/v1/admin/terminals/rotate-secret", {});
     },
+    deactivate(terminalId: string): Promise<void> {
+      return api.delete(`/api/v1/admin/terminals/${encodeURIComponent(terminalId)}`);
+    },
   },
 
   reconciliation: {

--- a/frontend/src/lib/admin/infrastructureHooks.ts
+++ b/frontend/src/lib/admin/infrastructureHooks.ts
@@ -28,6 +28,16 @@ export function useRotateSecret() {
   });
 }
 
+export function useDeactivateTerminal() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (terminalId: string) => adminApi.terminals.deactivate(terminalId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: adminQueryKeys.terminals() });
+    },
+  });
+}
+
 export function useReconciliationRuns(days: number = 7) {
   return useQuery({
     queryKey: adminQueryKeys.reconciliationRuns(days),


### PR DESCRIPTION
Per-row Unregister button in the Infrastructure → Terminals section. Confirmation modal + soft-delete via DELETE /api/v1/admin/terminals/{id}.