### PR TITLE
fix(groups): strip IEEE-754 artifacts from commission-rate percent strings

### DIFF
--- a/frontend/src/components/realty/BulkMemberCommissionEditDrawer.tsx
+++ b/frontend/src/components/realty/BulkMemberCommissionEditDrawer.tsx
@@ -7,6 +7,10 @@ import { Drawer } from "@/components/ui/Drawer";
 import { useToast } from "@/components/ui/Toast/useToast";
 import { useBulkCommissionEdit } from "@/hooks/realty/useBulkCommissionEdit";
 import { isApiError } from "@/lib/api";
+import {
+  rateToPercentDisplay,
+  rateToPercentInput,
+} from "@/lib/realty/commission";
 import type {
   AgentCardDto,
   BulkCommissionRateEntry,
@@ -94,10 +98,9 @@ function BulkMemberCommissionEditForm({ group, onClose }: FormProps) {
   const [rates, setRates] = useState<Record<string, string>>(() => {
     const initial: Record<string, string> = {};
     for (const agent of sortedAgents) {
-      initial[agent.memberPublicId] =
-        agent.agentCommissionRate != null
-          ? (agent.agentCommissionRate * 100).toString()
-          : "";
+      initial[agent.memberPublicId] = rateToPercentInput(
+        agent.agentCommissionRate,
+      );
     }
     return initial;
   });
@@ -286,7 +289,7 @@ interface BulkRowProps {
 function BulkRow({ agent, value, onChange, error, disabled }: BulkRowProps) {
   const currentRateLabel =
     agent.agentCommissionRate != null
-      ? `${(agent.agentCommissionRate * 100).toFixed(2)}%`
+      ? `${rateToPercentDisplay(agent.agentCommissionRate)}%`
       : "—";
   return (
     <li

--- a/frontend/src/components/realty/CommissionRateForm.tsx
+++ b/frontend/src/components/realty/CommissionRateForm.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { useUpdatePermissions } from "@/hooks/realty/useRealtyGroups";
+import { rateToPercentInput } from "@/lib/realty/commission";
 import type { AgentCardDto } from "@/types/realty";
 import { CommissionRateInput } from "./CommissionRateInput";
 
@@ -37,9 +38,7 @@ export function CommissionRateForm({
 }: CommissionRateFormProps) {
   const mutate = useUpdatePermissions();
   const [rateInput, setRateInput] = useState<string>(() =>
-    member.agentCommissionRate != null
-      ? (member.agentCommissionRate * 100).toString()
-      : "",
+    rateToPercentInput(member.agentCommissionRate),
   );
   const [error, setError] = useState<string | null>(null);
 

--- a/frontend/src/components/realty/MembersTab.tsx
+++ b/frontend/src/components/realty/MembersTab.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { Modal } from "@/components/ui/Modal";
 import { useLeaveGroup, useRemoveMember } from "@/hooks/realty/useRealtyGroups";
+import { rateToPercentDisplay } from "@/lib/realty/commission";
 import { permissionLabel } from "@/lib/realty/permissions";
 import type {
   AgentCardDto,
@@ -177,7 +178,7 @@ export function MembersTab({
                     >
                       Commission:{" "}
                       {m.agentCommissionRate != null
-                        ? `${(m.agentCommissionRate * 100).toFixed(2)}%`
+                        ? `${rateToPercentDisplay(m.agentCommissionRate)}%`
                         : "Not set"}
                     </span>
                   )}

--- a/frontend/src/lib/realty/commission.test.ts
+++ b/frontend/src/lib/realty/commission.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { rateToPercentDisplay, rateToPercentInput } from "./commission";
+
+describe("rateToPercentInput", () => {
+  it("strips IEEE-754 float artifacts (the 0.07 -> '7.000000000000001' bug)", () => {
+    expect(rateToPercentInput(0.07)).toBe("7");
+  });
+
+  it("preserves a half-percent value", () => {
+    expect(rateToPercentInput(0.075)).toBe("7.5");
+  });
+
+  it("renders a round zero correctly", () => {
+    expect(rateToPercentInput(0)).toBe("0");
+  });
+
+  it("renders the DB column's max precision (DECIMAL(5,4))", () => {
+    expect(rateToPercentInput(0.1234)).toBe("12.34");
+  });
+
+  it("renders the column's smallest non-zero step", () => {
+    expect(rateToPercentInput(0.0001)).toBe("0.01");
+  });
+
+  it("renders 100% correctly", () => {
+    expect(rateToPercentInput(1)).toBe("100");
+  });
+
+  it("returns empty string for null / undefined / non-finite inputs", () => {
+    expect(rateToPercentInput(null)).toBe("");
+    expect(rateToPercentInput(undefined)).toBe("");
+    expect(rateToPercentInput(NaN)).toBe("");
+    expect(rateToPercentInput(Infinity)).toBe("");
+  });
+});
+
+describe("rateToPercentDisplay", () => {
+  it("renders fixed two-decimal precision even for round values", () => {
+    expect(rateToPercentDisplay(0.07)).toBe("7.00");
+    expect(rateToPercentDisplay(0.1)).toBe("10.00");
+  });
+
+  it("strips the IEEE float artifact before formatting (same input that bit the form)", () => {
+    // Without the integer-space rounding, `(0.07 * 100).toFixed(2)` would
+    // still be "7.00" by accident, but `0.07 * 100` left raw can leak into
+    // any downstream code that does its own arithmetic. The helper rounds
+    // first so downstream computations stay clean.
+    expect(rateToPercentDisplay(0.07)).toBe("7.00");
+  });
+
+  it("renders half-percent and partial values to two decimals", () => {
+    expect(rateToPercentDisplay(0.075)).toBe("7.50");
+    expect(rateToPercentDisplay(0.1234)).toBe("12.34");
+  });
+
+  it("returns empty string for null / undefined / non-finite inputs", () => {
+    expect(rateToPercentDisplay(null)).toBe("");
+    expect(rateToPercentDisplay(undefined)).toBe("");
+    expect(rateToPercentDisplay(NaN)).toBe("");
+  });
+});

--- a/frontend/src/lib/realty/commission.ts
+++ b/frontend/src/lib/realty/commission.ts
@@ -1,0 +1,41 @@
+/**
+ * Decimal-to-percent string helpers for the agent-commission-rate UI.
+ *
+ * <p>Backend stores commission rates as PostgreSQL DECIMAL(5,4): the column
+ * carries at most four fractional digits (0.0001 = 0.01%, 0.9999 = 99.99%).
+ * Naively computing `rate * 100` then `.toString()` exposes IEEE-754 binary
+ * float artifacts — the canonical example being `0.07 * 100 ===
+ * 7.000000000000001` — which would surface as the literal `"7.000000000000001"`
+ * in a controlled input's default value. These helpers do the conversion
+ * with integer rounding so the user-facing string always matches the rate
+ * the backend wrote.
+ */
+
+/**
+ * Decimal commission rate (0..1) to a percentage string suitable as a
+ * controlled input's default value. Trailing zeros are stripped so a round
+ * 7% rate renders as `"7"`, not `"7.00"`.
+ *
+ * <p>Returns `""` for `null`, `undefined`, or any non-finite input — callers
+ * use the empty string as the "no current rate" sentinel in the input.
+ */
+export function rateToPercentInput(rate: number | null | undefined): string {
+  if (rate == null || !Number.isFinite(rate)) return "";
+  // Round on integer-space: `rate * 10000` collapses the 4-decimal DB
+  // precision onto an integer, and dividing by 100 brings it back to a
+  // percent with at most 2 decimal places. Both operations dodge the binary
+  // float artifacts that `rate * 100` produces directly.
+  const percent = Math.round(rate * 10000) / 100;
+  return percent.toString();
+}
+
+/**
+ * Decimal commission rate (0..1) to a percentage string suitable for
+ * read-only display ("Commission: 7.00%"). Always renders with exactly
+ * two fractional digits to keep column widths stable across rows. Returns
+ * `""` for `null` / `undefined` so callers can branch on the empty case.
+ */
+export function rateToPercentDisplay(rate: number | null | undefined): string {
+  if (rate == null || !Number.isFinite(rate)) return "";
+  return (Math.round(rate * 10000) / 100).toFixed(2);
+}


### PR DESCRIPTION
Leader set 7%, modal rendered '7.000000000000001%'. `(0.07 * 100).toString()` is the float-math signature; backend stored `0.0700` correctly, frontend was misrendering the readback.

Pulled the conversion into `lib/realty/commission.ts` with two helpers (`rateToPercentInput` for editable inputs, `rateToPercentDisplay` for fixed-width labels) — both round on integer space (`rate * 10000 / 100`) to dodge the binary artifact. Call sites updated: `CommissionRateForm` (the modal in the bug report), `BulkMemberCommissionEditDrawer`, `MembersTab`.

## Test plan
- [x] 1952/1952 frontend tests (11 new)
- [x] verify + build green