### PR TITLE
fix(groups): constrain hero cover to match column width

### DIFF
--- a/frontend/src/components/realty/browse/PublicGroupProfile.tsx
+++ b/frontend/src/components/realty/browse/PublicGroupProfile.tsx
@@ -80,16 +80,18 @@ export function PublicGroupProfile({ group }: PublicGroupProfileProps) {
 
   return (
     <div>
-      <RealtyGroupHeroBanner
-        name={group.name}
-        slug={group.slug}
-        description={group.description}
-        website={group.website}
-        memberSince={group.memberSince}
-        memberCount={group.memberCount}
-        coverUrl={group.coverUrl}
-        logoUrl={group.logoUrl}
-      />
+      <div className="mx-auto w-full max-w-5xl px-4 sm:px-6">
+        <RealtyGroupHeroBanner
+          name={group.name}
+          slug={group.slug}
+          description={group.description}
+          website={group.website}
+          memberSince={group.memberSince}
+          memberCount={group.memberCount}
+          coverUrl={group.coverUrl}
+          logoUrl={group.logoUrl}
+        />
+      </div>
 
       <div className="mx-auto w-full max-w-5xl px-4 sm:px-6 mt-6">
         <div className="flex flex-wrap items-center justify-between gap-3 mb-5">


### PR DESCRIPTION
Wraps RealtyGroupHeroBanner on /groups/[slug] in mx-auto max-w-5xl px-4 sm:px-6 so the cover aligns with the stat grid + tabs column below instead of bleeding edge-to-edge across the viewport.