### PR TITLE
fix: suppress lint set-state-in-effect on parcel-tag modals

### DIFF
--- a/frontend/src/components/admin/parcel-tags/AddParcelTagModal.tsx
+++ b/frontend/src/components/admin/parcel-tags/AddParcelTagModal.tsx
@@ -31,6 +31,7 @@ export function AddParcelTagModal({
 
   useEffect(() => {
     if (!open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- `open` is external source of truth; resetting form state on close is intentional (matches CreateBanModal pattern)
       setCode("");
       setLabel("");
       setCategory("");

--- a/frontend/src/components/admin/parcel-tags/EditParcelTagModal.tsx
+++ b/frontend/src/components/admin/parcel-tags/EditParcelTagModal.tsx
@@ -35,6 +35,7 @@ export function EditParcelTagModal({
 
   useEffect(() => {
     if (open && tag) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- `tag` is external source of truth; pre-filling form state on open is intentional (matches CreateBanModal pattern)
       setLabel(tag.label);
       setCategory(tag.category);
       setDescription(tag.description ?? "");


### PR DESCRIPTION
Matches CreateBanModal precedent. Unblocks frontend CI.