### PR TITLE
fix(groups): bulk commission edit invalidates wrong query prefix

### DIFF
--- a/frontend/src/hooks/realty/useBulkCommissionEdit.test.tsx
+++ b/frontend/src/hooks/realty/useBulkCommissionEdit.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/msw/server";
+import { useBulkCommissionEdit } from "./useBulkCommissionEdit";
+import { realtyQueryKeys } from "./useRealtyGroups";
+
+const GROUP_PUBLIC_ID = "00000000-0000-0000-0000-000000000001";
+const GROUP_SLUG = "mainland-realty";
+
+function makeQc() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function wrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useBulkCommissionEdit", () => {
+  beforeEach(() => {
+    server.use(
+      http.patch(
+        `*/api/v1/realty-groups/${GROUP_PUBLIC_ID}/members/commission-rates`,
+        () => new HttpResponse(null, { status: 204 }),
+      ),
+    );
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("invalidates the entire realty query prefix on success (so /manage/members refetches after the drawer closes)", async () => {
+    const qc = makeQc();
+    // Seed three slices of the group cache — they should all be marked
+    // stale by the bulk-edit mutation's success handler. The earlier bug
+    // was that the mutation used a non-existent ["realty", "groups", id]
+    // prefix (plural "groups") that matched none of these keys.
+    qc.setQueryData(realtyQueryKeys.group(GROUP_PUBLIC_ID), { stale: false });
+    qc.setQueryData(realtyQueryKeys.groupBySlug(GROUP_SLUG), { stale: false });
+    qc.setQueryData(realtyQueryKeys.groupMembers(GROUP_PUBLIC_ID), {
+      stale: false,
+    });
+
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useBulkCommissionEdit(GROUP_PUBLIC_ID), {
+      wrapper: wrapper(qc),
+    });
+
+    await result.current.mutateAsync({ rates: [] });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: realtyQueryKeys.all,
+      });
+    });
+
+    // All three seeded keys are descendants of realtyQueryKeys.all, so the
+    // invalidation hit every one.
+    expect(qc.getQueryState(realtyQueryKeys.group(GROUP_PUBLIC_ID))?.isInvalidated)
+      .toBe(true);
+    expect(qc.getQueryState(realtyQueryKeys.groupBySlug(GROUP_SLUG))?.isInvalidated)
+      .toBe(true);
+    expect(
+      qc.getQueryState(realtyQueryKeys.groupMembers(GROUP_PUBLIC_ID))
+        ?.isInvalidated,
+    ).toBe(true);
+  });
+});

--- a/frontend/src/hooks/realty/useBulkCommissionEdit.ts
+++ b/frontend/src/hooks/realty/useBulkCommissionEdit.ts
@@ -1,6 +1,7 @@
 "use client";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { realtyGroupBulkCommissionApi } from "@/lib/api/realtyGroupBulkCommission";
+import { realtyQueryKeys } from "./useRealtyGroups";
 import type { BulkCommissionRatesRequest } from "@/types/realty";
 
 /**
@@ -8,11 +9,14 @@ import type { BulkCommissionRatesRequest } from "@/types/realty";
  * server rolls back the whole batch on any single failure (member not in
  * group, negative rate, suspended group).
  *
- * <p>Invalidates the group's members + analytics queries on success so
- * the table re-renders against the new rates immediately. We invalidate
- * the broad {@code ["realty", "groups", groupPublicId]} prefix to cover
- * every cached slice of the group (members tab, analytics tab, leader
- * card).
+ * <p>Invalidates the whole realty prefix on success so every cached slice
+ * of the group (members tab via {@code group-by-slug}, the publicId-keyed
+ * group, members list, analytics, my-groups summary) refetches against
+ * the new rates immediately. Mirrors the {@code invalidateAll} pattern
+ * used by every other realty mutation — the earlier scoped invalidation
+ * used a non-existent {@code ["realty", "groups", id]} prefix (plural
+ * "groups") that matched nothing, so the members tab stayed stale until
+ * the user refreshed.
  */
 export function useBulkCommissionEdit(groupPublicId: string) {
   const qc = useQueryClient();
@@ -20,12 +24,7 @@ export function useBulkCommissionEdit(groupPublicId: string) {
     mutationFn: (body: BulkCommissionRatesRequest) =>
       realtyGroupBulkCommissionApi.update(groupPublicId, body),
     onSuccess: () => {
-      qc.invalidateQueries({
-        queryKey: ["realty", "groups", groupPublicId],
-      });
-      qc.invalidateQueries({
-        queryKey: ["realty", "analytics", "commissions", groupPublicId],
-      });
+      qc.invalidateQueries({ queryKey: realtyQueryKeys.all });
     },
   });
 }


### PR DESCRIPTION
After 'Save all' in the bulk commission drawer the members page stayed stale until a manual refresh. The mutation invalidated `['realty', 'groups', publicId]` — plural `groups` — but the actual query keys are `['realty', 'group', ...]` (singular) and `['realty', 'group-by-slug', slug]`. Mismatched prefix → nothing marked stale.

Switched to `invalidateQueries({ queryKey: realtyQueryKeys.all })`, matching the `invalidateAll(qc)` pattern every other realty mutation uses.

## Test plan
- [x] 1953/1953 frontend tests (1 new asserting the invalidation key matches all three relevant cache slices)
- [x] verify green