### PR TITLE
feat(bot): idle-park + heartbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ cd frontend && npm run verify         # grep-based rules: no dark: variants, no 
 │   └── src/Slpa.Bot/
 │       ├── Sl/              LibreMetaverseBotSession (login loop, reconnect backoff, teleport + ParcelProperties read with SimParcelsDownloaded-gated parcel filtering, already-in-region shortcut, 6/min rate limiter)
 │       ├── Backend/         HttpBackendClient (bearer auth, hand-rolled retry 1s/2s/4s/8s/15s, 401 → AuthConfigException + process exit)
-│       ├── Tasks/           TaskLoop (BackgroundService, claim → dispatch → loop, dual backoff), VerifyHandler (observation-only), MonitorHandler (mechanical classifier using ExpectedMaxSalePriceLindens threshold)
+│       ├── Tasks/           TaskLoop (BackgroundService, claim → dispatch → loop, dual backoff), VerifyHandler (observation-only), MonitorHandler (mechanical classifier using ExpectedMaxSalePriceLindens threshold), IdleParker (teleports to configured rectangle when idle), HeartbeatLoop (periodic Redis heartbeat so logged-in bots appear in the admin Bot-pool panel)
 │       └── Health/          GET /health — 200 only for Online, 503 for Starting/Reconnecting/Error/Stopped
 ├── docs/
 │   ├── initial-design/      Spec, schema, user flows

--- a/bot/README.md
+++ b/bot/README.md
@@ -15,6 +15,17 @@ auction monitoring, BOT-tier escrow monitoring).
 | `Backend__BaseUrl`              | no       | `http://localhost:8080`                | backend origin                             |
 | `Backend__SharedSecret`         | yes      | —                                      | matches `slpa.bot.shared-secret`           |
 | `RateLimit__TeleportsPerMinute` | no       | `6`                                    | SL's hard cap                              |
+| `IdlePark__Enabled`             | no       | `true`                                 | master switch; `false` disables, keeps coords |
+| `IdlePark__Region`              | no       | `Hadron`                               | idle home region; blank disables (warns)   |
+| `IdlePark__Corner1X`            | no       | `44`                                   | rectangle corner 1 X                       |
+| `IdlePark__Corner1Y`            | no       | `73`                                   | rectangle corner 1 Y                       |
+| `IdlePark__Corner2X`            | no       | `30`                                   | opposite corner X                          |
+| `IdlePark__Corner2Y`            | no       | `65`                                   | opposite corner Y                          |
+| `IdlePark__Z`                   | no       | `25`                                   | landing altitude                           |
+| `IdlePark__ParkCooldownSeconds` | no       | `180`                                  | min interval between park attempts         |
+| `Heartbeat__IntervalSeconds`    | no       | `60`                                   | heartbeat cadence; backend TTL is 180s     |
+
+Idle-parking is on by default with the Hadron rectangle baked in. When a bot has no task to service and is outside the configured rectangle, it teleports to a random point inside it. The heartbeat runs independently of the task loop and of session state, so a logged-in bot always appears in the admin Bot-pool panel.
 
 ASP.NET uses `__` (double underscore) as the section separator for
 environment variables. In `appsettings.json` these are nested under
@@ -54,6 +65,12 @@ tests never touch `GridClient` directly.
 6. Confirm the bot teleports and posts to `PUT /api/v1/bot/tasks/{id}/verify`.
 7. Verify bot reads the correct parcel at the landing coordinates, not an
    arbitrary parcel in the same region.
+8. Leave the bot with an empty task queue for ~1 min. Confirm it teleports
+   into the configured rectangle (region `Hadron`, X 30-44, Y 65-73). An
+   idle bot already inside the rectangle stays put (no teleport churn).
+9. Open the admin Infrastructure page, Bot pool section. Within ~60 s the
+   bot shows as `1/1 healthy` with its region. Kill the bot process; after
+   ~180 s the row flips red (Redis TTL lapsed).
 
 ## Prerequisites
 

--- a/bot/README.md
+++ b/bot/README.md
@@ -29,7 +29,7 @@ Idle-parking is on by default with the Hadron rectangle baked in. When a bot has
 
 ASP.NET uses `__` (double underscore) as the section separator for
 environment variables. In `appsettings.json` these are nested under
-`Bot`, `Backend`, and `RateLimit` keys.
+`Bot`, `Backend`, `RateLimit`, `IdlePark`, and `Heartbeat` keys.
 
 ## Local run
 

--- a/bot/src/Slpa.Bot/Backend/HttpBackendClient.cs
+++ b/bot/src/Slpa.Bot/Backend/HttpBackendClient.cs
@@ -106,6 +106,20 @@ public sealed class HttpBackendClient : IBackendClient
         resp.EnsureSuccessStatusCode();
     }
 
+    public async Task SendHeartbeatAsync(
+        BotHeartbeatRequest body, CancellationToken ct)
+    {
+        using var resp = await SendWithRetryAsync(() =>
+        {
+            var req = new HttpRequestMessage(HttpMethod.Post, "/api/v1/bot/heartbeat")
+            {
+                Content = JsonContent.Create(body, options: JsonOpts)
+            };
+            return req;
+        }, ct).ConfigureAwait(false);
+        resp.EnsureSuccessStatusCode();
+    }
+
     private async Task<HttpResponseMessage> SendWithRetryAsync(
         Func<HttpRequestMessage> requestFactory, CancellationToken ct)
     {

--- a/bot/src/Slpa.Bot/Backend/IBackendClient.cs
+++ b/bot/src/Slpa.Bot/Backend/IBackendClient.cs
@@ -17,9 +17,9 @@ public interface IBackendClient
     Task PostMonitorAsync(long taskId, BotMonitorResultRequest body, CancellationToken ct);
 
     /// <summary>
-    /// Fire-and-forget heartbeat. Reuses the shared bearer auth + 5xx retry.
-    /// Throws <see cref="AuthConfigException"/> on 401 (the caller swallows
-    /// it — the claim path is the authoritative 401 handler).
+    /// Best-effort heartbeat (blocking: awaits the shared bearer auth + 5xx
+    /// retry ladder). Throws <see cref="AuthConfigException"/> on 401 (the
+    /// caller swallows it — the claim path is the authoritative 401 handler).
     /// </summary>
     Task SendHeartbeatAsync(BotHeartbeatRequest body, CancellationToken ct);
 }

--- a/bot/src/Slpa.Bot/Backend/IBackendClient.cs
+++ b/bot/src/Slpa.Bot/Backend/IBackendClient.cs
@@ -15,6 +15,13 @@ public interface IBackendClient
 
     /// <summary>Report MONITOR_* outcome. Backend re-arms or cancels the row.</summary>
     Task PostMonitorAsync(long taskId, BotMonitorResultRequest body, CancellationToken ct);
+
+    /// <summary>
+    /// Fire-and-forget heartbeat. Reuses the shared bearer auth + 5xx retry.
+    /// Throws <see cref="AuthConfigException"/> on 401 (the caller swallows
+    /// it — the claim path is the authoritative 401 handler).
+    /// </summary>
+    Task SendHeartbeatAsync(BotHeartbeatRequest body, CancellationToken ct);
 }
 
 /// <summary>

