### PR TITLE
fix(photos): drop draft-privacy gate that broke <img src> for the seller

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/PhotoController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/PhotoController.java
@@ -3,14 +3,12 @@ package com.slparcelauctions.backend.auction;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.slparcelauctions.backend.auth.AuthPrincipal;
 import com.slparcelauctions.backend.common.exception.ResourceNotFoundException;
 import com.slparcelauctions.backend.storage.ObjectStorageService;
 import com.slparcelauctions.backend.storage.StoredObject;
@@ -19,12 +17,15 @@ import lombok.RequiredArgsConstructor;
 
 /**
  * Public photo bytes endpoint. Single flat URL serves both seller-uploaded
- * and SL_PARCEL_SNAPSHOT photos — the photo id is the canonical identifier;
- * auction membership is internal.
+ * and SL_PARCEL_SNAPSHOT photos — the photo id is the canonical identifier.
  *
- * <p>Pre-ACTIVE auctions are draft-private: anonymous callers receive 404
- * to avoid enumerating draft listings by iterating photo IDs. The auction
- * seller can still preview draft photos by supplying their access token.
+ * <p>The endpoint is intentionally fully public — browsers fetching
+ * {@code <img src>} cannot send the JWT bearer token, so the seller-only
+ * draft-photo gate that lived here briefly returned 404 to the auction's
+ * own seller. Photo IDs are sequential but expose only raw image bytes;
+ * the auction's metadata (owner, status, region, price) is hidden behind
+ * {@link AuctionController}'s separate pre-ACTIVE 404 logic. Anyone
+ * iterating photo IDs sees disconnected images with no listing context.
  */
 @RestController
 @RequestMapping("/api/v1/photos")
@@ -36,35 +37,13 @@ public class PhotoController {
 
     @GetMapping("/{id}")
     @Transactional(readOnly = true)
-    public ResponseEntity<byte[]> get(
-            @PathVariable Long id,
-            @AuthenticationPrincipal AuthPrincipal principal) {
+    public ResponseEntity<byte[]> get(@PathVariable Long id) {
         AuctionPhoto photo = photoRepo.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Photo not found: " + id));
-
-        // Pre-ACTIVE auctions are draft-only. Non-sellers get 404 to hide the
-        // draft's existence (mirrors AuctionController.get() privacy pattern).
-        Auction auction = photo.getAuction();
-        if (isPreActive(auction.getStatus())) {
-            Long callerId = principal != null ? principal.userId() : null;
-            boolean isSeller = callerId != null
-                    && auction.getSeller().getId().equals(callerId);
-            if (!isSeller) {
-                throw new ResourceNotFoundException("Photo not found: " + id);
-            }
-        }
-
         StoredObject stored = storage.get(photo.getObjectKey());
         return ResponseEntity.ok()
                 .header(HttpHeaders.CACHE_CONTROL, "public, max-age=86400")
                 .contentType(MediaType.parseMediaType(stored.contentType()))
                 .body(stored.bytes());
-    }
-
-    private static boolean isPreActive(AuctionStatus s) {
-        return s == AuctionStatus.DRAFT
-                || s == AuctionStatus.DRAFT_PAID
-                || s == AuctionStatus.VERIFICATION_PENDING
-                || s == AuctionStatus.VERIFICATION_FAILED;
     }
 }


### PR DESCRIPTION
Browser `<img src>` doesn't send the JWT, so the seller-only draft photo gate in PhotoController sent 404 to the seller themselves. Photos already don't carry auction metadata — draft privacy is upheld by AuctionController's existing pre-ACTIVE 404 on /api/v1/auctions/{id}, not by this byte stream.