### PR TITLE
fix(auth): wipe React Query cache on logout (session leak)

### DIFF
--- a/docs/implementation/FOOTGUNS.md
+++ b/docs/implementation/FOOTGUNS.md
@@ -1814,6 +1814,44 @@ sellers start complaining about surprise cancellations, add a countdown
 indicator to the seller's listing detail page. Until then, operations
 can dial the cutoff up before user-facing UI lands.
 
+### F.112 — Logout must `queryClient.clear()` so per-user caches don't leak across sessions
+
+**Symptom shipped to prod:** after sign-out + page reload, the wallet
+balance pill still showed L$ from the previous user, and direct navigation
+to `/wallet` rendered the prior user's balance from cache.
+
+**Why:** `useLogout` (and `useLogoutAll`, and the 401 refresh-failed
+branch in `lib/auth/refresh.ts`) were only doing
+`setAccessToken(null) + setQueryData(["auth","session"], null)`. They
+were NOT clearing the rest of the React Query cache. So:
+
+- `useCurrentUser` is cached under `["currentUser"]` with
+  `gcTime: Number.POSITIVE_INFINITY` — its data NEVER ages out.
+- `useWallet` is cached under `["me","wallet"]` with default 5-minute
+  gcTime.
+- `["me","wallet","ledger",...]` pages, dashboard rows, and every other
+  authenticated-only query had the same survival problem.
+
+After logout the auth session flipped to "unauthenticated", but those
+cached entries kept serving the previous user's data to any consumer
+that mounted afterwards. The `/wallet` page's guard
+(`if (isPending || !user)`) depended on `useCurrentUser` data, which
+showed the stale verified-user; the page rendered, the wallet pill
+queried the same cached entries, balance from prior session displayed.
+
+**How to apply:** any code path that takes the user from "authenticated"
+to "unauthenticated" — explicit logout, logout-all, refresh failure —
+MUST call `queryClient.clear()` BEFORE re-establishing the null auth
+session entry. Order matters: `clear()` removes every entry including
+the auth one, then `setQueryData(SESSION_QUERY_KEY, null)` re-establishes
+the explicit null sentinel that `useAuth()` reads as "unauthenticated"
+without triggering a fresh bootstrap.
+
+Authenticated-only pages should also gate on `useAuth()` directly (not
+just on `useCurrentUser` data) so a future cache-clearing regression
+can't render cached content. See `app/wallet/page.tsx` for the canonical
+pattern.
+
 ## §G Realty groups
 
 ### G.1 `runZeroPayoutSuccessInline` is the entire post-payout work for case-3 escrows

--- a/frontend/src/app/wallet/page.tsx
+++ b/frontend/src/app/wallet/page.tsx
@@ -2,19 +2,35 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useAuth } from "@/lib/auth";
 import { useCurrentUser } from "@/lib/user";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { WalletPanel } from "@/components/wallet/WalletPanel";
 
 export default function WalletPage() {
   const router = useRouter();
+  const session = useAuth();
   const { data: user, isPending, isError } = useCurrentUser();
 
+  // Auth-state guard runs first: an unauthenticated viewer must never see the
+  // wallet, not even cached content from a prior session. The session check
+  // dispatches the redirect before useCurrentUser's enabled-gated state has a
+  // chance to render a stale-cache balance.
   useEffect(() => {
+    if (session.status === "unauthenticated") {
+      router.replace("/login?next=/wallet");
+      return;
+    }
     if (isPending || isError) return;
     if (!user?.verified) router.replace("/dashboard/verify");
-  }, [isPending, isError, user?.verified, router]);
+  }, [session.status, isPending, isError, user?.verified, router]);
 
+  if (session.status === "loading") {
+    return <LoadingSpinner label="Loading wallet..." />;
+  }
+  if (session.status === "unauthenticated") {
+    return <LoadingSpinner label="Redirecting to sign in..." />;
+  }
   if (isPending || !user) return <LoadingSpinner label="Loading wallet..." />;
   if (!user.verified) return <LoadingSpinner label="Redirecting..." />;
 

--- a/frontend/src/lib/auth/hooks.test.tsx
+++ b/frontend/src/lib/auth/hooks.test.tsx
@@ -149,6 +149,42 @@ describe("useLogout", () => {
       expect(queryClient.getQueryData(["auth", "session"])).toBeNull();
     });
   });
