### PR TITLE
chore(language): remove em-dashes from user/admin-visible copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,5 @@ infra/crash.*.log
 # .terraform.lock.hcl IS committed — Terraform's recommendation. Pins provider
 # versions so every machine + CI run resolves the same provider versions.
 infra/.scratch/
+
+.ignored-docs

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/reconciliation/ReconciliationService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/infrastructure/reconciliation/ReconciliationService.java
@@ -58,7 +58,7 @@ public class ReconciliationService {
         long sourceReserved = reservationRepo.sumAllActive();
         if (denormReserved != sourceReserved) {
             long denormDrift = denormReserved - sourceReserved;
-            log.error("Reconciliation aborted: DENORM_DRIFT — "
+            log.error("Reconciliation aborted: DENORM_DRIFT. "
                     + "users.reserved_lindens sum={} vs bid_reservations sum={} (diff={})",
                     denormReserved, sourceReserved, denormDrift);
             ReconciliationRun run = persist(now, 0L, null, denormDrift,
@@ -77,7 +77,7 @@ public class ReconciliationService {
         if (balanceOpt.isEmpty()) {
             persist(now, sumExpected(), null, null,
                     ReconciliationStatus.ERROR,
-                    "Balance data stale — terminal may be offline");
+                    "Balance data stale; terminal may be offline");
             log.error("Reconciliation aborted: balance reading stale (>2h)");
             return;
         }

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
@@ -175,7 +175,7 @@ public class EscrowService {
             try {
                 walletService.autoFundEscrow(auction.getId(), winner, finalBid, saved.getId());
             } catch (BidReservationAmountMismatchException e) {
-                log.error("BID-RESERVATION-AMOUNT-MISMATCH for auction {}: reservation=L${} != finalBid=L${} — freezing escrow",
+                log.error("BID-RESERVATION-AMOUNT-MISMATCH for auction {}: reservation=L${} != finalBid=L${}; freezing escrow",
                         auction.getId(), e.getReservationAmount(), e.getFinalBidAmount());
                 saved.setState(EscrowState.FROZEN);
                 saved.setFrozenAt(endedAt);

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java
@@ -218,7 +218,7 @@ public class NotificationPublisherImpl implements NotificationPublisher {
     @Override
     public void escrowPayoutStalled(long sellerUserId, long auctionId, long escrowId, String parcelName) {
         String title = "Payout delayed: " + parcelName;
-        String body = "Your payout is delayed — we're investigating. No action needed from you.";
+        String body = "Your payout is delayed. We're investigating; no action needed from you.";
         notificationService.publish(new NotificationEvent(
             sellerUserId, NotificationCategory.ESCROW_PAYOUT_STALLED, title, body,
             NotificationDataBuilder.escrowPayoutStalled(auctionId, escrowId, parcelName),
@@ -383,7 +383,7 @@ public class NotificationPublisherImpl implements NotificationPublisher {
                 }
                 yield "winner".equals(role)
                         ? "Dispute dismissed for " + parcelName
-                            + ". Escrow remains funded — please complete payment at the terminal."
+                            + ". Escrow remains funded; please complete payment at the terminal."
                         : "Dispute resolved for " + parcelName + ". Escrow remains funded.";
             }
             case RESUME_TRANSFER -> "Escrow unfrozen for " + parcelName

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/sl/WalletSlExceptionHandler.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/sl/WalletSlExceptionHandler.java
@@ -31,7 +31,7 @@ public class WalletSlExceptionHandler {
 
     @ExceptionHandler(InvalidSlHeadersException.class)
     public ResponseEntity<SlWalletResponse> handleInvalidHeaders(InvalidSlHeadersException e) {
-        log.warn("Wallet SL endpoint rejected: bad headers — {}", e.getMessage());
+        log.warn("Wallet SL endpoint rejected: bad headers: {}", e.getMessage());
         return ResponseEntity.ok(SlWalletResponse.error(
                 SlWalletResponseReason.BAD_HEADERS, e.getMessage()));
     }

--- a/frontend/src/app/admin/audit-log/AdminAuditLogPage.tsx
+++ b/frontend/src/app/admin/audit-log/AdminAuditLogPage.tsx
@@ -26,7 +26,7 @@ export function AdminAuditLogPage() {
       <header>
         <h1 className="text-xl font-semibold">Admin audit log</h1>
         <p className="text-xs opacity-60 mt-1">
-          Every admin action — fraud-flag triage, reports, bans, disputes,
+          Every admin action: fraud-flag triage, reports, bans, disputes,
           withdrawals, secret rotations.
         </p>
       </header>

--- a/frontend/src/app/admin/audit-log/AdminAuditLogTable.tsx
+++ b/frontend/src/app/admin/audit-log/AdminAuditLogTable.tsx
@@ -89,10 +89,10 @@ export function AdminAuditLogTable({ rows }: Props) {
                       )}
                     </>
                   ) : (
-                    "—"
+                    "-"
                   )}
                 </td>
-                <td className="py-2 px-2 opacity-85">{row.notes ?? "—"}</td>
+                <td className="py-2 px-2 opacity-85">{row.notes ?? "-"}</td>
                 <td className="py-2 px-2 text-brand">
                   {isOpen ? "▾" : "▸"}
                 </td>

--- a/frontend/src/app/admin/disputes/AdminDisputesTable.tsx
+++ b/frontend/src/app/admin/disputes/AdminDisputesTable.tsx
@@ -34,7 +34,7 @@ export function AdminDisputesTable({ rows }: Props) {
             <td className="py-2 px-2">
               <Link href={`/admin/disputes/${row.escrowId}`}>{row.auctionTitle}</Link>
             </td>
-            <td className="py-2 px-2">{row.reasonCategory ?? "—"}</td>
+            <td className="py-2 px-2">{row.reasonCategory ?? "-"}</td>
             <td className="py-2 px-2">{row.sellerEmail} → {row.winnerEmail}</td>
             <td className="py-2 px-2">L$ {row.salePriceL.toLocaleString()}</td>
             <td className="py-2 px-2">{new Date(row.openedAt).toLocaleString()}</td>

--- a/frontend/src/app/admin/disputes/[publicId]/EscrowLedgerPanel.tsx
+++ b/frontend/src/app/admin/disputes/[publicId]/EscrowLedgerPanel.tsx
@@ -15,7 +15,7 @@ export function EscrowLedgerPanel({ entries }: { entries: EscrowLedgerEntry[] })
               <tr key={i} className="border-b border-border-subtle/40">
                 <td className="py-2 px-3 opacity-60">{new Date(e.at).toLocaleString()}</td>
                 <td className="py-2 px-3 text-brand">{e.type}</td>
-                <td className="py-2 px-3">{e.amount === null ? "—" : `L$ ${e.amount}`}</td>
+                <td className="py-2 px-3">{e.amount === null ? "-" : `L$ ${e.amount}`}</td>
                 <td className="py-2 px-3 opacity-70">{e.detail}</td>
               </tr>
             ))

--- a/frontend/src/app/admin/infrastructure/AvailableToWithdrawCard.tsx
+++ b/frontend/src/app/admin/infrastructure/AvailableToWithdrawCard.tsx
@@ -9,7 +9,7 @@ export function AvailableToWithdrawCard() {
   return (
     <section className="bg-bg-muted rounded p-4">
       <h2 className="text-sm font-semibold mb-2">Available to withdraw</h2>
-      <p className="text-2xl font-bold mb-3">L$ {data?.available?.toLocaleString() ?? "—"}</p>
+      <p className="text-2xl font-bold mb-3">L$ {data?.available?.toLocaleString() ?? "-"}</p>
       <button
         type="button"
         onClick={() => setOpen(true)}

--- a/frontend/src/app/admin/infrastructure/BotPoolSection.tsx
+++ b/frontend/src/app/admin/infrastructure/BotPoolSection.tsx
@@ -37,11 +37,11 @@ export function BotPoolSection() {
                 <td className={`py-2 ${r.isAlive ? "text-success" : "text-danger"}`}>
                   ● {r.sessionState ?? "MISSING"}
                 </td>
-                <td className="py-2">{r.currentRegion ?? "—"}</td>
+                <td className="py-2">{r.currentRegion ?? "-"}</td>
                 <td className="py-2 opacity-80">
-                  {r.currentTaskType ? `${r.currentTaskType} ${r.currentTaskKey ?? ""}` : "—"}
+                  {r.currentTaskType ? `${r.currentTaskType} ${r.currentTaskKey ?? ""}` : "-"}
                 </td>
-                <td className="py-2 opacity-70">{r.isAlive ? `${secondsAgo(r.lastSeenAt)}s ago` : "—"}</td>
+                <td className="py-2 opacity-70">{r.isAlive ? `${secondsAgo(r.lastSeenAt)}s ago` : "-"}</td>
               </tr>
             ))}
           </tbody>

--- a/frontend/src/app/admin/infrastructure/ReconciliationSection.tsx
+++ b/frontend/src/app/admin/infrastructure/ReconciliationSection.tsx
@@ -25,8 +25,8 @@ export function ReconciliationSection() {
         <div className="bg-bg-subtle rounded p-3 mb-3 text-xs space-y-1">
           <Row label="Last run" value={new Date(latest.ranAt).toLocaleString()} />
           <Row label="Expected (locked sum)" value={`L$ ${latest.expected}`} />
-          <Row label="Observed (grid balance)" value={latest.observed !== null ? `L$ ${latest.observed}` : "—"} />
-          <Row label="Drift" value={latest.drift !== null ? `L$ ${latest.drift}` : "—"} />
+          <Row label="Observed (grid balance)" value={latest.observed !== null ? `L$ ${latest.observed}` : "-"} />
+          <Row label="Drift" value={latest.drift !== null ? `L$ ${latest.drift}` : "-"} />
           {latest.errorMessage && <p className="text-danger text-[11px] mt-2">{latest.errorMessage}</p>}
         </div>
       )}
@@ -38,7 +38,7 @@ export function ReconciliationSection() {
             {runs.map((r) => (
               <span key={r.id} className={`px-2 py-1 rounded text-[10.5px] ${badgeFor(r.status)}`}>
                 {new Date(r.ranAt).toLocaleDateString()}{" "}
-                {r.status === "BALANCED" ? "✓" : r.status === "MISMATCH" ? `⚠ L$ ${r.drift}` : "—"}
+                {r.status === "BALANCED" ? "✓" : r.status === "MISMATCH" ? `⚠ L$ ${r.drift}` : "-"}
               </span>
             ))}
           </div>

--- a/frontend/src/app/admin/infrastructure/RotateSecretModal.tsx
+++ b/frontend/src/app/admin/infrastructure/RotateSecretModal.tsx
@@ -10,7 +10,7 @@ export function RotateSecretModal({ onClose }: { onClose: () => void }) {
   if (rotate.data) {
     return (
       <Backdrop onClose={() => {}}>
-        <h2 className="text-sm font-semibold mb-2">New secret — save it now</h2>
+        <h2 className="text-sm font-semibold mb-2">New secret. Save it now.</h2>
         <p className="text-[11px] opacity-70 mb-3">
           This value will <strong>not</strong> be shown again. Copy it before closing.
         </p>
@@ -27,7 +27,7 @@ export function RotateSecretModal({ onClose }: { onClose: () => void }) {
           {rotate.data.terminalPushResults.map((r) => (
             <li key={r.terminalId} className={r.success ? "text-success" : "text-danger"}>
               {r.success ? "✓" : "✗"} {r.terminalName}
-              {r.errorMessage && <span className="opacity-70"> — {r.errorMessage}</span>}
+              {r.errorMessage && <span className="opacity-70">: {r.errorMessage}</span>}
             </li>
           ))}
         </ul>

--- a/frontend/src/app/admin/infrastructure/TerminalsSection.tsx
+++ b/frontend/src/app/admin/infrastructure/TerminalsSection.tsx
@@ -48,11 +48,11 @@ export function TerminalsSection() {
           <tbody>
             {rows.map((t) => (
               <tr key={t.terminalId} className="border-b border-border-subtle/40">
-                <td className="py-2">{t.regionName ?? "—"}</td>
+                <td className="py-2">{t.regionName ?? "-"}</td>
                 <td className="py-2">{t.terminalId}</td>
-                <td className="py-2 opacity-80">{t.lastSeenAt ? new Date(t.lastSeenAt).toLocaleString() : "—"}</td>
-                <td className="py-2">{t.lastReportedBalance !== null ? `L$ ${t.lastReportedBalance}` : "—"}</td>
-                <td className="py-2">v{t.currentSecretVersion ?? "—"}</td>
+                <td className="py-2 opacity-80">{t.lastSeenAt ? new Date(t.lastSeenAt).toLocaleString() : "-"}</td>
+                <td className="py-2">{t.lastReportedBalance !== null ? `L$ ${t.lastReportedBalance}` : "-"}</td>
+                <td className="py-2">v{t.currentSecretVersion ?? "-"}</td>
                 <td className="py-2 text-right">
                   <button
                     type="button"
@@ -79,7 +79,7 @@ export function TerminalsSection() {
           <div className="bg-bg-muted max-w-md w-full rounded-lg p-5">
             <h3 className="text-sm font-semibold mb-2">Unregister terminal</h3>
             <p className="text-xs opacity-80 mb-3">
-              This soft-deletes the terminal — sets <code>active=false</code> so the
+              This soft-deletes the terminal: sets <code>active=false</code> so the
               dispatcher stops routing commands to it. The row stays in the database
               for forensics. If the in-world script later re-registers, it will become
               active again.

--- a/frontend/src/app/admin/infrastructure/WithdrawalsHistorySection.tsx
+++ b/frontend/src/app/admin/infrastructure/WithdrawalsHistorySection.tsx
@@ -26,8 +26,8 @@ export function WithdrawalsHistorySection() {
                 w.status === "COMPLETED" ? "text-success" :
                 w.status === "FAILED" ? "text-danger" : "text-info"
               }`}>{w.status}</td>
-              <td className="py-2 opacity-70">{w.completedAt ? new Date(w.completedAt).toLocaleString() : "—"}</td>
-              <td className="py-2 opacity-70">{w.notes ?? "—"}</td>
+              <td className="py-2 opacity-70">{w.completedAt ? new Date(w.completedAt).toLocaleString() : "-"}</td>
+              <td className="py-2 opacity-70">{w.notes ?? "-"}</td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/app/auction/[publicId]/escrow/dispute/DisputeFormClient.tsx
+++ b/frontend/src/app/auction/[publicId]/escrow/dispute/DisputeFormClient.tsx
@@ -381,7 +381,7 @@ function DisputeFormBody({
   return (
     <form onSubmit={onSubmit} className="space-y-5" noValidate>
       <div className="rounded-md bg-bg-subtle p-4 text-xs text-fg-muted">
-        Escrow state: <strong>{escrow.state}</strong> — you are the{" "}
+        Escrow state: <strong>{escrow.state}</strong>. You are the{" "}
         <strong>{role}</strong>.
       </div>
 

--- a/frontend/src/app/auction/[publicId]/page.integration.test.tsx
+++ b/frontend/src/app/auction/[publicId]/page.integration.test.tsx
@@ -749,7 +749,7 @@ describe("AuctionDetailClient", () => {
     );
     const row = screen.getByTestId("auction-ended-row");
     expect(row).toHaveAttribute("data-outcome", "SOLD");
-    expect(row).toHaveTextContent("Auction ended — L$2,500");
+    expect(row).toHaveTextContent("Auction ended at L$2,500");
   });
 
   it("surfaces the snipe-extension banner on a snipe-triggering envelope", async () => {

--- a/frontend/src/app/auction/[publicId]/page.tsx
+++ b/frontend/src/app/auction/[publicId]/page.tsx
@@ -41,7 +41,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       [...a.photos].sort((p, q) => p.sortOrder - q.sortOrder)[0]?.url ?? null;
     const og = primaryPhoto ?? a.parcel.snapshotUrl ?? undefined;
     const currentBidDisplay =
-      typeof a.currentBid === "number" ? a.currentBid.toLocaleString() : "—";
+      typeof a.currentBid === "number" ? a.currentBid.toLocaleString() : "-";
     return {
       title: `${a.title} · SLPA`,
       description: `${a.parcel.regionName} · ${a.parcel.areaSqm} sqm · L$ ${currentBidDisplay}`,

--- a/frontend/src/app/dev/listing-card-demo/page.tsx
+++ b/frontend/src/app/dev/listing-card-demo/page.tsx
@@ -10,7 +10,7 @@ import type { AuctionSearchResultDto } from "@/types/search";
  */
 const sample: AuctionSearchResultDto = {
   publicId: "00000000-0000-0000-0000-000000000042",
-  title: "Demo — Premium Waterfront",
+  title: "Demo Premium Waterfront",
   status: "ACTIVE",
   endOutcome: null,
   parcel: {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -20,7 +20,7 @@ const jetbrainsMono = JetBrains_Mono({
 
 export const metadata: Metadata = {
   title: {
-    default: "SLPA — Second Life Parcel Auctions",
+    default: "SLPA: Second Life Parcel Auctions",
     template: "%s · SLPA",
   },
   description: "Player-to-player land auctions for Second Life.",

--- a/frontend/src/app/listings/(verified)/[publicId]/activate/ActivateClient.test.tsx
+++ b/frontend/src/app/listings/(verified)/[publicId]/activate/ActivateClient.test.tsx
@@ -126,7 +126,7 @@ describe("ActivateClient", () => {
       auth: "authenticated",
     });
     expect(
-      await screen.findByText(/Preview — this is how your listing/i),
+      await screen.findByText(/Preview: this is how your listing/i),
     ).toBeInTheDocument();
     expect(
       await screen.findByRole("button", { name: /Activate Listing/i }),

--- a/frontend/src/components/admin/bans/CreateBanModal.tsx
+++ b/frontend/src/components/admin/bans/CreateBanModal.tsx
@@ -257,7 +257,7 @@ export function CreateBanModal({ open, onClose, initialSlAvatarUuid, initialIpAd
             </div>
 
             <div className="rounded-lg bg-info-bg/30 border border-info-bg px-4 py-3 text-sm text-fg-muted">
-              On create: token version bumps for any user with this avatar UUID — their session
+              On create: token version bumps for any user with this avatar UUID, so their session
               invalidates on next refresh. Ban cache flushes immediately.
             </div>
 

--- a/frontend/src/components/admin/fraud-flags/FraudFlagEvidence.tsx
+++ b/frontend/src/components/admin/fraud-flags/FraudFlagEvidence.tsx
@@ -20,7 +20,7 @@ function EvidenceValue({ value, linkedUsers }: EvidenceValueProps) {
       return (
         <Link
           href={`/users/${linked.userId}`}
-          title={`${value} — ${linked.displayName ?? "(no display name)"}`}
+          title={`${value} (${linked.displayName ?? "no display name"})`}
           className="font-mono text-brand underline underline-offset-2"
         >
           {truncateUuid(value)}
@@ -30,7 +30,7 @@ function EvidenceValue({ value, linkedUsers }: EvidenceValueProps) {
     return (
       <span
         className="font-mono"
-        title={`${value} — (not a registered SLPA user)`}
+        title={`${value} (not a registered SLPA user)`}
       >
         {truncateUuid(value)}
       </span>

--- a/frontend/src/components/admin/fraud-flags/FraudFlagSlideOver.tsx
+++ b/frontend/src/components/admin/fraud-flags/FraudFlagSlideOver.tsx
@@ -60,7 +60,7 @@ export function FraudFlagSlideOver({ flagId, hasPrev, hasNext, onPrev, onNext, o
     recheck.mutate(detail.auction.id, {
       onSuccess: (result) => {
         if (result.ownerMatch) {
-          toast.success("Owner match — no change.");
+          toast.success("Owner match. No change.");
         } else if (result.auctionStatus === "SUSPENDED") {
           toast.error("Owner mismatch detected. Auction suspended.");
         } else {

--- a/frontend/src/components/admin/fraud-flags/FraudFlagTable.tsx
+++ b/frontend/src/components/admin/fraud-flags/FraudFlagTable.tsx
@@ -81,7 +81,7 @@ export function FraudFlagTable({ rows, selectedId, onSelect }: Props) {
                   )}
                 </td>
                 <td className={cn("px-3 py-2.5 text-right", statusClass)}>
-                  {row.auctionStatus ?? "—"}
+                  {row.auctionStatus ?? "-"}
                 </td>
               </tr>
             );

--- a/frontend/src/components/admin/fraud-flags/SiblingFlagWarning.tsx
+++ b/frontend/src/components/admin/fraud-flags/SiblingFlagWarning.tsx
@@ -11,7 +11,7 @@ export function SiblingFlagWarning({ count }: Props) {
     >
       This auction has <span className="font-medium">{count}</span> other open flag
       {count === 1 ? "" : "s"}. Resolving this one alone doesn&apos;t address{" "}
-      {count === 1 ? "it" : "them"} — {count === 1 ? "it needs" : "they need"} separate review.
+      {count === 1 ? "it" : "them"}; {count === 1 ? "it needs" : "they need"} separate review.
     </div>
   );
 }

--- a/frontend/src/components/admin/reports/AdminReportsTable.tsx
+++ b/frontend/src/components/admin/reports/AdminReportsTable.tsx
@@ -87,7 +87,7 @@ export function AdminReportsTable({ rows, selectedAuctionId, onSelect }: Props) 
                   )}
                 </td>
                 <td className="px-3 py-2.5 text-fg-muted">
-                  {row.sellerDisplayName ?? "—"}
+                  {row.sellerDisplayName ?? "-"}
                 </td>
                 <td className="px-3 py-2.5 text-right font-medium text-fg">
                   {row.openReportCount}

--- a/frontend/src/components/admin/users/AdminUsersTable.tsx
+++ b/frontend/src/components/admin/users/AdminUsersTable.tsx
@@ -74,7 +74,7 @@ export function AdminUsersTable({ rows }: Props) {
                     {truncateUuid(row.slAvatarUuid)}
                   </span>
                 ) : (
-                  <span className="text-fg-muted/50">—</span>
+                  <span className="text-fg-muted/50">-</span>
                 )}
               </td>
               <td className="px-3 py-2.5">
@@ -101,7 +101,7 @@ export function AdminUsersTable({ rows }: Props) {
                     BANNED
                   </span>
                 ) : (
-                  <span className="text-[11px] text-fg-muted">—</span>
+                  <span className="text-[11px] text-fg-muted">-</span>
                 )}
               </td>
               <td className="px-3 py-2.5 text-fg-muted text-[11px]">{formatDate(row.createdAt)}</td>

--- a/frontend/src/components/admin/users/tabs/CancellationsTab.tsx
+++ b/frontend/src/components/admin/users/tabs/CancellationsTab.tsx
@@ -78,7 +78,7 @@ export function CancellationsTab({ userId }: Props) {
                       {row.penaltyAmountL !== null && ` (L$ ${row.penaltyAmountL.toLocaleString()})`}
                     </span>
                   ) : (
-                    "—"
+                    "-"
                   )}
                 </td>
                 <td className="px-3 py-2.5 text-fg-muted text-[11px]">{formatDate(row.cancelledAt)}</td>

--- a/frontend/src/components/admin/users/tabs/ListingsTab.tsx
+++ b/frontend/src/components/admin/users/tabs/ListingsTab.tsx
@@ -83,11 +83,11 @@ export function ListingsTab({ userId }: Props) {
                       {row.title}
                     </Link>
                   </td>
-                  <td className="px-3 py-2.5 text-fg-muted">{row.regionName ?? "—"}</td>
+                  <td className="px-3 py-2.5 text-fg-muted">{row.regionName ?? "-"}</td>
                   <td className={`px-3 py-2.5 ${className}`}>{label}</td>
                   <td className="px-3 py-2.5 text-fg-muted text-[11px]">{formatDate(row.endsAt)}</td>
                   <td className="px-3 py-2.5 text-right text-fg">
-                    {row.finalBidAmount !== null ? `L$ ${row.finalBidAmount.toLocaleString()}` : "—"}
+                    {row.finalBidAmount !== null ? `L$ ${row.finalBidAmount.toLocaleString()}` : "-"}
                   </td>
                   <td className="px-3 py-2.5 text-right">
                     {row.status === "SUSPENDED" && (

--- a/frontend/src/components/admin/users/tabs/ModerationTab.tsx
+++ b/frontend/src/components/admin/users/tabs/ModerationTab.tsx
@@ -63,7 +63,7 @@ export function ModerationTab({ userId }: Props) {
                   {row.adminDisplayName ?? "System"}
                 </td>
                 <td className="px-3 py-2.5 text-fg-muted max-w-xs">
-                  <span className="line-clamp-2">{row.notes ?? "—"}</span>
+                  <span className="line-clamp-2">{row.notes ?? "-"}</span>
                 </td>
                 <td className="px-3 py-2.5 text-fg-muted text-[11px]">{formatDate(row.createdAt)}</td>
               </tr>

--- a/frontend/src/components/auction/AuctionEndedPanel.tsx
+++ b/frontend/src/components/auction/AuctionEndedPanel.tsx
@@ -220,7 +220,7 @@ function OutcomeBlock({
           className="text-lg font-bold tracking-tight text-fg"
           data-testid="auction-ended-headline"
         >
-          Reserve not met — auction ended without a sale
+          Reserve not met. Auction ended without a sale.
         </h2>
         <p className="text-sm text-fg-muted">
           Highest bid was L${formatAmount(numericHighBid(auction.currentHighBid))}
@@ -411,6 +411,6 @@ function numericHighBid(
 }
 
 function formatAmount(value: number | null): string {
-  if (value == null) return "—";
+  if (value == null) return "-";
   return value.toLocaleString();
 }

--- a/frontend/src/components/auction/AuctionEndedRow.test.tsx
+++ b/frontend/src/components/auction/AuctionEndedRow.test.tsx
@@ -66,7 +66,7 @@ function endedAuction(
 }
 
 describe("AuctionEndedRow", () => {
-  it("renders 'Auction ended — L$N' for SOLD", () => {
+  it("renders 'Auction ended at L$N' for SOLD", () => {
     renderWithProviders(
       <AuctionEndedRow
         auction={endedAuction({ endOutcome: "SOLD", finalBidAmount: 2500 })}
@@ -74,10 +74,10 @@ describe("AuctionEndedRow", () => {
     );
     const row = screen.getByTestId("auction-ended-row");
     expect(row).toHaveAttribute("data-outcome", "SOLD");
-    expect(row).toHaveTextContent("Auction ended — L$2,500");
+    expect(row).toHaveTextContent("Auction ended at L$2,500");
   });
 
-  it("renders 'Auction ended — L$N' for BOUGHT_NOW", () => {
+  it("renders 'Auction ended at L$N' for BOUGHT_NOW", () => {
     renderWithProviders(
       <AuctionEndedRow
         auction={endedAuction({
@@ -87,11 +87,11 @@ describe("AuctionEndedRow", () => {
       />,
     );
     expect(screen.getByTestId("auction-ended-row")).toHaveTextContent(
-      "Auction ended — L$50,000",
+      "Auction ended at L$50,000",
     );
   });
 
-  it("renders 'Ended — no winner' for RESERVE_NOT_MET", () => {
+  it("renders 'Ended with no winner' for RESERVE_NOT_MET", () => {
     renderWithProviders(
       <AuctionEndedRow
         auction={endedAuction({
@@ -101,11 +101,11 @@ describe("AuctionEndedRow", () => {
       />,
     );
     expect(screen.getByTestId("auction-ended-row")).toHaveTextContent(
-      "Ended — no winner",
+      "Ended with no winner",
     );
   });
 
-  it("renders 'Ended — no winner' for NO_BIDS", () => {
+  it("renders 'Ended with no winner' for NO_BIDS", () => {
     renderWithProviders(
       <AuctionEndedRow
         auction={endedAuction({
@@ -115,7 +115,7 @@ describe("AuctionEndedRow", () => {
       />,
     );
     expect(screen.getByTestId("auction-ended-row")).toHaveTextContent(
-      "Ended — no winner",
+      "Ended with no winner",
     );
   });
 });

--- a/frontend/src/components/auction/AuctionEndedRow.tsx
+++ b/frontend/src/components/auction/AuctionEndedRow.tsx
@@ -45,8 +45,8 @@ export function AuctionEndedRow({ auction }: AuctionEndedRowProps) {
   const hasWinner = outcome === "SOLD" || outcome === "BOUGHT_NOW";
 
   const label = hasWinner
-    ? `Auction ended — L$${formatAmount(finalBid)}`
-    : "Ended — no winner";
+    ? `Auction ended at L$${formatAmount(finalBid)}`
+    : "Ended with no winner";
 
   return (
     <div
@@ -62,6 +62,6 @@ export function AuctionEndedRow({ auction }: AuctionEndedRowProps) {
 }
 
 function formatAmount(value: number | null | undefined): string {
-  if (value == null || !Number.isFinite(value)) return "—";
+  if (value == null || !Number.isFinite(value)) return "-";
   return value.toLocaleString();
 }

--- a/frontend/src/components/auction/BidHistoryList.tsx
+++ b/frontend/src/components/auction/BidHistoryList.tsx
@@ -211,7 +211,7 @@ function BidHistoryPage({
         data-testid="bid-history-empty"
         className="rounded-lg bg-surface-raised px-4 py-6 text-sm text-fg-muted"
       >
-        No bids yet — be the first to bid.
+        No bids yet. Be the first to bid.
       </p>
     );
   }

--- a/frontend/src/components/auction/BidPanel.tsx
+++ b/frontend/src/components/auction/BidPanel.tsx
@@ -205,9 +205,9 @@ function CurrentBidDisplay({
 }
 
 function formatHighBid(value: number | string | null): string {
-  if (value == null) return "—";
+  if (value == null) return "-";
   const n = typeof value === "string" ? Number(value) : value;
-  if (!Number.isFinite(n)) return "—";
+  if (!Number.isFinite(n)) return "-";
   return n.toLocaleString();
 }
 

--- a/frontend/src/components/auction/PlaceBidForm.tsx
+++ b/frontend/src/components/auction/PlaceBidForm.tsx
@@ -216,7 +216,7 @@ export function PlaceBidForm({ auction, connectionState }: PlaceBidFormProps) {
         <ConfirmBidDialog
           isOpen
           title={`Confirm L$${confirm.amount.toLocaleString()}?`}
-          message={`You're about to bid L$${confirm.amount.toLocaleString()}. This is a large bid — please confirm.`}
+          message={`You're about to bid L$${confirm.amount.toLocaleString()}. This is a large bid; please confirm.`}
           confirmLabel="Place bid"
           dontAskAgainKey={LARGE_BID_DISMISS_KEY}
           onConfirm={() => {

--- a/frontend/src/components/auction/ProxyBidSection.tsx
+++ b/frontend/src/components/auction/ProxyBidSection.tsx
@@ -187,7 +187,7 @@ export function ProxyBidSection({
         </h3>
         {mode === "create" ? (
           <p className="text-xs text-fg-muted">
-            Set your maximum — we&apos;ll bid for you up to that amount.
+            Set your maximum and we&apos;ll bid for you up to that amount.
           </p>
         ) : null}
         {mode === "active" && existingProxy ? (

--- a/frontend/src/components/auction/SnipeExtensionBanner.tsx
+++ b/frontend/src/components/auction/SnipeExtensionBanner.tsx
@@ -31,7 +31,7 @@ const VISIBLE_MS = 4_000;
  * extension. Copy mirrors spec §10:
  *
  * <pre>
- *   Auction extended by {N}m — {remainingAfterExtension}
+ *   Auction extended by {N}m. {remainingAfterExtension}
  * </pre>
  *
  * Lifetime is driven by the parent: pass {@code isVisible=true} to
@@ -68,7 +68,7 @@ export function SnipeExtensionBanner({
         <span className="font-semibold">
           Auction extended by {extensionMinutes}m
         </span>
-        {" — "}
+        {". "}
         <span>{remainingAfterExtension}</span>
       </span>
     </div>

--- a/frontend/src/components/auction/StickyBidBar.tsx
+++ b/frontend/src/components/auction/StickyBidBar.tsx
@@ -347,9 +347,9 @@ function RightSlot({
 }
 
 function formatBid(value: number | string | null): string {
-  if (value == null) return "—";
+  if (value == null) return "-";
   const n = typeof value === "string" ? Number(value) : value;
-  if (!Number.isFinite(n)) return "—";
+  if (!Number.isFinite(n)) return "-";
   return n.toLocaleString();
 }
 
@@ -360,7 +360,7 @@ function numericBid(value: number | string | null): number | null {
 }
 
 function formatAmount(value: number | null): string {
-  if (value == null) return "—";
+  if (value == null) return "-";
   return value.toLocaleString();
 }
 

--- a/frontend/src/components/bids/MyBidSummaryRow.test.tsx
+++ b/frontend/src/components/bids/MyBidSummaryRow.test.tsx
@@ -107,11 +107,11 @@ describe("MyBidSummaryRow", () => {
     expect(screen.queryByText(/Proxy max/)).not.toBeInTheDocument();
   });
 
-  it("renders an em-dash for current when no current bid", () => {
+  it("renders a hyphen for current when no current bid", () => {
     render(
       <MyBidSummaryRow bid={summary({ currentBid: null })} />,
     );
-    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getByText("-")).toBeInTheDocument();
   });
 
   it("falls back to '(unnamed parcel)' when parcelName missing", () => {

--- a/frontend/src/components/bids/MyBidSummaryRow.tsx
+++ b/frontend/src/components/bids/MyBidSummaryRow.tsx
@@ -113,7 +113,7 @@ export function MyBidSummaryRow({ bid, className }: MyBidSummaryRowProps) {
           </div>
           <p className="text-xs text-fg-muted">
             <span>
-              {auction.parcelRegion ?? "—"}
+              {auction.parcelRegion ?? "-"}
               {auction.parcelAreaSqm != null
                 ? ` · ${auction.parcelAreaSqm.toLocaleString()} m²`
                 : ""}
@@ -141,7 +141,7 @@ export function MyBidSummaryRow({ bid, className }: MyBidSummaryRowProps) {
           <span className="text-fg-muted">
             Current{" "}
             <span className="font-semibold text-fg">
-              {currentBid == null ? "—" : `L$${currentBid.toLocaleString()}`}
+              {currentBid == null ? "-" : `L$${currentBid.toLocaleString()}`}
             </span>
           </span>
           {myProxyMaxAmount != null ? (

--- a/frontend/src/components/browse/ActiveFilters.test.tsx
+++ b/frontend/src/components/browse/ActiveFilters.test.tsx
@@ -36,7 +36,7 @@ describe("ActiveFilters", () => {
       maxPrice: 500,
     };
     renderWithProviders(<ActiveFilters query={q} onChange={() => {}} />);
-    expect(screen.getByText("L$100–500")).toBeInTheDocument();
+    expect(screen.getByText("L$100-500")).toBeInTheDocument();
   });
 
   it("renders maturity csv chip", () => {

--- a/frontend/src/components/browse/ActiveFilters.tsx
+++ b/frontend/src/components/browse/ActiveFilters.tsx
@@ -70,9 +70,9 @@ function buildChips(
     if (query.minPrice !== undefined && query.maxPrice === undefined) {
       label = `L$${query.minPrice}+`;
     } else if (query.minPrice === undefined && query.maxPrice !== undefined) {
-      label = `L$0–${query.maxPrice}`;
+      label = `L$0-${query.maxPrice}`;
     } else {
-      label = `L$${query.minPrice}–${query.maxPrice}`;
+      label = `L$${query.minPrice}-${query.maxPrice}`;
     }
     chips.push({
       key: "price",
@@ -85,9 +85,9 @@ function buildChips(
     if (query.minArea !== undefined && query.maxArea === undefined) {
       label = `${query.minArea} m²+`;
     } else if (query.minArea === undefined && query.maxArea !== undefined) {
-      label = `0–${query.maxArea} m²`;
+      label = `0-${query.maxArea} m²`;
     } else {
-      label = `${query.minArea}–${query.maxArea} m²`;
+      label = `${query.minArea}-${query.maxArea} m²`;
     }
     chips.push({
       key: "area",

--- a/frontend/src/components/browse/FilterSidebarContent.tsx
+++ b/frontend/src/components/browse/FilterSidebarContent.tsx
@@ -147,7 +147,7 @@ export function FilterSidebarContent({
               className="w-full bg-transparent text-sm outline-none"
             />
           </label>
-          <span className="text-[11px] font-medium text-fg-muted">–</span>
+          <span className="text-[11px] font-medium text-fg-muted">-</span>
           <label className="flex flex-1 items-center gap-1 rounded border border-border-subtle bg-bg-subtle px-2 py-1 focus-within:border-border">
             <span className="text-[11px] font-medium text-fg-muted">L$</span>
             <input
@@ -183,7 +183,7 @@ export function FilterSidebarContent({
             />
             <span className="text-[11px] font-medium text-fg-muted">m²</span>
           </label>
-          <span className="text-[11px] font-medium text-fg-muted">–</span>
+          <span className="text-[11px] font-medium text-fg-muted">-</span>
           <label className="flex flex-1 items-center gap-1 rounded border border-border-subtle bg-bg-subtle px-2 py-1 focus-within:border-border">
             <input
               type="number"

--- a/frontend/src/components/browse/ResultsEmpty.tsx
+++ b/frontend/src/components/browse/ResultsEmpty.tsx
@@ -23,7 +23,7 @@ export function ResultsEmpty({ reason, onClearFilters }: ResultsEmptyProps) {
       <EmptyState
         icon={Search}
         headline="No active auctions yet"
-        description="Check back soon — new parcels are listed throughout the day."
+        description="Check back soon. New parcels are listed throughout the day."
       />
     );
   }

--- a/frontend/src/components/browse/ResultsGrid.tsx
+++ b/frontend/src/components/browse/ResultsGrid.tsx
@@ -128,7 +128,7 @@ export function ResultsGrid({
         icon={AlertCircle}
         headline={
           tooMany
-            ? "Too many searches — try again in a minute"
+            ? "Too many searches. Try again in a minute."
             : "Couldn't load listings"
         }
         description={

--- a/frontend/src/components/curator/CuratorTrayTrigger.tsx
+++ b/frontend/src/components/curator/CuratorTrayTrigger.tsx
@@ -14,7 +14,7 @@ export interface CuratorTrayTriggerProps {
  * unauthenticated — the Curator Tray is a logged-in-only surface.
  *
  * <p>Count rendering:
- *   - {@code —} while the initial {@code useSavedIds} fetch is in flight.
+ *   - {@code -} while the initial {@code useSavedIds} fetch is in flight.
  *   - Literal {@code 1}..{@code 99} for small sets.
  *   - {@code 99+} once the set has >= 100 entries.
  */
@@ -28,7 +28,7 @@ export function CuratorTrayTrigger({
   if (session.status !== "authenticated") return null;
 
   const count = ids.size;
-  const label = isLoading ? "—" : count >= 100 ? "99+" : String(count);
+  const label = isLoading ? "-" : count >= 100 ? "99+" : String(count);
 
   return (
     <button

--- a/frontend/src/components/escrow/SellerEvidencePanel.tsx
+++ b/frontend/src/components/escrow/SellerEvidencePanel.tsx
@@ -38,7 +38,7 @@ export function SellerEvidencePanel({ auctionPublicId }: Props) {
       <h3 className="text-sm font-semibold">Submit your evidence</h3>
       <p className="text-[11px] opacity-65">
         A winner has disputed this sale. Submit your side of the story for admin
-        review. Submit-once — you cannot append later.
+        review. Submit-once: you cannot append later.
       </p>
       <textarea
         value={text}

--- a/frontend/src/components/escrow/state/TransferPendingStateCard.tsx
+++ b/frontend/src/components/escrow/state/TransferPendingStateCard.tsx
@@ -35,7 +35,7 @@ export function TransferPendingStateCard({ escrow, role }: StateCardProps) {
         </h2>
         <p className="text-sm text-fg-muted">
           Transferred at {formatTimestamp(escrow.transferConfirmedAt!)}.
-          Finalizing the transaction — payout is dispatching now.
+          Finalizing the transaction. Payout is dispatching now.
         </p>
       </section>
     );
@@ -127,7 +127,7 @@ function WinnerPreConfirmation({
         </p>
         <ul className="flex list-disc flex-col gap-1 pl-5 text-xs text-fg-muted">
           <li>
-            <span className="font-medium text-fg">Wait</span> — most
+            <span className="font-medium text-fg">Wait.</span> Most
             transfers complete on their own.
           </li>
           <li>

--- a/frontend/src/components/listing/ActivateListingPanel.tsx
+++ b/frontend/src/components/listing/ActivateListingPanel.tsx
@@ -155,7 +155,7 @@ export function ActivateListingPanel({ auctionPublicId }: ActivateListingPanelPr
         </h2>
         <p className="text-sm text-fg">
           Listing fee is <strong>{formatLindens(fee)}</strong>. Your wallet
-          has <strong>{formatLindens(wallet.available)}</strong> available —
+          has <strong>{formatLindens(wallet.available)}</strong> available;
           you need <strong>{formatLindens(short)}</strong> more. Pay any SLPA
           terminal in-world and your balance updates automatically.
         </p>
@@ -179,7 +179,7 @@ export function ActivateListingPanel({ auctionPublicId }: ActivateListingPanelPr
         Activate this listing
       </h2>
       <p className="text-sm text-fg">
-        Listing fee is <strong>{formatLindens(fee)}</strong> — debited from
+        Listing fee is <strong>{formatLindens(fee)}</strong>, debited from
         your SLPA wallet. Available balance:{" "}
         <strong>{formatLindens(wallet.available)}</strong>.
       </p>

--- a/frontend/src/components/listing/CancelListingModal.test.tsx
+++ b/frontend/src/components/listing/CancelListingModal.test.tsx
@@ -348,7 +348,7 @@ describe("CancelListingModal", () => {
     );
     expect(
       screen.getByText(
-        /No refund — cancelling an active listing does not refund the fee/i,
+        /No refund. Cancelling an active listing does not refund the fee/i,
       ),
     ).toBeInTheDocument();
   });

--- a/frontend/src/components/listing/CancelListingModal.tsx
+++ b/frontend/src/components/listing/CancelListingModal.tsx
@@ -52,7 +52,7 @@ const COPY_MAP: Record<CopyVariant, string> = {
   NO_BIDS:
     "No penalty will apply. Listing fee is non-refundable for already-paid auctions.",
   FIRST_OFFENSE:
-    "This is a cancellation with active bids. Your first such cancellation is recorded as a warning — no L$ penalty.",
+    "This is a cancellation with active bids. Your first such cancellation is recorded as a warning: no L$ penalty.",
   SECOND_OFFENSE:
     "This will be your 2nd cancellation with active bids. You will be suspended from new listings until you pay a L$1000 penalty at any SLPA terminal.",
   THIRD_OFFENSE:

--- a/frontend/src/components/listing/ListingPreviewCard.test.tsx
+++ b/frontend/src/components/listing/ListingPreviewCard.test.tsx
@@ -66,7 +66,7 @@ describe("ListingPreviewCard", () => {
   it("renders the preview banner when isPreview is set", () => {
     renderWithProviders(<ListingPreviewCard auction={base()} isPreview />);
     expect(
-      screen.getByText(/Preview — this is how your listing will appear/),
+      screen.getByText(/Preview: this is how your listing will appear/),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/components/listing/ListingPreviewCard.tsx
+++ b/frontend/src/components/listing/ListingPreviewCard.tsx
@@ -27,7 +27,7 @@ export type ListingPreviewAuction = Pick<
 
 export interface ListingPreviewCardProps {
   auction: ListingPreviewAuction;
-  /** When true, renders the "Preview — this is how buyers will see it" banner. */
+  /** When true, renders the "Preview: this is how buyers will see it" banner. */
   isPreview?: boolean;
   className?: string;
 }
@@ -67,7 +67,7 @@ export function ListingPreviewCard({
     >
       {isPreview && (
         <div className="rounded-lg bg-brand-soft px-3 py-2 text-xs text-brand">
-          Preview — this is how your listing will appear to buyers.
+          Preview: this is how your listing will appear to buyers.
         </div>
       )}
       {cover ? (

--- a/frontend/src/components/listing/ListingSummaryRow.test.tsx
+++ b/frontend/src/components/listing/ListingSummaryRow.test.tsx
@@ -121,12 +121,12 @@ describe("ListingSummaryRow", () => {
     );
   });
 
-  it("shows the em-dash bid fallback and 0 bids when there is no bid on ACTIVE", () => {
+  it("shows the hyphen bid fallback and 0 bids when there is no bid on ACTIVE", () => {
     renderWithProviders(
       <ListingSummaryRow auction={baseAuction({ currentHighBid: null, bidCount: 0 })} />,
       { auth: "authenticated" },
     );
-    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getByText("-")).toBeInTheDocument();
     expect(screen.getByText(/0 bids/)).toBeInTheDocument();
   });
 
@@ -199,7 +199,7 @@ describe("ListingSummaryRow", () => {
       { auth: "authenticated" },
     );
     expect(
-      screen.getByText(/Ended — reserve not met \(highest bid/),
+      screen.getByText(/Ended: reserve not met \(highest bid/),
     ).toBeInTheDocument();
     expect(screen.getByText("L$12,000")).toBeInTheDocument();
   });

--- a/frontend/src/components/listing/ListingSummaryRow.tsx
+++ b/frontend/src/components/listing/ListingSummaryRow.tsx
@@ -231,7 +231,7 @@ function ActiveBidSummary({
   return (
     <p className="text-xs text-fg-muted">
       <span className="font-medium text-fg">
-        {highBid == null ? "—" : `L$${highBid.toLocaleString()}`}
+        {highBid == null ? "-" : `L$${highBid.toLocaleString()}`}
       </span>
       <span>{` current · ${bidsText}`}</span>
       {endsAtDate != null ? (
@@ -289,7 +289,7 @@ function EndedBidSummary({
 
   if (outcome === "SOLD" || outcome === "BOUGHT_NOW") {
     const finalAmount = auction.finalBidAmount ?? highBid;
-    const formattedAmount = finalAmount == null ? "—" : `L$${finalAmount.toLocaleString()}`;
+    const formattedAmount = finalAmount == null ? "-" : `L$${finalAmount.toLocaleString()}`;
     return (
       <p className="text-xs text-fg-muted">
         Sold for{" "}
@@ -304,10 +304,10 @@ function EndedBidSummary({
     );
   }
   if (outcome === "RESERVE_NOT_MET") {
-    const formattedBid = highBid == null ? "—" : `L$${highBid.toLocaleString()}`;
+    const formattedBid = highBid == null ? "-" : `L$${highBid.toLocaleString()}`;
     return (
       <p className="text-xs text-fg-muted">
-        {"Ended — reserve not met (highest bid "}
+        {"Ended: reserve not met (highest bid "}
         <span className="font-medium text-fg">{formattedBid}</span>
         {")"}
       </p>

--- a/frontend/src/components/listing/ListingWizardForm.tsx
+++ b/frontend/src/components/listing/ListingWizardForm.tsx
@@ -404,7 +404,7 @@ function DescriptionField({
         maxLength={MAX_DESC}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="Describe what makes this parcel special — location, views, build history, etc."
+        placeholder="Describe what makes this parcel special: location, views, build history, etc."
         className="w-full resize-y rounded-lg bg-bg-subtle px-4 py-3 text-fg placeholder:text-fg-muted ring-1 ring-transparent transition-all focus:bg-surface-raised focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
       />
       <span

--- a/frontend/src/components/listing/VerificationMethodPicker.tsx
+++ b/frontend/src/components/listing/VerificationMethodPicker.tsx
@@ -118,7 +118,7 @@ export function VerificationMethodPicker({
             <p className="text-sm font-medium">Your last verification attempt failed</p>
             <p className="text-xs">{lastFailureNotes}</p>
             <p className="text-xs">
-              Pick a method to try again — no additional fee needed.
+              Pick a method to try again. No additional fee needed.
             </p>
           </div>
           <button

--- a/frontend/src/components/marketing/Hero.tsx
+++ b/frontend/src/components/marketing/Hero.tsx
@@ -29,7 +29,7 @@ export function Hero({ featured }: HeroProps) {
           </h1>
           <p className="mt-4 max-w-[540px] text-base leading-[1.5] text-fg-muted md:text-lg">
             Find premium Second Life parcels at fair prices. Every transaction
-            is protected by SLPA Escrow — no more lost L$ to bad-faith sellers.
+            is protected by SLPA Escrow, so you don&apos;t lose L$ to bad-faith sellers.
           </p>
           <div className="mt-7 flex flex-wrap gap-2.5">
             <Link href="/browse">

--- a/frontend/src/components/marketing/TrustStrip.tsx
+++ b/frontend/src/components/marketing/TrustStrip.tsx
@@ -15,7 +15,7 @@ const ITEMS: Array<{ icon: ReactNode; title: string; body: string }> = [
   {
     icon: <Gavel className="size-[22px]" aria-hidden />,
     title: "Fair bidding",
-    body: "Anti-snipe extensions, proxy bidding, and transparent bid histories — no last-second rug pulls.",
+    body: "Anti-snipe extensions, proxy bidding, and transparent bid histories prevent last-second rug pulls.",
   },
   {
     icon: <RefreshCw className="size-[22px]" aria-hidden />,

--- a/frontend/src/components/notifications/preferences/GroupToggleRow.tsx
+++ b/frontend/src/components/notifications/preferences/GroupToggleRow.tsx
@@ -35,7 +35,7 @@ export function GroupToggleRow({
           value ? "bg-brand" : "bg-bg-hover border border-border",
           mutedDisabled && "opacity-50 cursor-not-allowed"
         )}
-        aria-label={`${label} — ${value ? "on" : "off"}${mutedDisabled ? " (muted)" : ""}`}
+        aria-label={`${label}: ${value ? "on" : "off"}${mutedDisabled ? " (muted)" : ""}`}
         data-testid={`group-toggle-${group}`}
       >
         <span

--- a/frontend/src/components/notifications/preferences/MasterMuteRow.tsx
+++ b/frontend/src/components/notifications/preferences/MasterMuteRow.tsx
@@ -13,7 +13,7 @@ export function MasterMuteRow({ value, onChange }: MasterMuteRowProps) {
           Mute all SL IM notifications
         </div>
         <div className="text-xs text-fg-muted mt-1">
-          Master switch — overrides everything below.
+          Master switch: overrides everything below.
         </div>
       </div>
       <button

--- a/frontend/src/components/reviews/FlagModal.tsx
+++ b/frontend/src/components/reviews/FlagModal.tsx
@@ -86,7 +86,7 @@ export function FlagModal({ reviewPublicId, open, onClose }: FlagModalProps) {
           </DialogTitle>
           <p className="text-xs text-fg-muted">
             Tell us why this review needs moderator attention. Flagging is
-            confidential — the reviewer is not notified.
+            confidential. The reviewer is not notified.
           </p>
 
           <fieldset

--- a/frontend/src/components/reviews/RespondModal.tsx
+++ b/frontend/src/components/reviews/RespondModal.tsx
@@ -69,7 +69,7 @@ export function RespondModal({ reviewPublicId, open, onClose }: RespondModalProp
           </DialogTitle>
           <p className="text-xs text-fg-muted">
             Your response appears publicly beneath the review. You can only
-            respond once — no edits.
+            respond once, and no edits are allowed afterward.
           </p>
           <label className="flex flex-col gap-1">
             <span className="sr-only">Response text</span>

--- a/frontend/src/components/reviews/ReviewPanel.tsx
+++ b/frontend/src/components/reviews/ReviewPanel.tsx
@@ -255,7 +255,7 @@ function SubmitState({
           value={text}
           onChange={(e) => setText(e.target.value)}
           disabled={mutation.isPending}
-          placeholder="Share what went well — or what didn't."
+          placeholder="Share what went well, or what didn't."
           data-testid="review-panel-submit-text"
           className="w-full resize-y rounded-lg bg-bg-subtle px-4 py-3 text-fg placeholder:text-fg-muted ring-1 ring-border-subtle transition-all focus:outline-none focus:ring-brand"
         />

--- a/frontend/src/components/user/VerificationCodeDisplay.tsx
+++ b/frontend/src/components/user/VerificationCodeDisplay.tsx
@@ -48,7 +48,7 @@ export function VerificationCodeDisplay() {
         code={activeCode.code}
         label="Enter this code at any SLPA Verification Terminal"
         onCopySuccess={() => toast.success("Code copied to clipboard")}
-        onCopyError={() => toast.error("Failed to copy — copy the code manually")}
+        onCopyError={() => toast.error("Failed to copy. Copy the code manually.")}
       />
       <div className="flex items-center gap-2 text-fg-muted">
         <span className="text-xs">Expires in</span>

--- a/frontend/src/hooks/admin/useReinstateFraudFlag.ts
+++ b/frontend/src/hooks/admin/useReinstateFraudFlag.ts
@@ -24,7 +24,7 @@ export function useReinstateFraudFlag() {
           return;
         }
         if (err.problem.code === "AUCTION_NOT_SUSPENDED") {
-          toast.error("Auction state changed — refreshing.");
+          toast.error("Auction state changed. Refreshing.");
           qc.invalidateQueries({ queryKey: adminQueryKeys.fraudFlags() });
           return;
         }

--- a/frontend/src/hooks/useReviews.ts
+++ b/frontend/src/hooks/useReviews.ts
@@ -167,7 +167,7 @@ export function useFlagReview(
     onSuccess: () =>
       toast.success({
         title: "Review flagged",
-        description: "Thanks — our team will review it shortly.",
+        description: "Thanks. Our team will review it shortly.",
       }),
     onError: (err) => {
       const already = err instanceof ApiError && err.status === 409;

--- a/frontend/src/lib/listing/refundCalculation.ts
+++ b/frontend/src/lib/listing/refundCalculation.ts
@@ -30,7 +30,7 @@ export function computeRefund(
       return {
         kind: "NONE",
         amountLindens: null,
-        copy: "No refund — no fee was paid yet.",
+        copy: "No refund. No fee was paid yet.",
       };
     case "DRAFT_PAID":
     case "VERIFICATION_PENDING":
@@ -47,7 +47,7 @@ export function computeRefund(
         kind: "NONE",
         amountLindens: null,
         copy:
-          "No refund — cancelling an active listing does not refund the fee.",
+          "No refund. Cancelling an active listing does not refund the fee.",
       };
     default:
       return {

--- a/frontend/src/lib/ws/client.ts
+++ b/frontend/src/lib/ws/client.ts
@@ -100,7 +100,7 @@ function getOrCreateClient(): Client {
         if (e instanceof RefreshFailedError) {
           setState({
             status: "error",
-            detail: "Session expired — please sign in again",
+            detail: "Session expired. Please sign in again.",
           });
         } else {
           setState({

--- a/lsl-scripts/parcel-verifier/parcel-verifier.lsl
+++ b/lsl-scripts/parcel-verifier/parcel-verifier.lsl
@@ -131,7 +131,7 @@ default {
         if (data == EOF) {
             // Validate required config.
             if (PARCEL_VERIFY_URL == "") {
-                dieWithMessage("✗ Parcel Verifier: incomplete config — PARCEL_VERIFY_URL required");
+                dieWithMessage("✗ Parcel Verifier: incomplete config. PARCEL_VERIFY_URL required.");
                 return;
             }
 
@@ -223,7 +223,7 @@ default {
         llSetTimerEvent(0);
 
         if (status == 204) {
-            dieWithMessage("✓ Parcel verified — your listing is live on slparcels.com.");
+            dieWithMessage("✓ Parcel verified. Your listing is live on slparcels.com.");
         } else if (status >= 400 && status < 500) {
             string title  = llJsonGetValue(body, ["title"]);
             string detail = llJsonGetValue(body, ["detail"]);

--- a/lsl-scripts/sl-im-dispatcher/dispatcher.lsl
+++ b/lsl-scripts/sl-im-dispatcher/dispatcher.lsl
@@ -118,7 +118,7 @@ default {
         if (data == EOF) {
             // Notecard fully read; validate config.
             if (POLL_URL == "" || CONFIRM_URL_BASE == "" || SHARED_SECRET == "") {
-                llOwnerSay("SL IM dispatcher: incomplete config — POLL_URL / CONFIRM_URL_BASE / SHARED_SECRET required");
+                llOwnerSay("SL IM dispatcher: incomplete config. POLL_URL / CONFIRM_URL_BASE / SHARED_SECRET required.");
                 return;
             }
             if (DEBUG_MODE) llOwnerSay("SL IM dispatcher: ready (poll=" + POLL_URL + ")");

--- a/lsl-scripts/slpa-terminal/slpa-terminal.lsl
+++ b/lsl-scripts/slpa-terminal/slpa-terminal.lsl
@@ -387,7 +387,7 @@ sweepExpiredSlots() {
 addInflightCommand(key txKey, string idempotencyKey, key recipient, integer amount) {
     if (llGetListLength(inflightCmdTxKeys) >= MAX_INFLIGHT_CMDS) {
         llOwnerSay("SLPA Terminal: inflight command cap (" + (string)MAX_INFLIGHT_CMDS
-            + ") hit — refusing command. Backend retry will cover.");
+            + ") hit; refusing command. Backend retry will cover.");
         return;
     }
     // Cast to string at insertion: llListFindList in removeInflightByTxKey
@@ -507,7 +507,7 @@ default {
             // Now request HTTP-in URL.
             urlRequestId = llRequestURL();
         } else {
-            llOwnerSay("CRITICAL: PERMISSION_DEBIT denied — script halted. Owner must re-grant.");
+            llOwnerSay("CRITICAL: PERMISSION_DEBIT denied. Script halted. Owner must re-grant.");
         }
     }
 
@@ -562,7 +562,7 @@ default {
         if (action == "REFUND") {
             // Defensive: refunds are wallet credits in the new model and
             // shouldn't be dispatched to terminals. Log loud and fail.
-            llOwnerSay("CRITICAL: unexpected REFUND HTTP-in command — refunds are now wallet credits. idempotencyKey=" + ikey);
+            llOwnerSay("CRITICAL: unexpected REFUND HTTP-in command; refunds are now wallet credits. idempotencyKey=" + ikey);
             llHTTPResponse(id, 200,
                 "{\"status\":\"FAILED\",\"reason\":\"REFUND_NOT_SUPPORTED\"}");
             return;
@@ -634,7 +634,7 @@ default {
         // immediately and shout. Without this guard, llHTTPRequest("", ...)
         // would silently fail and the L$ would be stranded in the prim.
         if (DEPOSIT_URL == "" || SHARED_SECRET == "" || TERMINAL_ID == "") {
-            llOwnerSay("CRITICAL: deposit received but config incomplete — "
+            llOwnerSay("CRITICAL: deposit received but config incomplete: "
                 + "refunding L$" + (string)amount + " to " + (string)payer
                 + ". Check the 'config' notecard for DEPOSIT_URL, "
                 + "SHARED_SECRET, TERMINAL_ID.");
@@ -672,7 +672,7 @@ default {
         if (msg == "Withdraw") {
             integer slot = acquireOrResetSlot(id);
             if (slot < 0) {
-                llRegionSayTo(id, 0, "Terminal busy — try another nearby.");
+                llRegionSayTo(id, 0, "Terminal busy. Try another nearby.");
                 return;
             }
             llTextBox(id, "Enter L$ amount to withdraw:", mainChan);
@@ -712,7 +712,7 @@ default {
             withdrawTxKey      = (string)llGenerateKey();
             withdrawRetryCount = 0;
             fireWithdrawRequest();
-            llRegionSayTo(id, 0, "Withdrawal queued — L$" + (string)amt
+            llRegionSayTo(id, 0, "Withdrawal queued: L$" + (string)amt
                 + " will arrive shortly.");
         } else {
             llRegionSayTo(id, 0, "Withdrawal cancelled.");

--- a/lsl-scripts/slpa-verifier-giver/slpa-verifier-giver.lsl
+++ b/lsl-scripts/slpa-verifier-giver/slpa-verifier-giver.lsl
@@ -103,7 +103,7 @@ default {
             integer lastAt = llList2Integer(givenSessions, slot + 1);
             if (now - lastAt < RATE_LIMIT_SECONDS) {
                 llRegionSayTo(toucher, 0,
-                    "Just gave you one — wait a minute before requesting another.");
+                    "Just gave you one. Wait a minute before requesting another.");
                 return;
             }
             givenSessions = llListReplaceList(givenSessions,
@@ -115,7 +115,7 @@ default {
         // Verify the named inventory item exists
         if (llGetInventoryType(VERIFIER_NAME) == INVENTORY_NONE) {
             llRegionSayTo(toucher, 0,
-                "Sorry — the verifier object is missing. Please contact SLPA support.");
+                "Sorry, the verifier object is missing. Please contact SLPA support.");
             llOwnerSay("CRITICAL: '" + VERIFIER_NAME + "' missing from giver prim inventory.");
             return;
         }

--- a/lsl-scripts/verification-terminal/verification-terminal.lsl
+++ b/lsl-scripts/verification-terminal/verification-terminal.lsl
@@ -169,7 +169,7 @@ default {
         // llGetEnv("sim_channel") == "Second Life Server" on main grid.
         // This is distinct from X-SecondLife-Shard ("Production") checked backend-side.
         if (llGetEnv("sim_channel") != "Second Life Server") {
-            llOwnerSay("SLPA Verification Terminal: wrong grid — this script is mainland-only.");
+            llOwnerSay("SLPA Verification Terminal: wrong grid. This script is mainland-only.");
             return;  // halt; do not read notecard, do not set chrome
         }
 
@@ -189,7 +189,7 @@ default {
             }
             if (data == EOF) {
                 if (VERIFY_URL == "") {
-                    llOwnerSay("SLPA Verification Terminal: incomplete config — VERIFY_URL required");
+                    llOwnerSay("SLPA Verification Terminal: incomplete config. VERIFY_URL required.");
                     return;
                 }
                 if (DEBUG_MODE)
@@ -225,7 +225,7 @@ default {
         // If lock is held and not yet expired, bounce the toucher.
         if (lockHolder != NULL_KEY && lockExpiresAt > llGetUnixTime()) {
             llRegionSayTo(toucher, 0,
-                "Terminal busy — currently verifying " + lockHolderName + ".");
+                "Terminal busy: currently verifying " + lockHolderName + ".");
             return;
         }
 
@@ -301,7 +301,7 @@ default {
                     llOwnerSay("SLPA Verification Terminal: verify ok: userId=" + userId);
             } else {
                 llRegionSayTo(lockHolder, 0,
-                    "✗ Verification failed. Code may be expired — generate a new one on slparcels.com.");
+                    "✗ Verification failed. Code may be expired. Generate a new one on slparcels.com.");
                 if (DEBUG_MODE)
                     llOwnerSay("SLPA Verification Terminal: verify denied: not verified");
             }
@@ -328,7 +328,7 @@ default {
         if (timerPhase == TIMER_DATA) {
             // Avatar data (DATA_BORN / DATA_PAYINFO) didn't arrive in time.
             llRegionSayTo(lockHolder, 0,
-                "✗ Couldn't read your avatar data — please try again.");
+                "✗ Couldn't read your avatar data. Please try again.");
             releaseLock();
         } else {
             // TIMER_LOCK — 60s passed with no progress (user walked away, etc.).


### PR DESCRIPTION
## Summary
- Replace em-dashes (—) and en-dashes (–) with proper grammar across frontend, backend, and LSL user/admin-visible copy
- Empty-cell admin-table glyphs `?? "—"` → `?? "-"`; loading-state glyph in `CuratorTrayTrigger` → `"-"`
- Sentence-connector em-dashes rewritten case-by-case (period / parens / restructure)
- Adds `.ignored-docs/` to `.gitignore` (scratch space for local-only audit notes)

Curator terminology retained per brainstorm.

## Test plan
- [x] frontend/: `npm run lint`, `npm test`, `npx tsc --noEmit`, `npm run verify` (all green per implementer report)
- [x] backend/: `./mvnw test` (pass per implementer report)
- [x] grep verification: no em-dashes or en-dashes remain in non-comment lines of `frontend/src`, `backend/src/main`, `lsl-scripts/**/*.lsl`
- [ ] Manual smoke: /admin/infrastructure renders tables with "-" placeholders; /auction/{id} AuctionEndedRow renders correctly

## Out of scope
- "Curator" terminology
- Code comments / JSDoc / Javadoc / LSL //
- LSL READMEs
- AI-flagged copy rewrites (lives in local-only `.ignored-docs/ai-wording-audit-2026-05-04.md` for follow-up triage)
