### PR TITLE
fix(admin): admin ledger 500 — escrow_transactions joins use payer_id/payee_id

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ledger/AdminLedgerQueryRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ledger/AdminLedgerQueryRepository.java
@@ -312,8 +312,8 @@ public class AdminLedgerQueryRepository {
           END                                                          AS counterparty_user_id
         FROM escrow_transactions et
         JOIN escrows es ON es.id = et.escrow_id
-        LEFT JOIN users payer_u ON payer_u.sl_avatar_uuid = et.payer::uuid
-        LEFT JOIN users payee_u ON payee_u.sl_avatar_uuid = et.payee::uuid
+        LEFT JOIN users payer_u ON payer_u.id = et.payer_id
+        LEFT JOIN users payee_u ON payee_u.id = et.payee_id
         """;
 
     private static final String TERMINAL_CMD_ARM = """
@@ -339,7 +339,7 @@ public class AdminLedgerQueryRepository {
           recip_u.id                                                   AS user_id,
           NULL::bigint                                                 AS counterparty_user_id
         FROM terminal_commands tc
-        LEFT JOIN users recip_u ON recip_u.sl_avatar_uuid = tc.recipient_uuid::uuid
+        LEFT JOIN users recip_u ON recip_u.sl_avatar_uuid::text = tc.recipient_uuid
         """;
 
     private static final String WITHDRAWAL_ARM = """
@@ -364,7 +364,7 @@ public class AdminLedgerQueryRepository {
           recip_u.id                                                   AS user_id,
           admin_u.id                                                   AS counterparty_user_id
         FROM withdrawals w
-        LEFT JOIN users recip_u ON recip_u.sl_avatar_uuid = w.recipient_uuid::uuid
+        LEFT JOIN users recip_u ON recip_u.sl_avatar_uuid::text = w.recipient_uuid
         LEFT JOIN users admin_u ON admin_u.id = w.admin_user_id
         """;
 


### PR DESCRIPTION
## Bug

\`/api/v1/admin/ledger\` returned 500 with no useful detail to the frontend (\"Could not load ledger. Refresh to retry.\"). Root cause: the ESCROW_TXN arm of the UNION ALL referenced columns that don't exist.

\`EscrowTransaction.payer\` and \`.payee\` are \`User\` references via FK columns \`payer_id\` / \`payee_id\` — not SL avatar UUID strings. My original SQL did \`payer_u.sl_avatar_uuid = et.payer::uuid\` which (1) referenced a column that doesn't exist (\`et.payer\`) and (2) cast a Long FK to UUID. Postgres rejected the query at first row.

## Fix

- \`escrow_transactions\` arm: join on \`payer_u.id = et.payer_id\` and \`payee_u.id = et.payee_id\` (the actual FK columns).
- \`terminal_commands\` and \`withdrawals\` arms: harden the \`recipient_uuid\` joins by comparing as text (\`sl_avatar_uuid::text = recipient_uuid\`) instead of casting recipient_uuid to UUID. Avoids invalid-uuid syntax errors if any recipient row stores a non-canonical value.

## Test plan

- [x] backend \`./mvnw -q compile\`: passing
- [ ] post-deploy: hit \`/admin/ledger\` on prod, default view loads with rows from all five sources