### PR TITLE
fix(groups): transfer-leadership select encodes member UUID, not user UUID

### DIFF
--- a/frontend/src/components/admin/realty-groups/AdminGroupMembersList.tsx
+++ b/frontend/src/components/admin/realty-groups/AdminGroupMembersList.tsx
@@ -77,7 +77,11 @@ export function AdminGroupMembersList({ group }: AdminGroupMembersListProps) {
     setRemoveTarget(member);
     if (member.role === "LEADER") {
       const firstAgent = group.agents.find((a) => a.role !== "LEADER");
-      setReplacementLeader(firstAgent?.userPublicId ?? "");
+      // Replacement-leader IDs flow into the backend's
+      // `members.findByPublicId(newLeaderPublicId)` lookup, which keys on the
+      // member-row UUID, NOT the user UUID. Sending a userPublicId there
+      // would always 400 with TRANSFER_TARGET_NOT_MEMBER.
+      setReplacementLeader(firstAgent?.memberPublicId ?? "");
     } else {
       setReplacementLeader("");
     }
@@ -210,7 +214,7 @@ export function AdminGroupMembersList({ group }: AdminGroupMembersListProps) {
                   data-testid="admin-member-replacement-select"
                 >
                   {replacementCandidates.map((a) => (
-                    <option key={a.userPublicId} value={a.userPublicId}>
+                    <option key={a.memberPublicId} value={a.memberPublicId}>
                       {a.displayName}
                     </option>
                   ))}

--- a/frontend/src/components/realty/SettingsTab.test.tsx
+++ b/frontend/src/components/realty/SettingsTab.test.tsx
@@ -64,6 +64,37 @@ describe("SettingsTab", () => {
     expect(select.textContent).toContain("Agent");
   });
 
+  it("encodes the candidate option value as memberPublicId, not userPublicId", async () => {
+    // The backend's transferLeadership service does
+    // `members.findByPublicId(newLeaderPublicId)` -- it expects the
+    // realty_group_members row UUID, not the user UUID. Sending a
+    // userPublicId here triggers a 400 TRANSFER_TARGET_NOT_MEMBER. This
+    // test locks the wire shape so we can't regress.
+    renderWithProviders(
+      <SettingsTab
+        group={makeGroup({
+          agents: [
+            makeAgent({
+              memberPublicId: "mmmmmmmm-mmmm-mmmm-mmmm-mmmmmmmmmmmm",
+              userPublicId: "uuuuuuuu-uuuu-uuuu-uuuu-uuuuuuuuuuuu",
+              displayName: "Agent Zero",
+            }),
+          ],
+        })}
+      />,
+    );
+    await userEvent.click(screen.getByTestId("settings-transfer-button"));
+    const select = screen.getByTestId(
+      "settings-transfer-select",
+    ) as HTMLSelectElement;
+    const agentOption = Array.from(select.options).find(
+      (o) => o.textContent === "Agent Zero",
+    );
+    expect(agentOption).toBeDefined();
+    expect(agentOption!.value).toBe("mmmmmmmm-mmmm-mmmm-mmmm-mmmmmmmmmmmm");
+    expect(agentOption!.value).not.toBe("uuuuuuuu-uuuu-uuuu-uuuu-uuuuuuuuuuuu");
+  });
+
   it("disables the dissolve confirm until the group name is typed", async () => {
     renderWithProviders(<SettingsTab group={makeGroup({ name: "Tricky" })} />);
     await userEvent.click(screen.getByTestId("settings-dissolve-button"));

--- a/frontend/src/components/realty/SettingsTab.tsx
+++ b/frontend/src/components/realty/SettingsTab.tsx
@@ -158,7 +158,7 @@ export function SettingsTab({ group }: SettingsTabProps) {
             >
               <option value="">Pick an agent...</option>
               {transferCandidates.map((a) => (
-                <option key={a.userPublicId} value={a.userPublicId}>
+                <option key={a.memberPublicId} value={a.memberPublicId}>
                   {a.displayName}
                 </option>
               ))}


### PR DESCRIPTION
POST `/api/v1/realty-groups/{publicId}/transfer-leadership` rejected every transfer with 400 `TRANSFER_TARGET_NOT_MEMBER`. The backend's `members.findByPublicId(newLeaderPublicId)` keys on the `realty_group_members` row UUID, but the leader-side settings tab and the admin remove-leader replacement select were both encoding `value={a.userPublicId}` — the wrong UUID for that endpoint.

Both selects now encode `value={a.memberPublicId}`. Regression test on `SettingsTab` locks the option value down.

## Test plan
- [x] 1954/1954 frontend tests (1 new asserting option value is memberPublicId not userPublicId)
- [x] verify + build green
- [ ] Manual: pick an agent in /groups/{slug}/manage/settings → Transfer leadership → expect 200 (not 400)