### PR TITLE
fix: match Edit settings button to brand orange

### DIFF
--- a/frontend/src/components/listing/draft-editor/BidPanelPreview.tsx
+++ b/frontend/src/components/listing/draft-editor/BidPanelPreview.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { Input } from "@/components/ui/Input";
+import { Button } from "@/components/ui/Button";
 import {
   EditableSettingsModal,
   type EditableSettingsModalProps,
@@ -84,14 +85,14 @@ export function BidPanelPreview({
           value={settings}
           onSave={onSettingsChange}
           renderTrigger={(open) => (
-            <button
-              type="button"
+            <Button
+              variant="primary"
               onClick={open}
               data-testid="bid-panel-preview-edit-settings"
-              className="inline-flex items-center justify-center w-full h-9 px-4 rounded-sm bg-warning text-white text-sm font-medium hover:opacity-90 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-warning"
+              className="w-full"
             >
               Edit auction settings
-            </button>
+            </Button>
           )}
         />
       </div>


### PR DESCRIPTION
Use primary Button variant (brand-orange #E3631E, same as List Parcel) instead of bg-warning (#B45309 amber).