+
+  it("wipes per-user query caches so cached data does not survive into the unauthenticated state", async () => {
+    server.use(
+      http.post("*/api/v1/auth/logout", () => HttpResponse.json({}, { status: 200 }))
+    );
+
+    setAccessToken("some-token");
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(["auth", "session"], { id: 1, username: "test-user" });
+    // Seed per-user caches that historically survived logout because their
+    // gcTime outlived the auth flip (currentUser, wallet, ledger, etc.).
+    queryClient.setQueryData(["currentUser"], { id: 1, verified: true });
+    queryClient.setQueryData(["me", "wallet"], { balance: 4200, available: 4200 });
+    queryClient.setQueryData(["me", "wallet", "ledger", null, 0, 20], { rows: [] });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useLogout(), { wrapper });
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(["auth", "session"])).toBeNull();
+    });
+
+    // No per-user residue. queryClient.clear() removed every cache entry; the
+    // auth session is then re-established as the explicit null sentinel.
+    expect(queryClient.getQueryData(["currentUser"])).toBeUndefined();
+    expect(queryClient.getQueryData(["me", "wallet"])).toBeUndefined();
+    expect(
+      queryClient.getQueryData(["me", "wallet", "ledger", null, 0, 20]),
+    ).toBeUndefined();
+  });
 });
 
 describe("useForgotPassword", () => {

--- a/frontend/src/lib/auth/hooks.ts
+++ b/frontend/src/lib/auth/hooks.ts
@@ -107,8 +107,14 @@ export function useRegister() {
  * Out" expects to be logged out regardless of whether the backend acknowledged
  * the POST.
  *
- * Uses setQueryData(null) only (no removeQueries) for consistency with the
- * 401 interceptor's pattern. The null guard in useAuth handles the null state.
+ * Calls `queryClient.clear()` to wipe every cached query, then re-establishes
+ * the auth session entry as `null` so useAuth() returns "unauthenticated"
+ * without triggering a bootstrap. Without the clear, cached per-user data
+ * (currentUser with `gcTime: Infinity`, the user's wallet view, the user's
+ * ledger pages, the dashboard, etc.) survives logout and gets served from
+ * cache on the next render — most visibly the wallet balance pill and the
+ * /wallet page guard, which keys "is this user verified?" off `useCurrentUser`
+ * data that outlives the logout when not explicitly cleared.
  *
  * See FOOTGUNS §F.11.
  */
@@ -119,6 +125,7 @@ export function useLogout() {
     mutationFn: () => authApi.logout(),
     onSettled: () => {
       setAccessToken(null);
+      queryClient.clear();
       queryClient.setQueryData(SESSION_QUERY_KEY, null);
       router.push("/");
     },
@@ -150,6 +157,7 @@ export function useLogoutAll() {
     },
     onSettled: () => {
       setAccessToken(null);
+      queryClient.clear();
       queryClient.setQueryData(SESSION_QUERY_KEY, null);
       router.push("/");
     },

--- a/frontend/src/lib/auth/refresh.ts
+++ b/frontend/src/lib/auth/refresh.ts
@@ -55,6 +55,11 @@ export async function ensureFreshAccessToken(): Promise<string> {
       if (!response.ok) {
         setAccessToken(null);
         if (queryClientRef) {
+          // The refresh cookie is invalid / revoked / expired — session is
+          // dead. Wipe every cached query before re-establishing the null
+          // auth entry so per-user caches (currentUser, wallet, ledger,
+          // dashboard, etc.) don't survive into the unauthenticated state.
+          queryClientRef.clear();
           queryClientRef.setQueryData(SESSION_QUERY_KEY, null);
         }
         throw new RefreshFailedError(response.status);


### PR DESCRIPTION
Security fix for a session-bleed between users. After sign-out + page reload, the wallet pill kept showing the previous user's L\$ balance, and direct navigation to `/wallet` rendered the prior session's wallet from cache.

## Root cause

`useLogout` / `useLogoutAll` / the 401 refresh-failed branch only cleared the in-memory access token and the `["auth","session"]` cache entry. Per-user queries (currentUser with `gcTime: Infinity`, `["me","wallet"]`, ledger pages, dashboard rows) were never wiped, so the next render served them from cache to the anonymous viewer.

## Fix (commit `1045e368`)

- `useLogout` / `useLogoutAll`: `queryClient.clear()` before re-establishing the null auth-session sentinel.
- `lib/auth/refresh.ts`: same `clear()` in the refresh-failed branch — silent session expiry treated identically to explicit logout.
- `app/wallet/page.tsx`: gate on `useAuth()` directly and redirect to `/login?next=/wallet` on unauthenticated. Belt + suspenders so a future cache-clear regression cannot re-leak.
- New regression test in `hooks.test.tsx` seeds `["currentUser"]` / `["me","wallet"]` / a ledger page, fires `useLogout`, asserts all three are undefined afterward.
- `FOOTGUNS §F.112` documents the trap.

## Risk

- No DB migrations. No backend changes. Frontend only.
- `queryClient.clear()` is a one-shot wipe at logout — no in-flight query side effects.
- Existing test for `useLogout` (auth-session cleared, token nulled) still passes.