### PR TITLE
fix(listing): drop FeePaymentInstructions re-exports from barrel

### DIFF
--- a/frontend/src/components/listing/index.ts
+++ b/frontend/src/components/listing/index.ts
@@ -29,8 +29,8 @@ export {
   ActivateStatusStepper,
   statusToStepperIndex,
 } from "./ActivateStatusStepper";
-export { FeePaymentInstructions } from "./FeePaymentInstructions";
-export type { FeePaymentInstructionsProps } from "./FeePaymentInstructions";
+export { ActivateListingPanel } from "./ActivateListingPanel";
+export type { ActivateListingPanelProps } from "./ActivateListingPanel";
 export { VerificationMethodPicker } from "./VerificationMethodPicker";
 export type { VerificationMethodPickerProps } from "./VerificationMethodPicker";
 export { VerificationInProgressPanel } from "./VerificationInProgressPanel";


### PR DESCRIPTION
## Summary

PR #126 deleted FeePaymentInstructions but left dead re-exports in components/listing/index.ts, breaking the type-check step of frontend CI on main. Replace with the new ActivateListingPanel re-exports.

## Test plan

- [x] npm run build green locally