### PR TITLE
fix(parcel): always re-fetch on lookup, gate title prefill to create page

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/parcel/ParcelLookupService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/parcel/ParcelLookupService.java
@@ -46,38 +46,49 @@ public class ParcelLookupService {
 
     @Transactional
     public ParcelResponse lookup(UUID slParcelUuid) {
-        Optional<Parcel> existing = repo.findBySlParcelUuid(slParcelUuid);
-        if (existing.isPresent()) {
-            return ParcelResponse.from(existing.get());
-        }
-
+        // Lookup is user-initiated (the seller hits the Lookup button) — it
+        // must reflect current SL state. The parcels row exists as a stable
+        // FK target so multiple drafts can share it; we update its
+        // SL-sourced fields in place rather than caching across lookups.
         ParcelPageData parcelPage = worldApi.fetchParcelPage(slParcelUuid).block();
         RegionPageData regionPage = worldApi.fetchRegionPage(parcelPage.regionUuid()).block();
         Region region = regionService.upsert(regionPage);
 
         ParcelMetadata meta = parcelPage.parcel();
         OffsetDateTime now = OffsetDateTime.now(clock);
-        Parcel parcel = Parcel.builder()
+
+        Optional<Parcel> existing = repo.findBySlParcelUuid(slParcelUuid);
+        Parcel parcel = existing.orElseGet(() -> Parcel.builder()
                 .slParcelUuid(slParcelUuid)
-                .region(region)
-                .ownerUuid(meta.ownerUuid())
-                .ownerType(meta.ownerType())
-                .ownerName(meta.ownerName())
-                .parcelName(meta.parcelName())
-                .areaSqm(meta.areaSqm())
-                .description(meta.description())
-                .snapshotUrl(meta.snapshotUrl())
-                .positionX(meta.positionX())
-                .positionY(meta.positionY())
-                .positionZ(meta.positionZ())
-                .slurl(buildSlurl(region.getName(), meta.positionX(), meta.positionY(), meta.positionZ()))
                 .verified(true)
                 .verifiedAt(now)
-                .lastChecked(now)
-                .build();
-        parcel = repo.save(parcel);
-        log.info("Parcel row created: id={}, uuid={}, region_id={}, region={}",
-                parcel.getId(), slParcelUuid, region.getId(), region.getName());
+                .build());
+        parcel.setRegion(region);
+        parcel.setOwnerUuid(meta.ownerUuid());
+        parcel.setOwnerType(meta.ownerType());
+        parcel.setOwnerName(meta.ownerName());
+        parcel.setParcelName(meta.parcelName());
+        parcel.setAreaSqm(meta.areaSqm());
+        parcel.setDescription(meta.description());
+        parcel.setSnapshotUrl(meta.snapshotUrl());
+        parcel.setPositionX(meta.positionX());
+        parcel.setPositionY(meta.positionY());
+        parcel.setPositionZ(meta.positionZ());
+        parcel.setSlurl(buildSlurl(region.getName(), meta.positionX(), meta.positionY(), meta.positionZ()));
+        parcel.setLastChecked(now);
+
+        try {
+            parcel = repo.save(parcel);
+        } catch (org.springframework.dao.DataIntegrityViolationException e) {
+            // Concurrent first-lookup race on the sl_parcel_uuid unique
+            // constraint. Re-find the winner and return its current state.
+            parcel = repo.findBySlParcelUuid(slParcelUuid)
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Race-loss couldn't re-find parcel " + slParcelUuid, e));
+        }
+        log.info("Parcel lookup: id={} uuid={} region_id={} region={} {}",
+                parcel.getId(), slParcelUuid, region.getId(), region.getName(),
+                existing.isPresent() ? "(refreshed)" : "(created)");
         return ParcelResponse.from(parcel);
     }
 

--- a/backend/src/test/java/com/slparcelauctions/backend/parcel/ParcelControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/parcel/ParcelControllerIntegrationTest.java
@@ -109,28 +109,38 @@ class ParcelControllerIntegrationTest {
     }
 
     @Test
-    void lookup_sameUuidTwice_secondCallIsCacheHit() throws Exception {
+    void lookup_sameUuidTwice_secondCallReFetchesFromSL() throws Exception {
+        // Lookup is user-initiated (the seller hits the Lookup button) and
+        // must reflect current SL state. The parcels row is reused as a
+        // stable FK target — same row id across calls — but its
+        // SL-sourced fields are refreshed every time.
         UUID parcelUuid = UUID.fromString("55555555-5555-5555-5555-555555555555");
         UUID ownerUuid = UUID.fromString("66666666-6666-6666-6666-666666666666");
         stubMainlandMetadata(parcelUuid, ownerUuid, "Coniston", 1014.0, 1014.0);
 
         String body = objectMapper.writeValueAsString(new ParcelLookupRequest(parcelUuid));
 
-        mockMvc.perform(post("/api/v1/parcels/lookup")
+        MvcResult first = mockMvc.perform(post("/api/v1/parcels/lookup")
                 .header("Authorization", "Bearer " + verifiedAccessToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(body))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andReturn();
+        Long firstId = objectMapper.readTree(first.getResponse().getContentAsString())
+                .get("id").asLong();
 
-        mockMvc.perform(post("/api/v1/parcels/lookup")
+        MvcResult second = mockMvc.perform(post("/api/v1/parcels/lookup")
                 .header("Authorization", "Bearer " + verifiedAccessToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(body))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andReturn();
+        Long secondId = objectMapper.readTree(second.getResponse().getContentAsString())
+                .get("id").asLong();
 
-        // Second call must not hit external APIs
-        verify(worldApi, times(1)).fetchParcelPage(parcelUuid);
-        verify(worldApi, times(1)).fetchRegionPage(org.mockito.ArgumentMatchers.any(java.util.UUID.class));
+        assertThat(secondId).isEqualTo(firstId);
+        verify(worldApi, times(2)).fetchParcelPage(parcelUuid);
+        verify(worldApi, times(2)).fetchRegionPage(org.mockito.ArgumentMatchers.any(java.util.UUID.class));
         assertThat(parcelRepository.findBySlParcelUuid(parcelUuid)).isPresent();
     }
 

--- a/backend/src/test/java/com/slparcelauctions/backend/parcel/ParcelLookupServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/parcel/ParcelLookupServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.UUID;
@@ -88,26 +89,58 @@ class ParcelLookupServiceTest {
     }
 
     @Test
-    void lookup_existingUuid_shortCircuitsNoExternalCalls() {
-        UUID parcelUuid = UUID.randomUUID();
-        Region region = Region.builder().id(7L).name("Sansara")
+    void lookup_existingUuid_refreshesFieldsFromSL() {
+        // Lookup is user-initiated and must reflect current SL state. The
+        // existing parcels row is reused as a stable FK target for auctions
+        // but its SL-sourced fields are refreshed in place every call.
+        UUID parcelUuid = UUID.fromString("99999999-9999-9999-9999-999999999999");
+        UUID newOwner = UUID.fromString("88888888-8888-8888-8888-888888888888");
+        UUID regionUuid = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        Region staleRegion = Region.builder().id(6L).name("OldRegion")
                 .gridX(1000.0).gridY(1000.0).maturityRating("GENERAL").build();
         Parcel existing = Parcel.builder()
-                .id(99L).slParcelUuid(parcelUuid).region(region).build();
+                .id(99L).slParcelUuid(parcelUuid).region(staleRegion)
+                .ownerUuid(UUID.randomUUID()).parcelName("Stale name")
+                .verified(true).verifiedAt(OffsetDateTime.parse("2026-01-01T00:00:00Z"))
+                .build();
+        ParcelMetadata fresh = new ParcelMetadata(
+                parcelUuid, newOwner, "agent", "New Owner Holdings",
+                "Fresh Parcel Name", "Coniston",
+                2048, "fresh desc", "http://example.com/snap2.jpg", null,
+                64.0, 32.0, 11.0);
+        RegionPageData regionPage = new RegionPageData(
+                regionUuid, "Coniston", 1014.0, 1014.0, "M_NOT");
+        Region freshRegion = Region.builder()
+                .id(7L).slUuid(regionUuid).name("Coniston")
+                .gridX(1014.0).gridY(1014.0).maturityRating("MODERATE").build();
         when(repo.findBySlParcelUuid(parcelUuid)).thenReturn(Optional.of(existing));
+        when(worldApi.fetchParcelPage(parcelUuid))
+                .thenReturn(Mono.just(new ParcelPageData(fresh, regionUuid)));
+        when(worldApi.fetchRegionPage(regionUuid)).thenReturn(Mono.just(regionPage));
+        when(regionService.upsert(regionPage)).thenReturn(freshRegion);
+        when(repo.save(any(Parcel.class))).thenAnswer(inv -> inv.getArgument(0));
 
         ParcelResponse result = service.lookup(parcelUuid);
 
+        // Same row id (FK target stays stable for any auctions referencing it).
         assertThat(result.id()).isEqualTo(99L);
-        verify(worldApi, never()).fetchParcelPage(any());
-        verify(worldApi, never()).fetchRegionPage(any());
-        verify(regionService, never()).upsert(any());
+        // Refreshed fields from SL.
+        assertThat(result.parcelName()).isEqualTo("Fresh Parcel Name");
+        assertThat(result.ownerName()).isEqualTo("New Owner Holdings");
+        assertThat(result.ownerUuid()).isEqualTo(newOwner);
+        assertThat(result.regionName()).isEqualTo("Coniston");
+        assertThat(result.areaSqm()).isEqualTo(2048);
+        // verifiedAt is the first-time-verified stamp; not bumped on refresh.
+        assertThat(result.verifiedAt())
+                .isEqualTo(OffsetDateTime.parse("2026-01-01T00:00:00Z"));
+        verify(worldApi).fetchParcelPage(parcelUuid);
+        verify(worldApi).fetchRegionPage(regionUuid);
+        verify(regionService).upsert(regionPage);
     }
 
     @Test
     void lookup_worldApi404_propagates() {
         UUID parcelUuid = UUID.randomUUID();
-        when(repo.findBySlParcelUuid(parcelUuid)).thenReturn(Optional.empty());
         when(worldApi.fetchParcelPage(parcelUuid))
                 .thenReturn(Mono.error(new ParcelNotFoundInSlException(parcelUuid)));
 
@@ -125,7 +158,6 @@ class ParcelLookupServiceTest {
                 null, null, null, 128.0, 128.0, 22.0);
         RegionPageData regionPage = new RegionPageData(
                 regionUuid, "SomeEstate", 390.0, 390.0, "PG_NOT");
-        when(repo.findBySlParcelUuid(parcelUuid)).thenReturn(Optional.empty());
         when(worldApi.fetchParcelPage(parcelUuid))
                 .thenReturn(Mono.just(new ParcelPageData(meta, regionUuid)));
         when(worldApi.fetchRegionPage(regionUuid)).thenReturn(Mono.just(regionPage));

--- a/frontend/src/components/listing/ListingWizardForm.test.tsx
+++ b/frontend/src/components/listing/ListingWizardForm.test.tsx
@@ -126,10 +126,6 @@ describe("ListingWizardForm (create flow)", () => {
     renderWithProviders(<ListingWizardForm mode="create" />);
 
     await userEvent.type(
-      screen.getByLabelText(/listing title/i),
-      "Premium Waterfront",
-    );
-    await userEvent.type(
       screen.getByLabelText(/Parcel UUID/i),
       VALID_UUID,
     );
@@ -137,6 +133,10 @@ describe("ListingWizardForm (create flow)", () => {
       screen.getByRole("button", { name: /Look up/i }),
     );
     await screen.findByText("Beachfront retreat");
+    await userEvent.type(
+      screen.getByLabelText(/listing title/i),
+      "Premium Waterfront",
+    );
 
     const startingBid = await screen.findByLabelText(/Starting bid/i);
     await userEvent.clear(startingBid);
@@ -161,10 +161,6 @@ describe("ListingWizardForm (create flow)", () => {
     renderWithProviders(<ListingWizardForm mode="create" />);
 
     await userEvent.type(
-      screen.getByLabelText(/listing title/i),
-      "Premium Waterfront",
-    );
-    await userEvent.type(
       screen.getByLabelText(/Parcel UUID/i),
       VALID_UUID,
     );
@@ -172,6 +168,10 @@ describe("ListingWizardForm (create flow)", () => {
       screen.getByRole("button", { name: /Look up/i }),
     );
     await screen.findByText("Beachfront retreat");
+    await userEvent.type(
+      screen.getByLabelText(/listing title/i),
+      "Premium Waterfront",
+    );
 
     await userEvent.click(
       screen.getByRole("button", { name: /Save as Draft/i }),
@@ -223,10 +223,6 @@ describe("ListingWizardForm (create flow)", () => {
 
     renderWithProviders(<ListingWizardForm mode="create" />);
     await userEvent.type(
-      screen.getByLabelText(/listing title/i),
-      "Premium Waterfront",
-    );
-    await userEvent.type(
       screen.getByLabelText(/Parcel UUID/i),
       VALID_UUID,
     );
@@ -234,6 +230,10 @@ describe("ListingWizardForm (create flow)", () => {
       screen.getByRole("button", { name: /Look up/i }),
     );
     await screen.findByText("Beachfront retreat");
+    await userEvent.type(
+      screen.getByLabelText(/listing title/i),
+      "Premium Waterfront",
+    );
 
     await userEvent.click(
       screen.getByRole("button", { name: /Save as Draft/i }),
@@ -379,10 +379,6 @@ describe("ListingWizardForm (suspension gate)", () => {
     renderWithProviders(<ListingWizardForm mode="create" />);
 
     await userEvent.type(
-      screen.getByLabelText(/listing title/i),
-      "Premium Waterfront",
-    );
-    await userEvent.type(
       screen.getByLabelText(/Parcel UUID/i),
       VALID_UUID,
     );
@@ -390,6 +386,10 @@ describe("ListingWizardForm (suspension gate)", () => {
       screen.getByRole("button", { name: /Look up/i }),
     );
     await screen.findByText("Beachfront retreat");
+    await userEvent.type(
+      screen.getByLabelText(/listing title/i),
+      "Premium Waterfront",
+    );
     await userEvent.click(
       screen.getByRole("button", { name: /Save as Draft/i }),
     );

--- a/frontend/src/components/listing/ListingWizardForm.tsx
+++ b/frontend/src/components/listing/ListingWizardForm.tsx
@@ -304,25 +304,6 @@ export function ListingWizardForm({ mode, id }: ListingWizardFormProps) {
         <div className="flex flex-col gap-6">
           <FormError message={error ?? undefined} />
           <section className="flex flex-col gap-2">
-            <label
-              htmlFor="listing-title"
-              className="text-xs font-medium font-semibold tracking-wider uppercase text-fg-muted"
-            >
-              Listing Title
-            </label>
-            <p className="text-xs text-fg-muted">
-              A short, punchy headline for your listing (max 120 characters).
-            </p>
-            <TitleField
-              value={draft.state.title ?? ""}
-              onChange={(next) => {
-                draft.setTitle(next);
-                if (titleError) setTitleError(null);
-              }}
-              error={titleError}
-            />
-          </section>
-          <section className="flex flex-col gap-2">
             <h2 className="text-sm font-semibold tracking-tight text-fg">Parcel</h2>
             <ParcelLookupField
               initialParcel={parcel}
@@ -332,6 +313,25 @@ export function ListingWizardForm({ mode, id }: ListingWizardFormProps) {
           </section>
           {parcel && (
             <>
+              <section className="flex flex-col gap-2">
+                <label
+                  htmlFor="listing-title"
+                  className="text-xs font-medium font-semibold tracking-wider uppercase text-fg-muted"
+                >
+                  Listing Title
+                </label>
+                <p className="text-xs text-fg-muted">
+                  A short, punchy headline for your listing (max 120 characters).
+                </p>
+                <TitleField
+                  value={draft.state.title ?? ""}
+                  onChange={(next) => {
+                    draft.setTitle(next);
+                    if (titleError) setTitleError(null);
+                  }}
+                  error={titleError}
+                />
+              </section>
               <section className="flex flex-col gap-3">
                 <h2 className="text-sm font-semibold tracking-tight text-fg">
                   Auction settings

--- a/frontend/src/hooks/useListingDraft.ts
+++ b/frontend/src/hooks/useListingDraft.ts
@@ -311,20 +311,21 @@ export function useListingDraft(
   const setParcel = useCallback(
     (p: ParcelDto) => {
       setState((s) => {
-        // First-pick prefill: if the seller hasn't typed a title yet
-        // (untouched OR cleared back to empty) and the parcel ships an
-        // SL-side parcel name, seed the title from it. Once the seller
-        // edits the title, we never touch it again — including on a
-        // subsequent parcel swap. Edit mode flows through `hydrateFromServer`,
-        // not setParcel, so this branch never fires there.
+        // Create-mode-only first-pick prefill: if the seller hasn't typed a
+        // title yet (untouched OR cleared back to empty) and the parcel
+        // ships an SL-side parcel name, seed the title from it. Once the
+        // seller edits the title, we never touch it again — including on a
+        // subsequent parcel swap. Edit mode never auto-touches an existing
+        // auction's title under any circumstances.
         const titleEmpty =
           s.title === null || s.title.trim().length === 0;
-        const nextTitle =
-          titleEmpty && p.parcelName ? p.parcelName : s.title;
+        const shouldPrefill =
+          isCreateMode && titleEmpty && Boolean(p.parcelName);
+        const nextTitle = shouldPrefill ? p.parcelName : s.title;
         return { ...s, parcel: p, title: nextTitle, dirty: true };
       });
     },
-    [setState],
+    [setState, isCreateMode],
   );
 
   const setTitle = useCallback(


### PR DESCRIPTION
## Summary

Two related fixes:

1. **Backend**: \`ParcelLookupService.lookup\` now always fetches the parcel + region pages from SL on every call. The parcels row stays as a stable FK target (auctions can share it; locking happens at the auction layer), but its SL-sourced fields refresh in place. The previous cache-hit short-circuit served stale fields whenever SL changed (or a row was written before a new column landed, like \`parcel_name\` in V7).

2. **Frontend**: Listing Title section moved inside the \`{parcel && ...}\` gate so it doesn't render until the lookup completes — same pattern as Auction settings, Description, Tags, Photos. The \`useListingDraft.setParcel\` prefill is now gated on \`isCreateMode\` so an auction's title can never be auto-touched outside the create page.

## Test plan
- [x] \`ParcelLookupServiceTest\` (4) + \`ParcelControllerIntegrationTest\` (7) — green
- [x] Frontend full suite (1379 tests) green
- [x] \`next build\` + \`mvnw compile\` clean
- [ ] Manual smoke: lookup parcel \`541ac6f7-96ba-ab9b-e5bc-b0347372f919\` → title field renders only after lookup, prefilled with the SL-side parcel name; subsequent lookups see fresh data even if SL changed.