### PR TITLE
feat(wallet): collapsed ledger view + ledger auto-refresh on WS events

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/LedgerRow.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/LedgerRow.java
@@ -1,0 +1,12 @@
+package com.slparcelauctions.backend.wallet;
+
+/**
+ * A user-facing ledger row: a {@link UserLedgerEntry} with the optional
+ * collapsed withdrawal status.
+ *
+ * <p>The {@link UserLedgerRepository#findCollapsedForUser} query returns
+ * these. {@code withdrawalStatus} is non-null only for
+ * {@link UserLedgerEntryType#WITHDRAW_QUEUED} entries — for every other
+ * entry type it is null.
+ */
+public record LedgerRow(UserLedgerEntry entry, WithdrawalStatus withdrawalStatus) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.slparcelauctions.backend.wallet.me.LedgerCollapsedRepository;
+
 /**
  * Repository for {@link UserLedgerEntry} append-only rows.
  *
@@ -22,7 +24,8 @@ import org.springframework.data.repository.query.Param;
  */
 public interface UserLedgerRepository
         extends JpaRepository<UserLedgerEntry, Long>,
-                JpaSpecificationExecutor<UserLedgerEntry> {
+                JpaSpecificationExecutor<UserLedgerEntry>,
+                LedgerCollapsedRepository {
 
     /**
      * Idempotency lookup for the SL-headers wallet endpoints

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/WithdrawalStatus.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/WithdrawalStatus.java
@@ -1,0 +1,23 @@
+package com.slparcelauctions.backend.wallet;
+
+/**
+ * Frontend-facing status of a withdrawal as a single logical row.
+ *
+ * <p>The append-only ledger model writes three rows per logical withdrawal
+ * ({@code WITHDRAW_QUEUED}, then either {@code WITHDRAW_COMPLETED} or
+ * {@code WITHDRAW_REVERSED}). The user-facing wallet activity view collapses
+ * those into one display row: the {@code WITHDRAW_QUEUED} entry, decorated
+ * with the status of its terminal sibling. This enum names that decoration.
+ *
+ * <p>Null status is reserved for non-withdrawal ledger entries — the field
+ * on {@code LedgerEntryDto} is null for {@code DEPOSIT}, {@code BID_RESERVED},
+ * {@code ESCROW_DEBIT}, etc.
+ */
+public enum WithdrawalStatus {
+    /** No paired terminal row yet — withdrawal is in flight. */
+    PENDING,
+    /** Paired {@code WITHDRAW_COMPLETED} row exists — funds delivered. */
+    COMPLETED,
+    /** Paired {@code WITHDRAW_REVERSED} row exists — funds refunded. */
+    REVERSED;
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/me/LedgerCollapsedRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/me/LedgerCollapsedRepository.java
@@ -1,0 +1,36 @@
+package com.slparcelauctions.backend.wallet.me;
+
+import java.util.stream.Stream;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.slparcelauctions.backend.wallet.LedgerRow;
+
+/**
+ * Custom repository fragment for the user-facing collapsed ledger view.
+ * Mixed into {@link com.slparcelauctions.backend.wallet.UserLedgerRepository}
+ * via Spring Data's custom-fragment mechanism.
+ *
+ * <p>Both methods exclude {@code WITHDRAW_COMPLETED} and
+ * {@code WITHDRAW_REVERSED} rows entirely — the user sees a single
+ * {@code WITHDRAW_QUEUED} row decorated with the
+ * {@link com.slparcelauctions.backend.wallet.WithdrawalStatus} of its
+ * terminal sibling, computed in-query via SQL EXISTS subqueries.
+ */
+public interface LedgerCollapsedRepository {
+
+    /**
+     * Paginated collapsed-ledger query for {@code GET /me/wallet/ledger}.
+     * Sorted DESC by {@code createdAt}. Filter composes via
+     * {@link LedgerFilter}.
+     */
+    Page<LedgerRow> findCollapsedForUser(
+            Long userId, LedgerFilter filter, Pageable pageable);
+
+    /**
+     * Streaming collapsed-ledger query for the CSV export endpoint. Caller
+     * MUST close the stream and MUST run inside a read-only transaction.
+     */
+    Stream<LedgerRow> streamCollapsedForUser(Long userId, LedgerFilter filter);
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/me/LedgerCollapsedRepositoryImpl.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/me/LedgerCollapsedRepositoryImpl.java
@@ -1,0 +1,186 @@
+package com.slparcelauctions.backend.wallet.me;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.slparcelauctions.backend.wallet.LedgerRow;
+import com.slparcelauctions.backend.wallet.UserLedgerEntry;
+import com.slparcelauctions.backend.wallet.UserLedgerEntryType;
+import com.slparcelauctions.backend.wallet.WithdrawalStatus;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Tuple;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Single-query collapsed ledger reader. The {@link LedgerCollapsedRepository}
+ * fragment lives here so the query construction is shared between the
+ * paginated controller path and the CSV streaming path — same WHERE clause,
+ * same status CASE EXPR, same row shape.
+ *
+ * <p>The query:
+ * <ul>
+ *   <li>Excludes {@code WITHDRAW_COMPLETED} and {@code WITHDRAW_REVERSED}
+ *       rows from the result entirely. They still exist in the DB for
+ *       audit, but are never surfaced to the user.</li>
+ *   <li>For each remaining row, computes a
+ *       {@link WithdrawalStatus} via a {@code CASE} expression with
+ *       {@code EXISTS} subqueries that check for paired sibling rows
+ *       (matched on {@code refType='USER_LEDGER'} and {@code refId=q.id}).
+ *       Status is null for entry types other than
+ *       {@code WITHDRAW_QUEUED}.</li>
+ *   <li>Applies {@link LedgerFilter} via the same predicates that the
+ *       Specification path used.</li>
+ *   <li>Sorts DESC by {@code createdAt}.</li>
+ * </ul>
+ *
+ * <p>One SELECT for the page rows + one SELECT COUNT for the total. The
+ * EXISTS subqueries use the index-supported {@code (user_id, ref_type,
+ * ref_id)} predicate path, so they stay cheap even on a large ledger.
+ */
+@RequiredArgsConstructor
+public class LedgerCollapsedRepositoryImpl implements LedgerCollapsedRepository {
+
+    private final EntityManager em;
+
+    @Override
+    public Page<LedgerRow> findCollapsedForUser(
+            Long userId, LedgerFilter filter, Pageable pageable) {
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<Tuple> q = cb.createTupleQuery();
+        Root<UserLedgerEntry> root = q.from(UserLedgerEntry.class);
+
+        Expression<String> statusExpr = buildStatusExpression(cb, q, root);
+        q.multiselect(root.alias("entry"), statusExpr.alias("status"))
+                .where(buildPredicates(cb, root, userId, filter))
+                .orderBy(cb.desc(root.get("createdAt")));
+
+        TypedQuery<Tuple> tq = em.createQuery(q);
+        tq.setFirstResult((int) pageable.getOffset());
+        tq.setMaxResults(pageable.getPageSize());
+
+        // getResultList materializes the page eagerly; safe to use outside
+        // a long-lived session. Stream-then-collect would close the JDBC
+        // ResultSet between rows when no transaction is active.
+        List<LedgerRow> rows = tq.getResultList().stream()
+                .map(LedgerCollapsedRepositoryImpl::tupleToRow)
+                .toList();
+
+        long total = countMatching(cb, userId, filter);
+        return new PageImpl<>(rows, pageable, total);
+    }
+
+    @Override
+    public Stream<LedgerRow> streamCollapsedForUser(Long userId, LedgerFilter filter) {
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<Tuple> q = cb.createTupleQuery();
+        Root<UserLedgerEntry> root = q.from(UserLedgerEntry.class);
+
+        Expression<String> statusExpr = buildStatusExpression(cb, q, root);
+        q.multiselect(root.alias("entry"), statusExpr.alias("status"))
+                .where(buildPredicates(cb, root, userId, filter))
+                .orderBy(cb.desc(root.get("createdAt")));
+
+        return em.createQuery(q).getResultStream()
+                .map(LedgerCollapsedRepositoryImpl::tupleToRow);
+    }
+
+    private long countMatching(CriteriaBuilder cb, Long userId, LedgerFilter filter) {
+        CriteriaQuery<Long> cq = cb.createQuery(Long.class);
+        Root<UserLedgerEntry> cRoot = cq.from(UserLedgerEntry.class);
+        cq.select(cb.count(cRoot))
+                .where(buildPredicates(cb, cRoot, userId, filter));
+        return em.createQuery(cq).getSingleResult();
+    }
+
+    /**
+     * Predicate set shared by the page query, the streaming query, and the
+     * count query. Always scopes to the given userId, always excludes the
+     * two terminal withdrawal entry types, then applies the user filter.
+     */
+    private Predicate[] buildPredicates(
+            CriteriaBuilder cb, Root<UserLedgerEntry> root,
+            Long userId, LedgerFilter filter) {
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(cb.equal(root.get("userId"), userId));
+        // Hide the terminal rows — the WITHDRAW_QUEUED row is the canonical
+        // user-facing row; status is computed via the EXISTS subqueries.
+        predicates.add(cb.not(root.get("entryType").in(
+                UserLedgerEntryType.WITHDRAW_COMPLETED,
+                UserLedgerEntryType.WITHDRAW_REVERSED)));
+        if (filter != null) {
+            if (filter.entryTypes() != null && !filter.entryTypes().isEmpty()) {
+                predicates.add(root.get("entryType").in(filter.entryTypes()));
+            }
+            if (filter.from() != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("createdAt"), filter.from()));
+            }
+            if (filter.to() != null) {
+                predicates.add(cb.lessThan(root.get("createdAt"), filter.to()));
+            }
+            if (filter.amountMin() != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("amount"), filter.amountMin()));
+            }
+            if (filter.amountMax() != null) {
+                predicates.add(cb.lessThanOrEqualTo(root.get("amount"), filter.amountMax()));
+            }
+        }
+        return predicates.toArray(new Predicate[0]);
+    }
+
+    /**
+     * Builds the {@code CASE WHEN ... ELSE NULL END} expression yielding
+     * one of {@code "COMPLETED"}, {@code "REVERSED"}, {@code "PENDING"}
+     * for {@code WITHDRAW_QUEUED} rows, and SQL NULL for any other entry
+     * type.
+     */
+    private Expression<String> buildStatusExpression(
+            CriteriaBuilder cb, CriteriaQuery<?> q, Root<UserLedgerEntry> root) {
+        Subquery<Long> hasCompleted = existsSibling(cb, q, root, UserLedgerEntryType.WITHDRAW_COMPLETED);
+        Subquery<Long> hasReversed = existsSibling(cb, q, root, UserLedgerEntryType.WITHDRAW_REVERSED);
+        return cb.<String>selectCase()
+                .when(cb.notEqual(root.get("entryType"), UserLedgerEntryType.WITHDRAW_QUEUED),
+                        cb.<String>nullLiteral(String.class))
+                .when(cb.exists(hasCompleted), WithdrawalStatus.COMPLETED.name())
+                .when(cb.exists(hasReversed), WithdrawalStatus.REVERSED.name())
+                .otherwise(WithdrawalStatus.PENDING.name());
+    }
+
+    /**
+     * Subquery: a sibling row exists with the given terminal entry type
+     * and {@code refType='USER_LEDGER', refId=q.id}.
+     */
+    private Subquery<Long> existsSibling(
+            CriteriaBuilder cb, CriteriaQuery<?> q,
+            Root<UserLedgerEntry> queuedRoot, UserLedgerEntryType siblingType) {
+        Subquery<Long> sub = q.subquery(Long.class);
+        Root<UserLedgerEntry> sib = sub.from(UserLedgerEntry.class);
+        sub.select(cb.literal(1L))
+                .where(cb.and(
+                        cb.equal(sib.get("userId"), queuedRoot.get("userId")),
+                        cb.equal(sib.get("refType"), "USER_LEDGER"),
+                        cb.equal(sib.get("refId"), queuedRoot.get("id")),
+                        cb.equal(sib.get("entryType"), siblingType)));
+        return sub;
+    }
+
+    private static LedgerRow tupleToRow(Tuple t) {
+        UserLedgerEntry entry = t.get("entry", UserLedgerEntry.class);
+        String status = t.get("status", String.class);
+        return new LedgerRow(entry,
+                status == null ? null : WithdrawalStatus.valueOf(status));
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/me/LedgerCsvWriter.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/me/LedgerCsvWriter.java
@@ -8,30 +8,36 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
+import com.slparcelauctions.backend.wallet.LedgerRow;
 import com.slparcelauctions.backend.wallet.UserLedgerEntry;
 
 /**
- * Writes a stream of {@link UserLedgerEntry} rows to an OutputStream as
+ * Writes a stream of {@link LedgerRow} rows to an OutputStream as
  * RFC 4180 CSV. Used by the streaming export endpoint so multi-thousand-row
  * downloads don't hold the whole result in memory.
+ *
+ * <p>The {@code withdrawal_status} column is populated only for
+ * {@code WITHDRAW_QUEUED} rows; empty for every other entry type. Mirrors
+ * the user-facing wallet view, so a CSV export reflects what the user
+ * actually saw on screen.
  */
 public final class LedgerCsvWriter {
 
     private static final String HEADER =
             "id,created_at,entry_type,amount,balance_after,reserved_after,"
-                    + "ref_type,ref_id,description,sl_transaction_id";
+                    + "ref_type,ref_id,description,sl_transaction_id,withdrawal_status";
 
     private LedgerCsvWriter() {}
 
-    public static void write(Stream<UserLedgerEntry> rows, OutputStream out)
+    public static void write(Stream<LedgerRow> rows, OutputStream out)
             throws IOException {
         try (BufferedWriter w = new BufferedWriter(
                 new OutputStreamWriter(out, StandardCharsets.UTF_8))) {
             w.write(HEADER);
             w.write('\n');
-            rows.forEach(e -> {
+            rows.forEach(row -> {
                 try {
-                    w.write(toCsvLine(e));
+                    w.write(toCsvLine(row));
                     w.write('\n');
                 } catch (IOException ioe) {
                     throw new UncheckedIOException(ioe);
@@ -40,7 +46,8 @@ public final class LedgerCsvWriter {
         }
     }
 
-    private static String toCsvLine(UserLedgerEntry e) {
+    private static String toCsvLine(LedgerRow row) {
+        UserLedgerEntry e = row.entry();
         return e.getId() + ","
                 + escape(e.getCreatedAt().toString()) + ","
                 + e.getEntryType().name() + ","
@@ -50,7 +57,8 @@ public final class LedgerCsvWriter {
                 + escape(e.getRefType()) + ","
                 + (e.getRefId() == null ? "" : e.getRefId()) + ","
                 + escape(e.getDescription()) + ","
-                + escape(e.getSlTransactionId());
+                + escape(e.getSlTransactionId()) + ","
+                + (row.withdrawalStatus() == null ? "" : row.withdrawalStatus().name());
     }
 
     private static String escape(String s) {

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/me/LedgerStreamingService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/me/LedgerStreamingService.java
@@ -5,38 +5,30 @@ import java.util.stream.Stream;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.slparcelauctions.backend.wallet.UserLedgerEntry;
-
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Root;
+import com.slparcelauctions.backend.wallet.LedgerRow;
+import com.slparcelauctions.backend.wallet.UserLedgerRepository;
 
 import lombok.RequiredArgsConstructor;
 
 /**
- * Streams matching ledger entries for the given user + filter. Caller MUST
+ * Streams collapsed ledger rows for the given user + filter. Caller MUST
  * close the stream (try-with-resources) and MUST hold an active read-only
- * transaction. Sorted DESC by created_at.
+ * transaction. Sorted DESC by {@code created_at}.
  *
  * <p>Used by the CSV export endpoint so multi-thousand-row downloads don't
- * hold the full result set in memory.
+ * hold the full result set in memory. Delegates to
+ * {@link UserLedgerRepository#streamCollapsedForUser} so the streaming and
+ * paginated paths share one query shape — same WHERE, same status CASE
+ * EXPR, same row projection.
  */
 @Service
 @RequiredArgsConstructor
 public class LedgerStreamingService {
 
-    private final EntityManager em;
+    private final UserLedgerRepository ledgerRepository;
 
     @Transactional(readOnly = true)
-    public Stream<UserLedgerEntry> streamFiltered(Long userId, LedgerFilter filter) {
-        CriteriaBuilder cb = em.getCriteriaBuilder();
-        CriteriaQuery<UserLedgerEntry> q = cb.createQuery(UserLedgerEntry.class);
-        Root<UserLedgerEntry> root = q.from(UserLedgerEntry.class);
-        q.select(root)
-                .where(LedgerSpecifications.forUser(userId, filter)
-                        .toPredicate(root, q, cb))
-                .orderBy(cb.desc(root.get("createdAt")));
-        return em.createQuery(q).getResultStream();
+    public Stream<LedgerRow> streamFiltered(Long userId, LedgerFilter filter) {
+        return ledgerRepository.streamCollapsedForUser(userId, filter);
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/me/MeWalletController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/me/MeWalletController.java
@@ -36,7 +36,7 @@ import com.slparcelauctions.backend.auth.AuthPrincipal;
 import com.slparcelauctions.backend.common.PagedResponse;
 import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.user.UserRepository;
-import com.slparcelauctions.backend.wallet.UserLedgerEntry;
+import com.slparcelauctions.backend.wallet.LedgerRow;
 import com.slparcelauctions.backend.wallet.UserLedgerRepository;
 import com.slparcelauctions.backend.wallet.WalletService;
 import com.slparcelauctions.backend.wallet.exception.PenaltyOutstandingException;
@@ -79,7 +79,15 @@ public class MeWalletController {
     @Transactional(readOnly = true)
     public WalletViewResponse view(@AuthenticationPrincipal AuthPrincipal principal) {
         User user = userRepository.findById(principal.userId()).orElseThrow();
-        List<UserLedgerEntry> recent = ledgerRepository.findTop50ByUserIdOrderByCreatedAtDesc(principal.userId());
+        // Recent activity uses the collapsed view: WITHDRAW_COMPLETED /
+        // WITHDRAW_REVERSED rows are filtered out, and the surviving
+        // WITHDRAW_QUEUED rows carry a {@link WithdrawalStatus} computed
+        // in the same query so the UI can render a single Withdrawal row
+        // that flips state in place.
+        Pageable recentPage = PageRequest.of(0, 50,
+                Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<LedgerRow> recent = ledgerRepository.findCollapsedForUser(
+                principal.userId(), null, recentPage);
         long queuedForWithdrawal = ledgerRepository.sumPendingWithdrawals(principal.userId());
         return new WalletViewResponse(
                 user.getBalanceLindens(),
@@ -90,11 +98,12 @@ public class MeWalletController {
                 user.getWalletTermsAcceptedAt() != null,
                 user.getWalletTermsVersion(),
                 user.getWalletTermsAcceptedAt(),
-                recent.stream().map(MeWalletController::toDto).toList()
+                recent.getContent().stream().map(MeWalletController::toDto).toList()
         );
     }
 
-    private static WalletViewResponse.LedgerEntryDto toDto(UserLedgerEntry e) {
+    private static WalletViewResponse.LedgerEntryDto toDto(LedgerRow row) {
+        var e = row.entry();
         return new WalletViewResponse.LedgerEntryDto(
                 e.getId(),
                 e.getEntryType().name(),
@@ -104,7 +113,8 @@ public class MeWalletController {
                 e.getRefType(),
                 e.getRefId(),
                 e.getDescription(),
-                e.getCreatedAt()
+                e.getCreatedAt(),
+                row.withdrawalStatus()
         );
     }
 
@@ -122,8 +132,8 @@ public class MeWalletController {
         int pageSize = Math.min(Math.max(size, 1), MAX_LEDGER_PAGE_SIZE);
         int clampedPage = Math.max(page, 0);
         Pageable p = PageRequest.of(clampedPage, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<UserLedgerEntry> result = ledgerRepository.findAll(
-                LedgerSpecifications.forUser(principal.userId(), params.toFilter()), p);
+        Page<LedgerRow> result = ledgerRepository.findCollapsedForUser(
+                principal.userId(), params.toFilter(), p);
         return PagedResponse.from(result.map(MeWalletController::toDto));
     }
 
@@ -142,7 +152,7 @@ public class MeWalletController {
         String filename = "slpa-wallet-ledger-" + principal.userId() + "-"
                 + OffsetDateTime.now(clock).format(DateTimeFormatter.BASIC_ISO_DATE) + ".csv";
         StreamingResponseBody body = out -> {
-            try (Stream<UserLedgerEntry> rows =
+            try (Stream<LedgerRow> rows =
                     ledgerStreamingService.streamFiltered(principal.userId(), filter)) {
                 LedgerCsvWriter.write(rows, out);
             }

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/me/WalletViewResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/me/WalletViewResponse.java
@@ -3,6 +3,8 @@ package com.slparcelauctions.backend.wallet.me;
 import java.time.OffsetDateTime;
 import java.util.List;
 
+import com.slparcelauctions.backend.wallet.WithdrawalStatus;
+
 /**
  * GET /api/v1/me/wallet response. Surfaces the user's wallet state +
  * recent ledger activity for the dashboard wallet panel.
@@ -28,6 +30,7 @@ public record WalletViewResponse(
             String refType,
             Long refId,
             String description,
-            OffsetDateTime createdAt
+            OffsetDateTime createdAt,
+            WithdrawalStatus withdrawalStatus
     ) { }
 }

--- a/backend/src/test/java/com/slparcelauctions/backend/wallet/me/LedgerCollapsedRepositoryTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/wallet/me/LedgerCollapsedRepositoryTest.java
@@ -1,0 +1,166 @@
+package com.slparcelauctions.backend.wallet.me;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import com.slparcelauctions.backend.wallet.LedgerRow;
+import com.slparcelauctions.backend.wallet.UserLedgerEntry;
+import com.slparcelauctions.backend.wallet.UserLedgerEntryType;
+import com.slparcelauctions.backend.wallet.UserLedgerRepository;
+import com.slparcelauctions.backend.wallet.WithdrawalStatus;
+
+/**
+ * Integration coverage for the collapsed-ledger SQL: ensures
+ * {@code WITHDRAW_COMPLETED} / {@code WITHDRAW_REVERSED} rows are filtered
+ * out of results, and that surviving {@code WITHDRAW_QUEUED} rows carry
+ * the correct {@link WithdrawalStatus} computed from the EXISTS subqueries.
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class LedgerCollapsedRepositoryTest {
+
+    @Autowired UserLedgerRepository ledgerRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired TransactionTemplate txTemplate;
+
+    Clock clock = Clock.fixed(Instant.parse("2026-05-01T20:00:00Z"), ZoneOffset.UTC);
+
+    @Test
+    void collapsedQuery_excludesTerminalRowsAndStampsStatus() {
+        User user = newUser();
+
+        // 1. DEPOSIT (non-withdraw, status should be null).
+        appendDeposit(user, 1000L);
+        // 2. WITHDRAW_QUEUED with no terminal sibling — PENDING.
+        UserLedgerEntry pending = appendWithdrawQueued(user, 100L);
+        // 3. WITHDRAW_QUEUED + COMPLETED — collapsed to single COMPLETED row.
+        UserLedgerEntry doneQueued = appendWithdrawQueued(user, 200L);
+        appendWithdrawTerminal(user, doneQueued.getId(),
+                UserLedgerEntryType.WITHDRAW_COMPLETED);
+        // 4. WITHDRAW_QUEUED + REVERSED — collapsed to single REVERSED row.
+        UserLedgerEntry badQueued = appendWithdrawQueued(user, 300L);
+        appendWithdrawTerminal(user, badQueued.getId(),
+                UserLedgerEntryType.WITHDRAW_REVERSED);
+
+        Page<LedgerRow> page = ledgerRepo.findCollapsedForUser(user.getId(), null,
+                PageRequest.of(0, 25, Sort.by(Sort.Direction.DESC, "createdAt")));
+
+        // 4 underlying queued/deposit rows visible; 2 terminal rows hidden.
+        assertThat(page.getTotalElements()).isEqualTo(4L);
+        assertThat(page.getContent()).hasSize(4);
+
+        // Content: deposit (status null) + 3 queued rows with statuses.
+        assertThat(page.getContent())
+                .extracting(LedgerRow::withdrawalStatus)
+                .containsExactlyInAnyOrder(
+                        null,
+                        WithdrawalStatus.PENDING,
+                        WithdrawalStatus.COMPLETED,
+                        WithdrawalStatus.REVERSED);
+
+        // No terminal rows leak through.
+        assertThat(page.getContent())
+                .extracting(r -> r.entry().getEntryType())
+                .doesNotContain(
+                        UserLedgerEntryType.WITHDRAW_COMPLETED,
+                        UserLedgerEntryType.WITHDRAW_REVERSED);
+
+        // The pending row's status is PENDING (only verifying by the
+        // entry id since order is timestamp-driven).
+        LedgerRow pendingRow = page.getContent().stream()
+                .filter(r -> r.entry().getId().equals(pending.getId()))
+                .findFirst().orElseThrow();
+        assertThat(pendingRow.withdrawalStatus()).isEqualTo(WithdrawalStatus.PENDING);
+    }
+
+    @Test
+    void streamCollapsed_returnsSameShapeAsPaginated() {
+        User user = newUser();
+        appendDeposit(user, 500L);
+        UserLedgerEntry queued = appendWithdrawQueued(user, 50L);
+        appendWithdrawTerminal(user, queued.getId(),
+                UserLedgerEntryType.WITHDRAW_COMPLETED);
+
+        // Streaming requires an active read-only transaction so the JDBC
+        // cursor stays open across the consume.
+        var rows = txTemplate.execute(s -> {
+            try (var stream = ledgerRepo.streamCollapsedForUser(user.getId(), null)) {
+                return stream.toList();
+            }
+        });
+        assertThat(rows).hasSize(2);
+        assertThat(rows)
+                .extracting(LedgerRow::withdrawalStatus)
+                .containsExactlyInAnyOrder(null, WithdrawalStatus.COMPLETED);
+    }
+
+    private User newUser() {
+        return userRepo.save(User.builder()
+                .email("ledger-collapsed-" + UUID.randomUUID() + "@example.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .verified(true)
+                .balanceLindens(0L)
+                .reservedLindens(0L)
+                .penaltyBalanceOwed(0L)
+                .createdAt(OffsetDateTime.now(clock))
+                .build());
+    }
+
+    private UserLedgerEntry appendDeposit(User user, long amount) {
+        return ledgerRepo.save(UserLedgerEntry.builder()
+                .userId(user.getId())
+                .entryType(UserLedgerEntryType.DEPOSIT)
+                .amount(amount)
+                .balanceAfter(amount)
+                .reservedAfter(0L)
+                .slTransactionId(UUID.randomUUID().toString())
+                .createdAt(OffsetDateTime.now(clock).plusSeconds(0))
+                .build());
+    }
+
+    private UserLedgerEntry appendWithdrawQueued(User user, long amount) {
+        return ledgerRepo.save(UserLedgerEntry.builder()
+                .userId(user.getId())
+                .entryType(UserLedgerEntryType.WITHDRAW_QUEUED)
+                .amount(amount)
+                .balanceAfter(0L)
+                .reservedAfter(0L)
+                .idempotencyKey(UUID.randomUUID().toString())
+                .createdAt(OffsetDateTime.now(clock))
+                .build());
+    }
+
+    private UserLedgerEntry appendWithdrawTerminal(
+            User user, Long queuedId, UserLedgerEntryType type) {
+        UserLedgerEntry queuedRow = ledgerRepo.findById(queuedId).orElseThrow();
+        return ledgerRepo.save(UserLedgerEntry.builder()
+                .userId(user.getId())
+                .entryType(type)
+                .amount(queuedRow.getAmount())
+                .balanceAfter(0L)
+                .reservedAfter(0L)
+                .refType("USER_LEDGER")
+                .refId(queuedId)
+                .createdAt(OffsetDateTime.now(clock).plusSeconds(30))
+                .build());
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/wallet/me/LedgerCsvWriterTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/wallet/me/LedgerCsvWriterTest.java
@@ -10,8 +10,10 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
+import com.slparcelauctions.backend.wallet.LedgerRow;
 import com.slparcelauctions.backend.wallet.UserLedgerEntry;
 import com.slparcelauctions.backend.wallet.UserLedgerEntryType;
+import com.slparcelauctions.backend.wallet.WithdrawalStatus;
 
 /**
  * Unit-level coverage for {@link LedgerCsvWriter}. Asserts the header line,
@@ -22,7 +24,7 @@ class LedgerCsvWriterTest {
 
     private static final String EXPECTED_HEADER =
             "id,created_at,entry_type,amount,balance_after,reserved_after,"
-                    + "ref_type,ref_id,description,sl_transaction_id";
+                    + "ref_type,ref_id,description,sl_transaction_id,withdrawal_status";
 
     private static final OffsetDateTime FIXED_TS = OffsetDateTime.parse("2026-04-30T12:00:00Z");
 
@@ -41,7 +43,15 @@ class LedgerCsvWriterTest {
                 .createdAt(FIXED_TS);
     }
 
-    private static String run(Stream<UserLedgerEntry> rows) throws IOException {
+    private static LedgerRow row(UserLedgerEntry e) {
+        return new LedgerRow(e, null);
+    }
+
+    private static LedgerRow row(UserLedgerEntry e, WithdrawalStatus status) {
+        return new LedgerRow(e, status);
+    }
+
+    private static String run(Stream<LedgerRow> rows) throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         LedgerCsvWriter.write(rows, out);
         return out.toString(StandardCharsets.UTF_8);
@@ -55,7 +65,7 @@ class LedgerCsvWriterTest {
 
     @Test
     void headerRowMatchesExpected() throws Exception {
-        String csv = run(Stream.of(baseBuilder().build()));
+        String csv = run(Stream.of(row(baseBuilder().build())));
         String[] lines = csv.split("\n", -1);
         assertThat(lines[0]).isEqualTo(EXPECTED_HEADER);
     }
@@ -67,12 +77,12 @@ class LedgerCsvWriterTest {
                 .refType("AUCTION")
                 .slTransactionId("tx-001")
                 .build();
-        String csv = run(Stream.of(e));
+        String csv = run(Stream.of(row(e)));
         String dataLine = csv.split("\n", -1)[1];
         // No double-quotes anywhere in the data row.
         assertThat(dataLine).doesNotContain("\"");
         assertThat(dataLine).isEqualTo(
-                "1,2026-04-30T12:00Z,DEPOSIT,100,100,0,AUCTION,7,simpleAscii,tx-001");
+                "1,2026-04-30T12:00Z,DEPOSIT,100,100,0,AUCTION,7,simpleAscii,tx-001,");
     }
 
     @Test
@@ -80,7 +90,7 @@ class LedgerCsvWriterTest {
         UserLedgerEntry e = baseBuilder()
                 .description("hello, world")
                 .build();
-        String csv = run(Stream.of(e));
+        String csv = run(Stream.of(row(e)));
         String dataLine = csv.split("\n", -1)[1];
         assertThat(dataLine).contains(",\"hello, world\",");
     }
@@ -90,7 +100,7 @@ class LedgerCsvWriterTest {
         UserLedgerEntry e = baseBuilder()
                 .description("she said \"hi\"")
                 .build();
-        String csv = run(Stream.of(e));
+        String csv = run(Stream.of(row(e)));
         String dataLine = csv.split("\n", -1)[1];
         // " becomes "" and the whole field is wrapped in quotes.
         assertThat(dataLine).contains(",\"she said \"\"hi\"\"\",");
@@ -101,7 +111,7 @@ class LedgerCsvWriterTest {
         UserLedgerEntry e = baseBuilder()
                 .description("line1\nline2")
                 .build();
-        String csv = run(Stream.of(e));
+        String csv = run(Stream.of(row(e)));
         // Header + (data line containing literal newline + trailing newline).
         // We check the raw bytes around the description field rather than splitting on \n.
         assertThat(csv).contains(",\"line1\nline2\",");
@@ -112,7 +122,7 @@ class LedgerCsvWriterTest {
         UserLedgerEntry e = baseBuilder()
                 .description("line1\rline2")
                 .build();
-        String csv = run(Stream.of(e));
+        String csv = run(Stream.of(row(e)));
         assertThat(csv).contains(",\"line1\rline2\",");
     }
 
@@ -124,18 +134,38 @@ class LedgerCsvWriterTest {
                 .slTransactionId(null)
                 .refType(null)
                 .build();
-        String csv = run(Stream.of(e));
+        String csv = run(Stream.of(row(e)));
         String dataLine = csv.split("\n", -1)[1];
         // refType,ref_id,description,sl_transaction_id should all be empty.
         // Format: id,created_at,entry_type,amount,balance_after,reserved_after,ref_type,ref_id,description,sl_transaction_id
-        assertThat(dataLine).isEqualTo("1,2026-04-30T12:00Z,DEPOSIT,100,100,0,,,,");
+        assertThat(dataLine).isEqualTo("1,2026-04-30T12:00Z,DEPOSIT,100,100,0,,,,,");
+    }
+
+    @Test
+    void withdrawalStatusColumn_populatedForWithdrawQueuedRow() throws Exception {
+        UserLedgerEntry e = baseBuilder()
+                .id(99L)
+                .entryType(UserLedgerEntryType.WITHDRAW_QUEUED)
+                .description("withdraw")
+                .build();
+        String csv = run(Stream.of(row(e, WithdrawalStatus.COMPLETED)));
+        String dataLine = csv.split("\n", -1)[1];
+        assertThat(dataLine).endsWith(",COMPLETED");
+    }
+
+    @Test
+    void withdrawalStatusColumn_emptyForNonWithdrawalRow() throws Exception {
+        UserLedgerEntry e = baseBuilder().build();
+        String csv = run(Stream.of(row(e)));
+        String dataLine = csv.split("\n", -1)[1];
+        assertThat(dataLine).endsWith(",");
     }
 
     @Test
     void multipleRows_eachOnItsOwnLine() throws Exception {
         UserLedgerEntry a = baseBuilder().id(1L).description("first").build();
         UserLedgerEntry b = baseBuilder().id(2L).description("second").build();
-        String csv = run(Stream.of(a, b));
+        String csv = run(Stream.of(row(a), row(b)));
         String[] lines = csv.split("\n", -1);
         // header, row1, row2, trailing empty (because final \n).
         assertThat(lines).hasSize(4);

--- a/frontend/src/components/wallet/LedgerFilterBar.tsx
+++ b/frontend/src/components/wallet/LedgerFilterBar.tsx
@@ -8,14 +8,15 @@ import type { LedgerFilter, UserLedgerEntryType } from "@/types/wallet";
 
 /**
  * Subset of {@link UserLedgerEntryType} surfaced as quick-filter chips.
- * The full set is twelve entries — listing every one would crowd the bar
- * and most are infrequent (e.g. {@code WITHDRAW_REVERSED}, {@code
- * ADJUSTMENT}). The remaining types remain server-side queryable but the
- * UI only exposes these nine common ones, matching spec §6.2.
+ *
+ * The "Withdrawal" chip filters by {@code WITHDRAW_QUEUED} only — the
+ * collapsed-view backend hides {@code WITHDRAW_COMPLETED} and
+ * {@code WITHDRAW_REVERSED} rows entirely; one chip covers the full
+ * withdrawal lifecycle.
  */
 const CHIP_TYPES: { type: UserLedgerEntryType; label: string }[] = [
   { type: "DEPOSIT", label: "Deposit" },
-  { type: "WITHDRAW_QUEUED", label: "Withdraw" },
+  { type: "WITHDRAW_QUEUED", label: "Withdrawal" },
   { type: "BID_RESERVED", label: "Bid reserved" },
   { type: "BID_RELEASED", label: "Bid released" },
   { type: "ESCROW_DEBIT", label: "Escrow funded" },

--- a/frontend/src/components/wallet/LedgerTable.tsx
+++ b/frontend/src/components/wallet/LedgerTable.tsx
@@ -15,18 +15,35 @@ import {
 } from "@/components/ui/icons";
 import { cn } from "@/lib/cn";
 import { formatRelativeTime } from "@/lib/time/relativeTime";
-import type { LedgerEntry } from "@/types/wallet";
+import type { LedgerEntry, WithdrawalStatus } from "@/types/wallet";
 
 function formatLindens(amount: number): string {
   return `L$${amount.toLocaleString()}`;
 }
 
-function entryTypeLabel(t: LedgerEntry["entryType"]): string {
-  switch (t) {
+/**
+ * Label for a ledger row. WITHDRAW_QUEUED is special-cased so the user
+ * sees a single "Withdrawal" row that flips state in place: the
+ * (Pending) suffix appears while the dispatcher / in-world transfer is
+ * still in flight; once a paired completion / reversal lands the
+ * collapsed-view backend stamps the status and this label drops the
+ * suffix (or shows "Reversed" for the rare reversal case).
+ */
+function entryTypeLabel(e: LedgerEntry): string {
+  switch (e.entryType) {
     case "DEPOSIT": return "Deposit";
-    case "WITHDRAW_QUEUED": return "Withdraw queued";
-    case "WITHDRAW_COMPLETED": return "Withdraw completed";
-    case "WITHDRAW_REVERSED": return "Withdraw reversed";
+    case "WITHDRAW_QUEUED": {
+      switch (e.withdrawalStatus) {
+        case "COMPLETED": return "Withdrawal";
+        case "REVERSED": return "Withdrawal (Reversed)";
+        case "PENDING":
+        default: return "Withdrawal (Pending)";
+      }
+    }
+    // Defensive — the backend filters these out of /me/wallet/ledger,
+    // but historical responses or admin views might still contain them.
+    case "WITHDRAW_COMPLETED": return "Withdrawal";
+    case "WITHDRAW_REVERSED": return "Withdrawal (Reversed)";
     case "BID_RESERVED": return "Bid reserved";
     case "BID_RELEASED": return "Bid released";
     case "ESCROW_DEBIT": return "Escrow funded";
@@ -43,23 +60,35 @@ type EntryVisual = {
   tone: string;
 };
 
+const WITHDRAW_PENDING_VISUAL: EntryVisual = { Icon: Clock, tone: "text-warning" };
+const WITHDRAW_COMPLETED_VISUAL: EntryVisual = { Icon: ArrowUpFromLine, tone: "text-success" };
+const WITHDRAW_REVERSED_VISUAL: EntryVisual = { Icon: Undo2, tone: "text-error" };
+
+function withdrawalVisual(status: WithdrawalStatus | null): EntryVisual {
+  switch (status) {
+    case "COMPLETED": return WITHDRAW_COMPLETED_VISUAL;
+    case "REVERSED":  return WITHDRAW_REVERSED_VISUAL;
+    case "PENDING":
+    default:          return WITHDRAW_PENDING_VISUAL;
+  }
+}
+
 /**
- * Maps ledger entry types to a lucide icon + a Material-3 colour token
- * pair. Inflows (deposit / refund) use {@code text-success}; outflows that
- * are user-initiated and final use the neutral {@code text-on-surface};
- * "in-progress" or warning-tinted entries (queued withdraw, reserved bid,
- * penalty) use {@code text-warning}.
+ * Maps ledger entries to a lucide icon + a Material-3 colour token. The
+ * single "Withdrawal" row is colour-coded by `withdrawalStatus`:
+ * yellow Clock while pending, green ArrowUpFromLine when completed,
+ * red Undo2 if reversed.
  */
-function entryVisual(t: LedgerEntry["entryType"]): EntryVisual {
-  switch (t) {
+function entryVisual(e: LedgerEntry): EntryVisual {
+  switch (e.entryType) {
     case "DEPOSIT":
       return { Icon: ArrowDownToLine, tone: "text-success" };
     case "WITHDRAW_QUEUED":
-      return { Icon: Clock, tone: "text-on-surface-variant" };
+      return withdrawalVisual(e.withdrawalStatus);
     case "WITHDRAW_COMPLETED":
-      return { Icon: ArrowUpFromLine, tone: "text-on-surface" };
+      return WITHDRAW_COMPLETED_VISUAL;
     case "WITHDRAW_REVERSED":
-      return { Icon: Undo2, tone: "text-warning" };
+      return WITHDRAW_REVERSED_VISUAL;
     case "BID_RESERVED":
       return { Icon: Lock, tone: "text-warning" };
     case "BID_RELEASED":
@@ -143,7 +172,7 @@ export function LedgerTable({ entries, isLoading = false }: LedgerTableProps) {
   return (
     <ul className="text-sm">
       {entries.map((e) => {
-        const { Icon, tone } = entryVisual(e.entryType);
+        const { Icon, tone } = entryVisual(e);
         return (
           <li
             key={e.id}
@@ -160,7 +189,7 @@ export function LedgerTable({ entries, isLoading = false }: LedgerTableProps) {
               />
               <div className="min-w-0">
                 <div className="font-medium text-on-surface truncate">
-                  {entryTypeLabel(e.entryType)}
+                  {entryTypeLabel(e)}
                 </div>
                 <div
                   className="text-xs text-on-surface-variant"

--- a/frontend/src/components/wallet/WalletPanel.tsx
+++ b/frontend/src/components/wallet/WalletPanel.tsx
@@ -36,8 +36,9 @@ function genIdempotencyKey(): string {
 const LEDGER_ENTRY_TYPES: UserLedgerEntryType[] = [
   "DEPOSIT",
   "WITHDRAW_QUEUED",
-  "WITHDRAW_COMPLETED",
-  "WITHDRAW_REVERSED",
+  // WITHDRAW_COMPLETED / WITHDRAW_REVERSED removed: the collapsed-view
+  // backend hides those rows; surfacing them as filter chips would be
+  // dead state.
   "BID_RESERVED",
   "BID_RELEASED",
   "ESCROW_DEBIT",

--- a/frontend/src/lib/wallet/use-wallet-ws.ts
+++ b/frontend/src/lib/wallet/use-wallet-ws.ts
@@ -60,6 +60,7 @@ export function useWalletWsSubscription(enabled: boolean): void {
   useStompSubscription<WalletBalanceChangedEnvelope>(
     enabled ? "/user/queue/wallet" : "",
     (env) => {
+      // Optimistic patch — keeps the balance snappy.
       qc.setQueryData<WalletView>(walletQueryKey, (prev) => {
         if (!prev) return prev;
         return {
@@ -71,7 +72,14 @@ export function useWalletWsSubscription(enabled: boolean): void {
           queuedForWithdrawal: env.queuedForWithdrawal,
         };
       });
-      qc.invalidateQueries({ queryKey: ["me", "wallet", "ledger"] });
+      // Invalidate the ENTIRE wallet subtree — both the wallet view (so
+      // recentLedger refreshes) and every paginated ledger query
+      // (`["me", "wallet", "ledger", filter, page, size]`). The narrower
+      // `["me", "wallet", "ledger"]` predicate was failing to refetch the
+      // active ledger observer in production, leaving the activity table
+      // stale even though balance updated. The wider prefix is a strict
+      // superset and matches by definition.
+      qc.invalidateQueries({ queryKey: ["me", "wallet"] });
     },
   );
 }

--- a/frontend/src/types/wallet.ts
+++ b/frontend/src/types/wallet.ts
@@ -4,6 +4,13 @@
  * Append-only ledger entry types. Mirror of the backend
  * `UserLedgerEntryType`. Direction (debit vs credit) is implicit in the
  * type — the entry's `amount` is always positive.
+ *
+ * `WITHDRAW_COMPLETED` and `WITHDRAW_REVERSED` exist on the backend for
+ * audit but are filtered out of `/api/v1/me/wallet/ledger` responses —
+ * the user-facing collapsed view returns one row per logical withdrawal
+ * (the originating `WITHDRAW_QUEUED`) decorated with `withdrawalStatus`.
+ * Keep them in the union so historical clients / tests don't break, but
+ * production responses won't carry them.
  */
 export type UserLedgerEntryType =
   | "DEPOSIT"
@@ -19,6 +26,12 @@ export type UserLedgerEntryType =
   | "PENALTY_DEBIT"
   | "ADJUSTMENT";
 
+/**
+ * Status of a `WITHDRAW_QUEUED` row in the collapsed ledger view. Non-null
+ * only on `WITHDRAW_QUEUED` entries; null for every other entry type.
+ */
+export type WithdrawalStatus = "PENDING" | "COMPLETED" | "REVERSED";
+
 export interface LedgerEntry {
   id: number;
   entryType: UserLedgerEntryType;
@@ -29,6 +42,7 @@ export interface LedgerEntry {
   refId: number | null;
   description: string | null;
   createdAt: string;
+  withdrawalStatus: WithdrawalStatus | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Two coupled UX fixes for the wallet activity surface.

### 1. Single \"Withdrawal\" row with status (no more Queued/Completed pair)

Backend ledger stays append-only — three rows still get written per logical withdrawal. The user-facing read path collapses on the way out: a new \`LedgerCollapsedRepository\` fragment runs one Criteria query that excludes \`WITHDRAW_COMPLETED\` and \`WITHDRAW_REVERSED\` rows, and decorates each surviving \`WITHDRAW_QUEUED\` with a \`WithdrawalStatus\` (\`PENDING\` / \`COMPLETED\` / \`REVERSED\`) computed via EXISTS subqueries.

Frontend: one \"Withdrawal\" row whose icon + label flip in place:
- **PENDING**: yellow Clock, \`Withdrawal (Pending)\`
- **COMPLETED**: green ArrowUpFromLine, \`Withdrawal\`
- **REVERSED**: red Undo2, \`Withdrawal (Reversed)\`

Filter chips: the COMPLETED/REVERSED chips were dead state; \"Withdrawal\" now maps to \`WITHDRAW_QUEUED\` only and covers the full lifecycle.

### 2. Activity auto-refresh on WS events

The WS hook's \`invalidateQueries({queryKey: [\"me\", \"wallet\", \"ledger\"]})\` wasn't actually refetching the active ledger observer in production — balance updated but the activity table stayed stale. Broadened the predicate to \`[\"me\", \"wallet\"]\` (strict superset, covers wallet view + every paginated ledger query). Deposits and withdrawals now repaint the activity list without a page refresh.

## Tests

- \`LedgerCollapsedRepositoryTest\` (new): EXISTS-subquery status math + streaming/paginated equivalence
- \`LedgerCsvWriterTest\`: extended for the new \`withdrawal_status\` column
- 1626/1626 backend tests pass
- 1374/1374 frontend tests pass

## Test plan after deploy

- [ ] Deposit L\$ in-world — activity table repaints with the new DEPOSIT row, no refresh needed
- [ ] Withdraw L\$ — single \"Withdrawal (Pending)\" row appears with yellow Clock
- [ ] Funds arrive in-world — same row flips to \"Withdrawal\" with green icon, no refresh
- [ ] CSV export — new \`withdrawal_status\` column populated for withdrawal rows, empty for everything else