### PR TITLE
Promote: PATCH CORS fix + orange Edit settings button

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
@@ -284,7 +284,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(List.of(allowedOrigin));
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept", "X-Requested-With"));
         configuration.setAllowCredentials(true);
 

--- a/frontend/src/components/listing/draft-editor/BidPanelPreview.tsx
+++ b/frontend/src/components/listing/draft-editor/BidPanelPreview.tsx
@@ -1,7 +1,5 @@
 "use client";
 import { Input } from "@/components/ui/Input";
-import { Button } from "@/components/ui/Button";
-import { Pencil } from "@/components/ui/icons";
 import {
   EditableSettingsModal,
   type EditableSettingsModalProps,
@@ -86,15 +84,14 @@ export function BidPanelPreview({
           value={settings}
           onSave={onSettingsChange}
           renderTrigger={(open) => (
-            <Button
-              variant="secondary"
+            <button
+              type="button"
               onClick={open}
               data-testid="bid-panel-preview-edit-settings"
-              className="w-full"
+              className="inline-flex items-center justify-center w-full h-9 px-4 rounded-sm bg-warning text-white text-sm font-medium hover:opacity-90 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-warning"
             >
-              <Pencil className="size-4" aria-hidden="true" />
               Edit auction settings
-            </Button>
+            </button>
           )}
         />
       </div>


### PR DESCRIPTION
Promotion of PR #188 — unblocks photo drag-reorder in prod.

- Backend SecurityConfig: add PATCH to allowed CORS methods (was the root cause of the drag-reorder request being CORS-rejected)
- Frontend BidPanelPreview: drop Pencil icon, switch to orange button

## Deploy effect
- Backend: GH Actions deploy backend triggers (paths: backend/**) — ECS service redeploys
- Frontend: Amplify auto-rebuilds slparcels.com