### PR TITLE
feat: add Settings entry to user menu; default /settings to /profile

### DIFF
--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function SettingsIndexPage() {
-  redirect("/settings/notifications");
+  redirect("/settings/profile");
 }

--- a/frontend/src/components/auth/UserMenuDropdown.tsx
+++ b/frontend/src/components/auth/UserMenuDropdown.tsx
@@ -47,6 +47,10 @@ export function UserMenuDropdown({ user }: UserMenuDropdownProps) {
       label: "Profile",
       onSelect: () => router.push(`/users/${user.publicId}`),
     },
+    {
+      label: "Settings",
+      onSelect: () => router.push("/settings/profile"),
+    },
     ...(user.role === "ADMIN"
       ? [{ label: "Admin", onSelect: () => router.push("/admin") }]
       : []),


### PR DESCRIPTION
## Summary
Discoverability fix for the new \`/settings/profile\` route shipped in #221. Two small changes:
1. **UserMenuDropdown** — adds a "Settings" entry between Profile and Admin/Sign Out, landing on \`/settings/profile\`.
2. **\`/settings\` index** — redirect flips from \`/settings/notifications\` to \`/settings/profile\` so the more common section is the default.

The existing notifications-feed gear icon still works; the section nav (added in #221) lets you bounce between Profile and Notifications.

## Test plan
- [x] Frontend: \`UserMenuDropdown.test.tsx\` still passes; no other tests asserted the items shape.
- [ ] Manual: click avatar in navbar → Settings → lands on /settings/profile → DefaultCoverCard renders.