### PR TITLE
fix(user): override getDisplayName to fall back to username

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/user/User.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/User.java
@@ -320,6 +320,25 @@ public class User extends BaseMutableEntity {
         return balanceLindens - reservedLindens;
     }
 
+    /**
+     * Overrides Lombok's {@code @Getter} so every consumer — DTO mappers, WS
+     * envelopes, admin views — sees a non-blank name without each one having
+     * to remember a fallback. Returns the user's chosen SLParcels
+     * {@code displayName} when set, otherwise the SLParcels {@code username}
+     * (which is NOT NULL, so the wire never carries a null name).
+     *
+     * <p>Persistence is unaffected: Hibernate uses field access (the
+     * {@code @Id} on {@link BaseMutableEntity} is on a field), so reads and
+     * dirty-checks bypass this method and operate directly on the
+     * {@code displayName} column. The {@code @Setter} from Lombok continues
+     * to write the raw field, so {@code UserService.update} still skips
+     * {@code null} requests cleanly and the column can hold a real null.
+     */
+    public String getDisplayName() {
+        if (displayName != null && !displayName.isBlank()) return displayName;
+        return username;
+    }
+
     private static Map<String, Object> defaultNotifyEmail() {
         Map<String, Object> m = new LinkedHashMap<>();
         m.put("bidding", true);

--- a/backend/src/test/java/com/slparcelauctions/backend/user/UserEntityTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/user/UserEntityTest.java
@@ -33,4 +33,36 @@ class UserEntityTest {
         assertThat(u.getCompletedSales()).isEqualTo(0);
         assertThat(u.getCancelledWithBids()).isEqualTo(0);
     }
+
+    @Test
+    void getDisplayNameReturnsDisplayNameWhenSet() {
+        User u = User.builder()
+                .email("a@b.com").username("loginname")
+                .passwordHash("x")
+                .displayName("Chosen Name")
+                .build();
+        assertThat(u.getDisplayName()).isEqualTo("Chosen Name");
+    }
+
+    @Test
+    void getDisplayNameFallsBackToUsernameWhenDisplayNameNull() {
+        User u = User.builder()
+                .email("a@b.com").username("loginname")
+                .passwordHash("x")
+                .build();
+        assertThat(u.getDisplayName()).isEqualTo("loginname");
+    }
+
+    @Test
+    void getDisplayNameFallsBackToUsernameWhenDisplayNameBlank() {
+        // Empty / whitespace-only strings (from trimmed updates or older
+        // rows) are treated the same as null so a seller card never renders
+        // an empty name.
+        User u = User.builder()
+                .email("a@b.com").username("loginname")
+                .passwordHash("x")
+                .displayName("   ")
+                .build();
+        assertThat(u.getDisplayName()).isEqualTo("loginname");
+    }
 }


### PR DESCRIPTION
## Summary
- Auction detail page (and any other public surface that renders a seller / bidder / reviewer name) was showing a blank name when the user had not set a SLParcels displayName.
- Override Lombok's `@Getter` for `displayName` on `User` so it returns the chosen displayName when set, otherwise the NOT NULL `username` column. One change point — every existing `getDisplayName()` caller is now safe.
- Hibernate is unaffected (field access on `@Id` means persistence reads/writes the column directly, never going through the getter).

## Test plan
- [x] `UserEntityTest` covers: returns displayName when set, falls back to username when null, falls back to username when blank/whitespace
- [ ] Manual: load https://slparcels.com/auction/3b08a79a-98d5-4103-b74d-d5477b1d08b0 after deploy and confirm the seller card shows a name in place of the previously empty `<h2>`