--- a/bot/src/Slpa.Bot/Backend/Models/BotHeartbeatRequest.cs
+++ b/bot/src/Slpa.Bot/Backend/Models/BotHeartbeatRequest.cs
@@ -1,0 +1,15 @@
+namespace Slpa.Bot.Backend.Models;
+
+/// <summary>
+/// Mirrors the backend's BotHeartbeatRequest record. Serialized camelCase via
+/// the shared JsonOpts. Backend requires workerName/slUuid/sessionState
+/// non-blank; the rest are nullable.
+/// </summary>
+public sealed record BotHeartbeatRequest(
+    string WorkerName,
+    string SlUuid,
+    string SessionState,
+    string? CurrentRegion,
+    string? CurrentTaskKey,
+    string? CurrentTaskType,
+    DateTimeOffset? LastClaimAt);

--- a/bot/src/Slpa.Bot/Options/HeartbeatOptions.cs
+++ b/bot/src/Slpa.Bot/Options/HeartbeatOptions.cs
@@ -1,0 +1,12 @@
+namespace Slpa.Bot.Options;
+
+public sealed class HeartbeatOptions
+{
+    public const string SectionName = "Heartbeat";
+
+    /// <summary>
+    /// Send cadence. Backend TTL is 180s, so keep this well under 60s to
+    /// guarantee 3 beats per TTL window.
+    /// </summary>
+    public int IntervalSeconds { get; set; } = 60;
+}

--- a/bot/src/Slpa.Bot/Options/IdleParkOptions.cs
+++ b/bot/src/Slpa.Bot/Options/IdleParkOptions.cs
@@ -1,0 +1,26 @@
+namespace Slpa.Bot.Options;
+
+public sealed class IdleParkOptions
+{
+    public const string SectionName = "IdlePark";
+
+    /// <summary>Master switch; false disables without losing coords.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Target region; blank while enabled disables (with a warning).</summary>
+    public string Region { get; set; } = "Hadron";
+
+    public double Corner1X { get; set; } = 44;
+    public double Corner1Y { get; set; } = 73;
+    public double Corner2X { get; set; } = 30;
+    public double Corner2Y { get; set; } = 65;
+
+    /// <summary>Landing altitude.</summary>
+    public double Z { get; set; } = 25;
+
+    /// <summary>
+    /// Minimum interval between park teleport attempts; also the failed-park
+    /// backoff. Default 3 minutes.
+    /// </summary>
+    public int ParkCooldownSeconds { get; set; } = 180;
+}

--- a/bot/src/Slpa.Bot/Program.cs
+++ b/bot/src/Slpa.Bot/Program.cs
@@ -15,8 +15,14 @@ builder.Services.Configure<BackendOptions>(
     builder.Configuration.GetSection(BackendOptions.SectionName));
 builder.Services.Configure<RateLimitOptions>(
     builder.Configuration.GetSection(RateLimitOptions.SectionName));
+builder.Services.Configure<IdleParkOptions>(
+    builder.Configuration.GetSection(IdleParkOptions.SectionName));
+builder.Services.Configure<HeartbeatOptions>(
+    builder.Configuration.GetSection(HeartbeatOptions.SectionName));
 
 builder.Services.AddSingleton<IBotSession, LibreMetaverseBotSession>();
