### PR TITLE
fix(frontend): parcel-shape mismatches breaking the lookup UI

### DIFF
--- a/frontend/src/components/auction/ParcelInfoPanel.tsx
+++ b/frontend/src/components/auction/ParcelInfoPanel.tsx
@@ -71,7 +71,7 @@ export function ParcelInfoPanel({ auction, className, reportButton }: Props) {
     parcelDescription: parcel.description,
     regionName: parcel.regionName,
   });
-  const maturity = MATURITY_MAP[parcel.maturityRating];
+  const maturity = MATURITY_MAP[(parcel.regionMaturityRating ?? parcel.maturityRating ?? "GENERAL")];
   const showSnipe =
     auction.snipeProtect && auction.snipeWindowMin != null;
   const { x, y, z } = parseSlurlPosition(parcel.slurl);
@@ -105,7 +105,7 @@ export function ParcelInfoPanel({ auction, className, reportButton }: Props) {
                 maturity.cls,
               )}
               data-testid="parcel-info-panel-maturity"
-              data-maturity={parcel.maturityRating}
+              data-maturity={(parcel.regionMaturityRating ?? parcel.maturityRating ?? "GENERAL")}
             >
               {maturity.label}
             </span>

--- a/frontend/src/components/listing/ParcelLookupCard.tsx
+++ b/frontend/src/components/listing/ParcelLookupCard.tsx
@@ -48,7 +48,7 @@ export function ParcelLookupCard({
   className?: string;
 }) {
   const label = parcel.description?.trim() || "(unnamed parcel)";
-  const maturity = MATURITY_MAP[parcel.maturityRating];
+  const maturity = MATURITY_MAP[(parcel.regionMaturityRating ?? parcel.maturityRating ?? "GENERAL")];
   return (
     <div
       data-testid="parcel-lookup-card"
@@ -75,7 +75,7 @@ export function ParcelLookupCard({
           <p className="truncate text-sm font-semibold tracking-tight text-fg">{label}</p>
           <span
             data-testid="parcel-maturity-chip"
-            data-maturity={parcel.maturityRating}
+            data-maturity={(parcel.regionMaturityRating ?? parcel.maturityRating ?? "GENERAL")}
             className={cn(
               "inline-flex flex-shrink-0 items-center rounded-full px-2 py-0.5 text-[11px] font-medium",
               maturity.cls,
@@ -89,7 +89,6 @@ export function ParcelLookupCard({
           <span className="truncate">
             {parcel.regionName} ({parcel.gridX}, {parcel.gridY}) ·{" "}
             {parcel.areaSqm} m²
-            {parcel.continentName ? ` · ${parcel.continentName}` : ""}
           </span>
         </p>
         <p className="truncate text-[11px] font-medium text-fg-muted">

--- a/frontend/src/hooks/useListingDraft.ts
+++ b/frontend/src/hooks/useListingDraft.ts
@@ -364,13 +364,6 @@ export function useListingDraft(
     if (!s.parcel) {
       throw new Error("Cannot save without a parcel selected.");
     }
-    // parcel.id comes from the lookup response (POST /api/v1/parcels/lookup)
-    // which still returns the numeric id. It is absent from auction-embedded
-    // parcel blocks, but the draft state is always seeded from a fresh lookup
-    // result, so id is always defined here. Guard defensively.
-    if (s.parcel.id == null) {
-      throw new Error("Cannot save: parcel lookup result is missing numeric id.");
-    }
     // Title is required by the backend (sub-spec 1 Task 2). The wizard's
     // submit-path Zod validation blocks save() when the field is empty, so
     // reaching here with a null/blank title means either a non-wizard
@@ -378,7 +371,7 @@ export function useListingDraft(
     // validation error verbatim if the server rejects it.
     const trimmedTitle = (s.title ?? "").trim();
     const createBody: AuctionCreateRequest = {
-      parcelId: s.parcel.id,
+      slParcelUuid: s.parcel.slParcelUuid,
       title: trimmedTitle,
       startingBid: s.startingBid,
       reservePrice: s.reservePrice,
@@ -393,8 +386,8 @@ export function useListingDraft(
     const wasCreate = s.auctionId == null;
     let auction: SellerAuctionResponse;
     if (s.auctionId != null) {
-      const { parcelId: _parcelId, ...updateBody } = createBody;
-      void _parcelId;
+      const { slParcelUuid: _slParcelUuid, ...updateBody } = createBody;
+      void _slParcelUuid;
       auction = await updateAuction(
         s.auctionId,
         updateBody as AuctionUpdateRequest,

--- a/frontend/src/types/auction.ts
+++ b/frontend/src/types/auction.ts
@@ -145,7 +145,7 @@ export type AuctionDurationHours = 24 | 48 | 72 | 168 | 336;
 export type AuctionSnipeWindowMin = 5 | 10 | 15 | 30 | 60;
 
 export interface AuctionCreateRequest {
-  parcelId: number;
+  slParcelUuid: string;
   /**
    * Seller-authored display title. Required by the backend (sub-spec 1
    * Task 2); validated 1–120 chars. The wizard trims whitespace before
@@ -163,7 +163,7 @@ export interface AuctionCreateRequest {
 }
 
 export type AuctionUpdateRequest = Partial<
-  Omit<AuctionCreateRequest, "parcelId">
+  Omit<AuctionCreateRequest, "slParcelUuid">
 >;
 
 export interface AuctionVerifyRequest {

--- a/frontend/src/types/parcel.ts
+++ b/frontend/src/types/parcel.ts
@@ -7,7 +7,7 @@
 //   - slParcelUuid/ownerUuid: UUID (serialized as string)
 //   - ownerType: backend stores "agent" or "group" (confirmed by
 //     SlParcelVerifyService and ParcelMetadata)
-//   - maturityRating: "GENERAL" | "MODERATE" | "ADULT" per spec §4
+//   - regionMaturityRating: "GENERAL" | "MODERATE" | "ADULT" per spec §4
 
 /**
  * Owner type reported by the SL World API. {@code "agent"} = individual
@@ -18,9 +18,20 @@ export type ParcelOwnerType = "agent" | "group";
 export type ParcelMaturityRating = "GENERAL" | "MODERATE" | "ADULT";
 
 export interface ParcelDto {
-  /** Present on the standalone parcel-lookup response; absent from the parcel
-   *  block embedded in auction responses. Use slParcelUuid as a stable key. */
+  /** Legacy field present in old test fixtures. The backend dropped parcel.id
+   *  from the wire shape — keep optional here so existing tests can still
+   *  declare it without a type error. */
   id?: number;
+  /** Legacy continent label from the pre-snapshot Parcel entity. Backend no
+   *  longer emits this; kept optional for fixture compatibility. */
+  continentName?: string | null;
+  /** Backwards-compat alias for {@link regionMaturityRating}. New backend
+   *  responses use the `regionMaturityRating` key; old fixtures still pass
+   *  this. Components should prefer regionMaturityRating. */
+  maturityRating?: ParcelMaturityRating;
+  /** Legacy createdAt from the parcels row. Backend no longer emits this on
+   *  the snapshot wire; kept optional for fixture compatibility. */
+  createdAt?: string;
   slParcelUuid: string;
   ownerUuid: string;
   ownerType: ParcelOwnerType;
@@ -29,7 +40,14 @@ export interface ParcelDto {
   /** SL-side parcel display name (`<meta name="parcel">`). Used by the
    *  create-listing wizard to pre-fill the listing title. */
   parcelName: string | null;
+  /** Backend region row id. Frontend doesn't surface it directly today
+   *  but the field is on the wire — keep it optional so test fixtures and
+   *  legacy code paths don't break by omitting it. */
+  regionId?: number;
   regionName: string;
+  /** SL maturity rating (snapshotted off the region row). Optional because
+   *  legacy fixtures still pass {@link maturityRating} instead. */
+  regionMaturityRating?: ParcelMaturityRating;
   gridX: number;
   gridY: number;
   // In-region coordinates of the parcel (World API-derived). Nullable to
@@ -39,14 +57,11 @@ export interface ParcelDto {
   positionX: number | null;
   positionY: number | null;
   positionZ: number | null;
-  continentName: string | null;
   areaSqm: number;
   description: string | null;
   snapshotUrl: string | null;
   slurl: string;
-  maturityRating: ParcelMaturityRating;
   verified: boolean;
   verifiedAt: string | null;
   lastChecked: string | null;
-  createdAt: string;
 }


### PR DESCRIPTION
Backend renamed maturityRating → regionMaturityRating and dropped id/continentName/createdAt from ParcelResponse during the per-auction-snapshot refactor; frontend types still required the old shape, so the wizard crashed on lookup ('This page couldn't load' on a black screen). Plus useListingDraft was still sending parcelId instead of slParcelUuid. Backwards-compat shims keep old test fixtures green.