### PR TITLE
fix(parcel-tags): drop sortOrder, sort alphabetically by label

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java
@@ -180,7 +180,7 @@ public class AuctionDtoMapper {
 
     private List<ParcelTagResponse> tagList(Auction a) {
         return a.getTags().stream()
-                .sorted(Comparator.comparing(t -> t.getSortOrder() == null ? 0 : t.getSortOrder()))
+                .sorted(Comparator.comparing(t -> t.getLabel() == null ? "" : t.getLabel()))
                 .map(ParcelTagResponse::from)
                 .toList();
     }

--- a/backend/src/main/java/com/slparcelauctions/backend/parceltag/AdminParcelTagService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/parceltag/AdminParcelTagService.java
@@ -37,7 +37,7 @@ public class AdminParcelTagService {
 
     @Transactional(readOnly = true)
     public List<AdminParcelTagDto> listAll() {
-        return repo.findAllByOrderByCategoryAscSortOrderAsc().stream()
+        return repo.findAllByOrderByCategoryAscLabelAsc().stream()
                 .map(AdminParcelTagDto::from)
                 .toList();
     }
@@ -47,15 +47,11 @@ public class AdminParcelTagService {
         if (repo.existsByCode(req.code())) {
             throw new ParcelTagCodeConflictException(req.code());
         }
-        int sortOrder = req.sortOrder() != null
-                ? req.sortOrder()
-                : repo.findMaxSortOrderByCategory(req.category()) + 1;
         ParcelTag tag = ParcelTag.builder()
                 .code(req.code())
                 .label(req.label())
                 .category(req.category())
                 .description(req.description())
-                .sortOrder(sortOrder)
                 .active(true)
                 .build();
         ParcelTag saved = repo.save(tag);
@@ -65,7 +61,6 @@ public class AdminParcelTagService {
         details.put("code", saved.getCode());
         details.put("label", saved.getLabel());
         details.put("category", saved.getCategory());
-        details.put("sortOrder", saved.getSortOrder());
         adminActionService.record(adminUserId,
                 AdminActionType.PARCEL_TAG_CREATED,
                 AdminActionTargetType.PARCEL_TAG,
@@ -93,10 +88,6 @@ public class AdminParcelTagService {
                     "from", tag.getDescription() == null ? "" : tag.getDescription(),
                     "to", req.description()));
             tag.setDescription(req.description());
-        }
-        if (req.sortOrder() != null && !req.sortOrder().equals(tag.getSortOrder())) {
-            changes.put("sortOrder", Map.of("from", tag.getSortOrder(), "to", req.sortOrder()));
-            tag.setSortOrder(req.sortOrder());
         }
 
         ParcelTag saved = repo.save(tag);

--- a/backend/src/main/java/com/slparcelauctions/backend/parceltag/ParcelTag.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/parceltag/ParcelTag.java
@@ -34,10 +34,6 @@ public class ParcelTag extends BaseMutableEntity {
     private String description;
 
     @Builder.Default
-    @Column(name = "sort_order", nullable = false)
-    private Integer sortOrder = 0;
-
-    @Builder.Default
     @Column(nullable = false)
     private Boolean active = true;
 

--- a/backend/src/main/java/com/slparcelauctions/backend/parceltag/ParcelTagRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/parceltag/ParcelTagRepository.java
@@ -5,11 +5,10 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface ParcelTagRepository extends JpaRepository<ParcelTag, Long> {
 
-    List<ParcelTag> findByActiveTrueOrderByCategoryAscSortOrderAsc();
+    List<ParcelTag> findByActiveTrueOrderByCategoryAscLabelAsc();
 
     List<ParcelTag> findByCodeIn(Set<String> codes);
 
@@ -18,9 +17,5 @@ public interface ParcelTagRepository extends JpaRepository<ParcelTag, Long> {
     boolean existsByCode(String code);
 
     /** Admin view — returns inactive rows too. */
-    List<ParcelTag> findAllByOrderByCategoryAscSortOrderAsc();
-
-    /** Largest sortOrder within a category, or 0 if the category has no tags yet. */
-    @Query("select coalesce(max(t.sortOrder), 0) from ParcelTag t where t.category = :category")
-    int findMaxSortOrderByCategory(String category);
+    List<ParcelTag> findAllByOrderByCategoryAscLabelAsc();
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/parceltag/ParcelTagService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/parceltag/ParcelTagService.java
@@ -36,7 +36,7 @@ public class ParcelTagService {
     @Transactional(readOnly = true)
     public List<ParcelTagGroupResponse> listGroupedActive() {
         Map<String, List<ParcelTagResponse>> grouped = new LinkedHashMap<>();
-        for (ParcelTag t : repo.findByActiveTrueOrderByCategoryAscSortOrderAsc()) {
+        for (ParcelTag t : repo.findByActiveTrueOrderByCategoryAscLabelAsc()) {
             grouped.computeIfAbsent(t.getCategory(), k -> new ArrayList<>())
                     .add(ParcelTagResponse.from(t));
         }
@@ -59,14 +59,12 @@ public class ParcelTagService {
         if (repo.count() > 0) {
             return;
         }
-        int order = 0;
         for (String[] row : SEED_DATA) {
             ParcelTag t = ParcelTag.builder()
                     .code(row[0])
                     .label(row[1])
                     .category(row[2])
                     .description(row[3])
-                    .sortOrder(++order)
                     .active(true)
                     .build();
             repo.save(t);

--- a/backend/src/main/java/com/slparcelauctions/backend/parceltag/dto/AdminParcelTagDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/parceltag/dto/AdminParcelTagDto.java
@@ -15,7 +15,6 @@ public record AdminParcelTagDto(
         String label,
         String category,
         String description,
-        Integer sortOrder,
         Boolean active,
         OffsetDateTime createdAt,
         OffsetDateTime updatedAt) {
@@ -26,7 +25,6 @@ public record AdminParcelTagDto(
                 t.getLabel(),
                 t.getCategory(),
                 t.getDescription(),
-                t.getSortOrder(),
                 t.getActive(),
                 t.getCreatedAt(),
                 t.getUpdatedAt());

--- a/backend/src/main/java/com/slparcelauctions/backend/parceltag/dto/CreateParcelTagRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/parceltag/dto/CreateParcelTagRequest.java
@@ -10,9 +10,6 @@ import jakarta.validation.constraints.Size;
  * {@code code} is the immutable admin-facing primary key for a tag. Restricted
  * to uppercase letters / digits / underscore so it stays stable on the wire
  * (no ambiguity from spaces, hyphens, or case-folding mismatches).
- * <p>
- * {@code sortOrder} is optional — when null, the service assigns
- * {@code max(sortOrder in same category) + 1}.
  */
 public record CreateParcelTagRequest(
         @NotBlank
@@ -30,6 +27,4 @@ public record CreateParcelTagRequest(
         String category,
 
         @Size(max = 2000)
-        String description,
-
-        Integer sortOrder) {}
+        String description) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/parceltag/dto/ParcelTagResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/parceltag/dto/ParcelTagResponse.java
@@ -6,11 +6,10 @@ public record ParcelTagResponse(
         String code,
         String label,
         String category,
-        String description,
-        Integer sortOrder) {
+        String description) {
 
     public static ParcelTagResponse from(ParcelTag t) {
         return new ParcelTagResponse(
-                t.getCode(), t.getLabel(), t.getCategory(), t.getDescription(), t.getSortOrder());
+                t.getCode(), t.getLabel(), t.getCategory(), t.getDescription());
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/parceltag/dto/UpdateParcelTagRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/parceltag/dto/UpdateParcelTagRequest.java
@@ -4,16 +4,11 @@ import jakarta.validation.constraints.Size;
 
 /**
  * PATCH /api/v1/admin/parcel-tags/{code} request body. All fields are
- * optional; only supplied fields are written. Blank strings are treated
- * as no-op rather than "set empty" — clearing a field requires explicit
- * empty-string content (description) or an out-of-band action (label and
- * category have NotBlank constraints in the schema and can't be cleared
- * without recreating the row).
+ * optional; only supplied fields are written.
  * <p>
  * {@code code} is intentionally absent — it's the path key and immutable.
  */
 public record UpdateParcelTagRequest(
         @Size(min = 1, max = 100) String label,
         @Size(min = 1, max = 50) String category,
-        @Size(max = 2000) String description,
-        Integer sortOrder) {}
+        @Size(max = 2000) String description) {}

--- a/backend/src/main/resources/db/migration/V18__drop_parcel_tag_sort_order.sql
+++ b/backend/src/main/resources/db/migration/V18__drop_parcel_tag_sort_order.sql
@@ -1,0 +1,4 @@
+-- Drop the parcel_tags.sort_order column. Manual sort was YAGNI — the
+-- public catalogue and admin list now sort tags alphabetically by label
+-- within each category. See docs/superpowers/specs/2026-05-08-admin-parcel-tags-design.md.
+ALTER TABLE parcel_tags DROP COLUMN IF EXISTS sort_order;

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionServiceTest.java
@@ -418,7 +418,7 @@ class AuctionServiceTest {
         Set<String> codes = Set.of("waterfront", "unknown_tag");
         when(tagRepo.findByCodeIn(codes)).thenReturn(List.of(
                 ParcelTag.builder().id(1L).code("waterfront").label("Waterfront")
-                        .category("feature").active(true).sortOrder(1).build()));
+                        .category("feature").active(true).build()));
 
         AuctionCreateRequest req = new AuctionCreateRequest(
                 PARCEL_UUID, "Test listing", 1000L, null, null,

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/search/AuctionSearchPredicateBuilderTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/search/AuctionSearchPredicateBuilderTest.java
@@ -69,14 +69,12 @@ class AuctionSearchPredicateBuilderTest {
                 .code("beachfront-" + UUID.randomUUID())
                 .label("Beachfront")
                 .category("Waterfront")
-                .sortOrder(1)
                 .active(true)
                 .build());
         roadside = tagRepo.save(ParcelTag.builder()
                 .code("roadside-" + UUID.randomUUID())
                 .label("Roadside")
                 .category("Access")
-                .sortOrder(1)
                 .active(true)
                 .build());
     }

--- a/backend/src/test/java/com/slparcelauctions/backend/parceltag/AdminParcelTagControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/parceltag/AdminParcelTagControllerSliceTest.java
@@ -91,7 +91,7 @@ class AdminParcelTagControllerSliceTest {
 
     private static AdminParcelTagDto sampleDto(String code) {
         OffsetDateTime now = OffsetDateTime.now();
-        return new AdminParcelTagDto(code, "Label", "Cat", "Desc", 1, true, now, now);
+        return new AdminParcelTagDto(code, "Label", "Cat", "Desc", true, now, now);
     }
 
     @Test

--- a/backend/src/test/java/com/slparcelauctions/backend/parceltag/AdminParcelTagServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/parceltag/AdminParcelTagServiceTest.java
@@ -36,7 +36,6 @@ class AdminParcelTagServiceTest {
     @Test
     void create_happyPath_persistsAndAudits() {
         when(repo.existsByCode("BEACHFRONT")).thenReturn(false);
-        when(repo.findMaxSortOrderByCategory("Terrain")).thenReturn(8);
         when(repo.save(any(ParcelTag.class))).thenAnswer(inv -> {
             ParcelTag t = inv.getArgument(0);
             org.springframework.test.util.ReflectionTestUtils.setField(t, "id", 99L);
@@ -44,11 +43,11 @@ class AdminParcelTagServiceTest {
         });
 
         CreateParcelTagRequest req = new CreateParcelTagRequest(
-                "BEACHFRONT", "Beachfront", "Terrain", "Sandy beach", null);
+                "BEACHFRONT", "Beachfront", "Terrain", "Sandy beach");
         AdminParcelTagDto result = service.create(42L, req);
 
         assertThat(result.code()).isEqualTo("BEACHFRONT");
-        assertThat(result.sortOrder()).isEqualTo(9);
+        assertThat(result.label()).isEqualTo("Beachfront");
         assertThat(result.active()).isTrue();
         verify(adminActionService).record(
                 eq(42L),
@@ -60,24 +59,11 @@ class AdminParcelTagServiceTest {
     }
 
     @Test
-    void create_explicitSortOrder_isHonoured() {
-        when(repo.existsByCode("X")).thenReturn(false);
-        when(repo.save(any(ParcelTag.class))).thenAnswer(inv -> inv.getArgument(0));
-
-        CreateParcelTagRequest req = new CreateParcelTagRequest(
-                "X", "X", "C", "d", 0);
-        AdminParcelTagDto result = service.create(1L, req);
-
-        assertThat(result.sortOrder()).isZero();
-        verify(repo, never()).findMaxSortOrderByCategory(any());
-    }
-
-    @Test
     void create_duplicateCode_throwsConflict() {
         when(repo.existsByCode("WATERFRONT")).thenReturn(true);
 
         CreateParcelTagRequest req = new CreateParcelTagRequest(
-                "WATERFRONT", "x", "y", null, null);
+                "WATERFRONT", "x", "y", null);
 
         assertThatThrownBy(() -> service.create(1L, req))
                 .isInstanceOf(ParcelTagCodeConflictException.class);
@@ -90,13 +76,13 @@ class AdminParcelTagServiceTest {
     void update_writesOnlySuppliedFields_andAudits() {
         ParcelTag existing = ParcelTag.builder()
                 .code("WATERFRONT").label("Old").category("Terrain")
-                .description("d").sortOrder(1).active(true).build();
+                .description("d").active(true).build();
         org.springframework.test.util.ReflectionTestUtils.setField(existing, "id", 7L);
         when(repo.findByCode("WATERFRONT")).thenReturn(Optional.of(existing));
         when(repo.save(any(ParcelTag.class))).thenAnswer(inv -> inv.getArgument(0));
 
         UpdateParcelTagRequest req = new UpdateParcelTagRequest(
-                "New label", null, null, null);
+                "New label", null, null);
         AdminParcelTagDto result = service.update(42L, "WATERFRONT", req);
 
         assertThat(result.label()).isEqualTo("New label");
@@ -115,12 +101,12 @@ class AdminParcelTagServiceTest {
     void update_noChanges_skipsAudit() {
         ParcelTag existing = ParcelTag.builder()
                 .code("WATERFRONT").label("Same").category("T")
-                .description("d").sortOrder(1).active(true).build();
+                .description("d").active(true).build();
         when(repo.findByCode("WATERFRONT")).thenReturn(Optional.of(existing));
         when(repo.save(any(ParcelTag.class))).thenAnswer(inv -> inv.getArgument(0));
 
         UpdateParcelTagRequest req = new UpdateParcelTagRequest(
-                "Same", "T", "d", 1);
+                "Same", "T", "d");
         service.update(42L, "WATERFRONT", req);
 
         verify(adminActionService, never()).record(
@@ -132,7 +118,7 @@ class AdminParcelTagServiceTest {
         when(repo.findByCode("NOPE")).thenReturn(Optional.empty());
 
         UpdateParcelTagRequest req = new UpdateParcelTagRequest(
-                "x", null, null, null);
+                "x", null, null);
 
         assertThatThrownBy(() -> service.update(1L, "NOPE", req))
                 .isInstanceOf(ParcelTagNotFoundException.class);
@@ -142,7 +128,7 @@ class AdminParcelTagServiceTest {
     void toggleActive_flipsAndAudits() {
         ParcelTag existing = ParcelTag.builder()
                 .code("X").label("X").category("Y")
-                .sortOrder(1).active(true).build();
+                .active(true).build();
         org.springframework.test.util.ReflectionTestUtils.setField(existing, "id", 5L);
         when(repo.findByCode("X")).thenReturn(Optional.of(existing));
         when(repo.save(any(ParcelTag.class))).thenAnswer(inv -> inv.getArgument(0));

--- a/backend/src/test/java/com/slparcelauctions/backend/parceltag/ParcelTagServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/parceltag/ParcelTagServiceTest.java
@@ -47,11 +47,11 @@ class ParcelTagServiceTest {
 
     @Test
     void listGroupedActive_groupsTagsByCategoryPreservingOrder() {
-        // Repo already sorts ORDER BY category ASC, sort_order ASC.
-        ParcelTag t1 = ParcelTag.builder().id(1L).code("A").label("A").category("Cat1").sortOrder(1).active(true).build();
-        ParcelTag t2 = ParcelTag.builder().id(2L).code("B").label("B").category("Cat1").sortOrder(2).active(true).build();
-        ParcelTag t3 = ParcelTag.builder().id(3L).code("C").label("C").category("Cat2").sortOrder(1).active(true).build();
-        when(repo.findByActiveTrueOrderByCategoryAscSortOrderAsc())
+        // Repo already sorts ORDER BY category ASC, label ASC.
+        ParcelTag t1 = ParcelTag.builder().id(1L).code("A").label("A").category("Cat1").active(true).build();
+        ParcelTag t2 = ParcelTag.builder().id(2L).code("B").label("B").category("Cat1").active(true).build();
+        ParcelTag t3 = ParcelTag.builder().id(3L).code("C").label("C").category("Cat2").active(true).build();
+        when(repo.findByActiveTrueOrderByCategoryAscLabelAsc())
                 .thenReturn(List.of(t1, t2, t3));
 
         List<ParcelTagGroupResponse> groups = service.listGroupedActive();
@@ -68,7 +68,7 @@ class ParcelTagServiceTest {
 
     @Test
     void listGroupedActive_emptyRepo_returnsEmptyList() {
-        when(repo.findByActiveTrueOrderByCategoryAscSortOrderAsc())
+        when(repo.findByActiveTrueOrderByCategoryAscLabelAsc())
                 .thenReturn(List.of());
 
         assertThat(service.listGroupedActive()).isEmpty();

--- a/docs/superpowers/specs/2026-05-08-admin-parcel-tags-design.md
+++ b/docs/superpowers/specs/2026-05-08-admin-parcel-tags-design.md
@@ -14,13 +14,14 @@ Admins can add, edit, and disable/re-enable land tags (a.k.a. parcel tags) from 
 | Column | Constraints |
 |---|---|
 | `code` | unique, ≤50 chars, immutable from admin's perspective (referenced by every auction in the DB) |
-| `label` | ≤100 chars, displayed to buyers |
+| `label` | ≤100 chars, displayed to buyers; drives alphabetical ordering within a category |
 | `category` | ≤50 chars, free-text, groups tags on the browse filter |
 | `description` | nullable text, optional admin note |
-| `sortOrder` | integer, drives ordering within a category |
 | `active` | boolean, hides/shows in the public catalogue |
 
-Today the only public surface is `GET /api/v1/parcel-tags` (anonymous) returning **active** tags grouped by category, sorted by `sortOrder`. 25 canonical tags are seeded on first boot via `ParcelTagService.seedDefaultTagsIfEmpty()`. There's no admin endpoint — admins can't currently edit, disable, or add tags.
+> **2026-05-08 follow-up:** the original schema had a `sortOrder` integer column for manual within-category ordering. Dropped after launch as YAGNI — the seed data didn't actually use it semantically (just `++order` at insert time), and alphabetical-by-label is simpler, predictable, and self-maintaining. Migration `V18__drop_parcel_tag_sort_order.sql` removes the column. Public + admin lists now sort `category ASC, label ASC`.
+
+Today the only public surface is `GET /api/v1/parcel-tags` (anonymous) returning **active** tags grouped by category, sorted alphabetically by `label`. 25 canonical tags are seeded on first boot via `ParcelTagService.seedDefaultTagsIfEmpty()`. There's no admin endpoint — admins can't currently edit, disable, or add tags.
 
 The codebase has 14 admin controllers under `/api/v1/admin/...`. The natural pattern is one controller per domain (`AdminFraudFlagController`, `AdminUserController`, etc.), and `SecurityConfig` already gates `/api/v1/admin/**` to `ROLE_ADMIN`.
 

--- a/frontend/src/components/admin/parcel-tags/AddParcelTagModal.test.tsx
+++ b/frontend/src/components/admin/parcel-tags/AddParcelTagModal.test.tsx
@@ -40,7 +40,7 @@ describe("AddParcelTagModal", () => {
         received = await request.json();
         return HttpResponse.json({
           code: "X", label: "X", category: "Y", description: null,
-          sortOrder: 1, active: true, createdAt: "x", updatedAt: "x",
+          active: true, createdAt: "x", updatedAt: "x",
         });
       }),
     );

--- a/frontend/src/components/admin/parcel-tags/AddParcelTagModal.tsx
+++ b/frontend/src/components/admin/parcel-tags/AddParcelTagModal.tsx
@@ -24,7 +24,6 @@ export function AddParcelTagModal({
   const [label, setLabel] = useState("");
   const [category, setCategory] = useState("");
   const [description, setDescription] = useState("");
-  const [sortOrder, setSortOrder] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   const mutation = useCreateParcelTag();
@@ -36,7 +35,6 @@ export function AddParcelTagModal({
       setLabel("");
       setCategory("");
       setDescription("");
-      setSortOrder("");
       setError(null);
     }
   }, [open]);
@@ -54,7 +52,6 @@ export function AddParcelTagModal({
         label: label.trim(),
         category: category.trim(),
         description: description.trim() || undefined,
-        sortOrder: sortOrder.trim() ? Number(sortOrder) : undefined,
       });
       onClose();
     } catch (e) {
@@ -136,18 +133,6 @@ export function AddParcelTagModal({
               maxLength={2000}
               className="w-full resize-y rounded-lg bg-bg-subtle px-4 py-3 text-fg ring-1 ring-border-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
               data-testid="add-parcel-tag-description"
-            />
-          </Field>
-
-          <Field
-            label="Sort order (optional)"
-            hint="Defaults to one after the last tag in the chosen category."
-          >
-            <Input
-              type="number"
-              value={sortOrder}
-              onChange={(e) => setSortOrder(e.target.value)}
-              data-testid="add-parcel-tag-sort-order"
             />
           </Field>
 

--- a/frontend/src/components/admin/parcel-tags/AdminParcelTagsTable.test.tsx
+++ b/frontend/src/components/admin/parcel-tags/AdminParcelTagsTable.test.tsx
@@ -13,17 +13,17 @@ afterAll(() => server.close());
 const tags: AdminParcelTagDto[] = [
   {
     code: "WATERFRONT", label: "Waterfront", category: "Terrain",
-    description: null, sortOrder: 1, active: true,
+    description: null, active: true,
     createdAt: "x", updatedAt: "x",
   },
   {
     code: "SNOW", label: "Snow", category: "Terrain",
-    description: null, sortOrder: 2, active: false,
+    description: null, active: false,
     createdAt: "x", updatedAt: "x",
   },
   {
     code: "STREETFRONT", label: "Streetfront", category: "Roads",
-    description: null, sortOrder: 1, active: true,
+    description: null, active: true,
     createdAt: "x", updatedAt: "x",
   },
 ];

--- a/frontend/src/components/admin/parcel-tags/AdminParcelTagsTable.tsx
+++ b/frontend/src/components/admin/parcel-tags/AdminParcelTagsTable.tsx
@@ -29,7 +29,7 @@ function groupByCategory(tags: AdminParcelTagDto[]): CategoryGroup[] {
   }
   return order.map((category) => ({
     category,
-    tags: map.get(category)!.sort((a, b) => a.sortOrder - b.sortOrder),
+    tags: map.get(category)!.sort((a, b) => a.label.localeCompare(b.label)),
   }));
 }
 
@@ -84,7 +84,6 @@ export function AdminParcelTagsTable({ tags, onEdit }: AdminParcelTagsTableProps
                 <tr>
                   <th className="px-3 py-2 text-left">Code</th>
                   <th className="px-3 py-2 text-left">Label</th>
-                  <th className="px-3 py-2 text-left">Sort</th>
                   <th className="px-3 py-2 text-left">Active</th>
                   <th className="px-3 py-2 text-right">Actions</th>
                 </tr>
@@ -104,7 +103,6 @@ export function AdminParcelTagsTable({ tags, onEdit }: AdminParcelTagsTableProps
                       {tag.code}
                     </td>
                     <td className="px-3 py-2 text-fg">{tag.label}</td>
-                    <td className="px-3 py-2 text-fg-muted">{tag.sortOrder}</td>
                     <td className="px-3 py-2">
                       <span
                         className={cn(

--- a/frontend/src/components/admin/parcel-tags/EditParcelTagModal.test.tsx
+++ b/frontend/src/components/admin/parcel-tags/EditParcelTagModal.test.tsx
@@ -12,7 +12,7 @@ afterAll(() => server.close());
 
 const tag: AdminParcelTagDto = {
   code: "WATERFRONT", label: "Waterfront", category: "Terrain",
-  description: "Old desc", sortOrder: 3, active: true,
+  description: "Old desc", active: true,
   createdAt: "x", updatedAt: "x",
 };
 

--- a/frontend/src/components/admin/parcel-tags/EditParcelTagModal.tsx
+++ b/frontend/src/components/admin/parcel-tags/EditParcelTagModal.tsx
@@ -28,7 +28,6 @@ export function EditParcelTagModal({
   const [label, setLabel] = useState("");
   const [category, setCategory] = useState("");
   const [description, setDescription] = useState("");
-  const [sortOrder, setSortOrder] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   const mutation = useUpdateParcelTag();
@@ -39,7 +38,6 @@ export function EditParcelTagModal({
       setLabel(tag.label);
       setCategory(tag.category);
       setDescription(tag.description ?? "");
-      setSortOrder(String(tag.sortOrder));
       setError(null);
     }
   }, [open, tag]);
@@ -57,8 +55,6 @@ export function EditParcelTagModal({
     if (category.trim() !== tag.category) body.category = category.trim();
     if ((description.trim() || "") !== (tag.description ?? ""))
       body.description = description.trim();
-    const newSortOrder = sortOrder.trim() ? Number(sortOrder) : tag.sortOrder;
-    if (newSortOrder !== tag.sortOrder) body.sortOrder = newSortOrder;
 
     if (Object.keys(body).length === 0) {
       onClose();
@@ -140,15 +136,6 @@ export function EditParcelTagModal({
               maxLength={2000}
               className="w-full resize-y rounded-lg bg-bg-subtle px-4 py-3 text-fg ring-1 ring-border-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
               data-testid="edit-parcel-tag-description"
-            />
-          </Field>
-
-          <Field label="Sort order">
-            <Input
-              type="number"
-              value={sortOrder}
-              onChange={(e) => setSortOrder(e.target.value)}
-              data-testid="edit-parcel-tag-sort-order"
             />
           </Field>
 

--- a/frontend/src/components/auction/ParcelInfoPanel.test.tsx
+++ b/frontend/src/components/auction/ParcelInfoPanel.test.tsx
@@ -168,14 +168,12 @@ describe("ParcelInfoPanel", () => {
               label: "Waterfront",
               category: "feature",
               description: null,
-              sortOrder: 0,
             },
             {
               code: "residential",
               label: "Residential",
               category: "use",
               description: null,
-              sortOrder: 1,
             },
           ],
         })}

--- a/frontend/src/components/listing/ListingPreviewCard.test.tsx
+++ b/frontend/src/components/listing/ListingPreviewCard.test.tsx
@@ -91,7 +91,6 @@ describe("ListingPreviewCard", () => {
               label: "Beach",
               category: "Terrain",
               description: null,
-              sortOrder: 1,
             },
           ],
           photos: [

--- a/frontend/src/components/listing/draft-editor/EditableTags.test.tsx
+++ b/frontend/src/components/listing/draft-editor/EditableTags.test.tsx
@@ -14,7 +14,7 @@ describe("EditableTags", () => {
     renderWithProviders(
       <EditableTags
         value={[
-          { code: "WATERFRONT", label: "Waterfront", category: "Water", description: null, sortOrder: 1 },
+          { code: "WATERFRONT", label: "Waterfront", category: "Water", description: null },
         ]}
         onSave={vi.fn()}
       />,
@@ -38,7 +38,7 @@ describe("EditableTags", () => {
     renderWithProviders(
       <EditableTags
         value={[
-          { code: "WATERFRONT", label: "Waterfront", category: "Water", description: null, sortOrder: 1 },
+          { code: "WATERFRONT", label: "Waterfront", category: "Water", description: null },
         ]}
         onSave={onSave}
       />,

--- a/frontend/src/lib/admin/parcelTags.ts
+++ b/frontend/src/lib/admin/parcelTags.ts
@@ -5,7 +5,6 @@ export interface AdminParcelTagDto {
   label: string;
   category: string;
   description: string | null;
-  sortOrder: number;
   active: boolean;
   createdAt: string;
   updatedAt: string;
@@ -16,14 +15,12 @@ export interface CreateParcelTagPayload {
   label: string;
   category: string;
   description?: string;
-  sortOrder?: number;
 }
 
 export interface UpdateParcelTagPayload {
   label?: string;
   category?: string;
   description?: string;
-  sortOrder?: number;
 }
 
 export const adminParcelTagsApi = {

--- a/frontend/src/types/parcelTag.ts
+++ b/frontend/src/types/parcelTag.ts
@@ -1,13 +1,12 @@
 // Mirrors backend ParcelTagResponse + ParcelTagGroupResponse
 // (com.slparcelauctions.backend.parceltag.dto). Backend groups tags by
-// category and orders within each category by sortOrder.
+// category and orders within each category alphabetically by label.
 
 export interface ParcelTagDto {
   code: string;
   label: string;
   category: string;
   description: string | null;
-  sortOrder: number;
 }
 
 export interface ParcelTagGroupDto {


### PR DESCRIPTION
Per user feedback — sortOrder was YAGNI. Public + admin lists now sort `category ASC, label ASC`. Includes Flyway V18 migration to drop the column. All tests pass.