### PR TITLE
fix(admin): admin ledger toOffsetDateTime handles Instant

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/admin/ledger/AdminLedgerQueryRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/ledger/AdminLedgerQueryRepository.java
@@ -1,6 +1,7 @@
 package com.slparcelauctions.backend.admin.ledger;
 
 import java.math.BigInteger;
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -197,6 +198,7 @@ public class AdminLedgerQueryRepository {
     private static OffsetDateTime toOffsetDateTime(Object o) {
         if (o == null) return null;
         if (o instanceof OffsetDateTime odt) return odt;
+        if (o instanceof Instant inst) return inst.atOffset(ZoneOffset.UTC);
         if (o instanceof java.sql.Timestamp ts) {
             return ts.toInstant().atOffset(ZoneOffset.UTC);
         }


### PR DESCRIPTION
Backend native query returns `Instant` for `created_at`; the converter only handled `OffsetDateTime` and `java.sql.Timestamp`, throwing on every row.