### PR TITLE
fix: port SL Group Verify from slpa-terminal to verification-terminal

### DIFF
--- a/docs/implementation/FOOTGUNS.md
+++ b/docs/implementation/FOOTGUNS.md
@@ -1838,3 +1838,13 @@ can dial the cutoff up before user-facing UI lands.
 **Why:** F shipped suspension state as a separate `realty_group_suspensions` table with one row per suspension event. "Is suspended" is determined by `EXISTS (SELECT 1 FROM realty_group_suspensions WHERE realty_group_id = ? AND lifted_at IS NULL)`, not by a boolean column on the parent. The reverse-search ban-evasion gate in G §14 specifically joins on this pattern.
 
 **How to apply:** When writing any "is this group suspended right now?" query, never `SELECT g.suspended FROM realty_groups g` — the column will not exist and your query will throw. Use the active-suspension-row EXISTS pattern instead. `RealtyGroupGuard.requireGroupCanOperate` is the canonical Java-side check.
+
+### G.4 SL Group Verify lives on the Verification Terminal, not the SLParcels Terminal
+
+**Why:** E originally put the founder-of-an-SL-group verify flow on `lsl-scripts/slpa-terminal/` (the L$ kiosk) because the slpa-terminal already had the shared-secret + SL-header pipeline and group verify shipped in ~50 fewer LSL lines that way. That was a code-reuse decision, not a UX decision: a user walks into the SLParcels building, sees two terminals side-by-side, and reasonably assumes "verification" goes on the **Verification Terminal**. Post-G the flow lives on `lsl-scripts/verification-terminal/`. The slpa-terminal handles L$ flows only (deposit / withdraw / inbound PAYOUT/WITHDRAW).
+
+**How to apply:**
+- The backend endpoint `/api/v1/sl/sl-group/verify` is unchanged — only the in-world host moved. Don't search the slpa-terminal for `SL_GROUP_VERIFY_URL`; it was removed.
+- In-world deployments configure `SL_GROUP_VERIFY_URL` in the **verification-terminal's** `config` notecard. When set, touch opens a `llDialog` menu with `[Self, SL Group]`. When blank, touch goes straight to the self-verify text box (pre-port behavior).
+- E's spec doc (`2026-05-12-realty-groups-sl-group-listing-design.md` §7.3) still describes the original slpa-terminal placement — that doc is historical. The actual current placement is the verification-terminal per this note + `lsl-scripts/verification-terminal/README.md`.
+- If you ever need to add a third in-world flow (e.g. drift-ack, member group-pay receipts), decide first whether it belongs on the verification-terminal alongside the existing two flows, or whether the surface has grown enough to warrant a dedicated `group-terminal`. Don't reflexively shove it on slpa-terminal just because the shared-secret pipeline is there.

--- a/docs/postman/realty-groups-g-additions.md
+++ b/docs/postman/realty-groups-g-additions.md
@@ -146,8 +146,9 @@ The backend ships dissolve-blockers as 409 responses on the actual `DELETE` atte
 
 ## 4. Founder Terminal Verify — header fix
 
-Existing request `SL → SL Group → Founder Terminal Verify` was created during sub-project E with the wrong header name. Sub-project G corrects it to match `SlGroupVerifyController`:
+Existing request `SL → SL Group → Founder Terminal Verify` was created during sub-project E with the wrong header name. Sub-project G corrects it to match `SlGroupVerifyController`. The backend endpoint is unchanged — what's changing post-G in-world is which physical kiosk hosts this flow:
 
+- **In-world host:** the SLParcels **Verification Terminal** (`lsl-scripts/verification-terminal/`). NOT the SLParcels Terminal — group verification was moved off the L$ terminal to the verification terminal so the kiosk whose name advertises "verification" actually does it. Configure `SL_GROUP_VERIFY_URL` in the verification terminal's `config` notecard to enable the SL-group menu choice on touch.
 - **Method / URL**: `POST {{baseUrl}}/api/v1/sl/sl-group/verify`
 - **Headers**:
   - `Content-Type: application/json`

--- a/lsl-scripts/slpa-terminal/README.md
+++ b/lsl-scripts/slpa-terminal/README.md
@@ -1,8 +1,13 @@
 # SLParcels Terminal (wallet model)
 
-In-world wallet kiosk for SLParcels. Three touch-menu options (Deposit-instructions,
-Withdraw, SL Group Verify) plus a lockless `money()` deposit handler. Also accepts
+In-world wallet kiosk for SLParcels. Two touch-menu options (Deposit-instructions,
+Withdraw) plus a lockless `money()` deposit handler. Also accepts
 backend-initiated PAYOUT/WITHDRAW commands via HTTP-in.
+
+SL Group Verify (founder-of-an-SL-group verification, sub-project E spec
+section 7.3) is **not** on this terminal. It lives on the SLParcels
+Verification Terminal — same building, the kiosk whose name actually
+advertises "verification". See `lsl-scripts/verification-terminal/`.
 
 ## Architecture summary
 
@@ -21,23 +26,13 @@ backend-initiated PAYOUT/WITHDRAW commands via HTTP-in.
   with an unhandled failure (unknown terminal id, unparseable payer uuid,
   etc). Background retry: 10s / 30s / 90s / 5m / 15m. Multiple users can
   pay simultaneously — `money()` is naturally reentrant.
-- **Touch flow:** touch → `llDialog` `[Deposit, Withdraw, SL Group Verify]`
+- **Touch flow:** touch → `llDialog` `[Deposit, Withdraw]`
   (no lock acquired). Deposit selection → `llRegionSayTo` instructions, no
   state. Withdraw selection → acquire per-flow slot → text-box for amount →
   confirm dialog → POST to `/sl/wallet/withdraw-request`. On `OK`, the
   backend queues a `WALLET_WITHDRAWAL` `TerminalCommand` that fires
   asynchronously; on `REFUND_BLOCKED`, no L$ to bounce — `llRegionSayTo` the
-  reason. SL Group Verify selection → acquire per-flow verify slot →
-  text-box for the `SLPA-XXXXXXXXXXXX` code → POST to
-  `/sl/sl-group/verify` with `{ verificationCode, founderAvatarUuid }`.
-  Result goes to the toucher via `llDialog` `[OK]` (private; not open-chat
-  — terminal-output-genericisation policy from commit 5a5276a) and to the
-  terminal owner via `llOwnerSay` in DEBUG_MODE: 200 → "SL group
-  verified."; 410 → "code expired"; 422 (`SL_GROUP_FOUNDER_MISMATCH`) →
-  "not the founder"; 404 → "code not recognised"; other → generic "problem
-  with SL Group Verify" message. Backend ProblemDetail title/detail are
-  NOT surfaced to the toucher. No L$ involved on this path — no refund
-  logic.
+  reason.
 - **Per-flow withdraw slots:** single `llListen` opened at startup, never
   closed. Up to 4 concurrent withdraw sessions, one per avatar (per-avatar
   dedup). Strided list `[avatarKey, amountOrMinusOne, expiresAt, ...]`.
