### PR TITLE
fix: public auction GET 401 + reusable WalletTermsModal

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
@@ -161,6 +161,18 @@ public class SecurityConfig {
                         // FOOTGUNS §B.5: matcher order is first-match-wins,
                         // so this rule MUST sit before /api/v1/**.
                         .requestMatchers(HttpMethod.GET, "/api/v1/auctions/featured/*").permitAll()
+                        // Public auction detail (Epic 04). The controller
+                        // hides DRAFT/DRAFT_PAID/VERIFICATION_PENDING/
+                        // VERIFICATION_FAILED/SUSPENDED via 404 for non-
+                        // sellers and serves the public response shape for
+                        // ACTIVE / terminal statuses, so the bare detail
+                        // endpoint is anonymous-safe. Single-segment "*"
+                        // intentionally — multi-segment paths (e.g.
+                        // /auctions/{id}/photos/{pid}/bytes, /bids,
+                        // /reviews, /preview) have their own rules above.
+                        // FOOTGUNS §B.5: matcher order is first-match-wins,
+                        // so this rule MUST sit before /api/v1/**.
+                        .requestMatchers(HttpMethod.GET, "/api/v1/auctions/*").permitAll()
                         // Public bundled stats (Epic 07 sub-spec 1 §5.4).
                         // Anonymous homepage callers need the four-count
                         // snapshot; the response is wrapped in a 60s public

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/me/MeWalletController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/me/MeWalletController.java
@@ -231,7 +231,7 @@ public class MeWalletController {
         user.setWalletTermsVersion(req.termsVersion());
         userRepository.save(user);
         log.info("user {} accepted wallet ToU version {}", principal.userId(), req.termsVersion());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     /* ============================================================ */

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionControllerIntegrationTest.java
@@ -392,6 +392,29 @@ class AuctionControllerIntegrationTest {
     }
 
     @Test
+    void get_activeAnonymous_returnsPublicView() throws Exception {
+        // The public auction page is anonymous-safe — viewers can hit the
+        // detail endpoint without an Authorization header.
+        Auction a = seedAuction(AuctionStatus.ACTIVE, false, 0);
+
+        mockMvc.perform(get("/api/v1/auctions/" + a.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ACTIVE"))
+                .andExpect(jsonPath("$.listingFeePaid").doesNotExist());
+    }
+
+    @Test
+    void get_preActiveAnonymous_returns404() throws Exception {
+        // The 404-hide for pre-ACTIVE statuses applies to anonymous callers
+        // the same way it does to authenticated non-sellers.
+        Auction a = seedAuction(AuctionStatus.DRAFT, false, 0);
+
+        mockMvc.perform(get("/api/v1/auctions/" + a.getId()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("AUCTION_NOT_FOUND"));
+    }
+
+    @Test
     void get_cancelledAsNonSeller_returnsEndedWithoutWinnerOrFeeFields() throws Exception {
         Auction a = seedAuction(AuctionStatus.CANCELLED, true, 0);
         a.setWinnerId(null);

--- a/frontend/src/components/listing/ActivateListingPanel.test.tsx
+++ b/frontend/src/components/listing/ActivateListingPanel.test.tsx
@@ -76,7 +76,7 @@ describe("ActivateListingPanel", () => {
     expect(screen.getByText(/Loading fee details/i)).toBeInTheDocument();
   });
 
-  it("shows the wallet-terms gate when terms are not accepted", () => {
+  it("shows the wallet-terms gate with an inline Accept button when terms are not accepted", async () => {
     mockHooks({
       wallet: walletView({ termsAccepted: false, termsAcceptedAt: null }),
     });
@@ -84,13 +84,17 @@ describe("ActivateListingPanel", () => {
     expect(
       screen.getByRole("heading", { name: /Accept wallet terms first/i }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Open wallet/i })).toHaveAttribute(
-      "href",
-      "/wallet",
-    );
     expect(
       screen.queryByRole("button", { name: /Activate Listing/i }),
     ).not.toBeInTheDocument();
+    // Clicking the gate button opens the WalletTermsModal in-place — no
+    // navigation to /wallet.
+    await userEvent.click(
+      screen.getByRole("button", { name: /Accept wallet terms/i }),
+    );
+    expect(
+      screen.getByRole("heading", { name: /SLPA Wallet Terms of Use/i }),
+    ).toBeInTheDocument();
   });
 
   it("shows the penalty gate when penalty is owed", () => {

--- a/frontend/src/components/listing/ActivateListingPanel.tsx
+++ b/frontend/src/components/listing/ActivateListingPanel.tsx
@@ -11,6 +11,7 @@ import { payListingFee } from "@/lib/api/wallet";
 import { useListingFeeConfig } from "@/hooks/useListingFeeConfig";
 import { useWallet, walletQueryKey } from "@/lib/wallet/use-wallet";
 import { activateAuctionKey } from "@/hooks/useActivateAuction";
+import { WalletTermsModal } from "@/components/wallet/WalletTermsModal";
 
 function genIdempotencyKey(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -43,6 +44,7 @@ export function ActivateListingPanel({ auctionId }: ActivateListingPanelProps) {
   const feeQ = useListingFeeConfig();
   const walletQ = useWallet(true);
   const [error, setError] = useState<string | null>(null);
+  const [termsOpen, setTermsOpen] = useState(false);
 
   const mutation = useMutation({
     mutationFn: () => payListingFee(auctionId, genIdempotencyKey()),
@@ -89,24 +91,31 @@ export function ActivateListingPanel({ auctionId }: ActivateListingPanelProps) {
 
   if (!wallet.termsAccepted) {
     return (
-      <section
-        aria-labelledby="activate-fee-heading"
-        className="flex flex-col gap-3 rounded-lg bg-bg-subtle p-6"
-      >
-        <h2 id="activate-fee-heading" className="text-base font-bold tracking-tight text-fg">
-          Accept wallet terms first
-        </h2>
-        <p className="text-sm text-fg">
-          Listing fees are paid from your SLPA wallet. Open the wallet to
-          accept the terms of use, then come back to activate.
-        </p>
-        <Link
-          href="/wallet"
-          className="self-start text-sm font-medium text-brand underline underline-offset-4 hover:opacity-80"
+      <>
+        <section
+          aria-labelledby="activate-fee-heading"
+          className="flex flex-col gap-3 rounded-lg bg-bg-subtle p-6"
         >
-          Open wallet
-        </Link>
-      </section>
+          <h2 id="activate-fee-heading" className="text-base font-bold tracking-tight text-fg">
+            Accept wallet terms first
+          </h2>
+          <p className="text-sm text-fg">
+            Listing fees are paid from your SLPA wallet. Accept the wallet
+            terms of use to continue.
+          </p>
+          <Button
+            variant="secondary"
+            className="self-start"
+            onClick={() => setTermsOpen(true)}
+          >
+            Accept wallet terms
+          </Button>
+        </section>
+        <WalletTermsModal
+          open={termsOpen}
+          onClose={() => setTermsOpen(false)}
+        />
+      </>
     );
   }
 

--- a/frontend/src/components/wallet/WalletPanel.tsx
+++ b/frontend/src/components/wallet/WalletPanel.tsx
@@ -12,7 +12,6 @@ import { AlertTriangle } from "@/components/ui/icons";
 import {
   withdraw,
   payPenalty,
-  acceptTerms,
   getLedger,
   ledgerExportUrl,
 } from "@/lib/api/wallet";
@@ -20,6 +19,7 @@ import { useWallet, walletQueryKey } from "@/lib/wallet/use-wallet";
 import { useWalletWsSubscription } from "@/lib/wallet/use-wallet-ws";
 import { LedgerTable } from "@/components/wallet/LedgerTable";
 import { LedgerFilterBar } from "@/components/wallet/LedgerFilterBar";
+import { WalletTermsModal } from "@/components/wallet/WalletTermsModal";
 import type {
   LedgerFilter,
   UserLedgerEntryType,
@@ -315,61 +315,11 @@ export function WalletPanel() {
         )}
       </div>
 
-      <Modal
+      <WalletTermsModal
         open={showTerms}
-        title="SLPA Wallet Terms of Use"
         onClose={() => setShowTerms(false)}
-        footer={
-          <>
-            <Button variant="secondary" onClick={() => setShowTerms(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="primary"
-              onClick={async () => {
-                await acceptTerms({ termsVersion: "1.0" });
-                await refresh();
-                setShowTerms(false);
-                setShowDeposit(true);
-              }}
-            >
-              I Accept
-            </Button>
-          </>
-        }
-      >
-        <p>By using the SLPA wallet, you acknowledge:</p>
-        <ul className="list-disc pl-5 space-y-1">
-          <li>
-            <strong>Non-interest-bearing.</strong> L$ held in your wallet do not
-            earn interest, dividends, or any return.
-          </li>
-          <li>
-            <strong>L$ status.</strong> L$ are a Linden Lab limited-license token,
-            not currency. SLPA holds L$ on your behalf as a transactional convenience.
-          </li>
-          <li>
-            <strong>No L$&harr;USD conversion.</strong> SLPA does not exchange L$
-            for USD or any other currency.
-          </li>
-          <li>
-            <strong>Recoverable on shutdown.</strong> If SLPA ceases operations,
-            all positive wallet balances will be returned to your verified SL avatar.
-          </li>
-          <li>
-            <strong>Freezable for fraud.</strong> SLPA may freeze a wallet balance
-            pending fraud investigation, max 30 days absent legal process.
-          </li>
-          <li>
-            <strong>Dormancy.</strong> Wallets inactive for 30 days are flagged;
-            after 4 weekly notifications, balance auto-returns to your SL avatar.
-          </li>
-          <li>
-            <strong>Banned-Resident handling.</strong> If your SL account loses
-            good standing, your wallet balance returns to your last-verified SL avatar.
-          </li>
-        </ul>
-      </Modal>
+        onAccepted={() => setShowDeposit(true)}
+      />
 
       <Modal
         open={showDeposit}

--- a/frontend/src/components/wallet/WalletTermsModal.test.tsx
+++ b/frontend/src/components/wallet/WalletTermsModal.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/test/render";
+import { server } from "@/test/msw/server";
+import { WalletTermsModal } from "./WalletTermsModal";
+
+describe("WalletTermsModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the ToU body when open", () => {
+    renderWithProviders(
+      <WalletTermsModal open={true} onClose={vi.fn()} />,
+    );
+    expect(
+      screen.getByText(/SLPA Wallet Terms of Use/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Non-interest-bearing/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^I Accept$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing when closed", () => {
+    renderWithProviders(
+      <WalletTermsModal open={false} onClose={vi.fn()} />,
+    );
+    expect(
+      screen.queryByText(/SLPA Wallet Terms of Use/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls accept-terms, closes, and fires onAccepted on I Accept", async () => {
+    let posted = false;
+    server.use(
+      http.post("*/api/v1/me/wallet/accept-terms", () => {
+        posted = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    const onClose = vi.fn();
+    const onAccepted = vi.fn();
+    renderWithProviders(
+      <WalletTermsModal
+        open={true}
+        onClose={onClose}
+        onAccepted={onAccepted}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /^I Accept$/i }),
+    );
+    await waitFor(() => expect(posted).toBe(true));
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(onAccepted).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose on Cancel without posting", async () => {
+    let posted = false;
+    server.use(
+      http.post("*/api/v1/me/wallet/accept-terms", () => {
+        posted = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    const onClose = vi.fn();
+    renderWithProviders(
+      <WalletTermsModal open={true} onClose={onClose} />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /^Cancel$/i }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(posted).toBe(false);
+  });
+
+  it("surfaces a server error inline and does not close", async () => {
+    server.use(
+      http.post("*/api/v1/me/wallet/accept-terms", () =>
+        HttpResponse.json(
+          {
+            status: 500,
+            title: "Internal Server Error",
+            detail: "Database is on fire.",
+          },
+          { status: 500 },
+        ),
+      ),
+    );
+    const onClose = vi.fn();
+    renderWithProviders(
+      <WalletTermsModal open={true} onClose={onClose} />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /^I Accept$/i }),
+    );
+    expect(
+      await screen.findByText(/Database is on fire/i),
+    ).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/wallet/WalletTermsModal.tsx
+++ b/frontend/src/components/wallet/WalletTermsModal.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/Button";
+import { FormError } from "@/components/ui/FormError";
+import { Modal } from "@/components/ui/Modal";
+import { isApiError } from "@/lib/api";
+import { acceptTerms } from "@/lib/api/wallet";
+import { walletQueryKey } from "@/lib/wallet/use-wallet";
+
+/**
+ * Current wallet ToU version. Bumped server-side when the terms are
+ * materially revised; the user must re-accept on the next interaction.
+ */
+export const WALLET_TERMS_VERSION = "1.0";
+
+export interface WalletTermsModalProps {
+  open: boolean;
+  onClose: () => void;
+  /**
+   * Called after the seller accepts and the wallet cache has been
+   * invalidated. Use to chain a follow-up action — e.g. opening a deposit
+   * dialog on the wallet page, or no-op on the activate page since the
+   * panel re-renders into the ready state on its own.
+   */
+  onAccepted?: () => void;
+}
+
+/**
+ * Reusable wallet-terms acceptance modal. Renders the ToU bullet list and
+ * an "I Accept" button that POSTs {@code /me/wallet/accept-terms} and
+ * invalidates the wallet query so any consumer (the wallet page, the
+ * activate-listing panel, future deposit/withdraw triggers) flips out of
+ * its "terms not accepted" branch on the next render.
+ */
+export function WalletTermsModal({
+  open,
+  onClose,
+  onAccepted,
+}: WalletTermsModalProps) {
+  const qc = useQueryClient();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleAccept() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await acceptTerms({ termsVersion: WALLET_TERMS_VERSION });
+      await qc.invalidateQueries({ queryKey: walletQueryKey });
+      onClose();
+      onAccepted?.();
+    } catch (e: unknown) {
+      setError(
+        isApiError(e)
+          ? e.problem.detail ?? e.problem.title ?? "Could not accept terms."
+          : e instanceof Error
+            ? e.message
+            : "Could not accept terms.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal
+      open={open}
+      title="SLPA Wallet Terms of Use"
+      onClose={onClose}
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleAccept}
+            loading={submitting}
+            disabled={submitting}
+          >
+            I Accept
+          </Button>
+        </>
+      }
+    >
+      <p>By using the SLPA wallet, you acknowledge:</p>
+      <ul className="list-disc pl-5 space-y-1">
+        <li>
+          <strong>Non-interest-bearing.</strong> L$ held in your wallet do not
+          earn interest, dividends, or any return.
+        </li>
+        <li>
+          <strong>L$ status.</strong> L$ are a Linden Lab limited-license token,
+          not currency. SLPA holds L$ on your behalf as a transactional convenience.
+        </li>
+        <li>
+          <strong>No L$&harr;USD conversion.</strong> SLPA does not exchange L$
+          for USD or any other currency.
+        </li>
+        <li>
+          <strong>Recoverable on shutdown.</strong> If SLPA ceases operations,
+          all positive wallet balances will be returned to your verified SL avatar.
+        </li>
+        <li>
+          <strong>Freezable for fraud.</strong> SLPA may freeze a wallet balance
+          pending fraud investigation, max 30 days absent legal process.
+        </li>
+        <li>
+          <strong>Dormancy.</strong> Wallets inactive for 30 days are flagged;
+          after 4 weekly notifications, balance auto-returns to your SL avatar.
+        </li>
+        <li>
+          <strong>Banned-Resident handling.</strong> If your SL account loses
+          good standing, your wallet balance returns to your last-verified SL avatar.
+        </li>
+      </ul>
+      <FormError message={error ?? undefined} />
+    </Modal>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -148,6 +148,11 @@ async function request<T>(
   }
 
   if (response.status === 204) return undefined as T;
+  // Some backend endpoints (e.g. POST /me/wallet/accept-terms) reply 200
+  // with an empty body via Spring's ResponseEntity.ok().build(). Treat
+  // a Content-Length: 0 response as void so the JSON parser doesn't
+  // throw on an empty payload.
+  if (response.headers.get("Content-Length") === "0") return undefined as T;
   return (await response.json()) as T;
 }
 


### PR DESCRIPTION
Three fixes from live testing on prod: (1) public auction GET unblocked anonymously (was 401, now permitAll with the controller's existing 404-hide for pre-ACTIVE statuses); (2) reusable WalletTermsModal — sellers accept ToU in-place on the activate page; (3) accept-terms returns 204 instead of 200-empty, plus a defensive Content-Length: 0 short-circuit in api.ts.