### PR TITLE
fix(infra): open backend SG egress to all ports for SL HTTP-in callbacks

### DIFF
--- a/infra/networking/security_groups.tf
+++ b/infra/networking/security_groups.tf
@@ -86,22 +86,11 @@ resource "aws_vpc_security_group_egress_rule" "backend_to_redis" {
   description                  = "Backend to Redis"
 }
 
-resource "aws_vpc_security_group_egress_rule" "backend_to_internet_https" {
+resource "aws_vpc_security_group_egress_rule" "backend_to_internet_all" {
   security_group_id = aws_security_group.backend.id
   cidr_ipv4         = "0.0.0.0/0"
-  from_port         = 443
-  to_port           = 443
-  ip_protocol       = "tcp"
-  description       = "Backend to SL World API + AWS APIs (Parameter Store, S3) via NAT"
-}
-
-resource "aws_vpc_security_group_egress_rule" "backend_to_internet_http" {
-  security_group_id = aws_security_group.backend.id
-  cidr_ipv4         = "0.0.0.0/0"
-  from_port         = 80
-  to_port           = 80
-  ip_protocol       = "tcp"
-  description       = "Backend egress on port 80 for SL World API HTTP redirect handling during retries"
+  ip_protocol       = "-1"
+  description       = "Backend to internet via NAT. Covers SL World API (443), HTTP redirects (80), AWS APIs (443), and dispatcher POSTs to in-world LSL HTTP-in URLs on simulator-assigned high ports (e.g. 12046)."
 }
 
 # ----- Bots: no inbound; egress to backend (ALB-fronted) + internet --------- #


### PR DESCRIPTION
## Summary

The backend ECS task SG only permitted egress on TCP 80/443. The wallet-withdrawal flow is the first prod path that POSTs to in-world LSL HTTP-in capability URLs, which Linden serves on simulator-assigned high ports (e.g. 12046). Every dispatcher POST timed out at the SG.

Replaces the narrow 80/443-only egress rules with a single \`0.0.0.0/0\` all-protocols rule. Matches the SG's existing description.

**Already applied to prod via local \`terraform apply\`.** This PR is the code commit for the change.

## Verification

- Pre-fix: ${'`'}command 3${'`'}, ${'`'}command 4${'`'} STALLED after 4 transport-failure attempts (30s timeout each).
- Post-fix: ${'`'}17:31:40 Dispatched command 6 to terminal d66f1d83-... attempt 3/4${'`'} — clean POST, no timeout.
- User confirmed in-world end-to-end works.

## Test plan

- [x] Terraform plan reviewed (1 add, 2 destroy, no SG replacement)
- [x] Applied to prod
- [x] User confirmed withdraw works end-to-end
- [ ] Cleanup of 4 STALLED ${'`'}TerminalCommand${'`'}s (ids 3, 4, 5, 6) — followup