### PR TITLE
fix(sl-profile-photo): stretch 4:3 source to square 512x512

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/sl/SlProfilePhotoService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/sl/SlProfilePhotoService.java
@@ -1,9 +1,17 @@
 package com.slparcelauctions.backend.sl;
 
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.UUID;
+
+import javax.imageio.ImageIO;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -44,6 +52,7 @@ public class SlProfilePhotoService {
     static final Duration NEGATIVE_TTL = Duration.ofMinutes(5);
     static final String ALLOWED_HOST_PREFIX = "https://picture-service.secondlife.com/";
     static final long MAX_IMAGE_BYTES = 2L * 1024 * 1024;
+    static final int OUTPUT_SIZE = 512;
 
     private final WebClient slWorldWebClient;
     private final WebClient slPictureServiceWebClient;
@@ -138,8 +147,62 @@ public class SlProfilePhotoService {
             cacheNegative(cacheKey);
             return Optional.empty();
         }
-        cachePositive(cacheKey, imageBytes);
-        return Optional.of(imageBytes);
+        byte[] resized;
+        try {
+            resized = resizeToSquareOutput(imageBytes);
+        } catch (IOException e) {
+            log.warn("Failed to decode/resize SL profile photo for {}: {}",
+                    slAvatarUuid, e.getMessage());
+            cacheNegative(cacheKey);
+            return Optional.empty();
+        }
+        cachePositive(cacheKey, resized);
+        return Optional.of(resized);
+    }
+
+    /**
+     * SL stores profile photos as square textures (typically 512x512 J2C),
+     * but every public web endpoint serves a 4:3 letterboxed thumbnail
+     * (256x192 from picture-service, 320x240 at the largest from
+     * /app/image/{uuid}/2). To restore the originally-square aspect, we
+     * stretch the fetched bytes to {@code maxDim x maxDim} and then up-
+     * scale to {@link #OUTPUT_SIZE}x{@link #OUTPUT_SIZE} for display in
+     * the cropper. Bilinear interpolation keeps the resample artefact-
+     * minimal at this size.
+     *
+     * <p>Output is JPEG at quality default. The returned bytes are what
+     * the frontend renders and what the cropper saves crops out of, so a
+     * single round of resampling here is the only one the user sees.
+     */
+    private byte[] resizeToSquareOutput(byte[] inputBytes) throws IOException {
+        BufferedImage src = ImageIO.read(new ByteArrayInputStream(inputBytes));
+        if (src == null) {
+            throw new IOException("ImageIO.read returned null for " + inputBytes.length + " bytes");
+        }
+        int maxDim = Math.max(src.getWidth(), src.getHeight());
+        BufferedImage step1 = new BufferedImage(maxDim, maxDim, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g1 = step1.createGraphics();
+        try {
+            g1.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                    RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+            g1.drawImage(src, 0, 0, maxDim, maxDim, null);
+        } finally {
+            g1.dispose();
+        }
+        BufferedImage step2 = new BufferedImage(OUTPUT_SIZE, OUTPUT_SIZE, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g2 = step2.createGraphics();
+        try {
+            g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                    RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+            g2.drawImage(step1, 0, 0, OUTPUT_SIZE, OUTPUT_SIZE, null);
+        } finally {
+            g2.dispose();
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        if (!ImageIO.write(step2, "jpeg", baos)) {
+            throw new IOException("ImageIO.write returned false for jpeg output");
+        }
+        return baos.toByteArray();
     }
 
     private String safeRedisGet(String key) {

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/SlProfilePhotoServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/SlProfilePhotoServiceTest.java
@@ -14,10 +14,15 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.UUID;
+
+import javax.imageio.ImageIO;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -45,9 +50,12 @@ class SlProfilePhotoServiceTest {
 
     private static final UUID AVATAR = UUID.fromString("aa87bc38-c175-427d-b665-02e6838963cc");
     private static final String CACHE_KEY = "sl:profile-photo:" + AVATAR;
-    private static final byte[] PHOTO_BYTES = new byte[]{
-            (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0,
-            0x00, 0x10, 'J', 'F', 'I', 'F'};
+    /**
+     * A real, decodable 256x192 JPEG. The service's resize step needs
+     * ImageIO to be able to round-trip the bytes; a hand-written magic-
+     * bytes fixture is rejected. Generated once at class-load.
+     */
+    private static final byte[] PHOTO_BYTES = makeJpeg(256, 192);
 
     private static WireMockServer worldWm;
     private static WireMockServer pictureWm;
@@ -118,7 +126,7 @@ class SlProfilePhotoServiceTest {
     }
 
     @Test
-    void successfulScrapeAndImageFetch_returnsBytesAndCachesPositive() {
+    void successfulScrapeAndImageFetch_returnsResizedBytesAndCachesPositive() throws Exception {
         // Stub world.sl: parcelimg with a picture-service src whose path we
         // mirror locally so the bound WebClient resolves it correctly.
         worldWm.stubFor(get(urlPathEqualTo("/resident/" + AVATAR))
@@ -137,7 +145,11 @@ class SlProfilePhotoServiceTest {
         Optional<byte[]> result = service.fetchProfilePhoto(AVATAR);
 
         assertThat(result).isPresent();
-        assertThat(result.get()).isEqualTo(PHOTO_BYTES);
+        // Returned bytes are NOT the input — service stretches the 4:3 SL
+        // photo back to a square and scales to 512x512 before returning.
+        BufferedImage decoded = ImageIO.read(new ByteArrayInputStream(result.get()));
+        assertThat(decoded.getWidth()).isEqualTo(512);
+        assertThat(decoded.getHeight()).isEqualTo(512);
         verify(valueOps).set(eq(CACHE_KEY), anyString(), eq(Duration.ofHours(1)));
     }
 
@@ -230,6 +242,26 @@ class SlProfilePhotoServiceTest {
 
         assertThat(result).isPresent();
         worldWm.verify(exactly(1), getRequestedFor(urlPathEqualTo("/resident/" + AVATAR)));
+    }
+
+    /** Generates a real, decodable JPEG of the requested dimensions. */
+    private static byte[] makeJpeg(int width, int height) {
+        try {
+            BufferedImage img = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+            // Solid-color content — service decodes by dimensions, not pixels.
+            for (int y = 0; y < height; y++) {
+                for (int x = 0; x < width; x++) {
+                    img.setRGB(x, y, 0x808080);
+                }
+            }
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            if (!ImageIO.write(img, "jpeg", baos)) {
+                throw new IllegalStateException("ImageIO.write returned false");
+            }
+            return baos.toByteArray();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to generate test JPEG", e);
+        }
     }
 
     private static String htmlWithImg(String src) {


### PR DESCRIPTION
## Summary
SL stores profile textures as squares but every public web endpoint serves a 4:3 letterbox/crop (256x192 from picture-service, 320x240 from /app/image/{uuid}/2 at the largest). The cropper was therefore showing a horizontally-squished thumbnail.

Stretch the fetched bytes back to `maxDim × maxDim` (256x256 from a 256x192 source) and then upscale to 512x512 before caching + returning. Bilinear interpolation, JPEG output. Done backend-side so the cache holds the resized version and the frontend just renders whatever bytes come in.

## Test plan
- [x] `SlProfilePhotoServiceTest.successfulScrapeAndImageFetch_returnsResizedBytesAndCachesPositive` decodes the returned bytes and asserts 512x512
- [x] All 9 existing tests in the file still pass
- [ ] Manual: visit /dashboard/avatar and confirm the SL photo renders at correct proportions in the cropper