+builder.Services.AddSingleton<IIdleParker, IdleParker>();
+builder.Services.AddSingleton<BotActivityState>();
 builder.Services.AddHttpClient<IBackendClient, HttpBackendClient>((sp, client) =>
 {
     var opts = sp.GetRequiredService<IOptions<BackendOptions>>().Value;
@@ -28,6 +34,7 @@ builder.Services.AddSingleton<MonitorHandler>();
 builder.Services.AddSingleton<WithdrawGroupHandler>();
 builder.Services.AddHostedService<BotSessionBootstrapper>();
 builder.Services.AddHostedService<TaskLoop>();
+builder.Services.AddHostedService<HeartbeatLoop>();
 
 var app = builder.Build();
 app.MapBotHealth();

--- a/bot/src/Slpa.Bot/Sl/BotLocation.cs
+++ b/bot/src/Slpa.Bot/Sl/BotLocation.cs
@@ -1,0 +1,7 @@
+namespace Slpa.Bot.Sl;
+
+/// <summary>
+/// The bot's current region + (x, y) within that region. Z is irrelevant to
+/// the idle-park rectangle test, so it is not carried.
+/// </summary>
+public sealed record BotLocation(string Region, double X, double Y);

--- a/bot/src/Slpa.Bot/Sl/IBotSession.cs
+++ b/bot/src/Slpa.Bot/Sl/IBotSession.cs
@@ -11,6 +11,12 @@ public interface IBotSession : IAsyncDisposable
 
     Guid BotUuid { get; }
 
+    /// <summary>
+    /// The bot's current region + (x, y), or null when no sim is resolved
+    /// yet (transient post-login). Used by idle-park; never blocks.
+    /// </summary>
+    BotLocation? CurrentLocation { get; }
+
     /// <summary>Starts the login loop. Idempotent; returns when state != Starting.</summary>
     Task StartAsync(CancellationToken ct);
 
@@ -22,9 +28,14 @@ public interface IBotSession : IAsyncDisposable
     /// LibreMetaverse TeleportFinished / TeleportFailed race with a 30s
     /// timeout. Rate-limited per SL's 6/min cap. Throws
     /// <see cref="SessionLostException"/> if the session drops mid-teleport.
+    /// When <paramref name="forceMove"/> is false (default) and the bot is
+    /// already in the target sim, the teleport is skipped (returns Ok) — this
+    /// preserves the documented false-ACCESS_DENIED fix for monitor/verify.
+    /// Idle-park passes <c>forceMove: true</c> to relocate within a sim.
     /// </summary>
     Task<TeleportResult> TeleportAsync(
-        string regionName, double x, double y, double z, CancellationToken ct);
+        string regionName, double x, double y, double z,
+        CancellationToken ct, bool forceMove = false);
 
     /// <summary>
     /// Requests ParcelProperties for the parcel at (x, y) within the

--- a/bot/src/Slpa.Bot/Sl/LibreMetaverseBotSession.cs
+++ b/bot/src/Slpa.Bot/Sl/LibreMetaverseBotSession.cs
@@ -48,6 +48,17 @@ public sealed class LibreMetaverseBotSession : IBotSession
 
     public Guid BotUuid => _opts.BotUuid;
 
+    public BotLocation? CurrentLocation
+    {
+        get
+        {
+            var sim = _client.Network.CurrentSim;
+            if (sim is null) return null;
+            var p = _client.Self.SimPosition;
+            return new BotLocation(sim.Name, p.X, p.Y);
+        }
+    }
+
     public Task StartAsync(CancellationToken ct)
     {
         _runCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -207,7 +218,8 @@ public sealed class LibreMetaverseBotSession : IBotSession
     }
 
     public async Task<TeleportResult> TeleportAsync(
-        string regionName, double x, double y, double z, CancellationToken ct)
+        string regionName, double x, double y, double z,
+        CancellationToken ct, bool forceMove = false)
     {
         if (State != SessionState.Online)
         {
@@ -225,7 +237,8 @@ public sealed class LibreMetaverseBotSession : IBotSession
         // re-read. ReadParcelAsync will re-issue RequestAllSimParcels to
         // get fresh data regardless of whether we teleported.
         var currentSim = _client.Network.CurrentSim;
-        if (currentSim is not null
+        if (!forceMove
+            && currentSim is not null
             && string.Equals(currentSim.Name, regionName,
                 StringComparison.OrdinalIgnoreCase))
         {

--- a/bot/src/Slpa.Bot/Tasks/BotActivityState.cs
+++ b/bot/src/Slpa.Bot/Tasks/BotActivityState.cs
@@ -1,0 +1,37 @@
+using Slpa.Bot.Backend.Models;
+
+namespace Slpa.Bot.Tasks;
+
+/// <summary>
+/// What the bot is currently doing, for the heartbeat. Single-writer
+/// (TaskLoop), many-reader (HeartbeatLoop). Lock-free: an immutable snapshot
+/// swapped atomically through a volatile reference.
+///
+/// REPORTING ONLY. Never read by IdleParker — the heartbeat must never
+/// influence idle detection or the park decision (spec hard invariant).
+/// </summary>
+public sealed class BotActivityState
+{
+    public sealed record Snapshot(
+        long? CurrentTaskId,
+        string? CurrentTaskType,
+        DateTimeOffset? LastClaimAt);
+
+    private volatile Snapshot _snap = new(null, null, null);
+
+    public Snapshot Current => _snap;
+
+    /// <summary>
+    /// Records a claim round. <paramref name="task"/> null = empty queue:
+    /// updates LastClaimAt and clears the current task.
+    /// </summary>
+    public void RecordClaim(BotTaskResponse? task, DateTimeOffset now)
+        => _snap = new Snapshot(task?.Id, task?.TaskType.ToString(), now);
+
+    /// <summary>Task finished: clear task fields, keep LastClaimAt.</summary>
+    public void Clear()
+    {
+        var s = _snap;
+        _snap = new Snapshot(null, null, s.LastClaimAt);
+    }
+}

--- a/bot/src/Slpa.Bot/Tasks/HeartbeatLoop.cs
+++ b/bot/src/Slpa.Bot/Tasks/HeartbeatLoop.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Slpa.Bot.Backend;
+using Slpa.Bot.Backend.Models;
+using Slpa.Bot.Options;
+using Slpa.Bot.Sl;
+
+namespace Slpa.Bot.Tasks;
+
+/// <summary>
+/// Sends a heartbeat every <see cref="HeartbeatOptions.IntervalSeconds"/>.
+/// Runs regardless of session state (so the admin can tell "alive but
+/// Reconnecting" from "process dead = TTL expired"). Never crashes — every
+/// failure incl. <see cref="AuthConfigException"/> is logged and swallowed;
+/// the claim path remains the authoritative 401 handler.
+/// </summary>
+public sealed class HeartbeatLoop : BackgroundService
+{
+    private readonly IBotSession _session;
+    private readonly IBackendClient _backend;
+    private readonly BotActivityState _activity;
+    private readonly BotOptions _botOpts;
+    private readonly HeartbeatOptions _hbOpts;
+    private readonly ILogger<HeartbeatLoop> _log;
+
+    public HeartbeatLoop(
+        IBotSession session,
+        IBackendClient backend,
+        BotActivityState activity,
+        IOptions<BotOptions> botOpts,
+        IOptions<HeartbeatOptions> hbOpts,
+        ILogger<HeartbeatLoop> log)
+    {
+        _session = session;
+        _backend = backend;
+        _activity = activity;
+        _botOpts = botOpts.Value;
+        _hbOpts = hbOpts.Value;
+        _log = log;
+    }
+
+    protected override Task ExecuteAsync(CancellationToken ct) => RunAsync(ct);
+
+    internal async Task RunAsync(CancellationToken ct)
+    {
+        var interval = TimeSpan.FromSeconds(_hbOpts.IntervalSeconds);
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                await SendOnceAsync(ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex,
+                    "Heartbeat send failed; retrying next interval");
+            }
+
+            try
+            {
+                await Task.Delay(interval, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+    }
+
+    internal async Task SendOnceAsync(CancellationToken ct)
+    {
+        var snap = _activity.Current;
+        var loc = _session.CurrentLocation;
+        var req = new BotHeartbeatRequest(
+            WorkerName: _botOpts.Username,
+            SlUuid: _session.BotUuid.ToString(),
+            SessionState: _session.State.ToString(),
+            CurrentRegion: loc?.Region,
+            CurrentTaskKey: snap.CurrentTaskId?.ToString(),
+            CurrentTaskType: snap.CurrentTaskType,
+            LastClaimAt: snap.LastClaimAt);
+        await _backend.SendHeartbeatAsync(req, ct).ConfigureAwait(false);
+    }
+}

--- a/bot/src/Slpa.Bot/Tasks/IdleParker.cs
+++ b/bot/src/Slpa.Bot/Tasks/IdleParker.cs
@@ -120,6 +120,8 @@ public sealed class IdleParker : IIdleParker
         }
         catch (Exception ex)
         {
+            // Re-read the clock: TeleportAsync may have thrown after an
+            // unpredictable delay, so the pre-await `now` is a stale anchor.
             _nextParkUtc = _now()
                 + TimeSpan.FromSeconds(_opts.ParkCooldownSeconds);
             _log.LogWarning(ex,

--- a/bot/src/Slpa.Bot/Tasks/IdleParker.cs
+++ b/bot/src/Slpa.Bot/Tasks/IdleParker.cs
@@ -1,0 +1,130 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Slpa.Bot.Options;
+using Slpa.Bot.Sl;
+
+namespace Slpa.Bot.Tasks;
+
+/// <summary>
+/// Test seam for idle-parking. <see cref="IdleParker"/> is the only
+/// implementation; <c>TaskLoop</c> tests inject a no-op.
+/// </summary>
+public interface IIdleParker
+{
+    Task ParkIfNeededAsync(CancellationToken ct);
+}
+
+/// <summary>
+/// Relocates an idle bot into the configured rectangle. Stateless except for
+/// a cooldown timestamp: each idle cycle re-checks rectangle membership, so
+/// being inside the rectangle is its own idempotency. Observation-only state
+/// (heartbeat/activity) is deliberately NOT consulted here — "idle" is solely
+/// "TaskLoop.ClaimAsync returned null".
+/// </summary>
+public sealed class IdleParker : IIdleParker
+{
+    private readonly IBotSession _session;
+    private readonly IdleParkOptions _opts;
+    private readonly ILogger<IdleParker> _log;
+    private readonly Func<DateTimeOffset> _now;
+    private readonly Func<double> _rng;
+
+    private DateTimeOffset _nextParkUtc = DateTimeOffset.MinValue;
+    private bool _warnedDisabled;
+
+    public IdleParker(
+        IBotSession session,
+        IOptions<IdleParkOptions> opts,
+        ILogger<IdleParker> log)
+        : this(session, opts.Value, log,
+            () => DateTimeOffset.UtcNow, () => Random.Shared.NextDouble())
+    {
+    }
+
+    internal IdleParker(
+        IBotSession session,
+        IdleParkOptions opts,
+        ILogger<IdleParker> log,
+        Func<DateTimeOffset> now,
+        Func<double> rng)
+    {
+        _session = session;
+        _opts = opts;
+        _log = log;
+        _now = now;
+        _rng = rng;
+    }
+
+    public async Task ParkIfNeededAsync(CancellationToken ct)
+    {
+        try
+        {
+            if (!_opts.Enabled) return;
+
+            if (string.IsNullOrWhiteSpace(_opts.Region))
+            {
+                if (!_warnedDisabled)
+                {
+                    _log.LogWarning(
+                        "IdlePark enabled but Region is blank; idle-parking disabled.");
+                    _warnedDisabled = true;
+                }
+                return;
+            }
+
+            var now = _now();
+            if (now < _nextParkUtc) return;
+
+            var loc = _session.CurrentLocation;
+            if (loc is null) return;
+
+            double minX = Math.Min(_opts.Corner1X, _opts.Corner2X);
+            double maxX = Math.Max(_opts.Corner1X, _opts.Corner2X);
+            double minY = Math.Min(_opts.Corner1Y, _opts.Corner2Y);
+            double maxY = Math.Max(_opts.Corner1Y, _opts.Corner2Y);
+
+            bool inRegion = string.Equals(
+                loc.Region, _opts.Region, StringComparison.OrdinalIgnoreCase);
+            bool inRect = inRegion
+                && loc.X >= minX && loc.X <= maxX
+                && loc.Y >= minY && loc.Y <= maxY;
+            if (inRect) return; // already parked — no teleport, no cooldown
+
+            double x = minX + _rng() * (maxX - minX);
+            double y = minY + _rng() * (maxY - minY);
+            double z = _opts.Z;
+
+            _nextParkUtc = now + TimeSpan.FromSeconds(_opts.ParkCooldownSeconds);
+
+            var result = await _session
+                .TeleportAsync(_opts.Region, x, y, z, ct, forceMove: true)
+                .ConfigureAwait(false);
+
+            if (result.Success)
+            {
+                _log.LogInformation(
+                    "Idle-parked to {Region} ({X:F1},{Y:F1},{Z:F1})",
+                    _opts.Region, x, y, z);
+            }
+            else
+            {
+                _log.LogWarning(
+                    "Idle-park teleport to {Region} failed: {Failure}; " +
+                    "backing off {Cooldown}s",
+                    _opts.Region, result.Failure, _opts.ParkCooldownSeconds);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _nextParkUtc = _now()
+                + TimeSpan.FromSeconds(_opts.ParkCooldownSeconds);
+            _log.LogWarning(ex,
+                "Idle-park attempt threw; backing off {Cooldown}s",
+                _opts.ParkCooldownSeconds);
+        }
+    }
+}

--- a/bot/src/Slpa.Bot/Tasks/TaskLoop.cs
+++ b/bot/src/Slpa.Bot/Tasks/TaskLoop.cs
@@ -113,7 +113,14 @@ public sealed class TaskLoop : BackgroundService
 
             if (task is null)
             {
-                await _idleParker.ParkIfNeededAsync(ct).ConfigureAwait(false);
+                try
+                {
+                    await _idleParker.ParkIfNeededAsync(ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
                 await SafeDelayAsync(EmptyQueueBackoff, ct).ConfigureAwait(false);
                 continue;
             }

--- a/bot/src/Slpa.Bot/Tasks/TaskLoop.cs
+++ b/bot/src/Slpa.Bot/Tasks/TaskLoop.cs
@@ -22,6 +22,8 @@ public sealed class TaskLoop : BackgroundService
     private readonly Func<MonitorHandler> _monitor;
     private readonly Func<WithdrawGroupHandler> _withdrawGroup;
     private readonly IBackendClient _backend;
+    private readonly IIdleParker _idleParker;
+    private readonly BotActivityState _activity;
     private readonly ILogger<TaskLoop> _log;
 
     /// <summary>
@@ -30,11 +32,14 @@ public sealed class TaskLoop : BackgroundService
     public TaskLoop(
         IBotSession session,
         IBackendClient backend,
+        IIdleParker idleParker,
+        BotActivityState activity,
         VerifyHandler verify,
         MonitorHandler monitor,
         WithdrawGroupHandler withdrawGroup,
         ILogger<TaskLoop> log)
-        : this(session, backend, () => verify, () => monitor, () => withdrawGroup, log)
+        : this(session, backend, idleParker, activity,
+            () => verify, () => monitor, () => withdrawGroup, log)
     {
     }
 
@@ -45,6 +50,8 @@ public sealed class TaskLoop : BackgroundService
     internal TaskLoop(
         IBotSession session,
         IBackendClient backend,
+        IIdleParker idleParker,
+        BotActivityState activity,
         Func<VerifyHandler> verify,
         Func<MonitorHandler> monitor,
         Func<WithdrawGroupHandler> withdrawGroup,
@@ -52,6 +59,8 @@ public sealed class TaskLoop : BackgroundService
     {
         _session = session;
         _backend = backend;
+        _idleParker = idleParker;
+        _activity = activity;
         _verify = verify;
         _monitor = monitor;
         _withdrawGroup = withdrawGroup;
@@ -100,8 +109,11 @@ public sealed class TaskLoop : BackgroundService
                 continue;
             }
 
+            _activity.RecordClaim(task, DateTimeOffset.UtcNow);
+
             if (task is null)
             {
+                await _idleParker.ParkIfNeededAsync(ct).ConfigureAwait(false);
                 await SafeDelayAsync(EmptyQueueBackoff, ct).ConfigureAwait(false);
                 continue;
             }
@@ -122,6 +134,10 @@ public sealed class TaskLoop : BackgroundService
             catch (Exception ex)
             {
                 _log.LogError(ex, "Handler crashed on task {Id}; no callback", task.Id);
+            }
+            finally
+            {
+                _activity.Clear();
             }
         }
     }

--- a/bot/src/Slpa.Bot/appsettings.json
+++ b/bot/src/Slpa.Bot/appsettings.json
@@ -17,5 +17,18 @@
   },
   "RateLimit": {
     "TeleportsPerMinute": 6
+  },
+  "IdlePark": {
+    "Enabled": true,
+    "Region": "Hadron",
+    "Corner1X": 44,
+    "Corner1Y": 73,
+    "Corner2X": 30,
+    "Corner2Y": 65,
+    "Z": 25,
+    "ParkCooldownSeconds": 180
+  },
+  "Heartbeat": {
+    "IntervalSeconds": 60
   }
 }

--- a/bot/tests/Slpa.Bot.Tests/BotActivityStateTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/BotActivityStateTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using Slpa.Bot.Backend.Models;
+using Slpa.Bot.Tasks;
+using Xunit;
+
+namespace Slpa.Bot.Tests;
+
+public sealed class BotActivityStateTests
+{
+    private static BotTaskResponse Task1() => new(
+        7, BotTaskType.MONITOR_AUCTION, BotTaskStatus.IN_PROGRESS,
+        42, null, Guid.NewGuid(), "Hadron", 1, 2, 3,
+        999, null, null, null, null, null, null,
+        Guid.NewGuid(), null, null, null,
+        DateTimeOffset.UnixEpoch, null);
+
+    [Fact]
+    public void RecordClaim_WithTask_SetsIdTypeAndLastClaim()
+    {
+        var s = new BotActivityState();
+        var t = DateTimeOffset.UnixEpoch.AddMinutes(5);
+
+        s.RecordClaim(Task1(), t);
+
+        var snap = s.Current;
+        snap.CurrentTaskId.Should().Be(7);
+        snap.CurrentTaskType.Should().Be("MONITOR_AUCTION");
+        snap.LastClaimAt.Should().Be(t);
+    }
+
+    [Fact]
+    public void RecordClaim_WithNull_SetsLastClaim_ClearsTask()
+    {
+        var s = new BotActivityState();
+        s.RecordClaim(Task1(), DateTimeOffset.UnixEpoch);
+
+        var t = DateTimeOffset.UnixEpoch.AddMinutes(9);
+        s.RecordClaim(null, t);
+
+        var snap = s.Current;
+        snap.CurrentTaskId.Should().BeNull();
+        snap.CurrentTaskType.Should().BeNull();
+        snap.LastClaimAt.Should().Be(t);
+    }
+
+    [Fact]
+    public void Clear_NullsTask_KeepsLastClaim()
+    {
+        var s = new BotActivityState();
+        var t = DateTimeOffset.UnixEpoch.AddMinutes(3);
+        s.RecordClaim(Task1(), t);
+
+        s.Clear();
+
+        var snap = s.Current;
+        snap.CurrentTaskId.Should().BeNull();
+        snap.CurrentTaskType.Should().BeNull();
+        snap.LastClaimAt.Should().Be(t);
+    }
+
+    [Fact]
+    public async Task ConcurrentReadWrite_DoesNotThrow_AndEndsConsistent()
+    {
+        var s = new BotActivityState();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        var writer = Task.Run(() =>
+        {
+            var n = 0;
+            while (!cts.Token.IsCancellationRequested)
+            {
+                s.RecordClaim(Task1(), DateTimeOffset.UnixEpoch.AddSeconds(n++));
+                s.Clear();
+            }
+        });
+        var reader = Task.Run(() =>
+        {
+            while (!cts.Token.IsCancellationRequested)
+            {
+                _ = s.Current;
+            }
+        });
+
+        await Task.WhenAll(writer, reader);
+        s.Current.Should().NotBeNull();
+    }
+}

--- a/bot/tests/Slpa.Bot.Tests/HeartbeatLoopTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/HeartbeatLoopTests.cs
@@ -13,6 +13,8 @@ namespace Slpa.Bot.Tests;
 
 public sealed class HeartbeatLoopTests
 {
+    // intervalSeconds = 0 -> Task.Delay(Zero) -> tight loop; the RunAsync
+    // tests bound it with a short CancellationTokenSource timeout instead.
     private static HeartbeatLoop Make(
         FakeBotSession session, IBackendClient backend,
         BotActivityState activity, int intervalSeconds = 0)

--- a/bot/tests/Slpa.Bot.Tests/HeartbeatLoopTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/HeartbeatLoopTests.cs
@@ -1,0 +1,130 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Slpa.Bot.Backend;
+using Slpa.Bot.Backend.Models;
+using Slpa.Bot.Options;
+using Slpa.Bot.Sl;
+using Slpa.Bot.Tasks;
+using Xunit;
+
+namespace Slpa.Bot.Tests;
+
+public sealed class HeartbeatLoopTests
+{
+    private static HeartbeatLoop Make(
+        FakeBotSession session, IBackendClient backend,
+        BotActivityState activity, int intervalSeconds = 0)
+    {
+        var botOpts = Microsoft.Extensions.Options.Options.Create(new BotOptions { Username = "SLPABot1 Resident" });
+        var hbOpts = Microsoft.Extensions.Options.Options.Create(new HeartbeatOptions { IntervalSeconds = intervalSeconds });
+        return new HeartbeatLoop(session, backend, activity, botOpts, hbOpts,
+            NullLogger<HeartbeatLoop>.Instance);
+    }
+
+    [Fact]
+    public async Task SendOnce_BuildsRequestFromSessionAndActivity()
+    {
+        var session = new FakeBotSession
+        {
+            CurrentLocation = new BotLocation("Hadron", 31, 66)
+        };
+        session.SimulateLoginSuccess(); // Online
+        var activity = new BotActivityState();
+        activity.RecordClaim(
+            new BotTaskResponse(
+                7, BotTaskType.MONITOR_AUCTION, BotTaskStatus.IN_PROGRESS,
+                42, null, Guid.NewGuid(), "Hadron", 1, 2, 3, 999,
+                null, null, null, null, null, null, Guid.NewGuid(),
+                null, null, null, DateTimeOffset.UnixEpoch, null),
+            DateTimeOffset.UnixEpoch.AddMinutes(2));
+
+        BotHeartbeatRequest? captured = null;
+        var backend = new Mock<IBackendClient>();
+        backend.Setup(b => b.SendHeartbeatAsync(
+                It.IsAny<BotHeartbeatRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<BotHeartbeatRequest, CancellationToken>((r, _) => captured = r)
+            .Returns(Task.CompletedTask);
+
+        var loop = Make(session, backend.Object, activity);
+        await loop.SendOnceAsync(default);
+
+        captured.Should().NotBeNull();
+        captured!.WorkerName.Should().Be("SLPABot1 Resident");
+        captured.SlUuid.Should().Be(session.BotUuid.ToString());
+        captured.SessionState.Should().Be("Online");
+        captured.CurrentRegion.Should().Be("Hadron");
+        captured.CurrentTaskKey.Should().Be("7");
+        captured.CurrentTaskType.Should().Be("MONITOR_AUCTION");
+        captured.LastClaimAt.Should().Be(DateTimeOffset.UnixEpoch.AddMinutes(2));
+    }
+
+    [Fact]
+    public async Task SendOnce_WhenNotOnline_StillSends_WithState()
+    {
+        var session = new FakeBotSession(); // Starting, no location
+        var backend = new Mock<IBackendClient>();
+        BotHeartbeatRequest? captured = null;
+        backend.Setup(b => b.SendHeartbeatAsync(
+                It.IsAny<BotHeartbeatRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<BotHeartbeatRequest, CancellationToken>((r, _) => captured = r)
+            .Returns(Task.CompletedTask);
+
+        var loop = Make(session, backend.Object, new BotActivityState());
+        await loop.SendOnceAsync(default);
+
+        captured!.SessionState.Should().Be("Starting");
+        captured.CurrentRegion.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Run_SendsHeartbeat_AtLeastOnce()
+    {
+        var session = new FakeBotSession();
+        var backend = new Mock<IBackendClient>();
+        backend.Setup(b => b.SendHeartbeatAsync(
+                It.IsAny<BotHeartbeatRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var loop = Make(session, backend.Object, new BotActivityState());
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+        await loop.RunAsync(cts.Token);
+
+        backend.Verify(b => b.SendHeartbeatAsync(
+            It.IsAny<BotHeartbeatRequest>(), It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task Run_SwallowsBackendException_ContinuesLooping()
+    {
+        var session = new FakeBotSession();
+        var backend = new Mock<IBackendClient>();
+        backend.Setup(b => b.SendHeartbeatAsync(
+                It.IsAny<BotHeartbeatRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new AuthConfigException("401"));
+
+        var loop = Make(session, backend.Object, new BotActivityState());
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        var act = async () => await loop.RunAsync(cts.Token);
+        await act.Should().NotThrowAsync();
+        backend.Verify(b => b.SendHeartbeatAsync(
+            It.IsAny<BotHeartbeatRequest>(), It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task Run_PreCancelled_StopsCleanly()
+    {
+        var session = new FakeBotSession();
+        var backend = new Mock<IBackendClient>();
+        var loop = Make(session, backend.Object, new BotActivityState());
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await loop.RunAsync(cts.Token);
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/bot/tests/Slpa.Bot.Tests/HttpBackendClientTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/HttpBackendClientTests.cs
@@ -151,4 +151,37 @@ public sealed class HttpBackendClientTests : IAsyncLifetime
             new BotMonitorResultRequest(MonitorOutcome.ALL_GOOD, null, null, null, null),
             default);
     }
+
+    [Fact]
+    public async Task Heartbeat_200_ReturnsWithoutThrow()
+    {
+        _server
+            .Given(Request.Create().WithPath("/api/v1/bot/heartbeat").UsingPost()
+                .WithHeader("Authorization", "Bearer test-secret-xxxxxxxx"))
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        await _client.SendHeartbeatAsync(
+            new BotHeartbeatRequest(
+                "SLPABot1 Resident",
+                Guid.NewGuid().ToString(),
+                "Online",
+                "Hadron",
+                "7",
+                "MONITOR_AUCTION",
+                DateTimeOffset.UnixEpoch),
+            default);
+    }
+
+    [Fact]
+    public async Task Heartbeat_401_ThrowsAuthConfigException()
+    {
+        _server
+            .Given(Request.Create().WithPath("/api/v1/bot/heartbeat").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(401));
+
+        var act = async () => await _client.SendHeartbeatAsync(
+            new BotHeartbeatRequest("w", "u", "Online", null, null, null, null),
+            default);
+        await act.Should().ThrowAsync<AuthConfigException>();
+    }
 }

--- a/bot/tests/Slpa.Bot.Tests/IdleParkerTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/IdleParkerTests.cs
@@ -1,0 +1,22 @@
+using FluentAssertions;
+using Slpa.Bot.Options;
+using Xunit;
+
+namespace Slpa.Bot.Tests;
+
+public sealed class IdleParkerTests
+{
+    [Fact]
+    public void IdleParkOptions_DefaultsToHadronRectangle()
+    {
+        var o = new IdleParkOptions();
+        o.Enabled.Should().BeTrue();
+        o.Region.Should().Be("Hadron");
+        o.Corner1X.Should().Be(44);
+        o.Corner1Y.Should().Be(73);
+        o.Corner2X.Should().Be(30);
+        o.Corner2Y.Should().Be(65);
+        o.Z.Should().Be(25);
+        o.ParkCooldownSeconds.Should().Be(180);
+    }
+}

--- a/bot/tests/Slpa.Bot.Tests/IdleParkerTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/IdleParkerTests.cs
@@ -169,6 +169,25 @@ public sealed class IdleParkerTests
     }
 
     [Fact]
+    public async Task ExceptionThrown_IsSwallowed_AndSetsCooldown()
+    {
+        var now = DateTimeOffset.UnixEpoch;
+        var session = new FakeBotSession
+        {
+            CurrentLocation = new BotLocation("Ahern", 1, 1),
+            TeleportPolicy = _ => throw new InvalidOperationException("boom")
+        };
+        var parker = Make(session, Opts(), () => now, () => 0.5);
+
+        // Does not throw (generic catch swallows non-OCE).
+        await parker.ParkIfNeededAsync(default);
+        // Second call at same clock is blocked by the cooldown set in catch.
+        await parker.ParkIfNeededAsync(default);
+
+        session.TeleportCalls.Should().HaveCount(1);
+    }
+
+    [Fact]
     public async Task CurrentLocationNull_SkipsGracefully()
     {
         var now = DateTimeOffset.UnixEpoch;

--- a/bot/tests/Slpa.Bot.Tests/IdleParkerTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/IdleParkerTests.cs
@@ -1,11 +1,27 @@
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Slpa.Bot.Options;
+using Slpa.Bot.Sl;
+using Slpa.Bot.Tasks;
 using Xunit;
 
 namespace Slpa.Bot.Tests;
 
 public sealed class IdleParkerTests
 {
+    private static IdleParkOptions Opts() => new();
+
+    private static Func<double> Seq(params double[] xs)
+    {
+        var i = 0;
+        return () => xs[Math.Min(i++, xs.Length - 1)];
+    }
+
+    private static IdleParker Make(
+        FakeBotSession session, IdleParkOptions opts,
+        Func<DateTimeOffset> now, Func<double> rng) =>
+        new(session, opts, NullLogger<IdleParker>.Instance, now, rng);
+
     [Fact]
     public void IdleParkOptions_DefaultsToHadronRectangle()
     {
@@ -18,5 +34,167 @@ public sealed class IdleParkerTests
         o.Corner2Y.Should().Be(65);
         o.Z.Should().Be(25);
         o.ParkCooldownSeconds.Should().Be(180);
+    }
+
+    [Fact]
+    public async Task Disabled_WhenEnabledFalse_NoTeleport()
+    {
+        var opts = Opts();
+        opts.Enabled = false;
+        var session = new FakeBotSession { CurrentLocation = new BotLocation("Elsewhere", 1, 1) };
+        var parker = Make(session, opts, () => DateTimeOffset.UnixEpoch, () => 0.5);
+
+        await parker.ParkIfNeededAsync(default);
+
+        session.TeleportCalls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Disabled_WhenRegionBlank_NoTeleport()
+    {
+        var opts = Opts();
+        opts.Region = "  ";
+        var session = new FakeBotSession { CurrentLocation = new BotLocation("Elsewhere", 1, 1) };
+        var parker = Make(session, opts, () => DateTimeOffset.UnixEpoch, () => 0.5);
+
+        await parker.ParkIfNeededAsync(default);
+
+        session.TeleportCalls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task InRectangle_NoTeleport()
+    {
+        var session = new FakeBotSession { CurrentLocation = new BotLocation("Hadron", 37, 69) };
+        var parker = Make(session, Opts(), () => DateTimeOffset.UnixEpoch, () => 0.5);
+
+        await parker.ParkIfNeededAsync(default);
+
+        session.TeleportCalls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DifferentRegion_TeleportsIntoRectangle_Forced()
+    {
+        var session = new FakeBotSession { CurrentLocation = new BotLocation("Ahern", 50, 50) };
+        var parker = Make(session, Opts(), () => DateTimeOffset.UnixEpoch, () => 0.5);
+
+        await parker.ParkIfNeededAsync(default);
+
+        var call = session.TeleportCalls.Should().ContainSingle().Subject;
+        call.Region.Should().Be("Hadron");
+        call.ForceMove.Should().BeTrue();
+        call.X.Should().BeInRange(30, 44);
+        call.Y.Should().BeInRange(65, 73);
+        call.Z.Should().Be(25);
+    }
+
+    [Fact]
+    public async Task SameRegionOutsideRectangle_TeleportsForced()
+    {
+        var session = new FakeBotSession { CurrentLocation = new BotLocation("Hadron", 200, 200) };
+        var parker = Make(session, Opts(), () => DateTimeOffset.UnixEpoch, () => 0.5);
+
+        await parker.ParkIfNeededAsync(default);
+
+        var call = session.TeleportCalls.Should().ContainSingle().Subject;
+        call.ForceMove.Should().BeTrue();
+        call.X.Should().BeInRange(30, 44);
+        call.Y.Should().BeInRange(65, 73);
+    }
+
+    [Fact]
+    public async Task CornerOrderIndependent_StillParksWithinBounds()
+    {
+        var opts = Opts();
+        (opts.Corner1X, opts.Corner2X) = (opts.Corner2X, opts.Corner1X);
+        (opts.Corner1Y, opts.Corner2Y) = (opts.Corner2Y, opts.Corner1Y);
+        var session = new FakeBotSession { CurrentLocation = new BotLocation("Ahern", 1, 1) };
+        var parker = Make(session, opts, () => DateTimeOffset.UnixEpoch, () => 0.5);
+
+        await parker.ParkIfNeededAsync(default);
+
+        var call = session.TeleportCalls.Should().ContainSingle().Subject;
+        call.X.Should().BeInRange(30, 44);
+        call.Y.Should().BeInRange(65, 73);
+    }
+
+    [Fact]
+    public async Task RandomPoint_AtExtremes_WithinBounds()
+    {
+        var session = new FakeBotSession { CurrentLocation = new BotLocation("Ahern", 1, 1) };
+        var parker = Make(session, Opts(), () => DateTimeOffset.UnixEpoch, Seq(0.0, 1.0));
+
+        await parker.ParkIfNeededAsync(default);
+
+        var call = session.TeleportCalls.Should().ContainSingle().Subject;
+        call.X.Should().Be(30);   // minX + 0.0*(maxX-minX)
+        call.Y.Should().Be(73);   // minY + 1.0*(maxY-minY)
+    }
+
+    [Fact]
+    public async Task Cooldown_BlocksReattempt_ThenAllowsAfterExpiry()
+    {
+        var now = DateTimeOffset.UnixEpoch;
+        var session = new FakeBotSession { CurrentLocation = new BotLocation("Ahern", 1, 1) };
+        var parker = Make(session, Opts(), () => now, () => 0.5);
+
+        await parker.ParkIfNeededAsync(default);          // attempt 1
+        session.TeleportCalls.Should().HaveCount(1);
+
+        now = DateTimeOffset.UnixEpoch.AddSeconds(60);     // < 180s cooldown
+        await parker.ParkIfNeededAsync(default);
+        session.TeleportCalls.Should().HaveCount(1);       // blocked
+
+        now = DateTimeOffset.UnixEpoch.AddSeconds(181);    // cooldown expired
+        await parker.ParkIfNeededAsync(default);
+        session.TeleportCalls.Should().HaveCount(2);       // allowed
+    }
+
+    [Fact]
+    public async Task FailedTeleport_SetsCooldown()
+    {
+        var now = DateTimeOffset.UnixEpoch;
+        var session = new FakeBotSession
+        {
+            CurrentLocation = new BotLocation("Ahern", 1, 1),
+            TeleportPolicy = _ => TeleportResult.Fail(TeleportFailureKind.RegionNotFound)
+        };
+        var parker = Make(session, Opts(), () => now, () => 0.5);
+
+        await parker.ParkIfNeededAsync(default);
+        await parker.ParkIfNeededAsync(default);           // same clock — in cooldown
+
+        session.TeleportCalls.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task CurrentLocationNull_SkipsGracefully()
+    {
+        var now = DateTimeOffset.UnixEpoch;
+        var session = new FakeBotSession { CurrentLocation = null };
+        var parker = Make(session, Opts(), () => now, () => 0.5);
+
+        await parker.ParkIfNeededAsync(default);
+        session.TeleportCalls.Should().BeEmpty();
+
+        // No cooldown burned — once location appears it parks immediately.
+        session.CurrentLocation = new BotLocation("Ahern", 1, 1);
+        await parker.ParkIfNeededAsync(default);
+        session.TeleportCalls.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Cancellation_Propagates()
+    {
+        var session = new FakeBotSession
+        {
+            CurrentLocation = new BotLocation("Ahern", 1, 1),
+            TeleportPolicy = _ => throw new OperationCanceledException()
+        };
+        var parker = Make(session, Opts(), () => DateTimeOffset.UnixEpoch, () => 0.5);
+
+        var act = async () => await parker.ParkIfNeededAsync(default);
+        await act.Should().ThrowAsync<OperationCanceledException>();
     }
 }

--- a/bot/tests/Slpa.Bot.Tests/LibreMetaverseBotSessionTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/LibreMetaverseBotSessionTests.cs
@@ -47,6 +47,22 @@ public sealed class LibreMetaverseBotSessionTests
         await session.LogoutAsync(CancellationToken.None);
         session.State.Should().Be(SessionState.Stopped);
     }
+
+    [Fact]
+    public async Task FakeSession_CapturesForcedTeleport_AndExposesLocation()
+    {
+        var session = new FakeBotSession
+        {
+            CurrentLocation = new BotLocation("Hadron", 37, 69)
+        };
+
+        await session.TeleportAsync("Hadron", 31, 66, 25, default, forceMove: true);
+
+        session.CurrentLocation!.Region.Should().Be("Hadron");
+        var call = session.TeleportCalls.Should().ContainSingle().Subject;
+        call.ForceMove.Should().BeTrue();
+        call.Region.Should().Be("Hadron");
+    }
 }
 
 /// <summary>In-test fake. Mirrors the real session's state machine.</summary>
@@ -57,6 +73,11 @@ public sealed class FakeBotSession : IBotSession
 
     public Func<string, TeleportResult> TeleportPolicy { get; set; } =
         _ => TeleportResult.Ok();
+
+    public BotLocation? CurrentLocation { get; set; }
+
+    /// <summary>Every <see cref="TeleportAsync"/> call, for assertions.</summary>
+    public List<TeleportCall> TeleportCalls { get; } = new();
 
     public Func<double, double, ParcelSnapshot?> ReadPolicy { get; set; } =
         (_, _) => null;
@@ -80,8 +101,12 @@ public sealed class FakeBotSession : IBotSession
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     public Task<TeleportResult> TeleportAsync(
-        string regionName, double x, double y, double z, CancellationToken ct)
-        => Task.FromResult(TeleportPolicy(regionName));
+        string regionName, double x, double y, double z,
+        CancellationToken ct, bool forceMove = false)
+    {
+        TeleportCalls.Add(new TeleportCall(regionName, x, y, z, forceMove));
+        return Task.FromResult(TeleportPolicy(regionName));
+    }
 
     public Task<ParcelSnapshot?> ReadParcelAsync(
         double x, double y, CancellationToken ct)
@@ -96,3 +121,6 @@ public sealed class FakeBotSession : IBotSession
 
 /// <summary>Argument capture for <see cref="FakeBotSession.GiveGroupMoney"/>.</summary>
 public sealed record GiveGroupMoneyCall(Guid GroupUuid, int AmountL, string Memo);
+
+/// <summary>Argument capture for <see cref="FakeBotSession.TeleportAsync"/>.</summary>
+public sealed record TeleportCall(string Region, double X, double Y, double Z, bool ForceMove);

--- a/bot/tests/Slpa.Bot.Tests/LibreMetaverseBotSessionTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/LibreMetaverseBotSessionTests.cs
@@ -49,19 +49,18 @@ public sealed class LibreMetaverseBotSessionTests
     }
 
     [Fact]
-    public async Task FakeSession_CapturesForcedTeleport_AndExposesLocation()
+    public async Task FakeSession_CapturesForcedTeleportCall()
     {
-        var session = new FakeBotSession
-        {
-            CurrentLocation = new BotLocation("Hadron", 37, 69)
-        };
+        var session = new FakeBotSession();
 
         await session.TeleportAsync("Hadron", 31, 66, 25, default, forceMove: true);
 
-        session.CurrentLocation!.Region.Should().Be("Hadron");
         var call = session.TeleportCalls.Should().ContainSingle().Subject;
-        call.ForceMove.Should().BeTrue();
         call.Region.Should().Be("Hadron");
+        call.X.Should().Be(31);
+        call.Y.Should().Be(66);
+        call.Z.Should().Be(25);
+        call.ForceMove.Should().BeTrue();
     }
 }
 

--- a/bot/tests/Slpa.Bot.Tests/TaskLoopTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/TaskLoopTests.cs
@@ -123,6 +123,34 @@ public sealed class TaskLoopTests
     }
 
     [Fact]
+    public async Task EmptyQueue_IdleParkerCancellation_StopsCleanly()
+    {
+        var session = new FakeBotSession();
+        session.SimulateLoginSuccess();
+        var backend = new Mock<IBackendClient>();
+        backend.Setup(b => b.ClaimAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync((BotTaskResponse?)null);
+        var parker = new Mock<IIdleParker>();
+        parker.Setup(p => p.ParkIfNeededAsync(It.IsAny<CancellationToken>()))
+              .ThrowsAsync(new OperationCanceledException());
+
+        var loop = new TaskLoop(session, backend.Object,
+            parker.Object, new BotActivityState(),
+            () => new VerifyHandler(session, backend.Object,
+                    NullLogger<VerifyHandler>.Instance),
+            () => new MonitorHandler(session, backend.Object,
+                    NullLogger<MonitorHandler>.Instance),
+            () => new WithdrawGroupHandler(session, backend.Object,
+                    NullLogger<WithdrawGroupHandler>.Instance),
+            NullLogger<TaskLoop>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var act = async () => await loop.RunAsync(cts.Token);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
     public async Task ClaimedTask_RecordsActivity_ClearedAfterDispatch()
     {
         var session = new FakeBotSession();

--- a/bot/tests/Slpa.Bot.Tests/TaskLoopTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/TaskLoopTests.cs
@@ -148,6 +148,10 @@ public sealed class TaskLoopTests
         var act = async () => await loop.RunAsync(cts.Token);
 
         await act.Should().NotThrowAsync();
+        // Loop returned on the parker's OCE rather than swallowing it and
+        // looping again — exactly one park attempt.
+        parker.Verify(p => p.ParkIfNeededAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/bot/tests/Slpa.Bot.Tests/TaskLoopTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/TaskLoopTests.cs
@@ -18,6 +18,7 @@ public sealed class TaskLoopTests
         var backend = new Mock<IBackendClient>();
 
         var loop = new TaskLoop(session, backend.Object,
+            Mock.Of<IIdleParker>(), new BotActivityState(),
             () => new VerifyHandler(session, backend.Object,
                     NullLogger<VerifyHandler>.Instance),
             () => new MonitorHandler(session, backend.Object,
@@ -43,6 +44,7 @@ public sealed class TaskLoopTests
                .ReturnsAsync((BotTaskResponse?)null);
 
         var loop = new TaskLoop(session, backend.Object,
+            Mock.Of<IIdleParker>(), new BotActivityState(),
             () => new VerifyHandler(session, backend.Object,
                     NullLogger<VerifyHandler>.Instance),
             () => new MonitorHandler(session, backend.Object,
@@ -75,6 +77,7 @@ public sealed class TaskLoopTests
                });
 
         var loop = new TaskLoop(session, backend.Object,
+            Mock.Of<IIdleParker>(), new BotActivityState(),
             () => new VerifyHandler(session, backend.Object,
                     NullLogger<VerifyHandler>.Instance),
             () => new MonitorHandler(session, backend.Object,
@@ -90,6 +93,66 @@ public sealed class TaskLoopTests
                 It.IsAny<BotTaskCompleteRequest>(), It.IsAny<CancellationToken>()),
                 Times.Never);
         claims.Should().BeGreaterOrEqualTo(1);
+    }
+
+    [Fact]
+    public async Task EmptyQueue_InvokesIdleParker()
+    {
+        var session = new FakeBotSession();
+        session.SimulateLoginSuccess();
+        var backend = new Mock<IBackendClient>();
+        backend.Setup(b => b.ClaimAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync((BotTaskResponse?)null);
+        var parker = new Mock<IIdleParker>();
+
+        var loop = new TaskLoop(session, backend.Object,
+            parker.Object, new BotActivityState(),
+            () => new VerifyHandler(session, backend.Object,
+                    NullLogger<VerifyHandler>.Instance),
+            () => new MonitorHandler(session, backend.Object,
+                    NullLogger<MonitorHandler>.Instance),
+            () => new WithdrawGroupHandler(session, backend.Object,
+                    NullLogger<WithdrawGroupHandler>.Instance),
+            NullLogger<TaskLoop>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(400));
+        await loop.RunAsync(cts.Token);
+
+        parker.Verify(p => p.ParkIfNeededAsync(It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task ClaimedTask_RecordsActivity_ClearedAfterDispatch()
+    {
+        var session = new FakeBotSession();
+        session.SimulateLoginSuccess();
+        var backend = new Mock<IBackendClient>();
+        var claims = 0;
+        backend.Setup(b => b.ClaimAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(() =>
+               {
+                   claims++;
+                   return claims == 1 ? MakeVerifyTask() : null;
+               });
+        var activity = new BotActivityState();
+
+        var loop = new TaskLoop(session, backend.Object,
+            Mock.Of<IIdleParker>(), activity,
+            () => new VerifyHandler(session, backend.Object,
+                    NullLogger<VerifyHandler>.Instance),
+            () => new MonitorHandler(session, backend.Object,
+                    NullLogger<MonitorHandler>.Instance),
+            () => new WithdrawGroupHandler(session, backend.Object,
+                    NullLogger<WithdrawGroupHandler>.Instance),
+            NullLogger<TaskLoop>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(400));
+        await loop.RunAsync(cts.Token);
+
+        var snap = activity.Current;
+        snap.LastClaimAt.Should().NotBeNull();   // a claim happened
+        snap.CurrentTaskId.Should().BeNull();    // cleared in finally
     }
 
     private static BotTaskResponse MakeVerifyTask() => new(


### PR DESCRIPTION
## Summary

Two bot-side features (spec `docs/superpowers/specs/2026-05-15-bot-idle-park-and-heartbeat-design.md`, plan `docs/superpowers/plans/2026-05-15-bot-idle-park-and-heartbeat.md`):

- **Idle-park** — when a bot has no task to service it teleports to a random point inside a configurable rectangle in a configurable region (Hadron baked in as defaults, on by default, every field env-overridable via `IdlePark__*`). Rectangle-precise (forces an in-region move via a new optional `TeleportAsync(forceMove)`); a configurable `ParkCooldownSeconds` (default 180s) gates park attempts and doubles as the failed-park backoff. Stateless rectangle check — being inside the rectangle is its own idempotency.
- **Heartbeat** — fixes the admin Bot-pool panel showing `0/0` while bots are logged in. The backend `POST /api/v1/bot/heartbeat` endpoint already existed; the bot never called it. New `HeartbeatLoop` BackgroundService POSTs it every `Heartbeat__IntervalSeconds` (default 60s), running regardless of session state and never crashing (all failures incl. `AuthConfigException` swallowed). Carries session state + region + current task via a thread-safe `BotActivityState` written by `TaskLoop`.

**Hard invariant:** the heartbeat/activity state never influences idle detection or the park decision — `IdleParker` has zero coupling to `BotActivityState`/`HeartbeatLoop`, enforced structurally by its dependency graph. The heartbeat does not count against idle time.

## Scope

Bot-side only. No backend, Flyway, or frontend code changes. The `POST /api/v1/bot/heartbeat` request was mirrored into the SLPA Postman collection (Bot folder).

## Testing

`dotnet test bot/Slpa.Bot.sln` — 62/62 passing (TDD throughout; covers cooldown lifecycle, OCE shutdown, regardless-of-state heartbeat, exception-swallow, backend field-name parity, concurrent activity-state read/write). Runtime DI smoke-checked: the host composes and `HeartbeatLoop` fires.

Two plan-defect corrections shipped with proving tests: a dedicated OCE catch around the park call in `TaskLoop.RunAsync` (the plan wrongly assumed an existing catch would cover it), and a non-vacuous forced-teleport capture test.