### PR TITLE
fix(admin): admin ledger drill links use ?tab=wallet

### DIFF
--- a/frontend/src/components/admin/ledger/adminLedgerLinks.ts
+++ b/frontend/src/components/admin/ledger/adminLedgerLinks.ts
@@ -14,32 +14,29 @@ export function rowDrillLink(row: AdminLedgerRow): string | null {
   switch (row.kind) {
     case "USER_LEDGER": {
       if (!row.userPublicId) return null;
-      return `/admin/users/${row.userPublicId}/wallet?ledgerEntryId=${row.nativeId}`;
+      return `/admin/users/${row.userPublicId}?tab=wallet&ledgerEntryId=${row.nativeId}`;
     }
     case "ESCROW_TXN": {
-      // refId is the escrow id; we need an auction publicId to link to the
-      // escrow page, which we don't have in the row. Fall back to the
-      // user's wallet page when a user resolved (it shows the paired
-      // UserLedgerEntry); otherwise no link.
+      // refId is the escrow id; we don't have the auction publicId in the
+      // row. Fall back to the resolved user's wallet tab when present.
       if (row.userPublicId) {
-        return `/admin/users/${row.userPublicId}/wallet?escrowId=${row.refId ?? ""}`;
+        return `/admin/users/${row.userPublicId}?tab=wallet&escrowId=${row.refId ?? ""}`;
       }
       return null;
     }
     case "TERMINAL_CMD": {
       if (row.entryType === "WALLET_WITHDRAWAL" && row.userPublicId) {
-        return `/admin/users/${row.userPublicId}/wallet?terminalCommandId=${row.nativeId}`;
+        return `/admin/users/${row.userPublicId}?tab=wallet&terminalCommandId=${row.nativeId}`;
       }
       return `/admin/infrastructure?tab=terminals&commandId=${row.nativeId}`;
     }
     case "WITHDRAWAL":
       return `/admin/infrastructure?tab=withdrawals&withdrawalId=${row.nativeId}`;
     case "BID_RESERVATION": {
-      // refId is the bid id; we don't have auction publicId in the row, so
-      // best we can do without an extra fetch is link to the user's wallet
-      // (which shows the paired BID_RESERVED/BID_RELEASED ledger rows).
+      // refId is the bid id; without the auction publicId, best landing is
+      // the user's wallet tab (which shows the paired BID_RESERVED/BID_RELEASED rows).
       if (row.userPublicId) {
-        return `/admin/users/${row.userPublicId}/wallet`;
+        return `/admin/users/${row.userPublicId}?tab=wallet`;
       }
       return null;
     }

--- a/frontend/src/components/admin/users/AdminUserDetailPage.tsx
+++ b/frontend/src/components/admin/users/AdminUserDetailPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { useAdminUser } from "@/hooks/admin/useAdminUser";
 import { UserProfileHeader } from "./UserProfileHeader";
 import { UserStatsCards } from "./UserStatsCards";
@@ -17,8 +18,21 @@ type Props = {
   publicId: string;
 };
 
+const VALID_TABS: UserTab[] = [
+  "listings", "bids", "cancellations", "reports", "fraudFlags", "moderation", "wallet",
+];
+
+function isUserTab(s: string): s is UserTab {
+  return (VALID_TABS as string[]).includes(s);
+}
+
 export function AdminUserDetailPage({ publicId }: Props) {
-  const [activeTab, setActiveTab] = useState<UserTab>("listings");
+  const searchParams = useSearchParams();
+  const initialTab = (() => {
+    const raw = searchParams?.get("tab");
+    return raw && isUserTab(raw) ? raw : "listings";
+  })();
+  const [activeTab, setActiveTab] = useState<UserTab>(initialTab);
   const { data: user, isLoading, isError, refetch } = useAdminUser(publicId);
 
   if (isLoading) {


### PR DESCRIPTION
Drill links in /admin/ledger pointed at /admin/users/{id}/wallet which 404s — wallet is a tab on the user-detail page, not a separate route. Fix: AdminUserDetailPage seeds activeTab from ?tab= query param, and the link generator emits ?tab=wallet&ledgerEntryId=N.