### PR TITLE
fix(listing): persist + prefill listing title from SL parcel name

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionRepository.java
@@ -26,7 +26,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long>, JpaSpec
      * {@link org.hibernate.LazyInitializationException} under
      * {@code spring.jpa.open-in-view=false}.
      */
-    @EntityGraph(attributePaths = {"parcel", "tags"})
+    @EntityGraph(attributePaths = {"parcel", "parcel.region", "tags"})
     List<Auction> findBySellerIdOrderByCreatedAtDesc(Long sellerId);
 
     /**
@@ -52,7 +52,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long>, JpaSpec
      * Eagerly fetches {@code parcel} + {@code tags} — see class-level note on
      * {@link #findBySellerIdOrderByCreatedAtDesc}.
      */
-    @EntityGraph(attributePaths = {"parcel", "tags"})
+    @EntityGraph(attributePaths = {"parcel", "parcel.region", "tags"})
     Optional<Auction> findByIdAndSellerId(Long id, Long sellerId);
 
     /**
@@ -61,7 +61,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long>, JpaSpec
      * {@link JpaRepository#findById} so every load path — including seller,
      * public, and service-layer lookups — returns a fully-initialized aggregate.
      */
-    @EntityGraph(attributePaths = {"parcel", "tags"})
+    @EntityGraph(attributePaths = {"parcel", "parcel.region", "tags"})
     @Override
     Optional<Auction> findById(Long id);
 
@@ -75,7 +75,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long>, JpaSpec
      * does not apply here: this is a single-row lookup with no
      * {@code Pageable}, so the multiple to-many fetches stay safe.
      */
-    @EntityGraph(attributePaths = {"parcel", "seller", "photos", "tags"})
+    @EntityGraph(attributePaths = {"parcel", "parcel.region", "seller", "photos", "tags"})
     @Query("SELECT a FROM Auction a WHERE a.id = :id")
     Optional<Auction> findByIdForDetail(@Param("id") Long id);
 
@@ -164,7 +164,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long>, JpaSpec
      * layer re-sequences them against the incoming ID list to preserve exact
      * page order (same pattern as {@code MyBidsService}).
      */
-    @EntityGraph(attributePaths = {"parcel", "tags"})
+    @EntityGraph(attributePaths = {"parcel", "parcel.region", "tags"})
     @Query("SELECT a FROM Auction a WHERE a.id IN :ids ORDER BY a.endsAt ASC")
     List<Auction> findAllByIdInWithParcelAndTags(@Param("ids") Collection<Long> ids);
 
