### PR TITLE
fix(groups): card image URLs + object-contain for cover thumbnails

### DIFF
--- a/frontend/src/components/realty/GroupProfileForm.tsx
+++ b/frontend/src/components/realty/GroupProfileForm.tsx
@@ -191,7 +191,7 @@ export function GroupProfileForm({
                 <img
                   src={apiUrl(group.coverUrl) ?? undefined}
                   alt={`${group.name} cover`}
-                  className="aspect-[16/5] w-full rounded border border-border object-cover"
+                  className="aspect-[16/5] w-full rounded border border-border bg-bg-hover object-contain"
                   data-testid="group-profile-cover-preview"
                 />
               ) : (

--- a/frontend/src/components/realty/RealtyGroupHeroBanner.tsx
+++ b/frontend/src/components/realty/RealtyGroupHeroBanner.tsx
@@ -82,7 +82,7 @@ export function RealtyGroupHeroBanner({
           <img
             src={resolvedCover}
             alt=""
-            className="h-full w-full object-cover"
+            className="h-full w-full object-contain"
             aria-hidden="true"
             loading="lazy"
             data-testid="realty-group-hero-cover"

--- a/frontend/src/components/realty/browse/components/GroupCover.tsx
+++ b/frontend/src/components/realty/browse/components/GroupCover.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { apiUrl } from "@/lib/api/url";
+
 interface GroupCoverProps {
   coverUrl?: string | null;
   size?: "card" | "hero";
@@ -7,11 +9,12 @@ interface GroupCoverProps {
 
 export function GroupCover({ coverUrl, size = "card" }: GroupCoverProps) {
   const heightClass = size === "hero" ? "h-[200px]" : "h-[92px]";
+  const resolved = apiUrl(coverUrl ?? null);
 
-  if (coverUrl) {
+  if (resolved) {
     return (
-      <div className={`relative w-full ${heightClass} overflow-hidden`}>
-        <img src={coverUrl} alt="" className="w-full h-full object-cover" />
+      <div className={`relative w-full ${heightClass} overflow-hidden bg-bg-hover`}>
+        <img src={resolved} alt="" className="w-full h-full object-contain" />
       </div>
     );
   }

--- a/frontend/src/components/realty/browse/components/GroupLogo.tsx
+++ b/frontend/src/components/realty/browse/components/GroupLogo.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { apiUrl } from "@/lib/api/url";
 import { initialsOf } from "../lib/format";
 
 interface GroupLogoProps {
@@ -17,12 +18,13 @@ const SIZE: Record<NonNullable<GroupLogoProps["size"]>, string> = {
 };
 
 export function GroupLogo({ name, logoUrl, size = "md", square }: GroupLogoProps) {
-  if (logoUrl) {
+  const resolved = apiUrl(logoUrl ?? null);
+  if (resolved) {
     return (
       <img
-        src={logoUrl}
+        src={resolved}
         alt={`${name} logo`}
-        className={`${SIZE[size]} shrink-0 object-cover ${square ? "" : "rounded-lg"}`}
+        className={`${SIZE[size]} shrink-0 object-contain bg-surface-raised border border-border ${square ? "" : "rounded-lg"}`}
       />
     );
   }


### PR DESCRIPTION
Two bugs:

1. **Logos + cover thumbnails missing on `/groups` directory cards.** Template-ported `GroupLogo` + `GroupCover` used raw relative URLs the backend emits (`/api/v1/realty-groups/{id}/{logo|cover}/image`); the browser resolved them against the page origin (Amplify), which doesn't proxy `/api/*`, so the requests 404'd silently. Wrapped both with `apiUrl()`.
2. **Cover image cropped on `/groups/[slug]` + `/groups/[slug]/manage/profile`.** `object-cover` was chopping the sides off non-16:5 uploads. Switched cover `<img>` elements to `object-contain` (browse `GroupCover`, `RealtyGroupHeroBanner` on public profile + admin detail, `GroupProfileForm` preview) so the whole image fits inside its fixed-aspect box. Added a subtle background so letterboxed bars match the page chrome.

Logos in the browse cards also moved to `object-contain` so non-square uploads aren't clipped at the card level.