### PR TITLE
fix(listing): drop sessionStorage persistence on /listings/create

### DIFF
--- a/frontend/src/hooks/useListingDraft.test.tsx
+++ b/frontend/src/hooks/useListingDraft.test.tsx
@@ -182,24 +182,57 @@ describe("useListingDraft", () => {
     expect(result.current.state.parcel?.id).toBe(sampleParcel.id);
   });
 
-  it("persists draft state to sessionStorage across remounts", async () => {
+  it("does NOT persist create-mode draft state across remounts", async () => {
+    // Create mode is intentionally fresh-on-remount: leaving /listings/create
+    // mid-form and coming back should land on a blank wizard, not the prior
+    // session's leftovers. Persistence is reserved for edit mode where the
+    // auction has a stable id to key on.
     const { result, unmount } = renderHook(() => useListingDraft({}), {
       wrapper: makeWrapper(),
     });
     act(() => result.current.setParcel(sampleParcel));
     act(() => result.current.update("startingBid", 1234));
-    act(() => result.current.update("sellerDesc", "Preserve me"));
+    act(() => result.current.update("sellerDesc", "Should not survive"));
     unmount();
 
     const { result: result2 } = renderHook(() => useListingDraft({}), {
       wrapper: makeWrapper(),
     });
 
+    expect(result2.current.state.sellerDesc).toBe("");
+    expect(result2.current.state.startingBid).toBe(100);
+    expect(result2.current.state.parcel).toBeNull();
+    // The "new" slot should never have been written in the first place.
+    expect(window.sessionStorage.getItem("slpa:draft:new")).toBeNull();
+  });
+
+  it("persists edit-mode draft state to sessionStorage across remounts", async () => {
+    // Edit mode keeps the recovery behavior — sellers editing a saved
+    // auction shouldn't lose unsaved tweaks if a tab closes.
+    server.use(
+      http.get("*/api/v1/auctions/77", () =>
+        HttpResponse.json(
+          sellerResponse({ id: 77, sellerDesc: "From server" }),
+        ),
+      ),
+    );
+
+    const { result, unmount } = renderHook(() => useListingDraft({ id: 77 }), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.state.auctionId).toBe(77));
+    act(() => result.current.update("sellerDesc", "Locally edited"));
+    act(() => result.current.update("startingBid", 1234));
+    unmount();
+
+    const { result: result2 } = renderHook(() => useListingDraft({ id: 77 }), {
+      wrapper: makeWrapper(),
+    });
+
     await waitFor(() =>
-      expect(result2.current.state.sellerDesc).toBe("Preserve me"),
+      expect(result2.current.state.sellerDesc).toBe("Locally edited"),
     );
     expect(result2.current.state.startingBid).toBe(1234);
-    expect(result2.current.state.parcel?.id).toBe(sampleParcel.id);
   });
 
   it("queues removed uploaded photos for DELETE on next save", async () => {

--- a/frontend/src/hooks/useListingDraft.ts
+++ b/frontend/src/hooks/useListingDraft.ts
@@ -39,12 +39,19 @@ import type { ParcelDto } from "@/types/parcel";
  *     save; DELETE is queued and flushed on the next save().
  *
  * Persistence:
- *   - sessionStorage keyed by "slpa:draft:<auctionId|new>". Blob-backed
- *     stagedPhotos are intentionally dropped from the persisted snapshot
- *     (File/Blob can't round-trip JSON). Everything else — parcel, prices,
- *     tags, sellerDesc, auctionId, status, uploadedPhotos, removedPhotoIds —
- *     survives a tab close. Writes are debounced 150ms so per-keystroke
- *     edits don't hammer sessionStorage.
+ *   - Edit mode (id supplied): sessionStorage keyed by "slpa:draft:<id>".
+ *     Blob-backed stagedPhotos are intentionally dropped from the persisted
+ *     snapshot (File/Blob can't round-trip JSON). Everything else — parcel,
+ *     prices, tags, sellerDesc, auctionId, status, uploadedPhotos,
+ *     removedPhotoIds — survives a tab close. Writes are debounced 150ms.
+ *   - Create mode (no id): persistence is intentionally OFF. Visiting
+ *     /listings/create always starts blank. Sellers who navigate away
+ *     mid-form get a clean slate when they come back, which is the expected
+ *     behavior for a creation flow (the alternate "draft recovery" was
+ *     surprising — leaving the page mid-typing and returning still showed
+ *     the old form). Once the first save promotes auctionId from null to a
+ *     real id, the wizard navigates to /listings/<id>/activate and any
+ *     subsequent edits land in edit mode where persistence is on.
  */
 export interface DraftState {
   auctionId: number | null;
@@ -164,18 +171,20 @@ interface DraftContainer {
 
 function initialStateFrom(id: number | string | undefined): DraftContainer {
   if (typeof window === "undefined") return { state: EMPTY, hydrated: false };
+  // Create mode: ignore any sessionStorage entry under "new" and start blank.
+  // The persistence-on-write side (below) also skips writes in create mode,
+  // so any stale "new" slot from before this gate landed is harmless and
+  // simply orphaned.
+  if (id === undefined || id === null) {
+    return { state: EMPTY, hydrated: true };
+  }
   try {
-    const raw = window.sessionStorage.getItem(storageKey(id ?? null));
-    if (!raw) {
-      // In create mode with nothing persisted, EMPTY is the canonical
-      // starting point — mark hydrated so the server-fetch effect
-      // doesn't wait for data that will never arrive.
-      return { state: EMPTY, hydrated: id === undefined || id === null };
-    }
+    const raw = window.sessionStorage.getItem(storageKey(id));
+    if (!raw) return { state: EMPTY, hydrated: false };
     const parsed = JSON.parse(raw) as PersistedDraft;
     return { state: { ...parsed, stagedPhotos: [] }, hydrated: true };
   } catch {
-    return { state: EMPTY, hydrated: id === undefined || id === null };
+    return { state: EMPTY, hydrated: false };
   }
 }
 
@@ -244,13 +253,18 @@ export function useListingDraft(
   } | null>(null);
 
   // Persist every state change (minus blob-backed staged files) so a
-  // tab close doesn't nuke unsaved work. Gated on `hydrated` so we
-  // don't overwrite existing persisted state with the EMPTY placeholder
-  // before server hydration runs. Writes are debounced 150ms so a rapid
-  // keystroke burst turns into a single sessionStorage write at the end.
+  // tab close doesn't nuke unsaved work in edit mode. Gated on `hydrated`
+  // so we don't overwrite existing persisted state with the EMPTY placeholder
+  // before server hydration runs. Create mode skips writes entirely — see
+  // the persistence note in the file-level docblock. Writes are debounced
+  // 150ms so a rapid keystroke burst turns into a single sessionStorage
+  // write at the end.
+  const isCreateMode =
+    (options.id === undefined || options.id === null) && state.auctionId === null;
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (!hydrated) return;
+    if (isCreateMode) return;
     pendingWriteRef.current = { state, id: options.id, hydrated: true };
     const timerId = setTimeout(() => {
       const { stagedPhotos: _staged, ...persisted } = state;
@@ -266,7 +280,7 @@ export function useListingDraft(
       pendingWriteRef.current = null;
     }, 150);
     return () => clearTimeout(timerId);
-  }, [state, hydrated, options.id]);
+  }, [state, hydrated, options.id, isCreateMode]);
 
   // Unmount-only flush: if the component tears down while a debounced
   // write is still pending, write it out synchronously so tab-close


### PR DESCRIPTION
The Create-listing wizard rehydrated from sessionStorage on every mount. Sellers who left /listings/create mid-form and returned saw the old form still populated. Create mode now starts blank; edit mode keeps its crash-recovery persistence.

See PR #118 for the full writeup.

## Test plan
- [x] \`useListingDraft\` tests pass (6/6).
- [ ] Amplify rebuild on this push (frontend-only change; backend deploy workflow filters out).
- [ ] Manual smoke once Amplify finishes: open /listings/create, fill in a parcel + price, navigate to /dashboard, return to /listings/create — form should be blank.