### PR TITLE
fix(terminal): refresh lastSeenAt on every authenticated call + LSL heartbeat

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/terminals/TerminalHeartbeatService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/terminals/TerminalHeartbeatService.java
@@ -23,8 +23,13 @@ public class TerminalHeartbeatService {
         Terminal t = terminalRepo.findById(req.terminalKey())
                 .orElseThrow(() -> new IllegalArgumentException(
                         "Unknown terminal: " + req.terminalKey()));
-        t.setLastHeartbeatAt(OffsetDateTime.now(clock));
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        t.setLastHeartbeatAt(now);
         t.setLastReportedBalance(req.accountBalance());
+        // Heartbeats also keep the terminal "live" for the dispatcher.
+        // Without this, the dispatcher's lastSeenAt-based live window would
+        // expire even on a healthy heartbeating terminal.
+        t.setLastSeenAt(now);
         terminalRepo.save(t);
         log.info("Terminal heartbeat: {}, balance=L${}",
                 t.getTerminalId(), req.accountBalance());

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/command/PayoutResultController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/command/PayoutResultController.java
@@ -51,6 +51,9 @@ public class PayoutResultController {
             @Valid @RequestBody PayoutResultRequest body) {
         headerValidator.validate(shard, ownerKey);
         terminalService.assertSharedSecret(body.sharedSecret());
+        // Authenticated traffic from this terminal keeps it "live" in the
+        // dispatcher's view — see TerminalService#markSeen.
+        terminalService.markSeen(body.terminalId());
         terminalCommandService.applyCallback(body);
         return SlCallbackResponse.ok();
     }

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/terminal/TerminalService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/terminal/TerminalService.java
@@ -63,6 +63,27 @@ public class TerminalService {
      * Null / blank guards are kept as a fast fail path since they short-circuit
      * on configuration errors, not on attacker-controlled input.
      */
+    /**
+     * Refreshes {@code lastSeenAt} on the given terminal to {@code now}, so
+     * the dispatcher's {@code findAnyLive} window (active=true AND
+     * lastSeenAt within the live window) keeps the terminal in rotation.
+     *
+     * <p>Call this from any successful authenticated SL terminal callback —
+     * deposit, withdraw-request, payout-result, heartbeat — so the terminal
+     * stays live in the dispatcher's view as long as it is actively serving
+     * traffic, even if it hasn't re-registered recently.
+     *
+     * <p>No-op if the terminal id doesn't resolve (defensive — the caller
+     * has already validated existence by this point in production paths).
+     */
+    @Transactional
+    public void markSeen(String terminalId) {
+        terminalRepo.findById(terminalId).ifPresent(t -> {
+            t.setLastSeenAt(OffsetDateTime.now(clock));
+            terminalRepo.save(t);
+        });
+    }
+
     public void assertSharedSecret(String provided) {
         String expected = props.terminalSharedSecret();
         if (expected == null || expected.isBlank() || provided == null) {

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/sl/SlWalletController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/sl/SlWalletController.java
@@ -58,6 +58,12 @@ public class SlWalletController {
             return SlWalletResponse.error(SlWalletResponseReason.UNKNOWN_TERMINAL,
                     "terminalId not registered");
         }
+        // Authenticated traffic from this terminal keeps it "live" in the
+        // dispatcher's view — without this, lastSeenAt would only refresh on
+        // /sl/terminal/register, and an idle-but-healthy terminal would
+        // silently drop out of dispatch rotation after the live window
+        // expires.
+        terminalService.markSeen(req.terminalId());
 
         UUID payerUuid;
         try {
@@ -90,6 +96,12 @@ public class SlWalletController {
             return SlWalletResponse.error(SlWalletResponseReason.UNKNOWN_TERMINAL,
                     "terminalId not registered");
         }
+        // Authenticated traffic from this terminal keeps it "live" in the
+        // dispatcher's view — without this, lastSeenAt would only refresh on
+        // /sl/terminal/register, and an idle-but-healthy terminal would
+        // silently drop out of dispatch rotation after the live window
+        // expires.
+        terminalService.markSeen(req.terminalId());
 
         UUID payerUuid;
         try {

--- a/lsl-scripts/slpa-terminal/README.md
+++ b/lsl-scripts/slpa-terminal/README.md
@@ -33,6 +33,14 @@ backend-initiated PAYOUT/WITHDRAW commands via HTTP-in.
   and shouldn't arrive; if one does, log CRITICAL and fail.
 - **Region restart:** `changed(CHANGED_REGION_START)` triggers `llRequestURL()`
   + re-register. Backend's `terminals.http_in_url` is updated.
+- **Heartbeat (every 5 min):** the script periodically POSTs to
+  `/sl/terminal/heartbeat` so the backend dispatcher's `lastSeenAt` window
+  stays fresh. Without it, an idle but healthy terminal can drop out of
+  dispatch rotation between rezzes / inventory changes. The backend ALSO
+  refreshes `lastSeenAt` on every authenticated terminal call (deposit /
+  withdraw-request / payout-result), so heartbeats only matter when the
+  terminal is genuinely idle. Backward-compatible: if `HEARTBEAT_URL` is
+  empty in the notecard, heartbeats are skipped silently.
 
 ## Deployment
 
@@ -67,6 +75,7 @@ The new SLPA Parcel Verifier Giver prim (separate; see
 | `DEPOSIT_URL` | Full URL of `/api/v1/sl/wallet/deposit`. Required. |
 | `WITHDRAW_REQUEST_URL` | Full URL of `/api/v1/sl/wallet/withdraw-request`. Required. |
 | `PAYOUT_RESULT_URL` | Full URL of `/api/v1/sl/escrow/payout-result`. Required. |
+| `HEARTBEAT_URL` | Full URL of `/api/v1/sl/terminal/heartbeat`. Optional but recommended — see Architecture summary. |
 | `SHARED_SECRET` | The shared secret. **Required.** Obtain from `slpa.escrow.terminal-shared-secret`. |
 | `TERMINAL_ID` | Optional. Defaults to `(string)llGetKey()`. |
 | `REGION_NAME` | Optional. Defaults to `llGetRegionName()`. |
@@ -93,6 +102,9 @@ In steady state with `DEBUG_MODE=true`:
 - `SLPA Terminal: HTTP-in WITHDRAW to <recipient> L$<amount> ikey=...` — backend
   dispatched a wallet-withdrawal fulfillment to this terminal.
 - `SLPA Terminal: payout-result acknowledged.` — backend received our async result.
+- `SLPA Terminal: heartbeat ok.` — periodic 5-minute heartbeat acknowledged.
+- `SLPA Terminal: heartbeat failed status=...` — heartbeat POST failed; will
+  retry on the next interval. Not critical unless it persists.
 - `CRITICAL: SLPA Terminal: deposit ... not acknowledged after 5 retries` —
   deposit recovery failed; manual reconciliation required.
 - `CRITICAL: unexpected REFUND HTTP-in command` — the backend dispatched a

--- a/lsl-scripts/slpa-terminal/config.notecard.example
+++ b/lsl-scripts/slpa-terminal/config.notecard.example
@@ -2,11 +2,15 @@
 # Place this file (renamed to "config", no extension) in the prim's contents.
 # After editing, the script auto-resets via CHANGED_INVENTORY and re-registers.
 
-# Backend endpoint URLs — all four required.
+# Backend endpoint URLs — REGISTER/DEPOSIT/WITHDRAW_REQUEST/PAYOUT_RESULT
+# are required. HEARTBEAT_URL is optional but strongly recommended; without
+# it the terminal can drop out of dispatch rotation between rezzes /
+# inventory changes if it sits idle longer than the backend's live window.
 REGISTER_URL=https://slpa.app/api/v1/sl/terminal/register
 DEPOSIT_URL=https://slpa.app/api/v1/sl/wallet/deposit
 WITHDRAW_REQUEST_URL=https://slpa.app/api/v1/sl/wallet/withdraw-request
 PAYOUT_RESULT_URL=https://slpa.app/api/v1/sl/escrow/payout-result
+HEARTBEAT_URL=https://slpa.app/api/v1/sl/terminal/heartbeat
 
 # Shared secret for terminal authentication. REQUIRED.
 # Obtain from the backend's slpa.escrow.terminal-shared-secret config.

--- a/lsl-scripts/slpa-terminal/slpa-terminal.lsl
+++ b/lsl-scripts/slpa-terminal/slpa-terminal.lsl
@@ -30,6 +30,7 @@ string  REGISTER_URL          = "";
 string  DEPOSIT_URL           = "";
 string  WITHDRAW_REQUEST_URL  = "";
 string  PAYOUT_RESULT_URL     = "";
+string  HEARTBEAT_URL         = "";
 string  SHARED_SECRET         = "";
 string  TERMINAL_ID           = "";
 string  REGION_NAME           = "";
@@ -88,6 +89,20 @@ integer MAX_INFLIGHT_CMDS         = 16;
 // === Payout-result tracking ===
 key     payoutResultReqId = NULL_KEY;
 
+// === Heartbeat ===
+// The terminal periodically POSTs to /sl/terminal/heartbeat so the backend
+// dispatcher's `lastSeenAt` window stays fresh. Without this, an idle but
+// healthy terminal eventually drops out of dispatch rotation between
+// rezzes / inventory changes (the only other paths that re-register).
+//
+// HEARTBEAT_URL is optional in the notecard for backward compatibility:
+// pre-heartbeat deployments will simply skip heartbeats and rely on the
+// authenticated-call refresh of lastSeenAt added in the backend at the
+// same time as this LSL change. New deployments should set it.
+key     heartbeatReqId             = NULL_KEY;
+integer nextHeartbeatAt            = 0;
+integer HEARTBEAT_INTERVAL_SECONDS = 300;
+
 // === Timer phase ===
 integer TIMER_NONE              = 0;
 integer TIMER_SESSION_SWEEP     = 1;
@@ -119,6 +134,7 @@ parseConfigLine(string line) {
     else if (k == "DEPOSIT_URL")           DEPOSIT_URL           = v;
     else if (k == "WITHDRAW_REQUEST_URL")  WITHDRAW_REQUEST_URL  = v;
     else if (k == "PAYOUT_RESULT_URL")     PAYOUT_RESULT_URL     = v;
+    else if (k == "HEARTBEAT_URL")         HEARTBEAT_URL         = v;
     else if (k == "SHARED_SECRET")         SHARED_SECRET         = v;
     else if (k == "TERMINAL_ID")           TERMINAL_ID           = v;
     else if (k == "REGION_NAME")           REGION_NAME           = v;
@@ -190,6 +206,22 @@ scheduleRegisterRetry() {
     registerNextRetryAt = llGetUnixTime() + delay;
     timerPhase = TIMER_REGISTER_RETRY;
     llSetTimerEvent((float)delay);
+}
+
+postHeartbeat() {
+    // Reconciliation isn't wired yet — `accountBalance` is sent as 0
+    // until the backend reconciliation job lands and we add proper
+    // tracking via money() / transaction_result. The dispatcher only
+    // uses the heartbeat for `lastSeenAt`, so 0 is harmless today.
+    string body = "{"
+        + "\"terminalKey\":\"" + escapeJson(TERMINAL_ID) + "\","
+        + "\"accountBalance\":0"
+        + "}";
+    heartbeatReqId = llHTTPRequest(HEARTBEAT_URL,
+        [HTTP_METHOD, "POST",
+         HTTP_MIMETYPE, "application/json",
+         HTTP_BODY_MAXLENGTH, 16384],
+        body);
 }
 
 // ---------------- Deposit (money() handler) ----------------
@@ -385,6 +417,7 @@ default {
         DEPOSIT_URL           = "";
         WITHDRAW_REQUEST_URL  = "";
         PAYOUT_RESULT_URL     = "";
+        HEARTBEAT_URL         = "";
         SHARED_SECRET         = "";
         TERMINAL_ID           = "";
         REGION_NAME           = "";
@@ -415,6 +448,11 @@ default {
         inflightCmdRecipients      = [];
         inflightCmdAmounts         = [];
         payoutResultReqId   = NULL_KEY;
+        heartbeatReqId      = NULL_KEY;
+        // First heartbeat fires HEARTBEAT_INTERVAL_SECONDS after rez —
+        // by then registration has either succeeded or is retrying, so
+        // the heartbeat refreshes lastSeenAt on a known-good terminal.
+        nextHeartbeatAt     = llGetUnixTime() + HEARTBEAT_INTERVAL_SECONDS;
         timerPhase          = TIMER_NONE;
 
         // Mainland-only grid guard
@@ -787,6 +825,22 @@ default {
             }
             return;
         }
+
+        // ----- Heartbeat ack -----
+        if (req == heartbeatReqId) {
+            heartbeatReqId = NULL_KEY;
+            if (status >= 200 && status < 300) {
+                if (DEBUG_MODE)
+                    llOwnerSay("SLPA Terminal: heartbeat ok.");
+            } else {
+                // Heartbeats are best-effort: log and move on. Next interval
+                // will retry naturally.
+                if (DEBUG_MODE)
+                    llOwnerSay("SLPA Terminal: heartbeat failed status="
+                        + (string)status + " (will retry on next interval)");
+            }
+            return;
+        }
     }
 
     timer() {
@@ -802,6 +856,15 @@ default {
         }
         if (timerPhase == TIMER_WITHDRAW_RETRY && now >= withdrawNextRetryAt) {
             fireWithdrawRequest();
+        }
+
+        // Heartbeat tick (independent of timerPhase — runs on its own
+        // schedule, gated only on URL configured + no inflight request).
+        if (HEARTBEAT_URL != "" && TERMINAL_ID != ""
+                && heartbeatReqId == NULL_KEY
+                && now >= nextHeartbeatAt) {
+            postHeartbeat();
+            nextHeartbeatAt = now + HEARTBEAT_INTERVAL_SECONDS;
         }
 
         sweepExpiredSlots();


### PR DESCRIPTION
## Summary

- Bug fix: terminals dropped out of dispatch rotation when `lastSeenAt` aged out, leaving queued `WALLET_WITHDRAWAL` `TerminalCommand`s stuck.
- Backend: every authenticated terminal call (`/sl/wallet/deposit`, `/sl/wallet/withdraw-request`, `/sl/escrow/payout-result`, `/sl/terminal/heartbeat`) now refreshes `lastSeenAt` via `TerminalService.markSeen`.
- LSL: `slpa-terminal.lsl` posts to `/sl/terminal/heartbeat` every 5 minutes. `HEARTBEAT_URL` is optional for backwards compatibility.

Includes #89.

## Test plan

- [x] 65/65 terminal+wallet tests pass locally
- [ ] Deploy via `deploy-backend.yml`
- [ ] Reset in-world LSL terminal (Reset Scripts) so it picks up `HEARTBEAT_URL`
- [ ] Confirm stuck L$1 from earlier today drains as soon as terminal is live
- [ ] Withdraw L$1 → confirm L$ arrives in alt within ~30s