### PR TITLE
fix(groups): no-store cache for authenticated group endpoints

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/realty/controller/RealtyGroupPublicController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/controller/RealtyGroupPublicController.java
@@ -54,7 +54,7 @@ public class RealtyGroupPublicController {
         if (group.isDissolved()) {
             throw new GroupDissolvedException(group.getPublicId());
         }
-        return cached(mapper.toPublicDto(group, callerId(principal), isAdmin(principal)));
+        return cached(mapper.toPublicDto(group, callerId(principal), isAdmin(principal)), principal);
     }
 
     @GetMapping("/by-slug/{slug}")
@@ -73,12 +73,12 @@ public class RealtyGroupPublicController {
                     .orElseThrow(() -> new RealtyGroupNotFoundException(slug));
                 throw new GroupDissolvedException(dissolved.getPublicId());
             });
-        return cached(mapper.toPublicDto(group, callerId(principal), isAdmin(principal)));
+        return cached(mapper.toPublicDto(group, callerId(principal), isAdmin(principal)), principal);
     }
 
     @GetMapping("/{publicId}/members")
     @Transactional(readOnly = true)
-    public List<AgentCardDto> getMembers(
+    public ResponseEntity<List<AgentCardDto>> getMembers(
             @PathVariable UUID publicId,
             @AuthenticationPrincipal AuthPrincipal principal) {
         RealtyGroup group = groups.findByPublicId(publicId)
@@ -86,7 +86,16 @@ public class RealtyGroupPublicController {
         if (group.isDissolved()) {
             throw new GroupDissolvedException(group.getPublicId());
         }
-        return mapper.toAgentCards(group, callerId(principal), isAdmin(principal));
+        List<AgentCardDto> body = mapper.toAgentCards(group, callerId(principal), isAdmin(principal));
+        // Same caller-dependent body as the group-by-slug / by-publicId
+        // endpoints (members see commission rates + joinedAt, anonymous
+        // viewers don't). Same cache rule: public for anonymous, no-store
+        // for authenticated so a fresh PATCH is never masked by a stale
+        // cached response.
+        CacheControl cache = principal == null
+            ? CacheControl.maxAge(60, TimeUnit.SECONDS).cachePublic()
+            : CacheControl.noStore();
+        return ResponseEntity.ok().cacheControl(cache).body(body);
     }
 
     // ─────────────────────── helpers ───────────────────────
@@ -99,9 +108,42 @@ public class RealtyGroupPublicController {
         return principal != null && principal.role() == Role.ADMIN;
     }
 
-    private static ResponseEntity<RealtyGroupPublicDto> cached(RealtyGroupPublicDto body) {
+    /**
+     * Cache-Control for {@code getByPublicId} / {@code getBySlug}.
+     *
+     * <p>The response body depends on the caller's identity — members and
+     * admins see {@code agentCommissionRate}, {@code joinedAt}, and the full
+     * agent {@code permissions} flag set on each {@link AgentCardDto}, while
+     * anonymous (and non-member, non-admin) callers see those fields nulled
+     * out by the privacy gate in {@link RealtyGroupDtoMapper}.
+     *
+     * <p>A {@code public, max-age=N} header would let a shared cache (CDN /
+     * Amplify edge) serve one variant to every caller regardless of auth,
+     * which:
+     * <ul>
+     *   <li>leaks the member view ({@code agentCommissionRate} populated) to
+     *       anonymous viewers when an authenticated request warmed the
+     *       cache, and</li>
+     *   <li>masks a fresh write — a leader who PATCHes a commission rate
+     *       and immediately re-fetches the group could see the stale
+     *       anonymous-view response cached during the previous window.</li>
+     * </ul>
+     *
+     * <p>Fix: anonymous responses are publicly cacheable for 60 s (the body
+     * is the same for every anonymous caller, and these surfaces dominate
+     * the request volume); authenticated responses set {@code no-store} so
+     * each member/admin request goes to origin and reflects the latest
+     * server state.
+     */
+    private static ResponseEntity<RealtyGroupPublicDto> cached(
+            RealtyGroupPublicDto body, AuthPrincipal principal) {
+        if (principal == null) {
+            return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(60, TimeUnit.SECONDS).cachePublic())
+                .body(body);
+        }
         return ResponseEntity.ok()
-            .cacheControl(CacheControl.maxAge(60, TimeUnit.SECONDS).cachePublic())
+            .cacheControl(CacheControl.noStore())
             .body(body);
     }
 }

--- a/backend/src/test/java/com/slparcelauctions/backend/realty/controller/RealtyGroupPublicControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/realty/controller/RealtyGroupPublicControllerSliceTest.java
@@ -126,6 +126,44 @@ class RealtyGroupPublicControllerSliceTest {
     }
 
     @Test
+    void getByPublicId_authenticated_setsNoStoreSoFreshWritesAreNotMaskedByCache() throws Exception {
+        // Response body for an authenticated caller depends on membership +
+        // admin role (commission rate, joinedAt, permissions all gated). A
+        // shared cache with a public max-age would either leak the member
+        // view to anonymous viewers or hide a fresh PATCH (e.g. a leader
+        // updating a commission rate then re-fetching). The fix sets
+        // Cache-Control: no-store for any authenticated request so each
+        // member/admin response is fresh from origin.
+        mvc.perform(get("/api/v1/realty-groups/" + group.getPublicId())
+                .header("Authorization", "Bearer " + agentJwt))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Cache-Control", "no-store"));
+    }
+
+    @Test
+    void getBySlug_authenticated_setsNoStore() throws Exception {
+        mvc.perform(get("/api/v1/realty-groups/by-slug/" + group.getSlug())
+                .header("Authorization", "Bearer " + agentJwt))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Cache-Control", "no-store"));
+    }
+
+    @Test
+    void getMembers_authenticated_setsNoStore() throws Exception {
+        mvc.perform(get("/api/v1/realty-groups/" + group.getPublicId() + "/members")
+                .header("Authorization", "Bearer " + agentJwt))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Cache-Control", "no-store"));
+    }
+
+    @Test
+    void getMembers_anonymous_setsPublicMaxAge() throws Exception {
+        mvc.perform(get("/api/v1/realty-groups/" + group.getPublicId() + "/members"))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Cache-Control", "max-age=60, public"));
+    }
+
+    @Test
     void getByPublicId_nonMemberAuthenticated_hidesPermissionsAndJoinedAt() throws Exception {
         mvc.perform(get("/api/v1/realty-groups/" + group.getPublicId())
                 .header("Authorization", "Bearer " + outsiderJwt))


### PR DESCRIPTION
Leader PATCH'd a commission rate, immediately re-fetched, saw rate come back null. Root cause: `RealtyGroupPublicController` returned `Cache-Control: max-age=60, public` on responses whose body depends on the caller (privacy gate nulls `agentCommissionRate` / `joinedAt` / `permissions` for anonymous + non-member viewers). The shared-cache header masked fresh writes AND could leak the member view to anonymous viewers via a CDN-warmed entry.

Fix:
- Anonymous callers keep `public, max-age=60` (anonymous body is identical for every caller; valuable at the edge).
- Authenticated callers get `no-store` (each request goes to origin; no stale + no cross-user leak).
- `/{publicId}/members` previously had no Cache-Control at all → same auth-aware rule.

Audit of related surfaces: `FeaturedController`, `AuctionSearchController`, `SearchSuggestController`, `PublicStatsController`, `RealtyGroupAffiliationController`, `RealtyGroupImageController` are auth-independent; `OnboardingController` already used `cachePrivate`. No other endpoints combined auth-dependent body + public cache.

15/15 `RealtyGroupPublicControllerSliceTest` passing (4 new assertions covering the auth-aware Cache-Control branch).