### PR TITLE
fix(auction): @Transactional on GET /users/me/auctions

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionController.java
@@ -96,8 +96,14 @@ public class AuctionController {
     }
 
     @GetMapping("/users/me/auctions")
+    @org.springframework.transaction.annotation.Transactional(readOnly = true)
     public List<SellerAuctionResponse> listMine(
             @AuthenticationPrincipal AuthPrincipal principal) {
+        // @Transactional keeps the JPA session open through the stream so the
+        // mapper's `a.getSeller()` / `a.getParcel()` / `a.getTags()` proxy
+        // accesses can hydrate. OSIV is disabled (application.yml), so without
+        // this annotation the session closes before the mapper runs and we
+        // get LazyInitializationException at JSON serialization time.
         List<Auction> auctions = auctionService.loadOwnedBy(principal.userId());
         Map<Long, Escrow> escrows = loadEscrowsFor(auctions);
         return auctions.stream()


### PR DESCRIPTION
## Why
Dashboard 'My Listings' is 500ing in prod with LazyInitializationException on User#1 from /api/v1/users/me/auctions (correlationId d9d62aa0...).

## Root cause
- application.yml has `spring.jpa.open-in-view: false`
- Endpoint isn't @Transactional, so the JPA session closes when the controller method returns
- AuctionDtoMapper.toSellerResponse then hits `a.getSeller().getPublicId()` outside the session → LazyInitializationException

## Fix
Add `@Transactional(readOnly=true)` to the listMine method. Same pattern the @PUT endpoints in this controller already use.

## Why tests didn't catch it
Existing integration tests are @SpringBootTest + class-level @Transactional, which keeps the session open across the test and masks the production session-close behavior. All 37 AuctionControllerIntegrationTest cases still pass.
