### PR TITLE
fix(auth): api client awaits auth bootstrap before reading access token

### DIFF
--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from "next-themes";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState, type ReactNode } from "react";
 import { configureApiClient } from "@/lib/api";
+import { beginAuthBootstrap } from "@/lib/auth/session";
 import { ToastProvider } from "@/components/ui/Toast";
 import { CuratorTrayMount } from "@/components/curator/CuratorTrayMount";
 import { useNotificationStream } from "@/hooks/notifications/useNotificationStream";
@@ -27,6 +28,18 @@ export function Providers({ children }: { children: ReactNode }) {
     // Wire the API client to the QueryClient so the 401 interceptor can
     // update session cache state on failed refresh. See FOOTGUNS §F.3.
     configureApiClient(client);
+    // Open the auth-ready gate. Subsequent api.* calls await this until the
+    // bootstrap query (useAuth -> bootstrapSession) resolves and calls
+    // markAuthReady() in its finally. Before this gate existed, any useQuery
+    // hook racing the bootstrap could send its first request with no
+    // Authorization header, get the anonymous-view response from the
+    // backend's privacy gate, and cache the wrong shape for the rest of the
+    // session. Client-only — SSR fetches don't have access to the in-memory
+    // token at all, so server-side requests proceed unguarded (the gate's
+    // default-resolved state covers that path).
+    if (typeof window !== "undefined") {
+      beginAuthBootstrap();
+    }
     return client;
   });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,5 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { getAccessToken } from "@/lib/auth/session";
