### PR TITLE
fix: LSL key/string + JSON_TRUE bugs + dispatcher in-flight cap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,4 @@ infra/crash.log
 infra/crash.*.log
 # .terraform.lock.hcl IS committed — Terraform's recommendation. Pins provider
 # versions so every machine + CI run resolves the same provider versions.
+infra/.scratch/

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/scheduler/TerminalCommandDispatcherTask.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/scheduler/TerminalCommandDispatcherTask.java
@@ -184,8 +184,29 @@ public class TerminalCommandDispatcherTask {
         TerminalCommand cmd = cmdRepo.findByIdForUpdate(commandId).orElse(null);
         if (cmd == null || cmd.getStatus() != TerminalCommandStatus.IN_FLIGHT) return;
         OffsetDateTime now = OffsetDateTime.now(clock);
-        cmd.setStatus(TerminalCommandStatus.FAILED);
         cmd.setLastError("IN_FLIGHT timeout without callback");
+
+        // The IN_FLIGHT-timeout path used to requeue unconditionally — only
+        // the transport-failure path checked the attempt cap. That left an
+        // unACK'd command (terminal returned 200 but never POSTed payout-result,
+        // e.g. an LSL bug silently dropped transaction_result) able to loop
+        // forever via this method, never stalling and never refunding the user.
+        // Mirror the transport-stall behavior: at the cap, stall + refund
+        // wallet withdrawals + log; below the cap, requeue for immediate retry.
+        if (cmd.getAttemptCount() >= EscrowRetryPolicy.MAX_ATTEMPTS) {
+            cmd.setStatus(TerminalCommandStatus.FAILED);
+            cmd.setRequiresManualReview(true);
+            cmdRepo.save(cmd);
+            if (cmd.getPurpose() == TerminalCommandPurpose.WALLET_WITHDRAWAL) {
+                walletWithdrawalCallbackHandler.onStall(cmd,
+                        "IN_FLIGHT timeout without callback");
+            }
+            log.error("Terminal command {} STALLED after {} attempts (in-flight timeout)",
+                    cmd.getId(), cmd.getAttemptCount());
+            return;
+        }
+
+        cmd.setStatus(TerminalCommandStatus.FAILED);
         cmd.setNextAttemptAt(now);
         cmdRepo.save(cmd);
         log.warn("Command {} IN_FLIGHT timeout (dispatchedAt={}); requeued for immediate retry",

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/command/TerminalCommandDispatcherTaskTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/command/TerminalCommandDispatcherTaskTest.java
@@ -3,6 +3,7 @@ package com.slparcelauctions.backend.escrow.command;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -264,6 +265,53 @@ class TerminalCommandDispatcherTaskTest {
 
         // No save should happen for a non-IN_FLIGHT row.
         verify(cmdRepo, never()).save(any());
+    }
+
+    @Test
+    void markStaleAndRequeue_atAttemptCap_stallsAndDoesNotRequeue() {
+        // Reproduces the production bug: an IN_FLIGHT command with
+        // attemptCount = MAX_ATTEMPTS used to keep looping via this method
+        // because the cap check only existed on the transport-failure path.
+        TerminalCommand cmd = buildQueued();
+        cmd.setStatus(TerminalCommandStatus.IN_FLIGHT);
+        cmd.setDispatchedAt(OffsetDateTime.now(fixed).minusMinutes(10));
+        cmd.setAttemptCount(com.slparcelauctions.backend.escrow.command.EscrowRetryPolicy.MAX_ATTEMPTS);
+        when(cmdRepo.findByIdForUpdate(CMD_ID)).thenReturn(Optional.of(cmd));
+        when(cmdRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        task.markStaleAndRequeue(CMD_ID);
+
+        assertThat(cmd.getStatus()).isEqualTo(TerminalCommandStatus.FAILED);
+        assertThat(cmd.getRequiresManualReview()).isTrue();
+        // Stalled — must NOT schedule another retry.
+        assertThat(cmd.getNextAttemptAt())
+                .isEqualTo(OffsetDateTime.now(fixed).minusSeconds(1));
+    }
+
+    @Test
+    void markStaleAndRequeue_atAttemptCap_walletWithdrawalRefundsUser() {
+        TerminalCommand cmd = TerminalCommand.builder()
+                .id(CMD_ID)
+                .action(TerminalCommandAction.WITHDRAW)
+                .purpose(com.slparcelauctions.backend.escrow.command.TerminalCommandPurpose.WALLET_WITHDRAWAL)
+                .recipientUuid(UUID.randomUUID().toString())
+                .amount(100L)
+                .status(TerminalCommandStatus.IN_FLIGHT)
+                .attemptCount(com.slparcelauctions.backend.escrow.command.EscrowRetryPolicy.MAX_ATTEMPTS)
+                .dispatchedAt(OffsetDateTime.now(fixed).minusMinutes(10))
+                .idempotencyKey("WAL-99")
+                .requiresManualReview(false)
+                .build();
+        when(cmdRepo.findByIdForUpdate(CMD_ID)).thenReturn(Optional.of(cmd));
+        when(cmdRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        task.markStaleAndRequeue(CMD_ID);
+
+        // Reverses the wallet debit + IMs the user.
+        verify(walletWithdrawalCallbackHandler)
+                .onStall(eq(cmd), eq("IN_FLIGHT timeout without callback"));
+        assertThat(cmd.getStatus()).isEqualTo(TerminalCommandStatus.FAILED);
+        assertThat(cmd.getRequiresManualReview()).isTrue();
     }
 
     @Test

--- a/lsl-scripts/slpa-terminal/slpa-terminal.lsl
+++ b/lsl-scripts/slpa-terminal/slpa-terminal.lsl
@@ -390,7 +390,14 @@ addInflightCommand(key txKey, string idempotencyKey, key recipient, integer amou
             + ") hit — refusing command. Backend retry will cover.");
         return;
     }
-    inflightCmdTxKeys          = inflightCmdTxKeys          + [txKey];
+    // Cast to string at insertion: llListFindList in removeInflightByTxKey
+    // searches with a string cast, and LSL's list type-comparison is strict
+    // — a key-typed element does NOT match a string-typed search element
+    // even with identical UUIDs, so a missing cast here silently drops every
+    // transaction_result lookup, never POSTs /payout-result, and the
+    // dispatcher's IN_FLIGHT timeout requeues the command into a permanent
+    // retry loop.
+    inflightCmdTxKeys          = inflightCmdTxKeys          + [(string)txKey];
     inflightCmdIdempotencyKeys = inflightCmdIdempotencyKeys + [idempotencyKey];
     inflightCmdRecipients      = inflightCmdRecipients      + [(string)recipient];
     inflightCmdAmounts         = inflightCmdAmounts         + [amount];

--- a/lsl-scripts/verification-terminal/verification-terminal.lsl
+++ b/lsl-scripts/verification-terminal/verification-terminal.lsl
@@ -289,7 +289,12 @@ default {
             string userId      = llJsonGetValue(body, ["userId"]);
             string slAvatarName = llJsonGetValue(body, ["slAvatarName"]);
 
-            if (verified == "true") {
+            // llJsonGetValue returns the LSL JSON_TRUE constant ("~true")
+            // for a JSON boolean true, NOT the literal string "true". Comparing
+            // against the literal silently fails into the "verification failed"
+            // branch even on a successful verify response. Always compare
+            // boolean JSON values against JSON_TRUE / JSON_FALSE.
+            if (verified == JSON_TRUE) {
                 llRegionSayTo(lockHolder, 0,
                     "✓ Linked SLPA #" + userId + " to " + slAvatarName + ".");
                 if (DEBUG_MODE)


### PR DESCRIPTION
## Summary

Three coupled bug fixes from prod-test failures:
- LSL terminal: txKey stored as \`key\` but searched as \`string\` → silent drop in \`transaction_result\` → withdrawals stuck "Queued"
- LSL verification terminal: comparing against literal \`"true"\` instead of \`JSON_TRUE\` constant → "verification failed" on success
- Dispatcher: \`markStaleAndRequeue\` didn't enforce attempt cap → unACK'd commands looped forever

Includes #96.

## Test plan

- [x] 77/77 wallet+terminal+withdrawal tests pass
- [ ] Deploy
- [ ] Wipe DB
- [ ] Reset both in-world terminals + smoke-test