### PR TITLE
fix(admin-test): make backend test compile pass for the new DTO constructor

### DIFF
--- a/backend/src/test/java/com/slparcelauctions/backend/admin/users/AdminUserControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/users/AdminUserControllerSliceTest.java
@@ -149,7 +149,7 @@ class AdminUserControllerSliceTest {
     @Test
     void detail_admin_returns200() throws Exception {
         AdminUserDetailDto dto = new AdminUserDetailDto(
-            TARGET_UUID, "target-user-ctrl@x.com", "Target", null, null,
+            TARGET_UUID, "target-user-ctrl", "target-user-ctrl@x.com", "Target", null, null,
             Role.USER, false, null, null,
             0L, 0L, 0L, 0L, 0L, null, false, null);
         when(adminUserService.detail(anyLong())).thenReturn(dto);


### PR DESCRIPTION
Single-commit follow-up to PR #170. The deploy build runs test compilation even with -DskipTests; AdminUserControllerSliceTest still constructed AdminUserDetailDto with the old positional signature. Adds the new username field.