+import { awaitAuthReady, getAccessToken } from "@/lib/auth/session";
 import {
   ensureFreshAccessToken,
   configureRefresh,
@@ -111,11 +111,29 @@ async function handleUnauthorized<T>(
   return request<T>(path, options, /* isRetry */ true);
 }
 
+/**
+ * Paths that must not wait on the auth-ready gate. Every {@code /api/v1/auth/*}
+ * call either creates a session ({@code register}, {@code login}), bootstraps
+ * one ({@code refresh}), or tears one down ({@code logout},
+ * {@code logout-all}). Gating them on the gate would deadlock the bootstrap
+ * itself ({@code refresh} would await its own resolution) and would needlessly
+ * delay the login/logout flow.
+ */
+function isAuthEndpoint(path: string): boolean {
+  return path.startsWith("/api/v1/auth/");
+}
+
 async function request<T>(
   path: string,
   { body, headers, params, ...rest }: RequestOptions = {},
   isRetry = false
 ): Promise<T> {
+  // Wait for the auth bootstrap to settle before reading the token. See
+  // `lib/auth/session.ts` for why the gate exists. Bypass for the auth
+  // endpoints themselves to avoid deadlocking the bootstrap.
+  if (!isAuthEndpoint(path)) {
+    await awaitAuthReady();
+  }
   const token = getAccessToken();
   const isFormData = typeof FormData !== "undefined" && body instanceof FormData;
   const serializedBody =

--- a/frontend/src/lib/auth/hooks.ts
+++ b/frontend/src/lib/auth/hooks.ts
@@ -4,7 +4,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { authApi, type LoginRequest, type RegisterRequest } from "./api";
-import { setAccessToken } from "./session";
+import { markAuthReady, setAccessToken } from "./session";
 import type { AuthSession, AuthUser } from "./session";
 
 const SESSION_QUERY_KEY = ["auth", "session"] as const;
@@ -22,9 +22,16 @@ const SESSION_QUERY_KEY = ["auth", "session"] as const;
  * See FOOTGUNS §F.2.
  */
 async function bootstrapSession(): Promise<AuthUser> {
-  const response = await authApi.refresh();
-  setAccessToken(response.accessToken);
-  return response.user;
+  try {
+    const response = await authApi.refresh();
+    setAccessToken(response.accessToken);
+    return response.user;
+  } finally {
+    // Close the auth-ready gate so api.ts can release any requests that fired
+    // in parallel with the bootstrap. Fires on success AND on 401 — the gate's
+    // purpose is "is the token settled?", not "is the user logged in?".
+    markAuthReady();
+  }
 }
 
 /**

--- a/frontend/src/lib/auth/session.test.ts
+++ b/frontend/src/lib/auth/session.test.ts
@@ -1,9 +1,19 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { getAccessToken, setAccessToken } from "./session";
+import {
+  awaitAuthReady,
+  beginAuthBootstrap,
+  getAccessToken,
+  markAuthReady,
+  setAccessToken,
+} from "./session";
 
 describe("session token ref", () => {
   beforeEach(() => {
     setAccessToken(null);
+    // Reset the gate to resolved between tests so this suite's later cases
+    // don't poison subsequent tests (the module-level promise persists across
+    // test cases).
+    markAuthReady();
   });
 
   it("getAccessToken returns null by default", () => {
@@ -19,5 +29,50 @@ describe("session token ref", () => {
     setAccessToken("token-abc");
     setAccessToken(null);
     expect(getAccessToken()).toBeNull();
+  });
+});
+
+describe("auth-ready gate", () => {
+  beforeEach(() => {
+    // Default-resolved state for each test.
+    markAuthReady();
+  });
+
+  it("awaitAuthReady() resolves immediately by default (tests + SSR don't hang)", async () => {
+    await expect(awaitAuthReady()).resolves.toBeUndefined();
+  });
+
+  it("beginAuthBootstrap() flips the gate to pending until markAuthReady()", async () => {
+    beginAuthBootstrap();
+
+    // The gate is pending — racing a fast timeout proves the promise has not
+    // resolved synchronously.
+    const sentinel = Symbol("not-resolved");
+    const raced = await Promise.race([
+      awaitAuthReady().then(() => "resolved"),
+      new Promise((r) => setTimeout(() => r(sentinel), 25)),
+    ]);
+    expect(raced).toBe(sentinel);
+
+    // Closing the gate releases any waiter.
+    markAuthReady();
+    await expect(awaitAuthReady()).resolves.toBeUndefined();
+  });
+
+  it("the gate's resolved value is the token that was set before markAuthReady fired", async () => {
+    beginAuthBootstrap();
+
+    // Simulate the production flow: a fetch starts before the bootstrap
+    // resolves and awaits the gate. The bootstrap sets the token *before*
+    // closing the gate; the waiter should observe the post-bootstrap value.
+    const waiter = (async () => {
+      await awaitAuthReady();
+      return getAccessToken();
+    })();
+
+    setAccessToken("token-from-bootstrap");
+    markAuthReady();
+
+    await expect(waiter).resolves.toBe("token-from-bootstrap");
   });
 });

--- a/frontend/src/lib/auth/session.ts
+++ b/frontend/src/lib/auth/session.ts
@@ -21,6 +21,61 @@ export function setAccessToken(token: string | null): void {
 }
 
 /**
+ * Single-fire gate that the API client awaits on every non-bootstrap request.
+ *
+ * <p>Before this gate existed, the access token bootstrap (POST
+ * {@code /api/v1/auth/refresh}, fired by {@code useAuth}) ran in parallel with
+ * any other {@code useQuery} hooks on the page. A hook that fired its fetch
+ * before the bootstrap resolved would call {@code getAccessToken()} while the
+ * token was still {@code null}, send the request without an
+ * {@code Authorization} header, and get the anonymous-view response from the
+ * backend's privacy gate (commission rates / joinedAt / permissions all
+ * nulled). The cached anonymous response would then persist for the rest of
+ * the session.
+ *
+ * <p>The gate fixes this once for every caller: {@link awaitAuthReady}
+ * returns a promise that resolves the moment the bootstrap settles (success
+ * or 401), so a hook's first fetch is guaranteed to read the post-bootstrap
+ * token value.
+ *
+ * <p><b>Default state:</b> resolved. So Jest/Vitest tests (which use a test
+ * render wrapper that seeds {@code SESSION_QUERY_KEY} directly and never
+ * runs the bootstrap query) don't hang on every {@code api.get}. Production
+ * flips the gate to pending via {@link beginAuthBootstrap} called from
+ * {@code app/providers.tsx}; the bootstrap calls {@link markAuthReady} in
+ * {@code finally} to close the gate again.
+ */
+let authReady: Promise<void> = Promise.resolve();
+let resolveAuthReady: () => void = () => {};
+
+export function awaitAuthReady(): Promise<void> {
+  return authReady;
+}
+
+/**
+ * Open the gate. Called once on client mount from {@code app/providers.tsx};
+ * idempotent against double-calls because we only reopen if the gate is
+ * currently resolved — once {@link bootstrapSession} is in flight we don't
+ * want a re-mount of {@code <Providers>} (HMR, etc.) to clobber the pending
+ * promise mid-bootstrap.
+ */
+export function beginAuthBootstrap(): void {
+  authReady = new Promise<void>((resolve) => {
+    resolveAuthReady = resolve;
+  });
+}
+
+/**
+ * Close the gate. Called from {@code bootstrapSession}'s {@code finally} so
+ * the gate resolves on success AND on 401. Tests that seed the auth state
+ * directly (and never run the bootstrap) don't need to call this — the gate
+ * starts resolved.
+ */
+export function markAuthReady(): void {
+  resolveAuthReady();
+}
+
+/**
  * Frontend-side projection of the backend's `UserResponse` (Task 01-07 §3).
  * Only the fields the frontend actually uses are projected here; the backend
  * returns more fields (bio, profilePicUrl, slUsername, etc.) which are


### PR DESCRIPTION
Race-condition fix for the bug class where a useQuery hook fired in parallel with the initial `/api/v1/auth/refresh` bootstrap could send its first request before the access token landed, hit the backend anonymously, and cache the wrong-shape response under its queryKey.

**Concrete symptom this fixes:** the leader of a realty group PATCHes an agent's commission rate, the response from `/api/v1/realty-groups/by-slug/{slug}` keeps showing `agentCommissionRate: null` indefinitely because the by-slug fetch raced the auth bootstrap and went out without `Authorization`. Backend privacy gate nulled the field; cache held it.

**Mechanism of the fix:** a single-fire promise gate in `lib/auth/session.ts` that `lib/api.ts` awaits on every non-`/api/v1/auth/*` request. Default-resolved (tests + SSR don't hang); flipped to pending in `app/providers.tsx` on client mount; closed by `bootstrapSession`'s finally on success OR 401.

**Why a gate over the alternatives:**
- per-hook `enabled: session.status !== 'loading'` works but is per-hook and easy to forget on new hooks
- invalidate-on-auth-transition fires two network calls per affected query and doesn't prevent the wrong shape from being cached briefly
- the gate is invisible to consumers; every fetch is automatically auth-ordered

## Test plan

- [x] 1941/1941 frontend tests passing (3 new for the gate)
- [x] `npm run verify` green
- [x] `npm run build` green
- [ ] Manual smoke after deploy: leader PATCHes commission rate → refresh `/groups/{slug}/manage/members` → see the rate, not 'Not set'