### PR TITLE
fix(admin): align frontend with backend publicId convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ Every entity extends `BaseEntity` (immutable / append-only) or `BaseMutableEntit
 
 Subclass entities use Lombok `@SuperBuilder`, **not** `@Builder`. Do not redeclare `id`, `publicId`, `createdAt`, `updatedAt`, or `version` — they're inherited. Do not override `equals` or `hashCode` (they're `final`, keyed off `publicId`).
 
-DTO field naming: `publicId: UUID` for public DTOs. Bot / admin-internal DTOs keep `id: Long`. URL paths follow the same split: `/api/v1/auctions/{publicId}` for public, `/api/v1/bot/tasks/{taskId}` (Long) for internal.
+DTO field naming: `publicId: UUID` for both public DTOs and admin DTOs the frontend consumes. Bot-internal DTOs keep `id: Long`. URL paths follow the same split: `/api/v1/auctions/{publicId}` and `/api/v1/admin/users/{publicId}` use UUID; `/api/v1/bot/tasks/{taskId}` (Long) is bot-internal. Admin row DTOs that reference another entity (e.g. an auction inside `AdminUserListingRowDto`) carry that entity's `publicId` so the frontend can build `/auction/{publicId}` links without an extra round-trip; the redundant numeric `auctionId` is kept alongside for log/debug surfaces.
 
 JWT subject claim is the user's `publicId` (UUID string). The auth filter resolves `userId` (Long) via `UserRepository.findByPublicId` at request entry; the `AuthPrincipal` carries both.
 

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/AdminUserService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/AdminUserService.java
@@ -60,7 +60,14 @@ public class AdminUserService {
         UUID uuid = tryParseUuid(input);
         String search = uuid != null ? null
             : (input == null || input.isBlank() ? null : input.trim());
-        Page<User> page = userRepo.searchAdmin(search, uuid, pageable);
+        Page<User> page;
+        if (uuid != null) {
+            page = userRepo.searchAdminByUuid(uuid, pageable);
+        } else if (search != null) {
+            page = userRepo.searchAdminByText(search, pageable);
+        } else {
+            page = userRepo.searchAdminAll(pageable);
+        }
         OffsetDateTime now = OffsetDateTime.now(clock);
         return PagedResponse.from(page.map(u -> toSummary(u, now)));
     }
@@ -80,7 +87,7 @@ public class AdminUserService {
             }
         }
         return new AdminUserDetailDto(
-            u.getPublicId(), u.getEmail(), u.getDisplayName(),
+            u.getPublicId(), u.getUsername(), u.getEmail(), u.getDisplayName(),
             u.getSlAvatarUuid(), u.getSlDisplayName(),
             u.getRole(), Boolean.TRUE.equals(u.getVerified()), u.getVerifiedAt(),
             u.getCreatedAt(),
@@ -95,7 +102,7 @@ public class AdminUserService {
     public PagedResponse<AdminUserListingRowDto> listings(Long userId, Pageable pageable) {
         Page<Auction> page = auctionRepo.findBySellerIdOrderByCreatedAtDesc(userId, pageable);
         return PagedResponse.from(page.map(a -> new AdminUserListingRowDto(
-            a.getId(), a.getTitle(),
+            a.getId(), a.getPublicId(), a.getTitle(),
             a.getParcelSnapshot() != null ? a.getParcelSnapshot().getRegionName() : null,
             a.getStatus(), a.getEndsAt(), a.getFinalBidAmount())));
     }
@@ -104,7 +111,8 @@ public class AdminUserService {
     public PagedResponse<AdminUserBidRowDto> bids(Long userId, Pageable pageable) {
         Page<Bid> page = bidRepo.findByBidderIdOrderByCreatedAtDesc(userId, pageable);
         return PagedResponse.from(page.map(b -> new AdminUserBidRowDto(
-            b.getId(), b.getAuction().getId(), b.getAuction().getTitle(),
+            b.getId(), b.getAuction().getId(), b.getAuction().getPublicId(),
+            b.getAuction().getTitle(),
             b.getAmount(), b.getCreatedAt(), b.getAuction().getStatus())));
     }
 
@@ -112,7 +120,8 @@ public class AdminUserService {
     public PagedResponse<AdminUserCancellationRowDto> cancellations(Long userId, Pageable pageable) {
         Page<CancellationLog> page = cancellationLogRepo.findBySellerIdOrderByCancelledAtDesc(userId, pageable);
         return PagedResponse.from(page.map(c -> new AdminUserCancellationRowDto(
-            c.getId(), c.getAuction().getId(), c.getAuction().getTitle(),
+            c.getId(), c.getAuction().getId(), c.getAuction().getPublicId(),
+            c.getAuction().getTitle(),
             c.getCancelledFromStatus(), Boolean.TRUE.equals(c.getHadBids()),
             c.getReason(),
             c.getPenaltyKind() != null ? c.getPenaltyKind().name() : null,
@@ -125,7 +134,8 @@ public class AdminUserService {
         return PagedResponse.from(page.map(r -> {
             String direction = r.getReporter().getId().equals(userId) ? "FILED_BY" : "AGAINST_LISTING";
             return new AdminUserReportRowDto(
-                r.getId(), r.getAuction().getId(), r.getAuction().getTitle(),
+                r.getId(), r.getAuction().getId(), r.getAuction().getPublicId(),
+                r.getAuction().getTitle(),
                 r.getReason().name(), r.getStatus().name(),
                 direction, r.getCreatedAt(), r.getUpdatedAt());
         }));
@@ -137,6 +147,7 @@ public class AdminUserService {
         return PagedResponse.from(page.map(f -> new AdminUserFraudFlagRowDto(
             f.getId(),
             f.getAuction() != null ? f.getAuction().getId() : null,
+            f.getAuction() != null ? f.getAuction().getPublicId() : null,
             f.getAuction() != null ? f.getAuction().getTitle() : null,
             f.getReason().name(), f.isResolved(), f.getDetectedAt())));
     }
@@ -160,7 +171,7 @@ public class AdminUserService {
         boolean banned = u.getSlAvatarUuid() != null
             && !banRepo.findActiveByAvatar(u.getSlAvatarUuid(), now).isEmpty();
         return new AdminUserSummaryDto(
-            u.getPublicId(), u.getEmail(), u.getDisplayName(),
+            u.getPublicId(), u.getUsername(), u.getEmail(), u.getDisplayName(),
             u.getSlAvatarUuid(), u.getSlDisplayName(),
             u.getRole(), Boolean.TRUE.equals(u.getVerified()), banned,
             u.getCompletedSales(), u.getCancelledWithBids(),

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserBidRowDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserBidRowDto.java
@@ -1,12 +1,14 @@
 package com.slparcelauctions.backend.admin.users.dto;
 
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 import com.slparcelauctions.backend.auction.AuctionStatus;
 
 public record AdminUserBidRowDto(
     Long bidId,
     Long auctionId,
+    UUID auctionPublicId,
     String auctionTitle,
     long amount,
     OffsetDateTime placedAt,

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserCancellationRowDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserCancellationRowDto.java
@@ -1,10 +1,12 @@
 package com.slparcelauctions.backend.admin.users.dto;
 
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 public record AdminUserCancellationRowDto(
     Long logId,
     Long auctionId,
+    UUID auctionPublicId,
     String auctionTitle,
     String cancelledFromStatus,
     boolean hadBids,

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserDetailDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserDetailDto.java
@@ -8,6 +8,7 @@ import com.slparcelauctions.backend.user.Role;
 
 public record AdminUserDetailDto(
     UUID publicId,
+    String username,
     String email,
     String displayName,
     UUID slAvatarUuid,

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserFraudFlagRowDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserFraudFlagRowDto.java
@@ -1,10 +1,12 @@
 package com.slparcelauctions.backend.admin.users.dto;
 
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 public record AdminUserFraudFlagRowDto(
     Long flagId,
     Long auctionId,
+    UUID auctionPublicId,
     String auctionTitle,
     String reason,
     boolean resolved,

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserListingRowDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserListingRowDto.java
@@ -1,11 +1,13 @@
 package com.slparcelauctions.backend.admin.users.dto;
 
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 import com.slparcelauctions.backend.auction.AuctionStatus;
 
 public record AdminUserListingRowDto(
     Long auctionId,
+    UUID auctionPublicId,
     String title,
     String regionName,
     AuctionStatus status,

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserReportRowDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserReportRowDto.java
@@ -1,10 +1,12 @@
 package com.slparcelauctions.backend.admin.users.dto;
 
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 public record AdminUserReportRowDto(
     Long reportId,
     Long auctionId,
+    UUID auctionPublicId,
     String auctionTitle,
     String reason,
     String status,

--- a/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserSummaryDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/users/dto/AdminUserSummaryDto.java
@@ -7,6 +7,7 @@ import com.slparcelauctions.backend.user.Role;
 
 public record AdminUserSummaryDto(
     UUID publicId,
+    String username,
     String email,
     String displayName,
     UUID slAvatarUuid,

--- a/backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java
@@ -87,15 +87,25 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("""
         SELECT u FROM User u
-        WHERE (:uuid IS NOT NULL AND u.slAvatarUuid = :uuid)
-           OR (:uuid IS NULL AND :search IS NOT NULL AND
-               (LOWER(u.username) LIKE LOWER(CONCAT('%', :search, '%'))
-                OR LOWER(COALESCE(u.displayName, '')) LIKE LOWER(CONCAT('%', :search, '%'))
-                OR LOWER(COALESCE(u.slDisplayName, '')) LIKE LOWER(CONCAT('%', :search, '%'))))
-           OR (:search IS NULL AND :uuid IS NULL)
+        WHERE LOWER(u.username) LIKE LOWER(CONCAT('%', :search, '%'))
+           OR LOWER(COALESCE(u.displayName, '')) LIKE LOWER(CONCAT('%', :search, '%'))
+           OR LOWER(COALESCE(u.slDisplayName, '')) LIKE LOWER(CONCAT('%', :search, '%'))
         ORDER BY u.createdAt DESC
         """)
-    Page<User> searchAdmin(@Param("search") String search, @Param("uuid") UUID uuidOrNull, Pageable pageable);
+    Page<User> searchAdminByText(@Param("search") String search, Pageable pageable);
+
+    @Query("""
+        SELECT u FROM User u
+        WHERE u.slAvatarUuid = :uuid
+        ORDER BY u.createdAt DESC
+        """)
+    Page<User> searchAdminByUuid(@Param("uuid") UUID uuid, Pageable pageable);
+
+    @Query("""
+        SELECT u FROM User u
+        ORDER BY u.createdAt DESC
+        """)
+    Page<User> searchAdminAll(Pageable pageable);
 
     /**
      * Sum of all wallet balances. Used by ReconciliationService to compute the

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -190,6 +190,6 @@ slpa:
         top-users-in-log: 10
   admin:
     bootstrap-usernames:
-      - heath
+      - Heath Onyx
   web:
     base-url: ${SLPA_WEB_BASE_URL:http://localhost:3000}

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/users/AdminUserServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/users/AdminUserServiceTest.java
@@ -3,7 +3,6 @@ package com.slparcelauctions.backend.admin.users;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -98,12 +97,12 @@ class AdminUserServiceTest {
         Page<User> page = new PageImpl<>(List.of(user));
         Pageable pageable = PageRequest.of(0, 25);
 
-        when(userRepo.searchAdmin(isNull(), eq(uuid), eq(pageable))).thenReturn(page);
+        when(userRepo.searchAdminByUuid(eq(uuid), eq(pageable))).thenReturn(page);
 
         PagedResponse<AdminUserSummaryDto> result = service.search(uuid.toString(), pageable);
 
         assertThat(result.totalElements()).isEqualTo(1);
-        verify(userRepo).searchAdmin(isNull(), eq(uuid), eq(pageable));
+        verify(userRepo).searchAdminByUuid(eq(uuid), eq(pageable));
     }
 
     @Test
@@ -113,37 +112,37 @@ class AdminUserServiceTest {
         Page<User> page = new PageImpl<>(List.of(user));
         Pageable pageable = PageRequest.of(0, 25);
 
-        when(userRepo.searchAdmin(eq(input), isNull(), eq(pageable))).thenReturn(page);
+        when(userRepo.searchAdminByText(eq(input), eq(pageable))).thenReturn(page);
 
         PagedResponse<AdminUserSummaryDto> result = service.search(input, pageable);
 
         assertThat(result.totalElements()).isEqualTo(1);
-        verify(userRepo).searchAdmin(eq(input), isNull(), eq(pageable));
+        verify(userRepo).searchAdminByText(eq(input), eq(pageable));
     }
 
     @Test
-    void search_emptyInput_passesNullBoth() {
+    void search_emptyInput_callsAll() {
         Page<User> page = new PageImpl<>(Collections.emptyList());
         Pageable pageable = PageRequest.of(0, 25);
 
-        when(userRepo.searchAdmin(isNull(), isNull(), eq(pageable))).thenReturn(page);
+        when(userRepo.searchAdminAll(eq(pageable))).thenReturn(page);
 
         PagedResponse<AdminUserSummaryDto> result = service.search("", pageable);
 
         assertThat(result.totalElements()).isEqualTo(0);
-        verify(userRepo).searchAdmin(isNull(), isNull(), eq(pageable));
+        verify(userRepo).searchAdminAll(eq(pageable));
     }
 
     @Test
-    void search_nullInput_passesNullBoth() {
+    void search_nullInput_callsAll() {
         Page<User> page = new PageImpl<>(Collections.emptyList());
         Pageable pageable = PageRequest.of(0, 25);
 
-        when(userRepo.searchAdmin(isNull(), isNull(), eq(pageable))).thenReturn(page);
+        when(userRepo.searchAdminAll(eq(pageable))).thenReturn(page);
 
         service.search(null, pageable);
 
-        verify(userRepo).searchAdmin(isNull(), isNull(), eq(pageable));
+        verify(userRepo).searchAdminAll(eq(pageable));
     }
 
     // -------------------------------------------------------------------------

--- a/frontend/src/app/admin/users/[publicId]/page.tsx
+++ b/frontend/src/app/admin/users/[publicId]/page.tsx
@@ -4,13 +4,14 @@ type Props = {
   params: Promise<{ publicId: string }>;
 };
 
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export default async function AdminUserDetailRoute({ params }: Props) {
   const { publicId } = await params;
-  const userId = parseInt(publicId, 10);
 
-  if (!Number.isFinite(userId) || userId <= 0) {
+  if (!UUID_PATTERN.test(publicId)) {
     return <div className="py-12 text-sm text-danger">Invalid user ID.</div>;
   }
 
-  return <AdminUserDetailPage userId={userId} />;
+  return <AdminUserDetailPage publicId={publicId} />;
 }

--- a/frontend/src/components/admin/bans/UserSearchAutocomplete.tsx
+++ b/frontend/src/components/admin/bans/UserSearchAutocomplete.tsx
@@ -29,9 +29,9 @@ export function UserSearchAutocomplete({ onSelect, placeholder = "Search by name
   }, [query]);
 
   function handleSelect(user: AdminUserSummary) {
-    const name = user.displayName ?? user.email;
-    setQuery(name);
-    setClosedForQuery(name);
+    const label = user.displayName ?? user.username;
+    setQuery(label);
+    setClosedForQuery(label);
     onSelect(user);
   }
 
@@ -57,17 +57,17 @@ export function UserSearchAutocomplete({ onSelect, placeholder = "Search by name
         >
           {results.map((user) => (
             <li
-              key={user.id}
+              key={user.publicId}
               role="option"
               aria-selected={false}
               onClick={() => handleSelect(user)}
-              data-testid={`user-option-${user.id}`}
+              data-testid={`user-option-${user.publicId}`}
               className="flex flex-col px-4 py-2 cursor-pointer hover:bg-bg-muted transition-colors"
             >
               <span className="text-sm font-medium text-fg">
-                {user.displayName ?? "(no display name)"}
+                {user.displayName ?? user.username}
               </span>
-              <span className="text-[11px] text-fg-muted">{user.email}</span>
+              <span className="text-[11px] text-fg-muted">{user.email ?? "—"}</span>
             </li>
           ))}
         </ul>

--- a/frontend/src/components/admin/users/AdminUserDetailPage.tsx
+++ b/frontend/src/components/admin/users/AdminUserDetailPage.tsx
@@ -13,12 +13,12 @@ import { ModerationTab } from "./tabs/ModerationTab";
 import { UserActionsRail } from "./UserActionsRail";
 
 type Props = {
-  userId: number;
+  publicId: string;
 };
 
-export function AdminUserDetailPage({ userId }: Props) {
+export function AdminUserDetailPage({ publicId }: Props) {
   const [activeTab, setActiveTab] = useState<UserTab>("listings");
-  const { data: user, isLoading, isError, refetch } = useAdminUser(userId);
+  const { data: user, isLoading, isError, refetch } = useAdminUser(publicId);
 
   if (isLoading) {
     return (
@@ -46,12 +46,12 @@ export function AdminUserDetailPage({ userId }: Props) {
         <UserStatsCards stats={user} />
         <UserTabsNav active={activeTab} onChange={setActiveTab} />
 
-        {activeTab === "listings" && <ListingsTab userId={userId} />}
-        {activeTab === "bids" && <BidsTab userId={userId} />}
-        {activeTab === "cancellations" && <CancellationsTab userId={userId} />}
-        {activeTab === "reports" && <ReportsTab userId={userId} />}
-        {activeTab === "fraudFlags" && <FraudFlagsTab userId={userId} />}
-        {activeTab === "moderation" && <ModerationTab userId={userId} />}
+        {activeTab === "listings" && <ListingsTab publicId={publicId} />}
+        {activeTab === "bids" && <BidsTab publicId={publicId} />}
+        {activeTab === "cancellations" && <CancellationsTab publicId={publicId} />}
+        {activeTab === "reports" && <ReportsTab publicId={publicId} />}
+        {activeTab === "fraudFlags" && <FraudFlagsTab publicId={publicId} />}
+        {activeTab === "moderation" && <ModerationTab publicId={publicId} />}
       </div>
 
       <div className="sticky top-6">

--- a/frontend/src/components/admin/users/AdminUsersTable.tsx
+++ b/frontend/src/components/admin/users/AdminUsersTable.tsx
@@ -46,18 +46,18 @@ export function AdminUsersTable({ rows }: Props) {
         <tbody>
           {rows.map((row) => (
             <tr
-              key={row.id}
-              data-testid={`user-row-${row.id}`}
+              key={row.publicId}
+              data-testid={`user-row-${row.publicId}`}
               className="border-b border-border-subtle/50 hover:bg-bg-muted/50 cursor-pointer"
             >
               <td className="px-3 py-2.5">
                 <Link
-                  href={`/admin/users/${row.id}`}
+                  href={`/admin/users/${row.publicId}`}
                   className="block"
-                  data-testid={`user-link-${row.id}`}
+                  data-testid={`user-link-${row.publicId}`}
                 >
                   <div className="text-fg font-medium">
-                    {row.displayName ?? row.email}
+                    {row.displayName ?? row.username}
                   </div>
                   <div className="text-[11px] text-fg-muted mt-0.5">
                     {row.completedSales} sold
@@ -67,7 +67,7 @@ export function AdminUsersTable({ rows }: Props) {
                   </div>
                 </Link>
               </td>
-              <td className="px-3 py-2.5 text-fg-muted">{row.email}</td>
+              <td className="px-3 py-2.5 text-fg-muted">{row.email ?? <span className="text-fg-muted/50">-</span>}</td>
               <td className="px-3 py-2.5">
                 {row.slAvatarUuid ? (
                   <span className="font-mono text-[11px] text-fg-muted" title={row.slAvatarUuid}>

--- a/frontend/src/components/admin/users/DeleteUserModal.tsx
+++ b/frontend/src/components/admin/users/DeleteUserModal.tsx
@@ -10,9 +10,9 @@ type PreconditionError = {
   blockingIds: number[];
 };
 
-type Props = { userId: number; userEmail?: string | null; onClose: () => void };
+type Props = { publicId: string; userLabel?: string | null; onClose: () => void };
 
-export function DeleteUserModal({ userId, userEmail, onClose }: Props) {
+export function DeleteUserModal({ publicId, userLabel, onClose }: Props) {
   const [adminNote, setAdminNote] = useState("");
   const [error, setError] = useState<string | PreconditionError | null>(null);
   const router = useRouter();
@@ -21,7 +21,7 @@ export function DeleteUserModal({ userId, userEmail, onClose }: Props) {
   const submit = () => {
     setError(null);
     mutation.mutate(
-      { userId, adminNote },
+      { publicId, adminNote },
       {
         onSuccess: () => {
           onClose();
@@ -58,7 +58,7 @@ export function DeleteUserModal({ userId, userEmail, onClose }: Props) {
         onClick={(e) => e.stopPropagation()}
       >
         <h2 className="text-sm font-semibold mb-2">
-          Delete user{userEmail ? ` ${userEmail}` : ""}?
+          Delete user{userLabel ? ` ${userLabel}` : ""}?
         </h2>
         <p className="text-[11px] opacity-70 mb-3">
           This soft-deletes the user. Their identity is scrubbed but their auctions

--- a/frontend/src/components/admin/users/RecentIpsModal.tsx
+++ b/frontend/src/components/admin/users/RecentIpsModal.tsx
@@ -12,12 +12,12 @@ function formatDate(iso: string): string {
 }
 
 type Props = {
-  userId: number;
+  publicId: string;
   onClose: () => void;
 };
 
-export function RecentIpsModal({ userId, onClose }: Props) {
-  const { data, isLoading, isError } = useAdminUserIps(userId);
+export function RecentIpsModal({ publicId, onClose }: Props) {
+  const { data, isLoading, isError } = useAdminUserIps(publicId);
   const [banIp, setBanIp] = useState<string | null>(null);
 
   useEffect(() => {

--- a/frontend/src/components/admin/users/ReinstateListingModal.tsx
+++ b/frontend/src/components/admin/users/ReinstateListingModal.tsx
@@ -8,13 +8,13 @@ const NOTES_MAX = 1000;
 
 type Props = {
   auction: AdminUserListingRow;
-  userId: number;
+  userPublicId: string;
   onClose: () => void;
 };
 
-export function ReinstateListingModal({ auction, userId, onClose }: Props) {
+export function ReinstateListingModal({ auction, userPublicId, onClose }: Props) {
   const [notes, setNotes] = useState("");
-  const reinstate = useReinstateAuction(userId);
+  const reinstate = useReinstateAuction(userPublicId);
 
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
@@ -30,7 +30,7 @@ export function ReinstateListingModal({ auction, userId, onClose }: Props) {
     e.preventDefault();
     if (!canSubmit) return;
     reinstate.mutate(
-      { auctionId: auction.auctionId, notes: notes.trim() },
+      { auctionPublicId: auction.auctionPublicId, notes: notes.trim() },
       { onSuccess: onClose }
     );
   }

--- a/frontend/src/components/admin/users/UserActionsRail.tsx
+++ b/frontend/src/components/admin/users/UserActionsRail.tsx
@@ -26,9 +26,9 @@ export function UserActionsRail({ user, onRefresh }: Props) {
   const [showLiftBan, setShowLiftBan] = useState(false);
   const [showDeleteUser, setShowDeleteUser] = useState(false);
 
-  const promote = usePromoteUser(user.id);
-  const demote = useDemoteUser(user.id);
-  const resetFrivolous = useResetFrivolousCounter(user.id);
+  const promote = usePromoteUser(user.publicId);
+  const demote = useDemoteUser(user.publicId);
+  const resetFrivolous = useResetFrivolousCounter(user.publicId);
 
   const activeBanAsRow: AdminBanRow | null = user.activeBan
     ? {
@@ -36,7 +36,7 @@ export function UserActionsRail({ user, onRefresh }: Props) {
         banType: user.activeBan.banType,
         ipAddress: null,
         slAvatarUuid: user.slAvatarUuid,
-        avatarLinkedUserId: user.id,
+        avatarLinkedUserId: null,
         avatarLinkedDisplayName: user.displayName,
         firstSeenIp: null,
         reasonCategory: "OTHER",
@@ -67,19 +67,19 @@ export function UserActionsRail({ user, onRefresh }: Props) {
   const modalProps = {
     promote: {
       title: "Promote to admin",
-      description: `Grant ${user.displayName ?? user.email} admin privileges?`,
+      description: `Grant ${user.displayName ?? user.username} admin privileges?`,
       confirmLabel: "Promote",
       confirmVariant: "primary" as const,
     },
     demote: {
       title: "Demote from admin",
-      description: `Remove admin privileges from ${user.displayName ?? user.email}?`,
+      description: `Remove admin privileges from ${user.displayName ?? user.username}?`,
       confirmLabel: "Demote",
       confirmVariant: "destructive" as const,
     },
     resetFrivolous: {
       title: "Reset frivolous counter",
-      description: `Reset the frivolous cancellation counter for ${user.displayName ?? user.email}?`,
+      description: `Reset the frivolous cancellation counter for ${user.displayName ?? user.username}?`,
       confirmLabel: "Reset",
       confirmVariant: "primary" as const,
     },
@@ -196,7 +196,7 @@ export function UserActionsRail({ user, onRefresh }: Props) {
       <div className="rounded-lg bg-bg-muted border border-border-subtle p-4 flex flex-col gap-2">
         <div className="text-[11px] font-medium text-fg-muted mb-1">Quick links</div>
         <Link
-          href={`/users/${user.id}`}
+          href={`/users/${user.publicId}`}
           className="text-sm text-brand hover:underline underline-offset-2"
           target="_blank"
           data-testid="public-profile-link"
@@ -238,7 +238,7 @@ export function UserActionsRail({ user, onRefresh }: Props) {
       )}
 
       {showIps && (
-        <RecentIpsModal userId={user.id} onClose={() => setShowIps(false)} />
+        <RecentIpsModal publicId={user.publicId} onClose={() => setShowIps(false)} />
       )}
 
       <CreateBanModal
@@ -256,8 +256,8 @@ export function UserActionsRail({ user, onRefresh }: Props) {
 
       {showDeleteUser && (
         <DeleteUserModal
-          userId={user.id}
-          userEmail={user.email}
+          publicId={user.publicId}
+          userLabel={user.displayName ?? user.username}
           onClose={() => setShowDeleteUser(false)}
         />
       )}

--- a/frontend/src/components/admin/users/UserProfileHeader.tsx
+++ b/frontend/src/components/admin/users/UserProfileHeader.tsx
@@ -23,7 +23,7 @@ export function UserProfileHeader({ user }: Props) {
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
             <h1 className="text-2xl font-semibold text-fg truncate">
-              {user.displayName ?? user.email}
+              {user.displayName ?? user.username}
             </h1>
             {user.activeBan && (
               <span
@@ -58,7 +58,8 @@ export function UserProfileHeader({ user }: Props) {
             )}
           </div>
           <div className="mt-1.5 text-sm text-fg-muted flex flex-wrap gap-x-4 gap-y-0.5">
-            <span>{user.email}</span>
+            <span>@{user.username}</span>
+            {user.email && <span>{user.email}</span>}
             {user.slAvatarUuid && (
               <span
                 className="font-mono text-[11px]"

--- a/frontend/src/components/admin/users/tabs/BidsTab.tsx
+++ b/frontend/src/components/admin/users/tabs/BidsTab.tsx
@@ -15,12 +15,12 @@ function formatDate(iso: string): string {
 }
 
 type Props = {
-  userId: number;
+  publicId: string;
 };
 
-export function BidsTab({ userId }: Props) {
+export function BidsTab({ publicId }: Props) {
   const [page, setPage] = useState(0);
-  const { data, isLoading, isError } = useAdminUserBids(userId, page, PAGE_SIZE);
+  const { data, isLoading, isError } = useAdminUserBids(publicId, page, PAGE_SIZE);
 
   if (isLoading) {
     return <div className="py-6 text-sm text-fg-muted">Loading bids…</div>;
@@ -55,7 +55,7 @@ export function BidsTab({ userId }: Props) {
               >
                 <td className="px-3 py-2.5">
                   <Link
-                    href={`/auction/${row.auctionId}`}
+                    href={`/auction/${row.auctionPublicId}`}
                     className="text-brand hover:underline underline-offset-2 line-clamp-1"
                     target="_blank"
                   >

--- a/frontend/src/components/admin/users/tabs/CancellationsTab.tsx
+++ b/frontend/src/components/admin/users/tabs/CancellationsTab.tsx
@@ -15,12 +15,12 @@ function formatDate(iso: string): string {
 }
 
 type Props = {
-  userId: number;
+  publicId: string;
 };
 
-export function CancellationsTab({ userId }: Props) {
+export function CancellationsTab({ publicId }: Props) {
   const [page, setPage] = useState(0);
-  const { data, isLoading, isError } = useAdminUserCancellations(userId, page, PAGE_SIZE);
+  const { data, isLoading, isError } = useAdminUserCancellations(publicId, page, PAGE_SIZE);
 
   if (isLoading) {
     return <div className="py-6 text-sm text-fg-muted">Loading cancellations…</div>;
@@ -56,7 +56,7 @@ export function CancellationsTab({ userId }: Props) {
               >
                 <td className="px-3 py-2.5">
                   <Link
-                    href={`/auction/${row.auctionId}`}
+                    href={`/auction/${row.auctionPublicId}`}
                     className="text-brand hover:underline underline-offset-2 line-clamp-1"
                     target="_blank"
                   >

--- a/frontend/src/components/admin/users/tabs/FraudFlagsTab.tsx
+++ b/frontend/src/components/admin/users/tabs/FraudFlagsTab.tsx
@@ -15,12 +15,12 @@ function formatDate(iso: string): string {
 }
 
 type Props = {
-  userId: number;
+  publicId: string;
 };
 
-export function FraudFlagsTab({ userId }: Props) {
+export function FraudFlagsTab({ publicId }: Props) {
   const [page, setPage] = useState(0);
-  const { data, isLoading, isError } = useAdminUserFraudFlags(userId, page, PAGE_SIZE);
+  const { data, isLoading, isError } = useAdminUserFraudFlags(publicId, page, PAGE_SIZE);
 
   if (isLoading) {
     return <div className="py-6 text-sm text-fg-muted">Loading fraud flags…</div>;
@@ -54,13 +54,17 @@ export function FraudFlagsTab({ userId }: Props) {
                 data-testid={`fraud-flag-row-${row.flagId}`}
               >
                 <td className="px-3 py-2.5">
-                  <Link
-                    href={`/auction/${row.auctionId}`}
-                    className="text-brand hover:underline underline-offset-2 line-clamp-1"
-                    target="_blank"
-                  >
-                    {row.auctionTitle}
-                  </Link>
+                  {row.auctionPublicId ? (
+                    <Link
+                      href={`/auction/${row.auctionPublicId}`}
+                      className="text-brand hover:underline underline-offset-2 line-clamp-1"
+                      target="_blank"
+                    >
+                      {row.auctionTitle ?? "(deleted)"}
+                    </Link>
+                  ) : (
+                    <span className="text-fg-muted">(deleted)</span>
+                  )}
                 </td>
                 <td className="px-3 py-2.5 text-fg-muted">{row.reason}</td>
                 <td className="px-3 py-2.5">

--- a/frontend/src/components/admin/users/tabs/ListingsTab.tsx
+++ b/frontend/src/components/admin/users/tabs/ListingsTab.tsx
@@ -31,13 +31,13 @@ function formatDate(iso: string): string {
 }
 
 type Props = {
-  userId: number;
+  publicId: string;
 };
 
-export function ListingsTab({ userId }: Props) {
+export function ListingsTab({ publicId }: Props) {
   const [page, setPage] = useState(0);
   const [reinstateAuction, setReinstateAuction] = useState<AdminUserListingRow | null>(null);
-  const { data, isLoading, isError } = useAdminUserListings(userId, page, PAGE_SIZE);
+  const { data, isLoading, isError } = useAdminUserListings(publicId, page, PAGE_SIZE);
 
   if (isLoading) {
     return <div className="py-6 text-sm text-fg-muted">Loading listings…</div>;
@@ -76,7 +76,7 @@ export function ListingsTab({ userId }: Props) {
                 >
                   <td className="px-3 py-2.5">
                     <Link
-                      href={`/auction/${row.auctionId}`}
+                      href={`/auction/${row.auctionPublicId}`}
                       className="text-brand hover:underline underline-offset-2 line-clamp-1"
                       target="_blank"
                     >
@@ -117,7 +117,7 @@ export function ListingsTab({ userId }: Props) {
       {reinstateAuction && (
         <ReinstateListingModal
           auction={reinstateAuction}
-          userId={userId}
+          userPublicId={publicId}
           onClose={() => setReinstateAuction(null)}
         />
       )}

--- a/frontend/src/components/admin/users/tabs/ModerationTab.tsx
+++ b/frontend/src/components/admin/users/tabs/ModerationTab.tsx
@@ -16,12 +16,12 @@ function formatDate(iso: string): string {
 }
 
 type Props = {
-  userId: number;
+  publicId: string;
 };
 
-export function ModerationTab({ userId }: Props) {
+export function ModerationTab({ publicId }: Props) {
   const [page, setPage] = useState(0);
-  const { data, isLoading, isError } = useAdminUserModeration(userId, page, PAGE_SIZE);
+  const { data, isLoading, isError } = useAdminUserModeration(publicId, page, PAGE_SIZE);
 
   if (isLoading) {
     return <div className="py-6 text-sm text-fg-muted">Loading moderation history…</div>;

--- a/frontend/src/components/admin/users/tabs/ReportsTab.tsx
+++ b/frontend/src/components/admin/users/tabs/ReportsTab.tsx
@@ -15,12 +15,12 @@ function formatDate(iso: string): string {
 }
 
 type Props = {
-  userId: number;
+  publicId: string;
 };
 
-export function ReportsTab({ userId }: Props) {
+export function ReportsTab({ publicId }: Props) {
   const [page, setPage] = useState(0);
-  const { data, isLoading, isError } = useAdminUserReports(userId, page, PAGE_SIZE);
+  const { data, isLoading, isError } = useAdminUserReports(publicId, page, PAGE_SIZE);
 
   if (isLoading) {
     return <div className="py-6 text-sm text-fg-muted">Loading reports…</div>;
@@ -56,7 +56,7 @@ export function ReportsTab({ userId }: Props) {
               >
                 <td className="px-3 py-2.5">
                   <Link
-                    href={`/auction/${row.auctionId}`}
+                    href={`/auction/${row.auctionPublicId}`}
                     className="text-brand hover:underline underline-offset-2 line-clamp-1"
                     target="_blank"
                   >

--- a/frontend/src/hooks/admin/useAdminUser.ts
+++ b/frontend/src/hooks/admin/useAdminUser.ts
@@ -3,10 +3,10 @@ import { useQuery } from "@tanstack/react-query";
 import { adminApi } from "@/lib/admin/api";
 import { adminQueryKeys } from "@/lib/admin/queryKeys";
 
-export function useAdminUser(id: number) {
+export function useAdminUser(publicId: string) {
   return useQuery({
-    queryKey: adminQueryKeys.user(id),
-    queryFn: () => adminApi.users.detail(id),
+    queryKey: adminQueryKeys.user(publicId),
+    queryFn: () => adminApi.users.detail(publicId),
     staleTime: 10_000,
   });
 }

--- a/frontend/src/hooks/admin/useAdminUserBids.ts
+++ b/frontend/src/hooks/admin/useAdminUserBids.ts
@@ -3,10 +3,10 @@ import { useQuery } from "@tanstack/react-query";
 import { adminApi } from "@/lib/admin/api";
 import { adminQueryKeys } from "@/lib/admin/queryKeys";
 
-export function useAdminUserBids(id: number, page: number, size = 25) {
+export function useAdminUserBids(publicId: string, page: number, size = 25) {
   return useQuery({
-    queryKey: adminQueryKeys.userTab(id, "bids", { page, size }),
-    queryFn: () => adminApi.users.bids(id, page, size),
+    queryKey: adminQueryKeys.userTab(publicId, "bids", { page, size }),
+    queryFn: () => adminApi.users.bids(publicId, page, size),
     staleTime: 10_000,
   });
 }

--- a/frontend/src/hooks/admin/useAdminUserCancellations.ts
+++ b/frontend/src/hooks/admin/useAdminUserCancellations.ts
@@ -3,10 +3,10 @@ import { useQuery } from "@tanstack/react-query";
 import { adminApi } from "@/lib/admin/api";
 import { adminQueryKeys } from "@/lib/admin/queryKeys";
 
-export function useAdminUserCancellations(id: number, page: number, size = 25) {
+export function useAdminUserCancellations(publicId: string, page: number, size = 25) {
   return useQuery({
-    queryKey: adminQueryKeys.userTab(id, "cancellations", { page, size }),
-    queryFn: () => adminApi.users.cancellations(id, page, size),
+    queryKey: adminQueryKeys.userTab(publicId, "cancellations", { page, size }),
+    queryFn: () => adminApi.users.cancellations(publicId, page, size),
     staleTime: 10_000,
   });
 }

--- a/frontend/src/hooks/admin/useAdminUserFraudFlags.ts
+++ b/frontend/src/hooks/admin/useAdminUserFraudFlags.ts
@@ -3,10 +3,10 @@ import { useQuery } from "@tanstack/react-query";
 import { adminApi } from "@/lib/admin/api";
 import { adminQueryKeys } from "@/lib/admin/queryKeys";
 
-export function useAdminUserFraudFlags(id: number, page: number, size = 25) {
+export function useAdminUserFraudFlags(publicId: string, page: number, size = 25) {
   return useQuery({
-    queryKey: adminQueryKeys.userTab(id, "fraudFlags", { page, size }),
-    queryFn: () => adminApi.users.fraudFlags(id, page, size),
+    queryKey: adminQueryKeys.userTab(publicId, "fraudFlags", { page, size }),
+    queryFn: () => adminApi.users.fraudFlags(publicId, page, size),
     staleTime: 10_000,
   });
 }

--- a/frontend/src/hooks/admin/useAdminUserIps.ts
+++ b/frontend/src/hooks/admin/useAdminUserIps.ts
@@ -3,10 +3,10 @@ import { useQuery } from "@tanstack/react-query";
 import { adminApi } from "@/lib/admin/api";
 import { adminQueryKeys } from "@/lib/admin/queryKeys";
 
-export function useAdminUserIps(id: number, enabled = true) {
+export function useAdminUserIps(publicId: string, enabled = true) {
   return useQuery({
-    queryKey: adminQueryKeys.userIps(id),
-    queryFn: () => adminApi.users.ips(id),
+    queryKey: adminQueryKeys.userIps(publicId),
+    queryFn: () => adminApi.users.ips(publicId),
     enabled,
     staleTime: 30_000,
   });

--- a/frontend/src/hooks/admin/useAdminUserListings.ts
+++ b/frontend/src/hooks/admin/useAdminUserListings.ts
@@ -3,10 +3,10 @@ import { useQuery } from "@tanstack/react-query";
 import { adminApi } from "@/lib/admin/api";
 import { adminQueryKeys } from "@/lib/admin/queryKeys";
 
-export function useAdminUserListings(id: number, page: number, size = 25) {
+export function useAdminUserListings(publicId: string, page: number, size = 25) {
   return useQuery({
-    queryKey: adminQueryKeys.userTab(id, "listings", { page, size }),
-    queryFn: () => adminApi.users.listings(id, page, size),
+    queryKey: adminQueryKeys.userTab(publicId, "listings", { page, size }),
+    queryFn: () => adminApi.users.listings(publicId, page, size),
     staleTime: 10_000,
   });
 }

--- a/frontend/src/hooks/admin/useAdminUserModeration.ts
+++ b/frontend/src/hooks/admin/useAdminUserModeration.ts
@@ -3,10 +3,10 @@ import { useQuery } from "@tanstack/react-query";
 import { adminApi } from "@/lib/admin/api";
 import { adminQueryKeys } from "@/lib/admin/queryKeys";
 
-export function useAdminUserModeration(id: number, page: number, size = 25) {
+export function useAdminUserModeration(publicId: string, page: number, size = 25) {
   return useQuery({
-    queryKey: adminQueryKeys.userTab(id, "moderation", { page, size }),
-    queryFn: () => adminApi.users.moderation(id, page, size),
+    queryKey: adminQueryKeys.userTab(publicId, "moderation", { page, size }),
+    queryFn: () => adminApi.users.moderation(publicId, page, size),
     staleTime: 10_000,
   });
 }

--- a/frontend/src/hooks/admin/useAdminUserReports.ts
+++ b/frontend/src/hooks/admin/useAdminUserReports.ts
@@ -3,10 +3,10 @@ import { useQuery } from "@tanstack/react-query";
 import { adminApi } from "@/lib/admin/api";
 import { adminQueryKeys } from "@/lib/admin/queryKeys";
 
-export function useAdminUserReports(id: number, page: number, size = 25) {
+export function useAdminUserReports(publicId: string, page: number, size = 25) {
   return useQuery({
-    queryKey: adminQueryKeys.userTab(id, "reports", { page, size }),
-    queryFn: () => adminApi.users.reports(id, page, size),
+    queryKey: adminQueryKeys.userTab(publicId, "reports", { page, size }),
+    queryFn: () => adminApi.users.reports(publicId, page, size),
     staleTime: 10_000,
   });
 }

--- a/frontend/src/hooks/admin/useDemoteUser.ts
+++ b/frontend/src/hooks/admin/useDemoteUser.ts
@@ -5,13 +5,13 @@ import { adminQueryKeys } from "@/lib/admin/queryKeys";
 import { useToast } from "@/components/ui/Toast/useToast";
 import { isApiError } from "@/lib/api";
 
-export function useDemoteUser(userId: number) {
+export function useDemoteUser(publicId: string) {
   const qc = useQueryClient();
   const toast = useToast();
   return useMutation({
-    mutationFn: (notes: string) => adminApi.users.demote(userId, notes),
+    mutationFn: (notes: string) => adminApi.users.demote(publicId, notes),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: adminQueryKeys.user(userId) });
+      qc.invalidateQueries({ queryKey: adminQueryKeys.user(publicId) });
       qc.invalidateQueries({ queryKey: adminQueryKeys.users() });
       qc.invalidateQueries({ queryKey: adminQueryKeys.stats() });
       toast.success("User demoted.");

--- a/frontend/src/hooks/admin/usePromoteUser.ts
+++ b/frontend/src/hooks/admin/usePromoteUser.ts
@@ -5,13 +5,13 @@ import { adminQueryKeys } from "@/lib/admin/queryKeys";
 import { useToast } from "@/components/ui/Toast/useToast";
 import { isApiError } from "@/lib/api";
 
-export function usePromoteUser(userId: number) {
+export function usePromoteUser(publicId: string) {
   const qc = useQueryClient();
   const toast = useToast();
   return useMutation({
-    mutationFn: (notes: string) => adminApi.users.promote(userId, notes),
+    mutationFn: (notes: string) => adminApi.users.promote(publicId, notes),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: adminQueryKeys.user(userId) });
+      qc.invalidateQueries({ queryKey: adminQueryKeys.user(publicId) });
       qc.invalidateQueries({ queryKey: adminQueryKeys.users() });
       qc.invalidateQueries({ queryKey: adminQueryKeys.stats() });
       toast.success("User promoted to admin.");

--- a/frontend/src/hooks/admin/useReinstateAuction.ts
+++ b/frontend/src/hooks/admin/useReinstateAuction.ts
@@ -5,14 +5,14 @@ import { adminQueryKeys } from "@/lib/admin/queryKeys";
 import { useToast } from "@/components/ui/Toast/useToast";
 import { isApiError } from "@/lib/api";
 
-export function useReinstateAuction(userId: number) {
+export function useReinstateAuction(userPublicId: string) {
   const qc = useQueryClient();
   const toast = useToast();
   return useMutation({
-    mutationFn: ({ auctionId, notes }: { auctionId: number; notes: string }) =>
-      adminApi.auctions.reinstate(auctionId, notes),
+    mutationFn: ({ auctionPublicId, notes }: { auctionPublicId: string; notes: string }) =>
+      adminApi.auctions.reinstate(auctionPublicId, notes),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: adminQueryKeys.userTab(userId, "listings", { page: 0, size: 25 }) });
+      qc.invalidateQueries({ queryKey: adminQueryKeys.userTab(userPublicId, "listings", { page: 0, size: 25 }) });
       qc.invalidateQueries({ queryKey: adminQueryKeys.stats() });
       toast.success("Auction reinstated.");
     },
@@ -20,7 +20,7 @@ export function useReinstateAuction(userId: number) {
       const code = isApiError(err) ? (err.problem as { code?: string }).code : null;
       if (code === "AUCTION_NOT_SUSPENDED") {
         toast.error("Auction is no longer SUSPENDED. Refreshing.");
-        qc.invalidateQueries({ queryKey: adminQueryKeys.userTab(userId, "listings", { page: 0, size: 25 }) });
+        qc.invalidateQueries({ queryKey: adminQueryKeys.userTab(userPublicId, "listings", { page: 0, size: 25 }) });
         return;
       }
       toast.error("Couldn't reinstate auction.");

--- a/frontend/src/hooks/admin/useResetFrivolousCounter.ts
+++ b/frontend/src/hooks/admin/useResetFrivolousCounter.ts
@@ -4,13 +4,13 @@ import { adminApi } from "@/lib/admin/api";
 import { adminQueryKeys } from "@/lib/admin/queryKeys";
 import { useToast } from "@/components/ui/Toast/useToast";
 
-export function useResetFrivolousCounter(userId: number) {
+export function useResetFrivolousCounter(publicId: string) {
   const qc = useQueryClient();
   const toast = useToast();
   return useMutation({
-    mutationFn: (notes: string) => adminApi.users.resetFrivolousCounter(userId, notes),
+    mutationFn: (notes: string) => adminApi.users.resetFrivolousCounter(publicId, notes),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: adminQueryKeys.user(userId) });
+      qc.invalidateQueries({ queryKey: adminQueryKeys.user(publicId) });
       qc.invalidateQueries({ queryKey: adminQueryKeys.stats() });
       toast.success("Frivolous cancellation counter reset.");
     },

--- a/frontend/src/lib/admin/api.ts
+++ b/frontend/src/lib/admin/api.ts
@@ -129,41 +129,41 @@ export const adminApi = {
       if (params.search) sp.set("search", params.search);
       return api.get(`/api/v1/admin/users?${sp.toString()}`);
     },
-    detail(id: number): Promise<AdminUserDetail> {
-      return api.get(`/api/v1/admin/users/${id}`);
+    detail(publicId: string): Promise<AdminUserDetail> {
+      return api.get(`/api/v1/admin/users/${publicId}`);
     },
-    listings(id: number, page: number, size: number): Promise<Page<AdminUserListingRow>> {
-      return api.get(`/api/v1/admin/users/${id}/listings?page=${page}&size=${size}`);
+    listings(publicId: string, page: number, size: number): Promise<Page<AdminUserListingRow>> {
+      return api.get(`/api/v1/admin/users/${publicId}/listings?page=${page}&size=${size}`);
     },
-    bids(id: number, page: number, size: number): Promise<Page<AdminUserBidRow>> {
-      return api.get(`/api/v1/admin/users/${id}/bids?page=${page}&size=${size}`);
+    bids(publicId: string, page: number, size: number): Promise<Page<AdminUserBidRow>> {
+      return api.get(`/api/v1/admin/users/${publicId}/bids?page=${page}&size=${size}`);
     },
-    cancellations(id: number, page: number, size: number): Promise<Page<AdminUserCancellationRow>> {
-      return api.get(`/api/v1/admin/users/${id}/cancellations?page=${page}&size=${size}`);
+    cancellations(publicId: string, page: number, size: number): Promise<Page<AdminUserCancellationRow>> {
+      return api.get(`/api/v1/admin/users/${publicId}/cancellations?page=${page}&size=${size}`);
     },
-    reports(id: number, page: number, size: number): Promise<Page<AdminUserReportRow>> {
-      return api.get(`/api/v1/admin/users/${id}/reports?page=${page}&size=${size}`);
+    reports(publicId: string, page: number, size: number): Promise<Page<AdminUserReportRow>> {
+      return api.get(`/api/v1/admin/users/${publicId}/reports?page=${page}&size=${size}`);
     },
-    fraudFlags(id: number, page: number, size: number): Promise<Page<AdminUserFraudFlagRow>> {
-      return api.get(`/api/v1/admin/users/${id}/fraud-flags?page=${page}&size=${size}`);
+    fraudFlags(publicId: string, page: number, size: number): Promise<Page<AdminUserFraudFlagRow>> {
+      return api.get(`/api/v1/admin/users/${publicId}/fraud-flags?page=${page}&size=${size}`);
     },
-    moderation(id: number, page: number, size: number): Promise<Page<AdminUserModerationRow>> {
-      return api.get(`/api/v1/admin/users/${id}/moderation?page=${page}&size=${size}`);
+    moderation(publicId: string, page: number, size: number): Promise<Page<AdminUserModerationRow>> {
+      return api.get(`/api/v1/admin/users/${publicId}/moderation?page=${page}&size=${size}`);
     },
-    ips(id: number): Promise<UserIpProjection[]> {
-      return api.get(`/api/v1/admin/users/${id}/ips`);
+    ips(publicId: string): Promise<UserIpProjection[]> {
+      return api.get(`/api/v1/admin/users/${publicId}/ips`);
     },
-    promote(id: number, notes: string): Promise<void> {
-      return api.post(`/api/v1/admin/users/${id}/promote`, { notes });
+    promote(publicId: string, notes: string): Promise<void> {
+      return api.post(`/api/v1/admin/users/${publicId}/promote`, { notes });
     },
-    demote(id: number, notes: string): Promise<void> {
-      return api.post(`/api/v1/admin/users/${id}/demote`, { notes });
+    demote(publicId: string, notes: string): Promise<void> {
+      return api.post(`/api/v1/admin/users/${publicId}/demote`, { notes });
     },
-    resetFrivolousCounter(id: number, notes: string): Promise<void> {
-      return api.post(`/api/v1/admin/users/${id}/reset-frivolous-counter`, { notes });
+    resetFrivolousCounter(publicId: string, notes: string): Promise<void> {
+      return api.post(`/api/v1/admin/users/${publicId}/reset-frivolous-counter`, { notes });
     },
-    delete(userId: number, adminNote: string): Promise<void> {
-      return api.delete(`/api/v1/admin/users/${userId}`, { body: { adminNote } });
+    delete(publicId: string, adminNote: string): Promise<void> {
+      return api.delete(`/api/v1/admin/users/${publicId}`, { body: { adminNote } });
     },
   },
 
@@ -209,13 +209,13 @@ export const adminApi = {
   },
 
   auctions: {
-    reinstate(id: number, notes: string): Promise<{
+    reinstate(publicId: string, notes: string): Promise<{
       auctionId: number;
       status: string;
       newEndsAt: string;
       suspensionDurationSeconds: number;
     }> {
-      return api.post(`/api/v1/admin/auctions/${id}/reinstate`, { notes });
+      return api.post(`/api/v1/admin/auctions/${publicId}/reinstate`, { notes });
     },
   },
 

--- a/frontend/src/lib/admin/deletionHooks.ts
+++ b/frontend/src/lib/admin/deletionHooks.ts
@@ -12,8 +12,8 @@ export function useDeleteSelf() {
 export function useDeleteUser() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ userId, adminNote }: { userId: number; adminNote: string }) =>
-      adminApi.users.delete(userId, adminNote),
+    mutationFn: ({ publicId, adminNote }: { publicId: string; adminNote: string }) =>
+      adminApi.users.delete(publicId, adminNote),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: adminQueryKeys.users() });
     },

--- a/frontend/src/lib/admin/queryKeys.ts
+++ b/frontend/src/lib/admin/queryKeys.ts
@@ -27,10 +27,10 @@ export const adminQueryKeys = {
   users: () => [...adminQueryKeys.all, "users"] as const,
   usersList: (filters: { search?: string; page: number; size: number }) =>
     [...adminQueryKeys.users(), "list", filters] as const,
-  user: (id: number) => [...adminQueryKeys.users(), "detail", id] as const,
-  userTab: (id: number, tab: string, filters: { page: number; size: number }) =>
-    [...adminQueryKeys.user(id), tab, filters] as const,
-  userIps: (id: number) => [...adminQueryKeys.user(id), "ips"] as const,
+  user: (publicId: string) => [...adminQueryKeys.users(), "detail", publicId] as const,
+  userTab: (publicId: string, tab: string, filters: { page: number; size: number }) =>
+    [...adminQueryKeys.user(publicId), tab, filters] as const,
+  userIps: (publicId: string) => [...adminQueryKeys.user(publicId), "ips"] as const,
   audit: (filters: {
     targetType?: AdminActionTargetType;
     targetId?: number;

--- a/frontend/src/lib/admin/types.ts
+++ b/frontend/src/lib/admin/types.ts
@@ -188,8 +188,9 @@ export type ActiveBanSummary = {
 };
 
 export type AdminUserSummary = {
-  id: number;
-  email: string;
+  publicId: string;
+  username: string;
+  email: string | null;
   displayName: string | null;
   slAvatarUuid: string | null;
   slDisplayName: string | null;
@@ -202,8 +203,9 @@ export type AdminUserSummary = {
 };
 
 export type AdminUserDetail = {
-  id: number;
-  email: string;
+  publicId: string;
+  username: string;
+  email: string | null;
   displayName: string | null;
   slAvatarUuid: string | null;
   slDisplayName: string | null;
@@ -223,6 +225,7 @@ export type AdminUserDetail = {
 
 export type AdminUserListingRow = {
   auctionId: number;
+  auctionPublicId: string;
   title: string;
   regionName: string | null;
   status: AuctionStatus;
@@ -233,6 +236,7 @@ export type AdminUserListingRow = {
 export type AdminUserBidRow = {
   bidId: number;
   auctionId: number;
+  auctionPublicId: string;
   auctionTitle: string;
   amount: number;
   placedAt: string;
@@ -242,6 +246,7 @@ export type AdminUserBidRow = {
 export type AdminUserCancellationRow = {
   logId: number;
   auctionId: number;
+  auctionPublicId: string;
   auctionTitle: string;
   cancelledFromStatus: string;
   hadBids: boolean;
@@ -255,6 +260,7 @@ export type AdminUserCancellationRow = {
 export type AdminUserReportRow = {
   reportId: number;
   auctionId: number;
+  auctionPublicId: string;
   auctionTitle: string;
   reason: string;
   status: string;
@@ -265,8 +271,9 @@ export type AdminUserReportRow = {
 
 export type AdminUserFraudFlagRow = {
   flagId: number;
-  auctionId: number;
-  auctionTitle: string;
+  auctionId: number | null;
+  auctionPublicId: string | null;
+  auctionTitle: string | null;
   reason: string;
   resolved: boolean;
   detectedAt: string;

--- a/frontend/src/test/msw/handlers.ts
+++ b/frontend/src/test/msw/handlers.ts
@@ -597,15 +597,15 @@ export const adminHandlers = {
   },
 
   userDetailSuccess(detail: AdminUserDetail) {
-    return http.get(`*/api/v1/admin/users/${detail.id}`, () => HttpResponse.json(detail));
+    return http.get(`*/api/v1/admin/users/${detail.publicId}`, () => HttpResponse.json(detail));
   },
 
-  userIpsSuccess(userId: number, ips: UserIpProjection[]) {
-    return http.get(`*/api/v1/admin/users/${userId}/ips`, () => HttpResponse.json(ips));
+  userIpsSuccess(publicId: string, ips: UserIpProjection[]) {
+    return http.get(`*/api/v1/admin/users/${publicId}/ips`, () => HttpResponse.json(ips));
   },
 
-  userListingsSuccess(userId: number, rows: AdminUserModerationRow[]) {
-    return http.get(`*/api/v1/admin/users/${userId}/listings`, () =>
+  userListingsSuccess(publicId: string, rows: AdminUserModerationRow[]) {
+    return http.get(`*/api/v1/admin/users/${publicId}/listings`, () =>
       HttpResponse.json({
         content: rows,
         totalElements: rows.length,


### PR DESCRIPTION
## Summary

Three admin/users page bugs the user reported plus the related convention-drift items I caught in the audit.

- **Name column showed email** — DTO now exposes \`username\`; table fallback is \`displayName ?? username\`.
- **Row link → /admin/users/undefined** — backend has been sending \`publicId: UUID\` for a while; frontend still typed it as \`id: number\`. Renamed across 14 hooks, 7 components, 1 route, and the API client URL templates.
- **/admin/users without ?search returned 500** — Postgres typed the null \`:search\` parameter as bytea and \`LOWER(bytea)\` failed. Split \`UserRepository.searchAdmin\` into three single-purpose methods.
- **Auction reinstate** — frontend was passing a Long auctionId into \`/api/v1/admin/auctions/{publicId}/reinstate\` (UUID). Admin row DTOs now carry \`auctionPublicId\`; \`useReinstateAuction\` and the modal pass it through.
- **CLAUDE.md** updated: the previous \"admin DTOs keep id: Long\" guidance was stale; admin DTOs use \`publicId\`.

## Test plan

- [x] \`npx tsc --noEmit\` clean on production code (test fixtures still drift from AuthUser; orthogonal cleanup)
- [x] \`npx next build\` succeeds locally
- [ ] post-deploy: search /admin/users with no filter loads
- [ ] post-deploy: row click goes to /admin/users/{uuid}
- [ ] post-deploy: name column shows \"Heath Onyx\", not email