### PR TITLE
promote dev → main: SL profile photo cache bust + browser cache tighten

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/onboarding/OnboardingController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/onboarding/OnboardingController.java
@@ -62,7 +62,12 @@ public class OnboardingController {
         return slProfilePhotoService.fetchProfilePhoto(u.getSlAvatarUuid())
                 .map(bytes -> ResponseEntity.ok()
                         .contentType(MediaType.IMAGE_JPEG)
-                        .cacheControl(CacheControl.maxAge(Duration.ofHours(1)).cachePrivate())
+                        // Short browser cache (1 min) — the page fetches once per
+                        // onboarding flow and a long cache strands users on stale
+                        // bytes if we ever change the encoded shape (cf. the v2
+                        // stretch retrofit). Backend Redis still caches for 1h
+                        // for cross-user efficiency.
+                        .cacheControl(CacheControl.maxAge(Duration.ofMinutes(1)).cachePrivate())
                         .body(bytes))
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }

--- a/backend/src/main/java/com/slparcelauctions/backend/sl/SlProfilePhotoService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/sl/SlProfilePhotoService.java
@@ -46,7 +46,13 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SlProfilePhotoService {
 
-    static final String CACHE_PREFIX = "sl:profile-photo:";
+    /**
+     * Versioned cache key prefix. Bump the suffix any time the bytes we
+     * cache change shape (resize, format, source URL) — old entries
+     * become unreachable and TTL out naturally. v2 added the 4:3-to-square
+     * stretch + 512x512 upscale.
+     */
+    static final String CACHE_PREFIX = "sl:profile-photo:v2:";
     static final String NEGATIVE_SENTINEL = "NONE";
     static final Duration POSITIVE_TTL = Duration.ofHours(1);
     static final Duration NEGATIVE_TTL = Duration.ofMinutes(5);

--- a/backend/src/test/java/com/slparcelauctions/backend/onboarding/OnboardingControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/onboarding/OnboardingControllerSliceTest.java
@@ -156,7 +156,7 @@ class OnboardingControllerSliceTest {
                 .andExpect(content().contentType(MediaType.IMAGE_JPEG))
                 .andExpect(content().bytes(bytes))
                 .andExpect(header().string("Cache-Control",
-                        org.hamcrest.Matchers.containsString("max-age=3600")));
+                        org.hamcrest.Matchers.containsString("max-age=60")));
     }
 
     @Test

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/SlProfilePhotoServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/SlProfilePhotoServiceTest.java
@@ -49,7 +49,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 class SlProfilePhotoServiceTest {
 
     private static final UUID AVATAR = UUID.fromString("aa87bc38-c175-427d-b665-02e6838963cc");
-    private static final String CACHE_KEY = "sl:profile-photo:" + AVATAR;
+    private static final String CACHE_KEY = "sl:profile-photo:v2:" + AVATAR;
     /**
      * A real, decodable 256x192 JPEG. The service's resize step needs
      * ImageIO to be able to round-trip the bytes; a hand-written magic-


### PR DESCRIPTION
Single PR: #217. Required to make the 4:3→512x512 stretch actually take effect for existing users (Redis cache from prior deploy was serving old un-stretched bytes).