### PR TITLE
fix(frontend): / dynamic + defensive tag coercion

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,6 +4,17 @@ import { TrustStrip } from "@/components/marketing/TrustStrip";
 import { fetchFeatured } from "@/lib/api/auctions-search";
 
 /**
+ * Render at request time, never at build time. Static prerendering would
+ * couple the Amplify build to whatever the backend happens to return at
+ * build time — a single bad-shape field on a featured auction (e.g. an
+ * accidentally-leaked entity row inside a list) crashes the build and
+ * blocks every other page from deploying. The home page's data
+ * (countdowns, current bids) changes on every visit anyway, so a static
+ * snapshot is never the right cache.
+ */
+export const dynamic = "force-dynamic";
+
+/**
  * Homepage server component. Fans out the three featured-rail fetches under
  * a single Promise.allSettled so one endpoint's 5xx doesn't cascade into a
  * full-page 500 — failing rails render a neutral placeholder instead.

--- a/frontend/src/components/auction/ListingCard.tsx
+++ b/frontend/src/components/auction/ListingCard.tsx
@@ -85,8 +85,16 @@ export function ListingCard({ listing, variant, className }: ListingCardProps) {
   const imageSrc =
     listing.primaryPhotoUrl ?? listing.parcel.snapshotUrl ?? undefined;
   const maxTags = MAX_TAGS[variant];
-  const visibleTags = listing.parcel.tags.slice(0, maxTags);
-  const overflow = listing.parcel.tags.length - visibleTags.length;
+  // Defensive coercion: the backend has historically wavered between
+  // string[] (current contract — labels) and ParcelTag entity rows (a
+  // bug we hit during the per-auction-snapshot rollout that crashed
+  // SSR with "Objects are not valid as a React child"). Tolerate both
+  // shapes here so a backend regression cannot crash the build again.
+  const tagLabels: string[] = (listing.parcel.tags ?? []).map((t) =>
+    typeof t === "string" ? t : ((t as { label?: string }).label ?? ""),
+  );
+  const visibleTags = tagLabels.slice(0, maxTags);
+  const overflow = tagLabels.length - visibleTags.length;
   const showHeart = !PRE_ACTIVE.has(listing.status);
 
   return (


### PR DESCRIPTION
Two safety nets so Amplify SSR never depends on what the prod backend serves at build time: home page is force-dynamic (no static prerender), and ListingCard coerces parcel.tags to string[] at render time. Either alone would have unblocked the failing builds; both together makes the failure mode impossible to reach again.