### PR TITLE
fix: wrap photo URLs with apiUrl() in 4 render sites

### DIFF
--- a/frontend/src/components/auction/ListingCard.tsx
+++ b/frontend/src/components/auction/ListingCard.tsx
@@ -4,6 +4,7 @@ import { StatusChip } from "@/components/ui/StatusChip";
 import { CountdownTimer } from "@/components/ui/CountdownTimer";
 import { ShieldCheck, MapPin, Heart } from "@/components/ui/icons";
 import { cn } from "@/lib/cn";
+import { apiUrl } from "@/lib/api/url";
 import { deriveStatusChip } from "@/lib/search/status-chip";
 import { useSavedIds, useToggleSaved } from "@/hooks/useSavedAuctions";
 import type { AuctionSearchResultDto } from "@/types/search";
@@ -82,8 +83,13 @@ export function ListingCard({ listing, variant, className }: ListingCardProps) {
     endOutcome: listing.endOutcome,
     endsAt: listing.endsAt,
   });
+  // Backend emits relative `/api/v1/photos/{publicId}` paths; the browser
+  // resolves them against slparcels.com which doesn't proxy /api/* to the
+  // backend. apiUrl() rewrites to slpa.app per the SSR-caveats convention.
   const imageSrc =
-    listing.primaryPhotoUrl ?? listing.parcel.snapshotUrl ?? undefined;
+    apiUrl(listing.primaryPhotoUrl) ??
+    apiUrl(listing.parcel.snapshotUrl) ??
+    undefined;
   const maxTags = MAX_TAGS[variant];
   // Defensive coercion: the backend has historically wavered between
   // string[] (current contract — labels) and ParcelTag entity rows (a

--- a/frontend/src/components/dashboard/CancellationHistorySection.tsx
+++ b/frontend/src/components/dashboard/CancellationHistorySection.tsx
@@ -5,6 +5,7 @@ import { Card } from "@/components/ui/Card";
 import { ChevronDown, ChevronUp } from "@/components/ui/icons";
 import { Pagination } from "@/components/ui/Pagination";
 import { cn } from "@/lib/cn";
+import { apiUrl } from "@/lib/api/url";
 import { useCancellationHistory } from "@/hooks/useCancellationHistory";
 import type { CancellationHistoryDto } from "@/types/cancellation";
 import { CancellationConsequenceBadge } from "@/components/cancellation/CancellationConsequenceBadge";
@@ -38,7 +39,7 @@ function CancellationHistoryRow({ row }: { row: CancellationHistoryDto }) {
           {row.primaryPhotoUrl && (
             // eslint-disable-next-line @next/next/no-img-element -- Deferred: swap to next/image when backend returns image dimensions + a stable remotePatterns list for SL CDN hosts is agreed upon. Matches the PendingReviewsSection deferral.
             <img
-              src={row.primaryPhotoUrl}
+              src={apiUrl(row.primaryPhotoUrl) ?? undefined}
               alt=""
               className="h-full w-full object-cover"
               loading="lazy"

--- a/frontend/src/components/marketing/HeroFeaturedStack.tsx
+++ b/frontend/src/components/marketing/HeroFeaturedStack.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import type { AuctionSearchResultDto } from "@/types/search";
 import { cn } from "@/lib/cn";
+import { apiUrl } from "@/lib/api/url";
 
 /**
  * Hero right-side 3D card stack: up to three featured auctions rendered as
@@ -33,7 +34,7 @@ export function HeroFeaturedStack({ featured }: { featured: AuctionSearchResultD
             {(listing.primaryPhotoUrl ?? listing.parcel.snapshotUrl) && (
               // eslint-disable-next-line @next/next/no-img-element
               <img
-                src={listing.primaryPhotoUrl ?? listing.parcel.snapshotUrl ?? ""}
+                src={apiUrl(listing.primaryPhotoUrl) ?? apiUrl(listing.parcel.snapshotUrl) ?? ""}
                 alt=""
                 className="h-full w-full object-cover"
                 loading="eager"

--- a/frontend/src/components/reviews/PendingReviewsSection.tsx
+++ b/frontend/src/components/reviews/PendingReviewsSection.tsx
@@ -5,6 +5,7 @@ import { Avatar } from "@/components/ui/Avatar";
 import { Card } from "@/components/ui/Card";
 import { ArrowRight } from "@/components/ui/icons";
 import { cn } from "@/lib/cn";
+import { apiUrl } from "@/lib/api/url";
 import { usePendingReviews } from "@/hooks/useReviews";
 import type { PendingReviewDto } from "@/types/review";
 
@@ -53,7 +54,7 @@ function PendingReviewRow({ item }: { item: PendingReviewDto }) {
         {item.primaryPhotoUrl && (
           // eslint-disable-next-line @next/next/no-img-element -- Deferred: swap to next/image when backend returns image dimensions + a stable remotePatterns list for SL CDN hosts is agreed upon. Matches the ListingCard deferral.
           <img
-            src={item.primaryPhotoUrl}
+            src={apiUrl(item.primaryPhotoUrl) ?? undefined}
             alt=""
             className="h-full w-full object-cover"
             loading="lazy"


### PR DESCRIPTION
## Why
Browse-page photos were 404ing on slparcels.com (page origin doesn't proxy /api/* to slpa.app). Backend was emitting valid /api/v1/photos/{publicId} URLs (after #194), but four React render sites used the raw string instead of wrapping with apiUrl().

## Fix
- ListingCard.tsx
- HeroFeaturedStack.tsx
- CancellationHistorySection.tsx
- PendingReviewsSection.tsx

All 1432 frontend tests pass.
