### PR TITLE
fix(search): serialize parcel tags as label strings (Amplify SSR build fix)

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/search/AuctionSearchResultMapper.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/search/AuctionSearchResultMapper.java
@@ -123,17 +123,19 @@ public class AuctionSearchResultMapper {
     }
 
     /**
-     * {@link ParcelTag} is an entity, not naturally {@link Comparable}; sort by
-     * id for a stable client-visible order. Null ids (transient tags) sink to
-     * the front via the natural ordering of {@code Long.compare(0, ...)}.
+     * Project tag entities to their human-readable labels (sorted by id for
+     * a stable client-visible order). Returning the full entity used to
+     * leak audit columns and crash the frontend's React SSR — the
+     * frontend's TS type for this field is {@code string[]}.
      */
-    private List<ParcelTag> sortedTagsList(Set<ParcelTag> tags) {
+    private List<String> sortedTagsList(Set<ParcelTag> tags) {
         if (tags == null || tags.isEmpty()) {
             return List.of();
         }
         return tags.stream()
                 .sorted(Comparator.comparingLong(
                         t -> t.getId() == null ? 0L : t.getId()))
+                .map(ParcelTag::getLabel)
                 .toList();
     }
 

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/search/ParcelSummaryDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/search/ParcelSummaryDto.java
@@ -2,8 +2,16 @@ package com.slparcelauctions.backend.auction.search;
 
 import java.util.List;
 
-import com.slparcelauctions.backend.parceltag.ParcelTag;
-
+/**
+ * Lean parcel projection for each browse / featured-row / search-result
+ * card. {@code tags} is a list of human-readable labels (e.g.
+ * "Waterfront", "Hilltop") that the frontend renders directly into chip
+ * elements. Previously this field carried the full {@link
+ * com.slparcelauctions.backend.parceltag.ParcelTag} entity which leaked
+ * audit columns ({@code active}, {@code createdAt}, {@code updatedAt})
+ * and crashed React SSR ("Objects are not valid as a React child")
+ * because the frontend's TS type already expected {@code string[]}.
+ */
 public record ParcelSummaryDto(
         Long id,
         String name,
@@ -16,5 +24,5 @@ public record ParcelSummaryDto(
         Double positionX,
         Double positionY,
         Double positionZ,
-        List<ParcelTag> tags) {
+        List<String> tags) {
 }


### PR DESCRIPTION
Amplify build (#42) failed with 'Objects are not valid as a React child' on /. Root cause: ParcelSummaryDto.tags was List<ParcelTag> serializing the full entity row, but the frontend's TS type was string[] and ListingCard renders {t} directly. Switching to List<String> of labels matches the frontend's long-standing assumption.