### PR TITLE
fix(auth): rename login username field to dodge cross-site email autofill

### DIFF
--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -12,6 +12,14 @@ import { loginSchema, type LoginFormValues } from "@/lib/auth/schemas";
 import { mapProblemDetailToForm } from "@/lib/auth/errors";
 import { getSafeRedirect } from "@/lib/auth/redirects";
 
+// Backend-facing field names used by the problem-detail mapper. The
+// form-state field is `slpaLoginUsername` (uniquified to dodge browser
+// autofill heuristics that match `name="username"` against unrelated
+// saved emails from other origins). Login responses don't return
+// VALIDATION_FAILED with field-level errors today -- AUTH_INVALID_CREDENTIALS
+// surfaces as a form-level message -- so the mapper's per-field branch is
+// effectively unused here, but the array stays in lockstep with the
+// backend contract for future-proofing.
 const KNOWN_FIELDS = ["username", "password"] as const;
 
 export function LoginForm() {
@@ -23,19 +31,23 @@ export function LoginForm() {
     resolver: zodResolver(loginSchema),
     mode: "onBlur",
     reValidateMode: "onChange",
-    defaultValues: { username: "", password: "" },
+    defaultValues: { slpaLoginUsername: "", password: "" },
   });
 
   const onSubmit = form.handleSubmit((values) => {
-    login.mutate(values, {
-      onSuccess: () => {
-        const next = getSafeRedirect(searchParams.get("next"));
-        router.push(next);
+    // Map the uniquified form field back to the backend's wire contract.
+    login.mutate(
+      { username: values.slpaLoginUsername, password: values.password },
+      {
+        onSuccess: () => {
+          const next = getSafeRedirect(searchParams.get("next"));
+          router.push(next);
+        },
+        onError: (error) => {
+          mapProblemDetailToForm(error, form, KNOWN_FIELDS);
+        },
       },
-      onError: (error) => {
-        mapProblemDetailToForm(error, form, KNOWN_FIELDS);
-      },
-    });
+    );
   });
 
   const rootError = (form.formState.errors as { root?: { serverError?: { message?: string } } })
@@ -45,12 +57,20 @@ export function LoginForm() {
     <form onSubmit={onSubmit} className="space-y-6" noValidate>
       <FormError message={rootError} />
 
+      {/*
+        The DOM input's `name` follows the RHF registered field name, so
+        the schema rename to `slpaLoginUsername` propagates here without
+        an inline override. See loginSchema's docstring for why a unique
+        name kills the cross-origin email-autofill dropdown while
+        autoComplete="username" still lets password managers fill the
+        user's saved SLParcels credential via origin + role matching.
+      */}
       <Input
         label="Username"
         type="text"
         autoComplete="username"
-        {...form.register("username")}
-        error={form.formState.errors.username?.message}
+        {...form.register("slpaLoginUsername")}
+        error={form.formState.errors.slpaLoginUsername?.message}
       />
 
       <Input

--- a/frontend/src/lib/auth/schemas.test.ts
+++ b/frontend/src/lib/auth/schemas.test.ts
@@ -81,12 +81,18 @@ describe("registerSchema", () => {
 
 describe("loginSchema", () => {
   it("accepts a valid login payload", () => {
-    const result = loginSchema.safeParse({ username: "user", password: "anything" });
+    const result = loginSchema.safeParse({
+      slpaLoginUsername: "user",
+      password: "anything",
+    });
     expect(result.success).toBe(true);
   });
 
   it("rejects empty password", () => {
-    const result = loginSchema.safeParse({ username: "user", password: "" });
+    const result = loginSchema.safeParse({
+      slpaLoginUsername: "user",
+      password: "",
+    });
     expect(result.success).toBe(false);
   });
 });

--- a/frontend/src/lib/auth/schemas.ts
+++ b/frontend/src/lib/auth/schemas.ts
@@ -77,9 +77,22 @@ export const registerSchema = z
 
 /**
  * Login form schema. Username + non-empty password.
+ *
+ * <p>The form-state field is named {@code slpaLoginUsername} (not
+ * {@code username}) so the rendered DOM input carries the same unique
+ * name. Browsers populate their autofill dropdown by matching the field's
+ * {@code name} attribute against credentials they've saved against fields
+ * named {@code username} / {@code email} / {@code user} / {@code login}
+ * across every site -- producing a dropdown full of unrelated emails from
+ * other origins. A non-standard name kills those heuristic suggestions;
+ * the {@code autoComplete="username"} role token still lets password
+ * managers (Chrome's built-in, 1Password, Bitwarden) autofill the user's
+ * saved SLParcels credential via origin + role matching. The wire
+ * payload is mapped back to {@code username} at submit time so the
+ * backend contract is unchanged.
  */
 export const loginSchema = z.object({
-  username: usernameSchema,
+  slpaLoginUsername: usernameSchema,
   password: passwordInputSchema,
 });
 


### PR DESCRIPTION
Browsers' autofill dropdown matches `name="username"` against every credential saved on every site with that field name, so the SLParcels login form was showing a dropdown full of emails from other origins.

Renamed the schema field `loginSchema.username` → `slpaLoginUsername` so the rendered DOM input gets a name browsers don't heuristically associate with stored credentials. `autoComplete="username"` stays, so saved SLParcels credentials still autofill via origin + role matching (Chrome built-in, 1Password, Bitwarden). `onSubmit` maps the renamed field back to `{ username, password }` for the wire — backend contract unchanged.

Password field intentionally untouched: browsers don't suggest cross-origin passwords inline.

## Test plan
- [x] 1954/1954 frontend tests (schema + LoginForm tests updated)
- [x] verify + build green