### PR TITLE
fix(frontend): UserMenuDropdown breaks Amplify build with nullable email

### DIFF
--- a/frontend/src/components/auth/UserMenuDropdown.tsx
+++ b/frontend/src/components/auth/UserMenuDropdown.tsx
@@ -13,7 +13,7 @@ export function UserMenuDropdown({ user }: UserMenuDropdownProps) {
   const logout = useLogout();
   const router = useRouter();
 
-  const displayLabel = user.displayName ?? user.email.split("@")[0];
+  const displayLabel = user.displayName ?? user.username;
 
   const trigger = (
     <button


### PR DESCRIPTION
Single-commit follow-up to #168. The dev → main merge build failed in Amplify because UserMenuDropdown.tsx still treated user.email as non-null after the username refactor flipped AuthUser.email to string | null. Switch the displayLabel fallback to user.username, which is always present.