### PR TITLE
Promote: photo publicId fix + List Parcel confirm

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationStatusService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationStatusService.java
@@ -109,7 +109,7 @@ public class CancellationStatusService {
         // and project to the flat photo URL served by {@link PhotoController}.
         return auction.getPhotos().stream()
                 .min(Comparator.comparing(AuctionPhoto::getSortOrder))
-                .map(p -> "/api/v1/photos/" + p.getId())
+                .map(p -> "/api/v1/photos/" + p.getPublicId())
                 .orElse(null);
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/search/AuctionPhotoBatchRepositoryImpl.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/search/AuctionPhotoBatchRepositoryImpl.java
@@ -40,11 +40,15 @@ public class AuctionPhotoBatchRepositoryImpl implements AuctionPhotoBatchReposit
         // Window function picks the first photo per auction. Indexed via the
         // primary key on (id) — if (auction_id, sort_order) shows up in
         // slow-query logs, add a covering index then.
+        //
+        // URL uses public_id (UUID), not id (Long). PhotoController only
+        // resolves UUIDs via findByPublicId — emitting `/api/v1/photos/{long-id}`
+        // here 404s every browse-card thumbnail.
         String sql = """
                 SELECT auction_id, url
                 FROM (
                   SELECT auction_id,
-                         '/api/v1/photos/' || id AS url,
+                         '/api/v1/photos/' || public_id AS url,
                          ROW_NUMBER() OVER (
                            PARTITION BY auction_id
                            ORDER BY sort_order ASC, id ASC

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationStatusServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/CancellationStatusServiceTest.java
@@ -253,8 +253,10 @@ class CancellationStatusServiceTest {
 
     @Test
     void historyFor_resolvesPrimaryPhotoUrlFromAuctionPhoto() {
+        UUID p2PublicId = UUID.randomUUID();
         AuctionPhoto p1 = AuctionPhoto.builder().id(50L).sortOrder(1).build();
         AuctionPhoto p2 = AuctionPhoto.builder().id(51L).sortOrder(0).build();
+        org.springframework.test.util.ReflectionTestUtils.setField(p2, "publicId", p2PublicId);
         Auction auction = Auction.builder()
                 .id(303L)
                 .title("Photo'd auction")
@@ -279,7 +281,9 @@ class CancellationStatusServiceTest {
         Page<CancellationHistoryDto> page = service.historyFor(USER_ID, PageRequest.of(0, 10));
 
         // Picks the photo with the smallest sortOrder (p2 = sortOrder 0).
+        // URL emits the photo's publicId (UUID) — PhotoController only resolves
+        // UUIDs via findByPublicId.
         assertThat(page.getContent().get(0).primaryPhotoUrl())
-                .isEqualTo("/api/v1/photos/51");
+                .isEqualTo("/api/v1/photos/" + p2PublicId);
     }
 }

--- a/frontend/src/app/listings/(verified)/[publicId]/activate/DraftEditorClient.tsx
+++ b/frontend/src/app/listings/(verified)/[publicId]/activate/DraftEditorClient.tsx
@@ -18,6 +18,7 @@ import { EditablePhotoGallery } from "@/components/listing/draft-editor/Editable
 import { BidPanelPreview } from "@/components/listing/draft-editor/BidPanelPreview";
 import { DraftActionBar } from "@/components/listing/draft-editor/DraftActionBar";
 import { DeleteDraftModal } from "@/components/listing/draft-editor/DeleteDraftModal";
+import { ConfirmListParcelModal } from "@/components/listing/draft-editor/ConfirmListParcelModal";
 import {
   useDraftEditorMutations,
   type DraftSettings,
@@ -59,6 +60,7 @@ export function DraftEditorClient({ auction }: DraftEditorClientProps) {
   const feeQ = useListingFeeConfig();
   const walletQ = useWallet(true);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [confirmListOpen, setConfirmListOpen] = useState(false);
 
   const listMutation = useMutation({
     mutationFn: () => payListingFee(auction.publicId, genIdempotencyKey()),
@@ -66,6 +68,7 @@ export function DraftEditorClient({ auction }: DraftEditorClientProps) {
       qc.invalidateQueries({ queryKey: activateAuctionKey(auction.publicId) });
       qc.invalidateQueries({ queryKey: walletQueryKey });
       toast.success("Listing fee paid. Choose a verification method next.");
+      setConfirmListOpen(false);
     },
     onError: (e) => {
       const detail = isApiError(e)
@@ -128,7 +131,7 @@ export function DraftEditorClient({ auction }: DraftEditorClientProps) {
         walletBalance={wallet.available}
         isListing={listMutation.isPending}
         insufficientFunds={insufficientFunds}
-        onListParcel={() => listMutation.mutate()}
+        onListParcel={() => setConfirmListOpen(true)}
         onDeleteDraft={() => setDeleteOpen(true)}
       />
       <main className="max-w-7xl mx-auto px-4 lg:px-8 pt-4 pb-24 lg:pb-12 w-full">
@@ -194,6 +197,14 @@ export function DraftEditorClient({ auction }: DraftEditorClientProps) {
         open={deleteOpen}
         onClose={() => setDeleteOpen(false)}
         auction={auction}
+      />
+      <ConfirmListParcelModal
+        open={confirmListOpen}
+        onClose={() => setConfirmListOpen(false)}
+        onConfirm={() => listMutation.mutate()}
+        listingFee={fee}
+        walletBalance={wallet.available}
+        isListing={listMutation.isPending}
       />
     </div>
   );

--- a/frontend/src/components/listing/draft-editor/ConfirmListParcelModal.test.tsx
+++ b/frontend/src/components/listing/draft-editor/ConfirmListParcelModal.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, userEvent } from "@/test/render";
+import { ConfirmListParcelModal } from "./ConfirmListParcelModal";
+
+describe("ConfirmListParcelModal", () => {
+  it("renders fee, wallet, and balance-after when open", () => {
+    renderWithProviders(
+      <ConfirmListParcelModal
+        open
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        listingFee={100}
+        walletBalance={5000}
+      />,
+    );
+    expect(screen.getByText(/List this parcel\?/i)).toBeInTheDocument();
+    expect(screen.getByText("L$100")).toBeInTheDocument();
+    expect(screen.getByText("L$5,000")).toBeInTheDocument();
+    expect(screen.getByText("L$4,900")).toBeInTheDocument();
+  });
+
+  it("Cancel calls onClose, Confirm calls onConfirm", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onConfirm = vi.fn();
+    renderWithProviders(
+      <ConfirmListParcelModal
+        open
+        onClose={onClose}
+        onConfirm={onConfirm}
+        listingFee={100}
+        walletBalance={5000}
+      />,
+    );
+    await user.click(screen.getByTestId("confirm-list-parcel-cancel"));
+    expect(onClose).toHaveBeenCalled();
+    await user.click(screen.getByTestId("confirm-list-parcel-confirm"));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it("disables both buttons while isListing", () => {
+    renderWithProviders(
+      <ConfirmListParcelModal
+        open
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        listingFee={100}
+        walletBalance={5000}
+        isListing
+      />,
+    );
+    expect(screen.getByTestId("confirm-list-parcel-cancel")).toBeDisabled();
+    expect(screen.getByTestId("confirm-list-parcel-confirm")).toBeDisabled();
+  });
+});

--- a/frontend/src/components/listing/draft-editor/ConfirmListParcelModal.tsx
+++ b/frontend/src/components/listing/draft-editor/ConfirmListParcelModal.tsx
@@ -1,0 +1,100 @@
+"use client";
+import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
+import { Button } from "@/components/ui/Button";
+
+export interface ConfirmListParcelModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Fires the listing-fee mutation. Modal stays open until parent flips `open`. */
+  onConfirm: () => void;
+  listingFee: number;
+  walletBalance: number;
+  /** Pending = button shows spinner + close is disabled. */
+  isListing?: boolean;
+}
+
+/**
+ * Pre-debit confirmation for the "List parcel" action. Shows the seller
+ * the listing fee, their current wallet balance, and the resulting
+ * post-debit balance so they can verify the math before committing.
+ *
+ * Distinct from {@link DeleteDraftModal} — this is an L$-spending
+ * confirmation, not a destructive one.
+ */
+export function ConfirmListParcelModal({
+  open,
+  onClose,
+  onConfirm,
+  listingFee,
+  walletBalance,
+  isListing = false,
+}: ConfirmListParcelModalProps) {
+  const balanceAfter = walletBalance - listingFee;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => (isListing ? null : onClose())}
+      className="relative z-50"
+    >
+      <div
+        className="fixed inset-0 bg-inverse-surface/40 backdrop-blur-sm"
+        aria-hidden="true"
+      />
+      <div className="fixed inset-0 flex items-center justify-center p-4">
+        <DialogPanel
+          data-testid="confirm-list-parcel-modal"
+          className="w-full max-w-md flex flex-col gap-4 rounded-lg bg-bg-subtle p-6"
+        >
+          <DialogTitle className="text-base font-bold tracking-tight text-fg">
+            List this parcel?
+          </DialogTitle>
+          <p className="text-sm text-fg-muted">
+            Listing your parcel debits the listing fee from your SLParcels
+            wallet and starts the verification flow. The fee is non-refundable
+            once the listing reaches buyers.
+          </p>
+          <dl className="flex flex-col gap-2 rounded-lg bg-surface-raised p-4 text-sm">
+            <div className="flex items-baseline justify-between">
+              <dt className="text-fg-muted">Listing fee</dt>
+              <dd className="font-medium text-fg">
+                L${listingFee.toLocaleString()}
+              </dd>
+            </div>
+            <div className="flex items-baseline justify-between">
+              <dt className="text-fg-muted">Wallet balance</dt>
+              <dd className="font-medium text-fg">
+                L${walletBalance.toLocaleString()}
+              </dd>
+            </div>
+            <div className="flex items-baseline justify-between border-t border-border-subtle pt-2">
+              <dt className="text-fg-muted">Balance after</dt>
+              <dd className="font-medium text-fg">
+                L${balanceAfter.toLocaleString()}
+              </dd>
+            </div>
+          </dl>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="secondary"
+              onClick={onClose}
+              disabled={isListing}
+              data-testid="confirm-list-parcel-cancel"
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              onClick={onConfirm}
+              disabled={isListing}
+              loading={isListing}
+              data-testid="confirm-list-parcel-confirm"
+            >
+              Confirm and list
+            </Button>
+          </div>
+        </DialogPanel>
+      </div>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
Promotion of #194 — fixes browse-page 404s and adds List Parcel confirmation modal. Both backend (paths: backend/**) and frontend (Amplify) deploys trigger.