### PR TITLE
promote dev → main: getDisplayName fallback + auction Transactional + tag-category cleanup

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/user/User.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/User.java
@@ -320,6 +320,25 @@ public class User extends BaseMutableEntity {
         return balanceLindens - reservedLindens;
     }
 
+    /**
+     * Overrides Lombok's {@code @Getter} so every consumer — DTO mappers, WS
+     * envelopes, admin views — sees a non-blank name without each one having
+     * to remember a fallback. Returns the user's chosen SLParcels
+     * {@code displayName} when set, otherwise the SLParcels {@code username}
+     * (which is NOT NULL, so the wire never carries a null name).
+     *
+     * <p>Persistence is unaffected: Hibernate uses field access (the
+     * {@code @Id} on {@link BaseMutableEntity} is on a field), so reads and
+     * dirty-checks bypass this method and operate directly on the
+     * {@code displayName} column. The {@code @Setter} from Lombok continues
+     * to write the raw field, so {@code UserService.update} still skips
+     * {@code null} requests cleanly and the column can hold a real null.
+     */
+    public String getDisplayName() {
+        if (displayName != null && !displayName.isBlank()) return displayName;
+        return username;
+    }
+
     private static Map<String, Object> defaultNotifyEmail() {
         Map<String, Object> m = new LinkedHashMap<>();
         m.put("bidding", true);

--- a/backend/src/test/java/com/slparcelauctions/backend/user/UserEntityTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/user/UserEntityTest.java
@@ -33,4 +33,36 @@ class UserEntityTest {
         assertThat(u.getCompletedSales()).isEqualTo(0);
         assertThat(u.getCancelledWithBids()).isEqualTo(0);
     }
+
+    @Test
+    void getDisplayNameReturnsDisplayNameWhenSet() {
+        User u = User.builder()
+                .email("a@b.com").username("loginname")
+                .passwordHash("x")
+                .displayName("Chosen Name")
+                .build();
+        assertThat(u.getDisplayName()).isEqualTo("Chosen Name");
+    }
+
+    @Test
+    void getDisplayNameFallsBackToUsernameWhenDisplayNameNull() {
+        User u = User.builder()
+                .email("a@b.com").username("loginname")
+                .passwordHash("x")
+                .build();
+        assertThat(u.getDisplayName()).isEqualTo("loginname");
+    }
+
+    @Test
+    void getDisplayNameFallsBackToUsernameWhenDisplayNameBlank() {
+        // Empty / whitespace-only strings (from trimmed updates or older
+        // rows) are treated the same as null so a seller card never renders
+        // an empty name.
+        User u = User.builder()
+                .email("a@b.com").username("loginname")
+                .passwordHash("x")
+                .displayName("   ")
+                .build();
+        assertThat(u.getDisplayName()).isEqualTo("loginname");
+    }
 }


### PR DESCRIPTION
## Summary
Promote dev to main. Six commits ahead:

- **fix(user)**: override `getDisplayName` to fall back to `username` (#211) — fixes blank seller name on auction detail page
- **fix(auction)**: `@Transactional` on read endpoints (#208) — fixes LazyInitializationException on `tag.category` POST /api/v1/auctions
- **chore(parcel-tags)**: drop the first-boot seed (#206)
- **feat(admin)**: promote parcel-tag categories to a first-class entity (#204)
- **docs(spec)**: admin parcel-tag categories design
- **fix(parcel-tags)**: drop sortOrder, sort by label alphabetically (#202)

## Test plan
- [ ] Backend ECS rolloutState COMPLETED on new taskdef
- [ ] Amplify build success on `main`
- [ ] Auction detail page shows seller name (regression check for #211)
- [ ] POST /api/v1/auctions succeeds (regression check for #208)