@@ -79,10 +74,6 @@ Never publish on Marketplace.
    - Right-click the prim → Pay → L$10. Confirm `deposit ok L$10 from <name>`.
    - Touch → Withdraw → enter L$5 → Yes. Confirm withdrawal arrives in your
      SL avatar within ~30s.
-   - Touch → SL Group Verify. If `SL_GROUP_VERIFY_URL` is set, you get a
-     `llTextBox` prompt for the `SLPA-XXXXXXXXXXXX` code; if not, you get an
-     "unavailable on this terminal" dialog. (Full happy-path verification
-     requires a live SL group registration from the web UI — see Operations.)
 
 The new SLParcels Parcel Verifier Giver prim (separate; see
 `lsl-scripts/slpa-verifier-giver/`) handles parcel-verifier give-out — it is
@@ -97,7 +88,6 @@ The new SLParcels Parcel Verifier Giver prim (separate; see
 | `WITHDRAW_REQUEST_URL` | Full URL of `/api/v1/sl/wallet/withdraw-request`. Required. |
 | `PAYOUT_RESULT_URL` | Full URL of `/api/v1/sl/escrow/payout-result`. Required. |
 | `HEARTBEAT_URL` | Full URL of `/api/v1/sl/terminal/heartbeat`. Optional but recommended — see Architecture summary. |
-| `SL_GROUP_VERIFY_URL` | Full URL of `/api/v1/sl/sl-group/verify`. Optional for backward compatibility — pre-E deployments degrade gracefully (user picking "SL Group Verify" gets an "unavailable on this terminal" dialog). New deployments should set it so realty-group founders can complete verification from this terminal. |
 | `SHARED_SECRET` | The shared secret. **Required.** Obtain from `slpa.escrow.terminal-shared-secret`. |
 | `TERMINAL_ID` | Optional. Defaults to `(string)llGetKey()`. |
 | `REGION_NAME` | Optional. Defaults to `llGetRegionName()`. |
@@ -137,64 +127,12 @@ In steady state with `DEBUG_MODE=true`:
 - `SLParcels Terminal: heartbeat ok.` — periodic 5-minute heartbeat acknowledged.
 - `SLParcels Terminal: heartbeat failed status=...` — heartbeat POST failed; will
   retry on the next interval. Not critical unless it persists.
-- `SLParcels Terminal: SL Group Verify OK for <avatar>` — founder-terminal
-  verification succeeded (sub-project E spec §7.3). The realty group leader
-  can now list parcels owned by that SL group.
-- `SLParcels Terminal: SL Group Verify failed for <avatar> status=... code=...` —
-  founder-terminal verification rejected. Mapped statuses: 410
-  (`SL_GROUP_VERIFICATION_EXPIRED`), 422 (`SL_GROUP_FOUNDER_MISMATCH`), 404
-  (code not recognised). Other statuses fall through to a generic
-  "verification failed" message to the toucher.
 - `CRITICAL: SLParcels Terminal: deposit ... not acknowledged after 5 retries` —
   deposit recovery failed; manual reconciliation required.
 - `CRITICAL: unexpected REFUND HTTP-in command` — the backend dispatched a
   REFUND action; refunds should be wallet credits in the new model. Investigate.
 - `CRITICAL: PERMISSION_DEBIT denied — script halted. Owner must re-grant.` —
   permissions issue.
-
-## SL Group Verify (sub-project E spec §7.3, §13.3)
-
-The "SL Group Verify" menu item supports the founder-of-an-SL-group
-verification path for realty groups listing parcels under case-3 (SL group
-owns the parcel). The leader of a realty group starts the registration in
-the SLParcels web UI; the SL group's founder finishes it by typing the
-short `SLPA-XXXXXXXXXXXX` code into any deployed SLParcels Terminal.
-
-- **Menu:** Main menu → **SL Group Verify**.
-- **Input:** the 12-character `SLPA-XXXXXXXXXXXX` verification code shown
-  on the realty group's SL Groups page after the leader initiates
-  registration. Trimmed of whitespace before send.
-- **Effect:** POSTs `{ verificationCode, founderAvatarUuid }` to
-  `/api/v1/sl/sl-group/verify`. Backend cross-checks the toucher's avatar
-  UUID against the SL group's founder via the World API and, on match,
-  flips the registration row to `verified=true,
-  verified_via=FOUNDER_TERMINAL`.
-- **Outcomes** (owner-said in DEBUG_MODE; toucher gets `llDialog` `[OK]`
-  on every status — private to the toucher, per the
-  terminal-output-genericisation policy in commit 5a5276a):
-  - 200 OK → "SL group verified. The realty group can now list parcels
-    owned by this SL group."
-  - 410 (`SL_GROUP_VERIFICATION_EXPIRED`) → "Verification code expired.
-    The realty group leader needs to start a new registration."
-  - 422 (`SL_GROUP_FOUNDER_MISMATCH`) → "You are not the founder of the SL
-    group registered with this code."
-  - 404 → "Verification code not recognised. Check the code and try again."
-  - 401 / other 4xx → "Verification failed; check the code and try again."
-- **Concurrency:** up to 4 per-terminal verify slots (one per avatar)
-  share the same 60s TTL + 10s sweeper as the withdraw slots. Only ONE
-  verify POST may be in flight per terminal at a time — a second avatar's
-  submit while the first is in flight gets a "busy, try again" dialog
-  (concurrent independent verifies should use separate terminals).
-- **No new env vars or permissions required.** The existing
-  `X-SecondLife-Owner-Key` SL header (validated server-side by
-  `SlHeaderValidator` on `/api/v1/sl/**`) is the trust gate. No
-  `sharedSecret` is sent on this path because the controller doesn't read
-  one; the wire shape exactly mirrors `SlGroupVerifyRequest`.
-- **Backward compatibility.** `SL_GROUP_VERIFY_URL` is optional in the
-  notecard. Pre-E deployments simply show an "unavailable on this
-  terminal" dialog when the menu item is chosen; the rest of the terminal
-  (deposit / withdraw / heartbeat / HTTP-in) continues to work
-  unchanged.
 
 ## Troubleshooting
 
@@ -210,9 +148,6 @@ short `SLPA-XXXXXXXXXXXX` code into any deployed SLParcels Terminal.
 | Withdraw text-box says `Terminal busy — try another nearby` | All 4 withdraw slots occupied. Walk to another terminal. (Should be vanishingly rare at SLParcels's traffic level.) |
 | Backend command dispatcher logs 403 | Shared secret mismatch. Update notecard, reset. |
 | `CRITICAL: unexpected REFUND HTTP-in command` | Stale code path or migration issue — refunds should be wallet credits. Investigate. |
-| "SL Group Verify is unavailable on this terminal." | `SL_GROUP_VERIFY_URL` is empty in the `config` notecard. Add the URL and reset the script. |
-| SL Group Verify owner-says "status=401" | Backend `/api/v1/sl/sl-group/verify` rejected the request at the SL-header gate. Confirm the terminal's owner UUID is in `slpa.sl.trusted-owner-keys`. **Heath-only note:** at the time of this writing the path may also be missing from `SecurityConfig` allowlist; check there if 401s persist after the owner-key is correct. |
-| SL Group Verify owner-says "status=415" | Backend returned `application/problem+json` for a 4xx. Confirm `SlProblemDetailContentTypeAdvice` covers `/api/v1/sl/sl-group/**` (the path prefix in advice is `/api/v1/sl/**`, so this should be automatic). |
 
 ## Limits
 

--- a/lsl-scripts/slpa-terminal/config.notecard.example
+++ b/lsl-scripts/slpa-terminal/config.notecard.example
@@ -12,11 +12,10 @@ WITHDRAW_REQUEST_URL=https://slpa.app/api/v1/sl/wallet/withdraw-request
 PAYOUT_RESULT_URL=https://slpa.app/api/v1/sl/escrow/payout-result
 HEARTBEAT_URL=https://slpa.app/api/v1/sl/terminal/heartbeat
 
-# Optional: SL Group Verify endpoint (sub-project E spec §7.3, §13.3).
-# Powers the "SL Group Verify" main-menu item. If left blank, the menu item
-# still appears but politely declines with an "unavailable on this terminal"
-# dialog. New deployments should set it.
-SL_GROUP_VERIFY_URL=https://slpa.app/api/v1/sl/sl-group/verify
+# SL Group Verify (founder-of-an-SL-group verification, sub-project E spec
+# section 7.3) is NOT on this terminal -- it lives on the SLParcels
+# Verification Terminal alongside Method C user verify. See
+# lsl-scripts/verification-terminal/config.notecard.example.
 
 # Shared secret for terminal authentication. REQUIRED.
 # Obtain from the backend's slpa.escrow.terminal-shared-secret config.

--- a/lsl-scripts/slpa-terminal/slpa-terminal.lsl
+++ b/lsl-scripts/slpa-terminal/slpa-terminal.lsl
@@ -1,10 +1,13 @@
 // SLParcels Terminal (wallet model)
 //
-// Single-object payment kiosk for SLParcels. Three touch-menu options:
-//   1. Deposit         — instructs user to right-click and pay any amount
-//   2. Withdraw        — touch-confirmed withdrawal from the user's SLParcels wallet
-//   3. SL Group Verify — founder-of-an-SL-group verification for realty groups
-//                        (sub-project E spec §7.3, §13.3)
+// Single-object payment kiosk for SLParcels. Two touch-menu options:
+//   1. Deposit  — instructs user to right-click and pay any amount
+//   2. Withdraw — touch-confirmed withdrawal from the user's SLParcels wallet
+//
+// SL Group Verify (the founder-of-an-SL-group verification flow for realty
+// groups, sub-project E spec section 7.3) lives on the SLParcels Verification
+// Terminal — the kiosk whose name actually advertises "verification". This
+// terminal handles L$ flows only.
 //
 // The terminal accepts deposits via the natural SL pay flow:
 //   * Right-click → Pay → enter amount → money() event fires
@@ -15,10 +18,6 @@
 // on a single shared listen — no terminal-wide lock, no per-flow listen
 // handles to leak. Up to 4 concurrent withdraw sessions; per-avatar dedup
 // (a second touch from the same avatar resets their existing slot).
-//
-// SL Group Verify uses a parallel per-flow slot list keyed by avatar so it
-// can dispatch llTextBox responses on the same shared listen without
-// stealing input from a concurrent withdraw flow.
 //
 // Also accepts backend-initiated PAYOUT/WITHDRAW commands via HTTP-in
 // (REFUND defensive — should never arrive in the wallet model since refunds
@@ -37,10 +36,6 @@ string  DEPOSIT_URL           = "";
 string  WITHDRAW_REQUEST_URL  = "";
 string  PAYOUT_RESULT_URL     = "";
 string  HEARTBEAT_URL         = "";
-// SL_GROUP_VERIFY_URL is optional for backward compatibility — pre-E
-// deployments simply degrade with an owner-say / dialog when a user picks
-// "SL Group Verify". New deployments should set it.
-string  SL_GROUP_VERIFY_URL   = "";
 string  SHARED_SECRET         = "";
 string  TERMINAL_ID           = "";
 string  REGION_NAME           = "";
@@ -72,19 +67,6 @@ list    withdrawSessions   = [];
 integer MAX_WITHDRAW_SESSIONS = 4;
 integer SESSION_TTL_SECONDS = 60;
 integer SLOT_STRIDE = 3;
-
-// === Per-flow SL Group Verify slots ===
-// Strided 2-wide list: [avatarKey, expiresAt, ...]. Independent of
-// withdrawSessions so a user can theoretically have both in flight, and
-// the listen dispatch checks withdraw slots first then verify slots.
-list    verifySessions     = [];
-integer MAX_VERIFY_SESSIONS = 4;
-integer VERIFY_SLOT_STRIDE  = 2;
-
-// === Background SL Group Verify POST (per text-box submit) ===
-key     verifyReqId        = NULL_KEY;
-key     verifyAvatar       = NULL_KEY;
-string  verifyCode         = "";
 
 // === Background deposit retry (per money() event) ===
 key     paymentReqId       = NULL_KEY;
@@ -158,7 +140,6 @@ parseConfigLine(string line) {
     else if (k == "WITHDRAW_REQUEST_URL")  WITHDRAW_REQUEST_URL  = v;
     else if (k == "PAYOUT_RESULT_URL")     PAYOUT_RESULT_URL     = v;
     else if (k == "HEARTBEAT_URL")         HEARTBEAT_URL         = v;
-    else if (k == "SL_GROUP_VERIFY_URL")   SL_GROUP_VERIFY_URL   = v;
     else if (k == "SHARED_SECRET")         SHARED_SECRET         = v;
     else if (k == "TERMINAL_ID")           TERMINAL_ID           = v;
     else if (k == "REGION_NAME")           REGION_NAME           = v;
@@ -403,69 +384,6 @@ sweepExpiredSlots() {
         }
         --i;
     }
-    // Sweep verify sessions on the same schedule
-    i = llGetListLength(verifySessions) / VERIFY_SLOT_STRIDE - 1;
-    while (i >= 0) {
-        integer expiresAt = llList2Integer(verifySessions, i * VERIFY_SLOT_STRIDE + 1);
-        if (expiresAt < now) {
-            verifySessions = llDeleteSubList(verifySessions,
-                i * VERIFY_SLOT_STRIDE, i * VERIFY_SLOT_STRIDE + VERIFY_SLOT_STRIDE - 1);
-        }
-        --i;
-    }
-}
-
-// ---------------- SL Group Verify slot helpers ----------------
-
-integer findVerifySlot(key avatar) {
-    integer i;
-    integer count = llGetListLength(verifySessions) / VERIFY_SLOT_STRIDE;
-    for (i = 0; i < count; ++i) {
-        key k = llList2Key(verifySessions, i * VERIFY_SLOT_STRIDE);
-        if (k == avatar) return i;
-    }
-    return -1;
-}
-
-// Returns slot index of new/reset slot, or -1 if at capacity (and not own).
-integer acquireOrResetVerifySlot(key avatar) {
-    integer existing = findVerifySlot(avatar);
-    if (existing >= 0) {
-        integer offset = existing * VERIFY_SLOT_STRIDE + 1;
-        verifySessions = llListReplaceList(verifySessions,
-            [llGetUnixTime() + SESSION_TTL_SECONDS], offset, offset);
-        return existing;
-    }
-    integer count = llGetListLength(verifySessions) / VERIFY_SLOT_STRIDE;
-    if (count >= MAX_VERIFY_SESSIONS) return -1;
-    verifySessions += [avatar, llGetUnixTime() + SESSION_TTL_SECONDS];
-    return count;
-}
-
-releaseVerifySlot(key avatar) {
-    integer slotIdx = findVerifySlot(avatar);
-    if (slotIdx < 0) return;
-    integer start = slotIdx * VERIFY_SLOT_STRIDE;
-    verifySessions = llDeleteSubList(verifySessions, start, start + VERIFY_SLOT_STRIDE - 1);
-}
-
-fireSlGroupVerify() {
-    // Spec §7.3 body shape: { verificationCode, founderAvatarUuid }.
-    // The backend SlGroupVerifyController (no shared-secret check at the
-    // controller; the SL header validator in /api/v1/sl/** is the trust
-    // gate) accepts this exact JSON. We do NOT include sharedSecret here
-    // because the controller doesn't read it — keeping the wire shape
-    // identical to the @RequestBody DTO avoids Jackson unknown-property
-    // surprises if validation is ever tightened.
-    string body = "{"
-        + "\"verificationCode\":\"" + escapeJson(verifyCode) + "\","
-        + "\"founderAvatarUuid\":\"" + (string)verifyAvatar + "\""
-        + "}";
-    verifyReqId = llHTTPRequest(SL_GROUP_VERIFY_URL,
-        [HTTP_METHOD, "POST",
-         HTTP_MIMETYPE, "application/json",
-         HTTP_BODY_MAXLENGTH, 16384],
-        body);
 }
 
 // ---------------- HTTP-in inflight ----------------
@@ -511,7 +429,6 @@ default {
         WITHDRAW_REQUEST_URL  = "";
         PAYOUT_RESULT_URL     = "";
         HEARTBEAT_URL         = "";
-        SL_GROUP_VERIFY_URL   = "";
         SHARED_SECRET         = "";
         TERMINAL_ID           = "";
         REGION_NAME           = "";
@@ -527,10 +444,6 @@ default {
         registerAttempt     = 0;
         registerNextRetryAt = 0;
         withdrawSessions    = [];
-        verifySessions      = [];
-        verifyReqId         = NULL_KEY;
-        verifyAvatar        = NULL_KEY;
-        verifyCode          = "";
         paymentReqId        = NULL_KEY;
         paymentPayer        = NULL_KEY;
         paymentAmount       = 0;
@@ -771,16 +684,11 @@ default {
     touch_start(integer num) {
         key toucher = llDetectedKey(0);
         // Per-toucher dialog filtered by avatar key in the listen handler.
-        // "SL Group Verify" is the founder-of-an-SL-group verification flow
-        // for realty groups (spec §7.3); it is offered on every terminal so
-        // a realty group's SL founder can complete verification from any
-        // SLParcels venue.
         llDialog(toucher,
             "What would you like to do?\n\n"
             + "Deposit: right-click & pay (any amount)\n"
-            + "Withdraw: pull L$ from your wallet to your avatar\n"
-            + "SL Group Verify: complete realty-group founder verification",
-            ["Deposit", "Withdraw", "SL Group Verify"], mainChan);
+            + "Withdraw: pull L$ from your wallet to your avatar",
+            ["Deposit", "Withdraw"], mainChan);
     }
 
     listen(integer chan, string name, key id, string msg) {
@@ -803,57 +711,11 @@ default {
             llTextBox(id, "Enter L$ amount to withdraw:", mainChan);
             return;
         }
-        if (msg == "SL Group Verify") {
-            if (SL_GROUP_VERIFY_URL == "") {
-                llDialog(id,
-                    "SL Group Verify is unavailable on this terminal. "
-                    + "Try another SLParcels terminal, or contact SLParcels staff.",
-                    ["OK"], mainChan);
-                if (DEBUG_MODE)
-                    llOwnerSay("SLParcels Terminal: SL Group Verify chosen but "
-                        + "SL_GROUP_VERIFY_URL is empty in the 'config' notecard.");
-                return;
-            }
-            integer vslot = acquireOrResetVerifySlot(id);
-            if (vslot < 0) {
-                llDialog(id, "Terminal busy with SL Group Verify requests, please try another terminal.",
-                    ["OK"], mainChan);
-                return;
-            }
-            llTextBox(id,
-                "Enter the SL Group Verify code from your SL Parcels web UI "
-                + "(format: SLPA-XXXXXXXXXXXX):",
-                mainChan);
-            return;
-        }
 
         // Dispatch by avatar key against per-flow withdraw slots
         integer slotIdx = findSlot(id);
         if (slotIdx < 0) {
-            // Not a withdraw flow — check for a pending SL Group Verify slot.
-            integer vIdx = findVerifySlot(id);
-            if (vIdx < 0) return;
-            // Reject mid-flight verify (one request at a time per terminal).
-            if (verifyReqId != NULL_KEY) {
-                llDialog(id,
-                    "Another SL Group Verify request is in flight on this terminal. "
-                    + "Please wait a moment and try again.",
-                    ["OK"], mainChan);
-                releaseVerifySlot(id);
-                return;
-            }
-            string trimmed = llStringTrim(msg, STRING_TRIM);
-            if (trimmed == "") {
-                llDialog(id, "Verification code cannot be empty.", ["OK"], mainChan);
-                releaseVerifySlot(id);
-                return;
-            }
-            verifyAvatar = id;
-            verifyCode   = trimmed;
-            fireSlGroupVerify();
-            // Note: do NOT releaseVerifySlot yet — the http_response handler
-            // releases on completion. The 60s slot TTL is the upper bound if
-            // the backend never responds (sweeper will reclaim it).
+            // Not a withdraw flow and not a known menu choice — ignore.
             return;
         }
         integer amt = slotAmount(slotIdx);
@@ -1014,61 +876,6 @@ default {
             } else {
                 llOwnerSay("CRITICAL: /payout-result POST failed status="
                     + (string)status);
-            }
-            return;
-        }
-
-        // ----- SL Group Verify response (spec §7.3) -----
-        if (req == verifyReqId) {
-            verifyReqId = NULL_KEY;
-            key avatar = verifyAvatar;
-            verifyAvatar = NULL_KEY;
-            verifyCode = "";
-            // Release the slot first so a follow-up retry from the same
-            // avatar can immediately re-enter.
-            releaseVerifySlot(avatar);
-
-            // Per terminal-output-genericisation policy (commit 5a5276a):
-            // user-facing results go via llDialog [OK] (private to the
-            // toucher), not llRegionSayTo on channel 0 (heard within ~20m).
-            // Backend ProblemDetail title/detail are NOT surfaced to the
-            // toucher; status-keyed canned strings only. Operator triage
-            // detail stays in the DEBUG_MODE llOwnerSay line.
-            if (status == 200) {
-                llDialog(avatar,
-                    "SL group verified. The realty group can now list "
-                    + "parcels owned by this SL group.",
-                    ["OK"], mainChan);
-                if (DEBUG_MODE)
-                    llOwnerSay("SLParcels Terminal: SL Group Verify OK for "
-                        + (string)avatar);
-                return;
-            }
-
-            // Parse ProblemDetail `code` extension (set by RealtyExceptionHandler).
-            string code = llJsonGetValue(body, ["code"]);
-            string failMsg;
-            if (status == 410) {
-                failMsg = "Verification code expired. The realty group "
-                    + "leader needs to start a new registration.";
-            } else if (status == 422 && code == "SL_GROUP_FOUNDER_MISMATCH") {
-                failMsg = "You are not the founder of the SL group "
-                    + "registered with this code.";
-            } else if (status == 404) {
-                // No pending registration matches the code.
-                failMsg = "Verification code not recognised. Check the code "
-                    + "and try again, or ask the realty group leader to "
-                    + "restart the SL group registration.";
-            } else {
-                failMsg = "There was a problem with SL Group Verify. "
-                    + "Check the code and try again.";
-            }
-            llDialog(avatar, failMsg, ["OK"], mainChan);
-            if (DEBUG_MODE) {
-                debugSayUser(avatar, "sl-group-verify", status, body);
-                llOwnerSay("SLParcels Terminal: SL Group Verify failed for "
-                    + (string)avatar + " status=" + (string)status
-                    + " code=" + code);
             }
             return;
         }

--- a/lsl-scripts/verification-terminal/README.md
+++ b/lsl-scripts/verification-terminal/README.md
@@ -1,17 +1,37 @@
 # SLParcels Verification Terminal
 
-In-world account-linking kiosk. Players touch this terminal, type their 6-digit
-SLParcels code, and the script POSTs their avatar metadata to the backend to link
-the SL account to a website account.
+In-world verification kiosk handling two flows:
+
+1. **Self verify** — players touch this terminal, type their 6-digit
+   SLParcels code, and the script POSTs avatar metadata to `/sl/verify`
+   to link the SL account to a website account (Method C).
+2. **SL Group verify** — realty-group founders type the
+   `SLPA-XXXXXXXXXXXX` code their group leader handed them, and the
+   script POSTs to `/sl/sl-group/verify` with the toucher's avatar UUID
+   so the backend can cross-check it against the SL group's founder.
+   Sub-project E spec section 7.3.
+
+If `SL_GROUP_VERIFY_URL` is set in the notecard, touch opens a `llDialog`
+menu so the toucher picks which flow to run. When it's blank, touch goes
+straight to the self-verify text box exactly as before.
 
 ## Architecture summary
 
 - **Trust:** SL-injected `X-SecondLife-Shard` + `X-SecondLife-Owner-Key` headers.
   No shared secret. The terminal must be owned by an SLParcels service avatar listed
-  in `slpa.sl.trusted-owner-keys`.
-- **State machine:** IDLE → (touch) lock + busy chrome → (llTextBox) code entry →
-  (dataserver) DATA_BORN + DATA_PAYINFO → (HTTP) POST /sl/verify → (http_response)
-  speak result → release lock → IDLE.
+  in `slpa.sl.trusted-owner-keys`. Both endpoints (`/sl/verify` and
+  `/sl/sl-group/verify`) accept SL-header trust at `/api/v1/sl/**`, and
+  the verification codes are single-use server-side.
+- **Self-verify state machine:** IDLE → (touch) lock + busy chrome →
+  (llTextBox) code entry → (dataserver) DATA_BORN + DATA_PAYINFO →
+  (HTTP) POST `/sl/verify` → (http_response) speak result → release
+  lock → IDLE.
+- **SL-group-verify state machine:** IDLE → (touch) lock + busy chrome
+  → (llDialog) pick "SL Group" → (llTextBox) `SLPA-...` code entry →
+  (HTTP) POST `/sl/sl-group/verify` with `{ verificationCode,
+  founderAvatarUuid }` → (http_response) speak result → release lock →
+  IDLE. No avatar-data fetch needed — the body is just the code + the
+  toucher's UUID.
 - **Lock:** single-user, 60s TTL. Subsequent touches see "Terminal busy"
   message. Multiple physical terminals at busy locations handle concurrent load.
 
@@ -37,7 +57,8 @@ User-facing kiosk distributed via Marketplace + SLParcels HQ + allied venues.
 
 | Key | Description |
 | --- | --- |
-| `VERIFY_URL` | Full URL of the backend's `/api/v1/sl/verify` endpoint. |
+| `VERIFY_URL` | Full URL of the backend's `/api/v1/sl/verify` endpoint. Required. |
+| `SL_GROUP_VERIFY_URL` | Full URL of `/api/v1/sl/sl-group/verify`. Optional — when blank, the SL-group menu item is hidden and touch goes straight to self-verify. New deployments should set it so realty-group founders can complete verification from this terminal. |
 | `DEBUG_MODE` | `true`/`false`, default `true`. Recommended `true` in prod. |
 
 Editing the notecard auto-resets the script via `CHANGED_INVENTORY`.
@@ -46,13 +67,55 @@ Editing the notecard auto-resets the script via `CHANGED_INVENTORY`.
 
 In steady state:
 
-- `SLParcels Verification Terminal: ready (verify=...)` — startup ping.
+- `SLParcels Verification Terminal: ready (verify=... sl-group=...)` — startup ping. `sl-group=<disabled>` when `SL_GROUP_VERIFY_URL` is blank.
 - `SLParcels Verification Terminal: touch from <name>` — when a user touches.
-- `SLParcels Verification Terminal: verify ok: userId=<n>` — successful link.
-- `SLParcels Verification Terminal: verify denied: <reason>` — backend rejected.
+- `SLParcels Verification Terminal: verify ok: userId=<n>` — successful self-verify link.
+- `SLParcels Verification Terminal: verify denied: <reason>` — backend rejected the self-verify request.
+- `SLParcels Verification Terminal: SL Group Verify OK for <uuid>` — successful founder-terminal verification. The realty group leader can now list parcels owned by that SL group.
+- `SLParcels Verification Terminal: SL Group Verify failed for <uuid> status=... code=... title=... detail=...` — founder-terminal verification rejected. Mapped statuses: 410 (`SL_GROUP_VERIFICATION_EXPIRED`), 422 (`SL_GROUP_FOUNDER_MISMATCH`), 404 (code not recognised). Other statuses fall through to a generic "try again" message to the toucher.
 
 If silent for >5 minutes during expected traffic, check land permissions for
 outbound HTTP and confirm the prim has the script + notecard.
+
+## SL Group Verify (sub-project E spec section 7.3, section 13.3)
+
+Founder-of-an-SL-group verification for realty groups listing parcels under
+case-3 (SL group owns the parcel). The leader of a realty group starts the
+registration in the SLParcels web UI; the SL group's founder finishes it by
+typing the short `SLPA-XXXXXXXXXXXX` code into this terminal.
+
+- **Menu:** touch the terminal → pick **SL Group**.
+- **Input:** the 12-character `SLPA-XXXXXXXXXXXX` code shown on the realty
+  group's SL Groups page after the leader initiates registration. Trimmed
+  of whitespace before send.
+- **Effect:** POSTs `{ verificationCode, founderAvatarUuid }` to
+  `/api/v1/sl/sl-group/verify`. Backend cross-checks the toucher's avatar
+  UUID against the SL group's founder via the World API and, on match,
+  flips the registration row to `verified=true,
+  verified_via=FOUNDER_TERMINAL`.
+- **Toucher-facing outcomes** (`llDialog` `[OK]` — private to the toucher
+  per the terminal-output-genericisation policy in commit 5a5276a):
+  - 200 OK → "SL group verified. The realty group can now list parcels
+    owned by this SL group."
+  - 410 (`SL_GROUP_VERIFICATION_EXPIRED`) → "Verification code expired.
+    The realty group leader needs to start a new registration."
+  - 422 (`SL_GROUP_FOUNDER_MISMATCH`) → "You are not the founder of the SL
+    group registered with this code."
+  - 404 → "Verification code not recognised. Check the code and try again."
+  - 401 / other 4xx → "There was a problem with SL Group Verify. Check the
+    code and try again."
+- **Concurrency:** this terminal is single-user-locked (60s TTL); the same
+  lock that gates self-verify gates SL-group-verify. A founder hitting a
+  busy terminal sees the standard "Terminal already in use" message and
+  should try another nearby terminal.
+- **No new env vars or permissions required.** Backend trust comes from
+  the existing `X-SecondLife-Owner-Key` SL header (validated by
+  `SlHeaderValidator` on `/api/v1/sl/**`). No `sharedSecret` is sent on
+  this path because the controller doesn't read one; the wire shape
+  exactly mirrors `SlGroupVerifyRequest`.
+- **Backward compatibility.** `SL_GROUP_VERIFY_URL` is optional in the
+  notecard. When blank, touch goes straight to the self-verify text box
+  exactly as in pre-port deployments; the SL-group menu item is hidden.
 
 ## Troubleshooting
 
@@ -63,6 +126,9 @@ outbound HTTP and confirm the prim has the script + notecard.
 | Periodic `5xx` responses | Backend issue. Check server logs. |
 | `403` responses | `X-SecondLife-Owner-Key` not in trusted set, or wrong shard. Confirm owner is an SLParcels service avatar. |
 | `✓` never appears after correct code | Possibly the dataserver event for DATA_BORN / DATA_PAYINFO was lost. The 30s data-timeout will fire and speak an error. User can re-touch. |
+| Touch goes straight to text box, no SL Group option | `SL_GROUP_VERIFY_URL` is blank in the notecard. Add the URL, save the notecard, the script auto-resets. |
+| SL Group Verify owner-says `status=401` | Backend `/api/v1/sl/sl-group/verify` rejected at the SL-header gate. Confirm the terminal's owner UUID is in `slpa.sl.trusted-owner-keys`. |
+| SL Group Verify owner-says `status=415` | Backend returned `application/problem+json` for a 4xx. Confirm `SlProblemDetailContentTypeAdvice` covers `/api/v1/sl/sl-group/**` (the path prefix in advice is `/api/v1/sl/**`, so this should be automatic). |
 
 ## Limits
 

--- a/lsl-scripts/verification-terminal/config.notecard.example
+++ b/lsl-scripts/verification-terminal/config.notecard.example
@@ -2,7 +2,14 @@
 # Place this file (renamed to "config", no extension) in the prim's contents.
 # After editing, the script auto-resets via CHANGED_INVENTORY.
 
+# Required: Method C user verify (account linking).
 VERIFY_URL=https://slpa.app/api/v1/sl/verify
+
+# Optional: SL Group Verify (founder-of-an-SL-group verification for realty
+# groups, sub-project E spec section 7.3). When set, touch opens a llDialog
+# menu so the toucher picks Self verify vs SL Group verify. When blank, touch
+# goes straight to the self-verify text box (pre-port behavior).
+SL_GROUP_VERIFY_URL=https://slpa.app/api/v1/sl/sl-group/verify
 
 # Optional: set to "false" in prod to silence per-touch chat.
 DEBUG_MODE=true

--- a/lsl-scripts/verification-terminal/verification-terminal.lsl
+++ b/lsl-scripts/verification-terminal/verification-terminal.lsl
@@ -1,8 +1,25 @@
 // SLParcels Verification Terminal
 //
-// Touch-driven account-linking kiosk. Players touch this terminal, type their
-// 6-digit SLParcels verification code, and the script POSTs avatar metadata to the
-// backend to link the SL account to a website account.
+// Touch-driven verification kiosk for two flows:
+//
+//   1. Self verify   — players touch this terminal, type their 6-digit
+//                      SLParcels code, and the script POSTs avatar metadata
+//                      to /sl/verify to link their SL account to a website
+//                      account (Method C).
+//   2. SL Group verify — realty-group founders type the SLPA-XXXX verification
+//                      code their group leader handed them, and the script
+//                      POSTs to /sl/sl-group/verify with the toucher's avatar
+//                      UUID for the backend to cross-check against the SL
+//                      group's founder (sub-project E spec section 7.3).
+//
+// If SL_GROUP_VERIFY_URL is empty in the notecard, the terminal behaves
+// exactly as before — touch goes straight to the self-verify text box. If
+// SL_GROUP_VERIFY_URL is set, touch opens a llDialog menu so the toucher
+// picks which flow they want.
+//
+// Trust model: SL-injected X-SecondLife-Shard + X-SecondLife-Owner-Key.
+// No shared secret in the notecard — both backend endpoints accept SL-header
+// trust at /api/v1/sl/**, and the verification codes are single-use server-side.
 //
 // Configuration is loaded from a notecard named "config" in the same prim.
 // See README.md for deployment and operations details.
@@ -14,8 +31,17 @@
 // SlHeaderValidator on every inbound request.
 
 // === Configuration loaded from notecard ===
-string  VERIFY_URL    = "";
-integer DEBUG_MODE = TRUE;
+string  VERIFY_URL          = "";
+// Sub-project E spec section 7.3, section 13.3. Optional; when blank, the
+// SL-group verify menu item is hidden and touch goes straight to self-verify.
+string  SL_GROUP_VERIFY_URL = "";
+integer DEBUG_MODE          = TRUE;
+
+// === Flow mode (set when the user picks from the top-level menu) ===
+integer MODE_NONE  = 0;
+integer MODE_SELF  = 1;
+integer MODE_GROUP = 2;
+integer mode       = 0;
 
 // === Notecard reading state ===
 key     notecardLineRequest = NULL_KEY;
@@ -71,7 +97,8 @@ parseConfigLine(string line) {
     string cfgKey = llStringTrim(llGetSubString(line, 0, eq - 1), STRING_TRIM);
     string val = llStringTrim(llGetSubString(line, eq + 1, -1), STRING_TRIM);
 
-    if (cfgKey == "VERIFY_URL")     VERIFY_URL = val;
+    if (cfgKey == "VERIFY_URL")            VERIFY_URL          = val;
+    else if (cfgKey == "SL_GROUP_VERIFY_URL") SL_GROUP_VERIFY_URL = val;
     else if (cfgKey == "DEBUG_MODE")
         DEBUG_MODE = (val == "true" || val == "TRUE" || val == "1");
 }
@@ -98,6 +125,8 @@ releaseLock() {
     payArrived     = FALSE;
     bornReqKey     = NULL_KEY;
     payReqKey      = NULL_KEY;
+    mode           = MODE_NONE;
+    storedCode     = "";
     timerPhase     = 0;
     llSetTimerEvent(0);
     setIdleChrome();
@@ -137,6 +166,24 @@ postVerifyRequest() {
         body);
 }
 
+// Sub-project E spec section 7.3: founder-of-an-SL-group verification.
+// Body shape matches the @RequestBody DTO on SlGroupVerifyController exactly.
+// No shared secret in the body -- the controller doesn't read it; trust comes
+// from the SL-injected X-SecondLife-Owner-Key + X-SecondLife-Shard headers
+// (checked at /api/v1/sl/** via SlHeaderValidator).
+postSlGroupVerifyRequest() {
+    string body = "{"
+        + "\"verificationCode\":\"" + escapeJson(storedCode) + "\","
+        + "\"founderAvatarUuid\":\"" + (string)storedAvatarUuid + "\""
+        + "}";
+
+    httpReqId = llHTTPRequest(SL_GROUP_VERIFY_URL,
+        [HTTP_METHOD, "POST",
+         HTTP_MIMETYPE, "application/json",
+         HTTP_BODY_MAXLENGTH, 16384],
+        body);
+}
+
 // ---------------------------------------------------------------------------
 // Default state
 // ---------------------------------------------------------------------------
@@ -144,8 +191,10 @@ postVerifyRequest() {
 default {
     state_entry() {
         // Initialize all globals to sentinel values.
-        VERIFY_URL       = "";
-        DEBUG_MODE  = TRUE;
+        VERIFY_URL          = "";
+        SL_GROUP_VERIFY_URL = "";
+        DEBUG_MODE          = TRUE;
+        mode                = MODE_NONE;
         lockHolder       = NULL_KEY;
         lockHolderName   = "";
         lockExpiresAt    = 0;
@@ -192,8 +241,13 @@ default {
                     llOwnerSay("SLParcels Verification Terminal: incomplete config. VERIFY_URL required.");
                     return;
                 }
-                if (DEBUG_MODE)
-                    llOwnerSay("SLParcels Verification Terminal: ready (verify=" + VERIFY_URL + ")");
+                if (DEBUG_MODE) {
+                    string slGroupReady;
+                    if (SL_GROUP_VERIFY_URL == "") slGroupReady = " sl-group=<disabled>";
+                    else slGroupReady = " sl-group=" + SL_GROUP_VERIFY_URL;
+                    llOwnerSay("SLParcels Verification Terminal: ready (verify=" + VERIFY_URL
+                        + slGroupReady + ")");
+                }
                 return;
             }
             parseConfigLine(data);
@@ -246,7 +300,20 @@ default {
             llOwnerSay("SLParcels Verification Terminal: touch from " + toucherName);
 
         listenHandle = llListen(menuChan, "", lockHolder, "");
-        llTextBox(lockHolder, "Enter your 6-digit SLParcels code:", menuChan);
+
+        // If SL Group Verify is configured, the toucher picks which flow to
+        // run. Otherwise default to self-verify exactly like pre-port behavior.
+        if (SL_GROUP_VERIFY_URL != "") {
+            mode = MODE_NONE;
+            llDialog(lockHolder,
+                "What would you like to verify?\n\n"
+                + "Self: link your SL avatar to your SLParcels account.\n"
+                + "SL Group: complete realty-group founder verification.",
+                ["Self", "SL Group"], menuChan);
+        } else {
+            mode = MODE_SELF;
+            llTextBox(lockHolder, "Enter your 6-digit SLParcels code:", menuChan);
+        }
 
         // Start lock-TTL timer (60s). Replaced by 30s data timer after code entry.
         timerPhase = TIMER_LOCK;
@@ -257,10 +324,53 @@ default {
         // Only handle our channel and our lock holder.
         if (channel != menuChan || id != lockHolder) return;
 
+        // Top-level menu choice (only reachable when SL_GROUP_VERIFY_URL is set).
+        if (mode == MODE_NONE) {
+            if (message == "Self") {
+                mode = MODE_SELF;
+                // Re-listen for the code entry on the same channel.
+                listenHandle = llListen(menuChan, "", lockHolder, "");
+                llTextBox(lockHolder, "Enter your 6-digit SLParcels code:", menuChan);
+                return;
+            }
+            if (message == "SL Group") {
+                mode = MODE_GROUP;
+                listenHandle = llListen(menuChan, "", lockHolder, "");
+                llTextBox(lockHolder,
+                    "Enter the SL Group Verify code from your SL Parcels web UI "
+                    + "(format: SLPA-XXXXXXXXXXXX):",
+                    menuChan);
+                return;
+            }
+            // Unrecognized menu reply -- release lock so the toucher can retry.
+            releaseLock();
+            return;
+        }
+
         // Remove the listen immediately — one shot.
         llListenRemove(listenHandle);
         listenHandle = -1;
 
+        if (mode == MODE_GROUP) {
+            string trimmed = llStringTrim(message, STRING_TRIM);
+            if (trimmed == "") {
+                llDialog(lockHolder, "Verification code cannot be empty.",
+                    ["OK"], menuChan);
+                releaseLock();
+                return;
+            }
+            storedCode = trimmed;
+            // No avatar-data fetch needed for SL group verify -- the body
+            // is just { verificationCode, founderAvatarUuid } and we already
+            // have storedAvatarUuid from touch_start.
+            postSlGroupVerifyRequest();
+            // Switch to 30s HTTP-response timeout (re-using TIMER_DATA phase).
+            timerPhase = TIMER_DATA;
+            llSetTimerEvent(30.0);
+            return;
+        }
+
+        // MODE_SELF: original 6-digit-code account-linking flow.
         if (!isSixDigitCode(message)) {
             llDialog(lockHolder, "Your verification code must be 6 digits. Please try again.", ["OK"], menuChan);
             releaseLock();
@@ -284,6 +394,53 @@ default {
         if (req != httpReqId) return;
         httpReqId = NULL_KEY;
 
+        if (mode == MODE_GROUP) {
+            // Sub-project E spec section 7.3 response handling. Per
+            // terminal-output-genericisation policy: user-facing results go
+            // via llDialog (private to the toucher), backend ProblemDetail
+            // title/detail stay in DEBUG_MODE owner-say only.
+            if (status == 200) {
+                llDialog(lockHolder,
+                    "SL group verified. The realty group can now list "
+                    + "parcels owned by this SL group.",
+                    ["OK"], menuChan);
+                if (DEBUG_MODE)
+                    llOwnerSay("SLParcels Verification Terminal: SL Group Verify OK for "
+                        + (string)storedAvatarUuid);
+            } else {
+                string gcode = llJsonGetValue(body, ["code"]);
+                string failMsg;
+                if (status == 410) {
+                    failMsg = "Verification code expired. The realty group "
+                        + "leader needs to start a new registration.";
+                } else if (status == 422 && gcode == "SL_GROUP_FOUNDER_MISMATCH") {
+                    failMsg = "You are not the founder of the SL group "
+                        + "registered with this code.";
+                } else if (status == 404) {
+                    failMsg = "Verification code not recognised. Check the code "
+                        + "and try again, or ask the realty group leader to "
+                        + "restart the SL group registration.";
+                } else {
+                    failMsg = "There was a problem with SL Group Verify. "
+                        + "Check the code and try again.";
+                }
+                llDialog(lockHolder, failMsg, ["OK"], menuChan);
+                if (DEBUG_MODE) {
+                    string gtitle  = llJsonGetValue(body, ["title"]);
+                    string gdetail = llJsonGetValue(body, ["detail"]);
+                    llOwnerSay("SLParcels Verification Terminal: SL Group Verify failed "
+                        + "for " + (string)storedAvatarUuid
+                        + " status=" + (string)status
+                        + " code=" + gcode
+                        + " title=" + gtitle
+                        + " detail=" + gdetail);
+                }
+            }
+            releaseLock();
+            return;
+        }
+
+        // MODE_SELF: original account-linking response handling.
         if (status == 200) {
             string verified    = llJsonGetValue(body, ["verified"]);
             string userId      = llJsonGetValue(body, ["userId"]);
@@ -329,10 +486,19 @@ default {
 
     timer() {
         if (timerPhase == TIMER_DATA) {
-            // Avatar data (DATA_BORN / DATA_PAYINFO) didn't arrive in time.
-            llDialog(lockHolder,
-                "We couldn't read your avatar data. Please try again.",
-                ["OK"], menuChan);
+            // MODE_SELF: avatar data (DATA_BORN / DATA_PAYINFO) didn't arrive.
+            // MODE_GROUP: HTTP response from /sl/sl-group/verify didn't arrive.
+            // Both surface the same generic "try again" so we don't leak
+            // implementation details to the toucher.
+            if (mode == MODE_GROUP) {
+                llDialog(lockHolder,
+                    "SL Group Verify took too long to respond. Please try again.",
+                    ["OK"], menuChan);
+            } else {
+                llDialog(lockHolder,
+                    "We couldn't read your avatar data. Please try again.",
+                    ["OK"], menuChan);
+            }
             releaseLock();
         } else {
             // TIMER_LOCK — 60s passed with no progress (user walked away, etc.).


### PR DESCRIPTION
Move the founder-of-an-SL-group verify flow from `lsl-scripts/slpa-terminal/` to `lsl-scripts/verification-terminal/`. UX correction — the verification flow now lives on the kiosk that says "verification" on it.

## Why

E originally bolted group verify onto the slpa-terminal because the shared-secret + SL-header pipeline was already there. That was a code-reuse choice masquerading as a UX choice. A user walking into the SLParcels building, seeing both terminals side by side, reasonably picks the verification-labelled kiosk to verify their group. We were violating the principle of least astonishment for ~50 lines of saved LSL.

## What moved

- `verification-terminal.lsl`: new `mode` (MODE_SELF / MODE_GROUP), touch opens `llDialog [Self, SL Group]` when `SL_GROUP_VERIFY_URL` is set; otherwise touch goes straight to self-verify (pre-port behavior). New `postSlGroupVerifyRequest()` mirrors the spec section 7.3 wire shape. `http_response` branches on `mode`; timer error message likewise.
- `slpa-terminal.lsl`: removed `SL_GROUP_VERIFY_URL` config, `verifySessions` slot list, verify helpers, the "SL Group Verify" menu option + listen branch, the `verifyReqId` http_response branch, and the verify-slot sweep. Menu is back to `[Deposit, Withdraw]`. ~190 lines removed.
- Both READMEs + notecard examples updated. Backend endpoint `/api/v1/sl/sl-group/verify` unchanged.
- Postman cloud collection request description updated via MCP to point at the verification-terminal.
- `docs/implementation/FOOTGUNS.md` gains G.4 explaining the placement so future authors don't reflexively shove group-only flows back onto the L\$ terminal.

## Trust posture (unchanged)

Both endpoints still accept SL-header trust at `/api/v1/sl/**`. No shared secret in the body — the `SlGroupVerifyController` doesn't read one, and the verification-terminal already lacks the slpa-terminal's `SHARED_SECRET` config field. SL-injected `X-SecondLife-Owner-Key` + `X-SecondLife-Shard` are the trust gate.

## Manual ops (post-deploy)

- Set `SL_GROUP_VERIFY_URL=https://slpa.app/api/v1/sl/sl-group/verify` in each deployed **verification-terminal**'s `config` notecard.
- Optionally remove the now-orphaned `SL_GROUP_VERIFY_URL` row from each **slpa-terminal**'s `config` notecard (harmless if left — the parser just no longer reads it).
- Notecard save auto-resets the script via `CHANGED_INVENTORY`.

## Risk

- No DB migrations. No bot / frontend / backend behavior change.
- LSL is not automated-tested; verification is read-back + in-world smoke test on next deploy.
- Backward compatible: blank `SL_GROUP_VERIFY_URL` on the verification-terminal preserves pre-port single-purpose self-verify behavior.