### PR TITLE
fix(auction): unbreak Amplify build — type FlagReviewModal correctly

### DIFF
--- a/frontend/src/components/auction/FlagReviewModal.tsx
+++ b/frontend/src/components/auction/FlagReviewModal.tsx
@@ -5,9 +5,10 @@ import { Modal } from "@/components/ui/Modal";
 import { Button } from "@/components/ui/Button";
 import { Flag } from "@/components/ui/icons";
 import { flagReview } from "@/lib/api/reviews";
+import type { ReviewFlagReason } from "@/types/review";
 import { cn } from "@/lib/cn";
 
-const REASONS: Array<{ value: string; label: string; hint: string }> = [
+const REASONS: Array<{ value: ReviewFlagReason; label: string; hint: string }> = [
   {
     value: "FALSE_INFO",
     label: "Contains false information",
@@ -48,15 +49,15 @@ export function FlagReviewModal({
   reviewId,
   reviewSnippet,
 }: FlagReviewModalProps) {
-  const [reason, setReason] = useState<string | null>(null);
-  const [notes, setNotes] = useState("");
+  const [reason, setReason] = useState<ReviewFlagReason | null>(null);
+  const [elaboration, setElaboration] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const reset = () => {
     setReason(null);
-    setNotes("");
+    setElaboration("");
     setSubmitting(false);
     setSubmitted(false);
     setError(null);
@@ -68,7 +69,11 @@ export function FlagReviewModal({
     setSubmitting(true);
     setError(null);
     try {
-      await flagReview(reviewId, { reason, notes: notes.trim() || undefined });
+      const trimmed = elaboration.trim();
+      await flagReview(reviewId, {
+        reason,
+        ...(trimmed.length > 0 ? { elaboration: trimmed } : {}),
+      });
       setSubmitted(true);
     } catch (err) {
       setError(
@@ -157,8 +162,8 @@ export function FlagReviewModal({
             ))}
           </div>
           <textarea
-            value={notes}
-            onChange={(e) => setNotes(e.target.value)}
+            value={elaboration}
+            onChange={(e) => setElaboration(e.target.value)}
             placeholder="Optional context (won't be shared with the reviewer)…"
             rows={3}
             className="mt-3 w-full rounded-sm border border-border bg-surface-raised px-3 py-2 text-sm text-fg placeholder:text-fg-muted focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand"


### PR DESCRIPTION
## Summary

Hotfix for the Amplify build break on \`main\` (job 26 failed at 2026-05-02 15:33Z, prod still serves the previous build at \`a74dc1f\`).

Two typecheck errors in \`frontend/src/components/auction/FlagReviewModal.tsx\` (introduced in PR #101's redesign sweep):

1. \`REASONS\` array and \`useState<reason>\` were typed as \`string\` but \`flagReview\` expects the \`ReviewFlagReason\` union (\`"SPAM" | "ABUSIVE" | "OFF_TOPIC" | "FALSE_INFO" | "OTHER"\`).
2. The state field was named \`notes\` but \`ReviewFlagRequest\` expects \`elaboration\`. Renamed throughout and switched to the conditional-spread pattern from the older \`FlagModal.tsx\` so empty input doesn't send \`elaboration: undefined\`.

Verified locally with \`npm run build\` — typecheck passes, full Next.js production build succeeds.

## Known follow-ups (NOT in this PR)

- The redesigned modal lacks the \"elaboration required when reason=OTHER\" UX guard that \`components/reviews/FlagModal.tsx\` enforces. Backend will 422 if a user submits OTHER without elaboration. Worth a separate PR.
- No frontend CI workflow exists, which is why this slipped through. Adding one is the next planned task.

## Test plan

- [ ] Amplify build green for the eventual \`main\` merge commit
- [ ] Manual: open the FlagReviewModal on a review, submit with reason set, verify request body has \`elaboration\` field and POST succeeds