@@ -181,7 +181,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long>, JpaSpec
      * against the original ID list themselves (the same pattern as
      * {@link #findAllByIdInWithParcelAndTags}).
      */
-    @EntityGraph(attributePaths = {"parcel", "seller"})
+    @EntityGraph(attributePaths = {"parcel", "parcel.region", "seller"})
     @Query("SELECT a FROM Auction a WHERE a.id IN :ids")
     List<Auction> findAllByIdWithParcelAndSeller(@Param("ids") Collection<Long> ids);
 

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLogRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationLogRepository.java
@@ -35,7 +35,7 @@ public interface CancellationLogRepository extends JpaRepository<CancellationLog
      * supplied by the caller via {@link Pageable} — the controller pins
      * {@code Sort.by("cancelledAt").descending()} per spec §7.4.
      */
-    @EntityGraph(attributePaths = {"auction", "auction.parcel", "auction.photos"})
+    @EntityGraph(attributePaths = {"auction", "auction.parcel", "auction.parcel.region", "auction.photos"})
     Page<CancellationLog> findBySellerId(Long sellerId, Pageable pageable);
 
     /**

--- a/backend/src/main/java/com/slparcelauctions/backend/parcel/Parcel.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/parcel/Parcel.java
@@ -77,6 +77,12 @@ public class Parcel {
     @Column(name = "owner_name", length = 255)
     private String ownerName;   // SL display name; null/blank when ownertype=group
 
+    @Column(name = "parcel_name", length = 255)
+    // SL-side parcel display name (from the parcel page's <meta name="parcel">).
+    // Used as the default listing title when a seller first picks this parcel
+    // in the create-listing wizard.
+    private String parcelName;
+
     @Column(name = "area_sqm")
     private Integer areaSqm;
 

--- a/backend/src/main/java/com/slparcelauctions/backend/parcel/ParcelLookupService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/parcel/ParcelLookupService.java
@@ -63,6 +63,7 @@ public class ParcelLookupService {
                 .ownerUuid(meta.ownerUuid())
                 .ownerType(meta.ownerType())
                 .ownerName(meta.ownerName())
+                .parcelName(meta.parcelName())
                 .areaSqm(meta.areaSqm())
                 .description(meta.description())
                 .snapshotUrl(meta.snapshotUrl())

--- a/backend/src/main/java/com/slparcelauctions/backend/parcel/dto/ParcelResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/parcel/dto/ParcelResponse.java
@@ -19,6 +19,7 @@ public record ParcelResponse(
         UUID ownerUuid,
         String ownerType,
         String ownerName,
+        String parcelName,
         String regionName,
         Double gridX,
         Double gridY,
@@ -39,7 +40,7 @@ public record ParcelResponse(
         Region r = p.getRegion();
         return new ParcelResponse(
                 p.getId(), p.getSlParcelUuid(), p.getOwnerUuid(), p.getOwnerType(),
-                p.getOwnerName(),
+                p.getOwnerName(), p.getParcelName(),
                 r.getName(), r.getGridX(), r.getGridY(),
                 p.getPositionX(), p.getPositionY(), p.getPositionZ(),
                 p.getAreaSqm(), p.getDescription(), p.getSnapshotUrl(), p.getSlurl(),

--- a/backend/src/main/resources/db/migration/V7__parcel_name.sql
+++ b/backend/src/main/resources/db/migration/V7__parcel_name.sql
@@ -1,0 +1,10 @@
+--
+-- Persist the parcel's display name (`<meta name="parcel">` from the SL
+-- World API). The wizard pre-fills the listing title from this value when
+-- the seller first picks a parcel — saves them retyping the SL-side name.
+-- Nullable because pre-existing rows (none in prod, possibly some in dev
+-- DBs) won't have it; new lookups always populate it.
+--
+
+ALTER TABLE public.parcels
+    ADD COLUMN parcel_name VARCHAR(255);

--- a/frontend/src/app/auction/[id]/page.integration.test.tsx
+++ b/frontend/src/app/auction/[id]/page.integration.test.tsx
@@ -99,6 +99,8 @@ function publicAuctionFixture(
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: null,
       areaSqm: 1024,
       description: "Beachfront parcel",

--- a/frontend/src/app/listings/(verified)/[id]/activate/ActivateClient.test.tsx
+++ b/frontend/src/app/listings/(verified)/[id]/activate/ActivateClient.test.tsx
@@ -43,6 +43,8 @@ function auctionBase(
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: null,
       areaSqm: 1024,
       description: "Beachfront parcel",

--- a/frontend/src/components/auction/AuctionEndedPanel.test.tsx
+++ b/frontend/src/components/auction/AuctionEndedPanel.test.tsx
@@ -39,6 +39,8 @@ function endedAuction(
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: null,
       areaSqm: 1024,
       description: "Beachfront",

--- a/frontend/src/components/auction/AuctionEndedRow.test.tsx
+++ b/frontend/src/components/auction/AuctionEndedRow.test.tsx
@@ -29,6 +29,8 @@ function endedAuction(
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: null,
       areaSqm: 1024,
       description: null,

--- a/frontend/src/components/auction/BidPanel.test.tsx
+++ b/frontend/src/components/auction/BidPanel.test.tsx
@@ -34,6 +34,8 @@ function publicAuction(
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: null,
       areaSqm: 1024,
       description: "Beachfront parcel",

--- a/frontend/src/components/auction/ParcelInfoPanel.test.tsx
+++ b/frontend/src/components/auction/ParcelInfoPanel.test.tsx
@@ -21,6 +21,8 @@ function publicAuctionFixture(
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: null,
       areaSqm: 1024,
       description: "Beachfront parcel",

--- a/frontend/src/components/auction/PlaceBidForm.test.tsx
+++ b/frontend/src/components/auction/PlaceBidForm.test.tsx
@@ -34,6 +34,8 @@ function auctionFixture(
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: null,
       areaSqm: 1024,
       description: "Beachfront parcel",

--- a/frontend/src/components/auction/ProxyBidSection.test.tsx
+++ b/frontend/src/components/auction/ProxyBidSection.test.tsx
@@ -37,6 +37,8 @@ function auctionFixture(
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: null,
       areaSqm: 1024,
       description: "Beachfront parcel",

--- a/frontend/src/components/auction/StickyBidBar.test.tsx
+++ b/frontend/src/components/auction/StickyBidBar.test.tsx
@@ -36,6 +36,8 @@ function auctionFixture(
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: null,
       areaSqm: 1024,
       description: "Beachfront",

--- a/frontend/src/components/listing/CancelListingModal.test.tsx
+++ b/frontend/src/components/listing/CancelListingModal.test.tsx
@@ -51,6 +51,8 @@ function baseAuction(
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: null,
       areaSqm: 1024,
       description: "Beachfront parcel",

--- a/frontend/src/components/listing/ListingPreviewCard.test.tsx
+++ b/frontend/src/components/listing/ListingPreviewCard.test.tsx
@@ -17,6 +17,8 @@ const parcel: ParcelDto = {
   positionX: 128,
   positionY: 128,
   positionZ: 0,
+  ownerName: null,
+  parcelName: null,
   continentName: null,
   areaSqm: 1024,
   description: "Beachfront retreat",

--- a/frontend/src/components/listing/ListingSummaryRow.test.tsx
+++ b/frontend/src/components/listing/ListingSummaryRow.test.tsx
@@ -34,6 +34,8 @@ function baseAuction(
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: null,
       areaSqm: 1024,
       description: "Beachfront parcel",

--- a/frontend/src/components/listing/ListingWizardForm.test.tsx
+++ b/frontend/src/components/listing/ListingWizardForm.test.tsx
@@ -39,6 +39,8 @@ const sampleParcel: ParcelDto = {
   positionX: 128,
   positionY: 128,
   positionZ: 0,
+  ownerName: null,
+  parcelName: null,
   continentName: "Heterocera",
   areaSqm: 1024,
   description: "Beachfront retreat",

--- a/frontend/src/components/listing/MyListingsTab.test.tsx
+++ b/frontend/src/components/listing/MyListingsTab.test.tsx
@@ -45,6 +45,8 @@ function row(
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: null,
       areaSqm: 1024,
       description: `Parcel ${id}`,

--- a/frontend/src/components/listing/ParcelLookupCard.test.tsx
+++ b/frontend/src/components/listing/ParcelLookupCard.test.tsx
@@ -14,6 +14,8 @@ const parcel: ParcelDto = {
   positionX: 128,
   positionY: 128,
   positionZ: 0,
+  ownerName: null,
+  parcelName: null,
   continentName: "Heterocera",
   areaSqm: 1024,
   description: "Beachfront retreat",

--- a/frontend/src/components/listing/ParcelLookupField.test.tsx
+++ b/frontend/src/components/listing/ParcelLookupField.test.tsx
@@ -23,6 +23,8 @@ const sampleParcel: ParcelDto = {
   positionX: 128,
   positionY: 128,
   positionZ: 0,
+  ownerName: null,
+  parcelName: null,
   continentName: "Heterocera",
   areaSqm: 1024,
   description: "Beachfront retreat",

--- a/frontend/src/components/listing/VerificationInProgressPanel.test.tsx
+++ b/frontend/src/components/listing/VerificationInProgressPanel.test.tsx
@@ -24,6 +24,8 @@ function makeAuction(
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: null,
       areaSqm: 1024,
       description: null,

--- a/frontend/src/components/user/ActiveListingsSection.test.tsx
+++ b/frontend/src/components/user/ActiveListingsSection.test.tsx
@@ -22,6 +22,8 @@ function listing(id: number, overrides: Partial<PublicAuctionResponse> = {}): Pu
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: null,
       areaSqm: 1024,
       description: `Parcel ${id}`,

--- a/frontend/src/hooks/useActivateAuction.test.tsx
+++ b/frontend/src/hooks/useActivateAuction.test.tsx
@@ -22,6 +22,8 @@ function base(overrides: Partial<SellerAuctionResponse> = {}): SellerAuctionResp
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: "Heterocera",
       areaSqm: 1024,
       description: null,

--- a/frontend/src/hooks/useListingDraft.test.tsx
+++ b/frontend/src/hooks/useListingDraft.test.tsx
@@ -20,6 +20,8 @@ const sampleParcel: ParcelDto = {
   positionX: 128,
   positionY: 128,
   positionZ: 0,
+  ownerName: null,
+  parcelName: null,
   continentName: "Heterocera",
   areaSqm: 1024,
   description: "Beachfront retreat",

--- a/frontend/src/hooks/useListingDraft.ts
+++ b/frontend/src/hooks/useListingDraft.ts
@@ -310,9 +310,21 @@ export function useListingDraft(
 
   const setParcel = useCallback(
     (p: ParcelDto) => {
-      update("parcel", p);
+      setState((s) => {
+        // First-pick prefill: if the seller hasn't typed a title yet
+        // (untouched OR cleared back to empty) and the parcel ships an
+        // SL-side parcel name, seed the title from it. Once the seller
+        // edits the title, we never touch it again — including on a
+        // subsequent parcel swap. Edit mode flows through `hydrateFromServer`,
+        // not setParcel, so this branch never fires there.
+        const titleEmpty =
+          s.title === null || s.title.trim().length === 0;
+        const nextTitle =
+          titleEmpty && p.parcelName ? p.parcelName : s.title;
+        return { ...s, parcel: p, title: nextTitle, dirty: true };
+      });
     },
-    [update],
+    [setState],
   );
 
   const setTitle = useCallback(

--- a/frontend/src/hooks/useMyListings.test.tsx
+++ b/frontend/src/hooks/useMyListings.test.tsx
@@ -29,6 +29,8 @@ function row(
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: null,
       areaSqm: 1024,
       description: `Parcel ${id}`,

--- a/frontend/src/lib/api/auctions.test.ts
+++ b/frontend/src/lib/api/auctions.test.ts
@@ -95,6 +95,8 @@ function publicAuction(
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: null,
       areaSqm: 1024,
       description: null,

--- a/frontend/src/test/fixtures/auction.ts
+++ b/frontend/src/test/fixtures/auction.ts
@@ -30,6 +30,8 @@ export function fakePublicAuction(
       positionX: 128,
       positionY: 128,
       positionZ: 0,
+      ownerName: null,
+      parcelName: null,
       continentName: null,
       areaSqm: 1024,
       description: "Beachfront parcel",

--- a/frontend/src/types/parcel.ts
+++ b/frontend/src/types/parcel.ts
@@ -19,6 +19,11 @@ export interface ParcelDto {
   slParcelUuid: string;
   ownerUuid: string;
   ownerType: ParcelOwnerType;
+  /** SL display name for the avatar/group that owns the parcel. */
+  ownerName: string | null;
+  /** SL-side parcel display name (`<meta name="parcel">`). Used by the
+   *  create-listing wizard to pre-fill the listing title. */
+  parcelName: string | null;
   regionName: string;
   gridX: number;
   gridY: number;


### PR DESCRIPTION
## Summary

Two fixes bundled because they surfaced from the same investigation:

### 1. \`LazyInitializationException\` on \`parcel.region.name\` in AuctionDtoMapper

Production GET \`/api/v1/auctions/{id}\` was 500-ing because \`AuctionRepository\`'s \`@EntityGraph\` fetched \`parcel\` but not \`parcel.region\`. Spring Data's default FETCH semantics treat unspecified attributes as LAZY, overriding the field-level \`@ManyToOne(EAGER) + @Fetch(JOIN)\` on \`Parcel.region\`. The DTO mapper runs after the \`@Transactional\` boundary returns, so the first \`region.getName()\` threw.

Added \`parcel.region\` (and \`auction.parcel.region\` in \`CancellationLogRepository\`) to every entity graph that already fetched \`parcel\`. Single-query load keeps the proxy initialised before the session closes.

### 2. Persist + prefill the SL-side parcel name

The parser already read \`<meta name="parcel">\` into \`ParcelMetadata.parcelName\`, but \`ParcelLookupService\` never persisted it — there was no column to store it in.

- **V7 migration**: \`parcels.parcel_name VARCHAR(255)\`, nullable.
- **Backend**: \`Parcel.parcelName\` field, \`ParcelLookupService.lookup\` writes it, \`ParcelResponse\` surfaces \`parcelName\` + \`ownerName\`.
- **Frontend**: \`ParcelDto\` picks up the two new fields. \`useListingDraft.setParcel\` pre-fills \`state.title\` from \`parcel.parcelName\` only when the title is null/empty. Once the seller types anything (or clears it back to non-empty), we never overwrite — including on a subsequent parcel swap. Edit mode flows through \`hydrateFromServer\`, not \`setParcel\`, so existing auction titles are never touched.
- 13 frontend test fixtures updated for the new \`ParcelDto\` fields.

## Test plan
- [x] \`./mvnw test -Dtest=ParcelControllerIntegrationTest,ParcelLookupServiceTest\` — green (11/11)
- [x] \`npm test\` — 1379/1380 pass (one pre-existing todo)
- [x] \`next build\` — green
- [ ] Smoke against prod after deploy: lookup a parcel in the create-listing wizard → title field auto-populates with the SL-side name (e.g., "Mountain 512sqm - Montezuma [M]"); typing in the title clears the auto-fill behavior; previously-failing GET /api/v1/auctions/{id} for a saved listing returns 200 with the full parcel info