### PR TITLE
fix(infra): unbreak bot deploy — scope ecs:ListServices via condition

### DIFF
--- a/infra/cicd/iam.tf
+++ b/infra/cicd/iam.tf
@@ -119,13 +119,22 @@ data "aws_iam_policy_document" "gha_deploy" {
     }
   }
 
-  # CodeDeploy hooks call ListServices on the cluster to discover targets.
-  # Cheap to grant; needed for `aws ecs describe-services --cluster <arn>` from
-  # workflows when iterating bot services.
+  # The deploy-bot workflow calls ListServices to discover slpa-${env}-bot-*
+  # services dynamically (bot pool size is driven by var.bot_active_count in
+  # the compute module). ecs:ListServices has NO resource-level support in IAM
+  # (same AWS constraint documented for RegisterTaskDefinition above), so it
+  # must be granted on "*" and scoped to this cluster via the ecs:cluster
+  # condition key instead. A cluster-ARN in `resources` is silently ineffective
+  # for this action.
   statement {
     sid       = "EcsListServices"
     actions   = ["ecs:ListServices"]
-    resources = [var.ecs_cluster_arn]
+    resources = ["*"]
+    condition {
+      test     = "ArnEquals"
+      variable = "ecs:cluster"
+      values   = [var.ecs_cluster_arn]
+    }
   }
 }
 


### PR DESCRIPTION
The `deploy bots` workflow has failed every run (3/3 on `main`) at the "Discover active bot services" step: the GitHub Actions OIDC role `slpa-prod-gha-deploy` was denied `ecs:ListServices`.

Root cause: `ecs:ListServices` has no IAM resource-level support, but the `EcsListServices` statement scoped it to the cluster ARN in `resources`, which IAM silently ignores for this action. The statement was applied (live policy had it) but ineffective.

Fix: grant on `"*"` with an `ecs:cluster` `ArnEquals` condition (same AWS constraint already documented for `RegisterTaskDefinition`/`DescribeTaskDefinition` in the same file). Cluster-scoped, not a blanket grant.

Applied to prod: `terraform apply -target=module.cicd` (plan was `0 add, 1 change, 0 destroy` — only the `gha_deploy` inline policy). Live policy verified to now allow `ecs:ListServices` with the cluster condition. This commit lands the IaC so a future apply from `main` does not revert the live fix.

No runtime/service impact — the role is only assumed by GitHub Actions during deploys.