### PR TITLE
chore(listing): show whole parcel image on the draft preview card

### DIFF
--- a/frontend/src/components/listing/ListingPreviewCard.tsx
+++ b/frontend/src/components/listing/ListingPreviewCard.tsx
@@ -75,7 +75,7 @@ export function ListingPreviewCard({
         <img
           src={cover}
           alt=""
-          className="h-48 w-full rounded-lg object-cover"
+          className="aspect-square w-full max-w-[700px] mx-auto rounded-lg object-contain bg-bg-subtle"
         />
       ) : null}
       <h3 className="text-base font-bold tracking-tight text-fg">{headline}</h3>


### PR DESCRIPTION
Switches the cover image on ListingPreviewCard from `object-cover h-48` (cropped to fill 192px tall) to `aspect-square w-full max-w-[700px] object-contain bg-bg-subtle` so the whole image shows at up to 700x700, centered, with neutral letterboxing.