### PR TITLE
fix(wallet): refund on every deposit error

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/sl/SlWalletController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/sl/SlWalletController.java
@@ -54,8 +54,15 @@ public class SlWalletController {
             @Valid @RequestBody SlWalletDepositRequest req) {
         headerValidator.validate(shard, ownerKey);
         terminalService.assertSharedSecret(req.sharedSecret());
+        // Deposit is L$-bearing — when ANY deposit-time check fails, the
+        // L$ is already in the script's hands and we instruct it to refund.
+        // Returning ERROR (script logs only, no bounce) would steal from the
+        // payer, so unrecognised terminals / unparseable payer UUIDs are
+        // mapped to REFUND too. Only the upstream auth failures
+        // (header / shared-secret) remain ERROR — those throw before we
+        // get here and indicate an attacker, not a real payer.
         if (!terminalRepository.existsById(req.terminalId())) {
-            return SlWalletResponse.error(SlWalletResponseReason.UNKNOWN_TERMINAL,
+            return SlWalletResponse.refund(SlWalletResponseReason.UNKNOWN_TERMINAL,
                     "terminalId not registered");
         }
         // Authenticated traffic from this terminal keeps it "live" in the
@@ -69,7 +76,7 @@ public class SlWalletController {
         try {
             payerUuid = UUID.fromString(req.payerUuid());
         } catch (IllegalArgumentException e) {
-            return SlWalletResponse.error(SlWalletResponseReason.UNKNOWN_TERMINAL,
+            return SlWalletResponse.refund(SlWalletResponseReason.UNKNOWN_TERMINAL,
                     "payerUuid not parseable as UUID");
         }
 

--- a/lsl-scripts/slpa-terminal/README.md
+++ b/lsl-scripts/slpa-terminal/README.md
@@ -11,10 +11,16 @@ backend-initiated PAYOUT/WITHDRAW commands via HTTP-in.
   withdraw-request / payout-result requests. Inbound HTTP-in: shared-secret
   check on every command.
 - **Deposit flow (lockless):** Right-click → Pay → enter L$ amount → `money()`
-  fires → POST to `/sl/wallet/deposit` → OK / REFUND / ERROR. On REFUND, the
-  script `llTransferLindenDollars` to bounce; on ERROR, owner-say only (could
-  be an attacker probing). Background retry: 10s / 30s / 90s / 5m / 15m.
-  Multiple users can pay simultaneously — `money()` is naturally reentrant.
+  fires → POST to `/sl/wallet/deposit` → OK / REFUND / ERROR. On REFUND **and
+  ERROR**, the script `llTransferLindenDollars` to bounce — the payer's L$
+  is in our hands, so any non-OK response refunds. The earlier "ERROR
+  could be an attacker probe, owner-say only" stance was unfounded:
+  pre-flight `X-SecondLife-Shard` + `X-SecondLife-Owner-Key` + shared-secret
+  validation already throws before any L$-bearing code path runs, so an
+  ERROR reaching the deposit response handler implies a legitimate payer
+  with an unhandled failure (unknown terminal id, unparseable payer uuid,
+  etc). Background retry: 10s / 30s / 90s / 5m / 15m. Multiple users can
+  pay simultaneously — `money()` is naturally reentrant.
 - **Touch flow:** touch → `llDialog` `[Deposit, Withdraw]` (no lock acquired).
   Deposit selection → `llRegionSayTo` instructions, no state. Withdraw
   selection → acquire per-flow slot → text-box for amount → confirm dialog →
@@ -97,6 +103,9 @@ In steady state with `DEBUG_MODE=true`:
 - `SLPA Terminal: deposit ok L$<amount> from <payer>` — successful deposit POST.
 - `SLPA Terminal: deposit refunded (UNKNOWN_PAYER) L$<amount> to <payer>` —
   bounced an unknown-payer deposit.
+- `SLPA Terminal: deposit refunded on ERROR (<reason>) L$<amount> to <payer>` —
+  backend returned a non-REFUND error code (e.g. UNKNOWN_TERMINAL); the
+  script bounces the L$ regardless so the payer is never out money.
 - `SLPA Terminal: deposit retry N/5: status=...` — transient, retrying.
 - `SLPA Terminal: withdraw queued L$<amount> for <payer>` — successful withdraw-request.
 - `SLPA Terminal: HTTP-in WITHDRAW to <recipient> L$<amount> ikey=...` — backend

--- a/lsl-scripts/slpa-terminal/slpa-terminal.lsl
+++ b/lsl-scripts/slpa-terminal/slpa-terminal.lsl
@@ -761,11 +761,20 @@ default {
                             + reason + ") L$" + (string)paymentAmount
                             + " to " + (string)paymentPayer);
                 } else if (s == "ERROR") {
-                    // ERROR — do NOT refund (could be an attack probe).
+                    // Deposit ERROR — refund anyway. The payer is real and
+                    // their L$ is in our hands; whatever the backend tripped
+                    // on (unknown terminal id, unparseable payer uuid, etc.)
+                    // is our problem, not theirs. The earlier "could be an
+                    // attack probe" rationale was unfounded — pre-flight
+                    // shared-secret + SL header validation already throw
+                    // before any L$-bearing path, so reaching this branch
+                    // implies a legitimate but unhandled failure.
                     string reason = llJsonGetValue(body, ["reason"]);
-                    llOwnerSay("SLPA Terminal: deposit ERROR (" + reason
-                        + ") L$" + (string)paymentAmount + " from " + (string)paymentPayer
-                        + " — NOT refunded.");
+                    llTransferLindenDollars(paymentPayer, paymentAmount);
+                    if (DEBUG_MODE)
+                        llOwnerSay("SLPA Terminal: deposit refunded on ERROR ("
+                            + reason + ") L$" + (string)paymentAmount
+                            + " to " + (string)paymentPayer);
                 }
                 paymentPayer = NULL_KEY;
                 paymentAmount = 0;


### PR DESCRIPTION
Backend now returns REFUND (not ERROR) for UNKNOWN_TERMINAL on deposits, and the LSL terminal refunds on ERROR responses too. Reaching these branches implies a real payer (auth + shared-secret pre-flight already rejected attackers), so anything that doesn't credit the wallet has to bounce the L$.

User trigger: today's DB wipe dropped the terminals row for an in-flight terminal; subsequent deposits returned UNKNOWN_TERMINAL, the script logged 'NOT refunded', and the payer was out L$100. After this PR, the same scenario auto-refunds via the existing REFUND path.