### PR TITLE
fix(listing): drop FeePaymentInstructions re-exports from barrel

### DIFF
--- a/frontend/src/components/listing/index.ts
+++ b/frontend/src/components/listing/index.ts
@@ -29,8 +29,8 @@ export {
   ActivateStatusStepper,
   statusToStepperIndex,
 } from "./ActivateStatusStepper";
-export { FeePaymentInstructions } from "./FeePaymentInstructions";
-export type { FeePaymentInstructionsProps } from "./FeePaymentInstructions";
+export { ActivateListingPanel } from "./ActivateListingPanel";
+export type { ActivateListingPanelProps } from "./ActivateListingPanel";
 export { VerificationMethodPicker } from "./VerificationMethodPicker";
 export type { VerificationMethodPickerProps } from "./VerificationMethodPicker";
 export { VerificationInProgressPanel } from "./VerificationInProgressPanel";


### PR DESCRIPTION
Fixes the broken type-check step of the previous main push (#127). Frontend CI was red because index.ts still re-exported the deleted component.