### PR TITLE
Deploy: LSL split — Pay to group sister script

### DIFF
--- a/lsl-scripts/README.md
+++ b/lsl-scripts/README.md
@@ -39,12 +39,21 @@ A script's README must cover:
   venues + Marketplace.
 - [`slpa-terminal/`](slpa-terminal/) — Wallet-model payment terminal. Right-
   click → Pay credits the user's wallet via `/sl/wallet/deposit` (lockless,
-  fully concurrent). Touch menu offers Deposit-instructions and Withdraw.
-  Withdraw uses per-flow slots dispatched by avatar key on a single shared
-  listen — no terminal-wide lock. Also receives HTTP-in commands from the
-  backend for PAYOUT / WITHDRAW execution (REFUND defensive — refunds are
-  wallet credits, never dispatched). SLParcels-team-deployed; holds shared
-  secret + PERMISSION_DEBIT.
+  fully concurrent). Touch menu offers Deposit-instructions and Withdraw
+  (plus "Pay to group" when the sister `slpa-terminal-group/` script is
+  loaded in the same prim). Withdraw uses per-flow slots dispatched by
+  avatar key on a single shared listen — no terminal-wide lock. Also
+  receives HTTP-in commands from the backend for PAYOUT / WITHDRAW
+  execution (REFUND defensive — refunds are wallet credits, never
+  dispatched). SLParcels-team-deployed; holds shared secret +
+  PERMISSION_DEBIT.
+- [`slpa-terminal-group/`](slpa-terminal-group/) — Sister script for
+  `slpa-terminal/`. Owns the "Pay to group" flow: typed-name text-box,
+  per-avatar deposit slot, `/sl/wallet/group-deposit` POST + retry +
+  refund. Lives in the SAME prim as `slpa-terminal/` and coordinates with
+  it via `llMessageLinked` (PING/PONG/START/CLAIM/RELEASE). Each LSL
+  script has its own 64KB heap, so the split exists purely to keep the
+  combined feature set off a single script's memory budget.
 - [`sl-im-dispatcher/`](sl-im-dispatcher/) — Polls SLParcels backend for pending
   SL IM notifications and delivers them via `llInstantMessage`. SLParcels-team-deployed
   (one instance per environment); not user-deployed.

--- a/lsl-scripts/slpa-terminal-group/README.md
+++ b/lsl-scripts/slpa-terminal-group/README.md
@@ -1,0 +1,164 @@
+# SLParcels Terminal — Pay to group (sister script)
+
+Sister script to [`slpa-terminal/`](../slpa-terminal/). Owns the "Pay to
+group" flow on the same prim: the typed-name text-box, the pending
+group-deposit slot, the `/sl/wallet/group-deposit` POST + retry chain +
+refund-on-error.
+
+The wallet and group-pay logic used to live together in
+`slpa-terminal.lsl`, but the combined feature set tripped Stack-Heap
+Collision on real terminals. Each LSL script in a prim gets its own
+64KB heap; splitting into two cooperating scripts doubles the budget
+and keeps each script's footprint manageable. Both scripts go in the
+SAME prim and share the same `config` notecard.
+
+## Architecture summary
+
+- **Coordination** is via `llMessageLinked` between the two scripts in
+  the same prim. Fixed integer protocol codes:
+  - `10 PING` — wallet → group at wallet's `state_entry`. "Are you here?"
+  - `11 PONG` — group → wallet response. Wallet uses this to decide
+    whether to show the "Pay to group" button.
+  - `12 START` — wallet → group. "Avatar X just tapped Pay to group."
+  - `13 CLAIM` — group → wallet. "Avatar X has typed a group name;
+    skip your personal-deposit POST when their next `money()` event
+    fires."
+  - `14 RELEASE` — group → wallet. "Drop the claim on avatar X."
+
+- **money() fires in BOTH scripts** when an avatar pays the prim. The
+  wallet script (running independently) checks its claimed-avatars list
+  on every `money()` event; if the payer is in it, wallet skips its
+  `/sl/wallet/deposit` POST and lets this script POST
+  `/sl/wallet/group-deposit` instead. Single ledger credit per pay.
+
+- **Flow:** touch the prim → wallet's dialog shows
+  `[Deposit, Pay to group, Withdraw]` (the third button only appears
+  when this script PONGed at startup) → user picks "Pay to group" →
+  wallet `llMessageLinked`s START to this script → this script opens
+  `llTextBox` "Type the realty group's name" on its own channel → user
+  types a name → this script stores the slot + CLAIMs the avatar with
+  wallet → user has 60 seconds to right-click → Pay → `money()` fires
+  in BOTH scripts → wallet skips, this script POSTs
+  `/sl/wallet/group-deposit` with `groupName`.
+
+- **Refund discipline** (per [CLAUDE.md](../../CLAUDE.md) "always refund
+  on deposit error"): L$ is in the script's hands by the time `money()`
+  fires. Every post-auth failure — `REFUND`/`UNKNOWN_GROUP` (typo),
+  permission revoked, group dissolved, suspended, frozen depositor,
+  unparseable response, retry exhaustion, expired slot — bounces the
+  L$ back via `llTransferLindenDollars`.
+
+- **Retry chain** mirrors the wallet's personal-deposit chain: 10s /
+  30s / 90s / 5m / 15m. Idempotent on `slTransactionKey`. After the
+  five-try chain exhausts, the script refunds and logs CRITICAL for
+  ops reconciliation.
+
+- **No HTTP-in.** This script doesn't register a URL with the backend;
+  the wallet script's HTTP-in URL is the prim's single dispatch
+  endpoint. This script only makes outbound `llHTTPRequest` calls.
+
+- **PERMISSION_DEBIT** is per-script; this script requests its own
+  grant at `state_entry`. On first reset after adding this script to a
+  prim, accept a SECOND debit dialog (the wallet's grant alone doesn't
+  let this script `llTransferLindenDollars`).
+
+## Deployment
+
+1. **Wallet script must be present first.** This script is a sister to
+   `slpa-terminal.lsl` and assumes the same prim already runs the
+   wallet script (config notecard, terminal registration, etc.).
+2. Drop `slpa-terminal-group.lsl` into the prim's contents. The script
+   auto-resets via `CHANGED_INVENTORY`.
+3. Accept the **PERMISSION_DEBIT** dialog when prompted (separate grant
+   from the wallet script's).
+4. Confirm on owner-say:
+   - `SLParcels Group Pay: config loaded.`
+   - The wallet script's startup ping will trigger a PONG; the touch
+     menu now includes "Pay to group".
+5. Smoke-test:
+   - Touch → Pay to group → type a real group's display name → wait
+     for "You have 60 seconds..." chat → right-click → Pay → L$10.
+     Confirm `ok L$10 to '<group name>'` owner-say and the
+     `MEMBER_DEPOSIT` row on the group's wallet ledger.
+   - Touch → Pay to group → type a non-existent name → Pay → L$10.
+     Confirm `refunded (UNKNOWN_GROUP) L$10` and the L$ comes back.
+   - Touch → Pay to group → type a name → wait > 65 seconds → Pay →
+     L$10. Confirm the slot-expired refund path fires.
+
+## Configuration
+
+Reads the SAME `config` notecard as the wallet script. Recognised keys:
+
+| Key | Description |
+| --- | --- |
+| `GROUP_DEPOSIT_URL` | Full URL of `/api/v1/sl/wallet/group-deposit`. **Required** for this script to do anything useful. |
+| `SHARED_SECRET` | Same secret as the wallet script's. **Required.** |
+| `TERMINAL_ID` | Optional; defaults to `(string)llGetKey()`. Same value the wallet script uses. |
+| `REGION_NAME` | Optional; defaults to `llGetRegionName()`. |
+| `DEBUG_MODE` | Optional; `true`/`false`. Default `true`. Controls per-event owner-say. |
+
+All other keys (REGISTER_URL, DEPOSIT_URL, etc.) are silently ignored —
+those belong to the wallet script.
+
+## Operations
+
+In steady state with `DEBUG_MODE=true`:
+
+- `SLParcels Group Pay: config loaded.` — startup confirmation.
+- `SLParcels Group Pay: ok L$<N> to '<group name>'` — successful
+  deposit.
+- `SLParcels Group Pay: refunded (<REASON>) L$<N> to <payer>` — backend
+  returned REFUND; L$ bounced.
+- `SLParcels Group Pay: refunded on ERROR (<REASON>) L$<N> to <payer>` —
+  backend returned ERROR; L$ bounced defensively (the
+  always-refund-on-deposit-error rule).
+- `SLParcels Group Pay: retry N/5: status=<code>` — transient backend
+  error; retrying on the same `slTransactionKey`.
+- `SLParcels Group Pay: slot expired before pay, refunded L$<N> to
+  <payer>` — payer paid more than 60s after typing the group name; L$
+  bounced rather than crediting their personal wallet (wallet skipped
+  due to a stale CLAIM).
+- `CRITICAL: SLParcels Group Pay: deposit ... not acknowledged after 5
+  retries; refunded payer` — backend POST never succeeded after five
+  retries; bounced L$ and logged for ops reconciliation.
+- `CRITICAL: SLParcels Group Pay: PERMISSION_DEBIT denied.` — owner
+  declined the debit dialog. Refunds-on-error won't work. Reset and
+  accept.
+- `CRITICAL: SLParcels Group Pay: incomplete config notecard.` — one
+  of GROUP_DEPOSIT_URL / SHARED_SECRET / TERMINAL_ID is missing or
+  empty.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| Touch menu doesn't show "Pay to group" | This script not present in the prim, or its `state_entry` halted before sending PONG. Check owner-say for `incomplete config notecard` or `PERMISSION_DEBIT denied`. |
+| "Pay to group" button does nothing | Wallet sent START but this script's `link_message` handler didn't fire — either the script is halted or PERMISSION_DEBIT was denied. Reset and re-accept the debit dialog. |
+| Pay L$ went to the payer's personal wallet, not the group | The 60-second slot expired before they paid, OR the avatar never typed a name (text-box was cancelled). The wallet's claim was released, so personal deposit took over. |
+| `REFUND/UNKNOWN_GROUP` on a name that should exist | Backend's case-insensitive match against active groups returned empty. The group is dissolved, suspended, or the name contains a typo (check whitespace and Unicode characters). |
+| Both scripts log "deposit ok" for the same pay | Coordination bug — CLAIM didn't propagate. Reset both scripts; check timing of the wallet's startup PING. |
+
+## Limits
+
+- **One concurrent group-deposit per terminal.** A second `money()`
+  arriving while the first is mid-retry chain refunds immediately. In
+  practice deposit POSTs are sub-second when the backend is healthy, so
+  this only matters during a backend outage.
+- **Single-slot text-box state.** A second avatar starting "Pay to
+  group" clobbers the first's pending text-box; the first's typed
+  response (if any) is silently ignored.
+- **`llTransferLindenDollars` rate limit** is shared with the wallet
+  script (30 payments per 30s per owner per region). Refund-heavy
+  failure modes could approach the cap during an outage.
+
+## Security
+
+- Holds the same shared secret as the wallet script (read from the same
+  notecard). Anyone with edit-rights on the prim can read both.
+- The `groupName` field is user-typed and sent verbatim to the backend;
+  the backend does the case-insensitive match against active group
+  names. Validation happens server-side, so a malformed name just
+  results in a REFUND.
+- HMAC-SHA256 per-request auth is on the deferred list for Phase 2
+  hardening once the LSL terminal is dogfooded — same posture as the
+  wallet script.

--- a/lsl-scripts/slpa-terminal-group/config.notecard.example
+++ b/lsl-scripts/slpa-terminal-group/config.notecard.example
@@ -1,0 +1,29 @@
+# config notecard for SLParcels Terminal -- shared between the wallet
+# script (slpa-terminal.lsl) and this sister "Pay to group" script
+# (slpa-terminal-group.lsl). Place this file (renamed to "config", no
+# extension) in the SAME prim's contents. Both scripts read it.
+#
+# This example shows ONLY the keys this sister script needs. The wallet
+# script has additional keys (REGISTER_URL, DEPOSIT_URL,
+# WITHDRAW_REQUEST_URL, PAYOUT_RESULT_URL, HEARTBEAT_URL) which the
+# sister script silently ignores. See slpa-terminal/config.notecard.example
+# for the complete notecard.
+
+# Backend endpoint for the "Pay to group" POST. REQUIRED.
+GROUP_DEPOSIT_URL=https://slpa.app/api/v1/sl/wallet/group-deposit
+
+# Shared secret for terminal authentication. Same value as the wallet
+# script reads. REQUIRED. Obtain from slpa.escrow.terminal-shared-secret.
+SHARED_SECRET=replace-with-real-secret-from-deployment-secrets-store
+
+# Optional: defaults to (string)llGetKey() if empty. Should match the
+# wallet script's TERMINAL_ID so both scripts present as one terminal
+# to the backend.
+TERMINAL_ID=
+
+# Optional: defaults to llGetRegionName() if empty.
+REGION_NAME=
+
+# Optional: false to silence per-event chat AND user-facing diagnostic
+# lines on HTTP errors. Recommended true in prod for observability.
+DEBUG_MODE=true

--- a/lsl-scripts/slpa-terminal-group/slpa-terminal-group.lsl
+++ b/lsl-scripts/slpa-terminal-group/slpa-terminal-group.lsl
@@ -1,0 +1,384 @@
+// SLParcels Terminal — "Pay to group" sister script.
+//
+// Designed to be dropped into the SAME prim as `slpa-terminal.lsl`. The
+// wallet script owns touch/dialog/personal-deposit/withdraw/HTTP-in;
+// this script owns ONLY the "Pay to group" flow. The split exists
+// because the combined feature set tripped Stack-Heap Collision on real
+// terminals -- each LSL script gets its own 64KB heap, so two scripts in
+// one prim doubles the budget.
+//
+// Coordination protocol (llMessageLinked, fixed integer codes):
+//   PING (10)    wallet -> group : at wallet's state_entry
+//   PONG (11)    group  -> wallet: response to PING
+//   START (12)   wallet -> group : user X tapped "Pay to group"
+//   CLAIM (13)   group  -> wallet: user X has a pending slot; route
+//                                  their next money() to me
+//   RELEASE (14) group  -> wallet: drop the CLAIM on user X
+//
+// money() fires in BOTH scripts when an avatar pays. The CLAIM/RELEASE
+// protocol lets the wallet skip its personal-deposit POST whenever this
+// script intends to handle the L$ — so a single payment results in a
+// single ledger credit.
+//
+// Configuration is shared with the wallet script via the same `config`
+// notecard in the prim's contents. This script reads only the keys it
+// needs (GROUP_DEPOSIT_URL, SHARED_SECRET, TERMINAL_ID, REGION_NAME,
+// DEBUG_MODE) and silently ignores the rest.
+
+// === Config ===
+string  GROUP_DEPOSIT_URL = "";
+string  SHARED_SECRET     = "";
+string  TERMINAL_ID       = "";
+string  REGION_NAME       = "";
+integer DEBUG_MODE        = TRUE;
+
+// === Notecard reading state ===
+key     notecardLineRequest = NULL_KEY;
+integer notecardLineNum     = 0;
+
+// === Permissions ===
+integer debitGranted = FALSE;
+
+// === Listen channel for the typed group-name text-box ===
+integer mainChan         = 0;
+integer mainListenHandle = -1;
+
+// === Link-message protocol codes (must match wallet script) ===
+integer LM_PING    = 10;
+integer LM_PONG    = 11;
+integer LM_START   = 12;
+integer LM_CLAIM   = 13;
+integer LM_RELEASE = 14;
+
+// === Pending text-box input (single-slot, last-write-wins) ===
+key     pendingNameAvatar    = NULL_KEY;
+integer pendingNameExpiresAt = 0;
+integer NAME_INPUT_TTL       = 60;
+integer GROUP_NAME_MAX_CHARS = 64;
+
+// === Pending group-deposit slot (single-slot per terminal) ===
+//   When the avatar has typed a name and the slot is set, the next
+//   money() event from that avatar within DEPOSIT_SLOT_TTL seconds
+//   POSTs to /sl/wallet/group-deposit. We keep it single-slot to
+//   match wallet's CLAIMED_CAP=4 in spirit -- a second concurrent
+//   "Pay to group" overwrites; rare in practice.
+key     pendingDepositAvatar    = NULL_KEY;
+string  pendingDepositGroupName = "";
+integer pendingDepositExpiresAt = 0;
+integer DEPOSIT_SLOT_TTL        = 60;
+
+// === In-flight /group-deposit request tracking ===
+key     depositReqId        = NULL_KEY;
+key     depositPayer        = NULL_KEY;
+integer depositAmount       = 0;
+string  depositTxKey        = "";
+string  depositGroupName    = "";
+integer depositRetryCount   = 0;
+integer depositNextRetryAt  = 0;
+
+// === Timer phase ===
+integer TIMER_NONE        = 0;
+integer TIMER_SWEEP       = 1;
+integer TIMER_DEPOSIT_RETRY = 2;
+integer timerPhase        = 0;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+readNotecardLine(integer n) {
+    notecardLineNum     = n;
+    notecardLineRequest = llGetNotecardLine("config", n);
+}
+
+parseConfigLine(string line) {
+    if (llStringLength(line) == 0) return;
+    if (llSubStringIndex(line, "#") == 0) return;
+    integer eq = llSubStringIndex(line, "=");
+    if (eq < 1) return;
+    string k = llStringTrim(llGetSubString(line, 0, eq - 1), STRING_TRIM);
+    string v = llStringTrim(llGetSubString(line, eq + 1, -1), STRING_TRIM);
+    if      (k == "GROUP_DEPOSIT_URL") GROUP_DEPOSIT_URL = v;
+    else if (k == "SHARED_SECRET")     SHARED_SECRET     = v;
+    else if (k == "TERMINAL_ID")       TERMINAL_ID       = v;
+    else if (k == "REGION_NAME")       REGION_NAME       = v;
+    else if (k == "DEBUG_MODE")
+        DEBUG_MODE = (v == "true" || v == "TRUE" || v == "1");
+}
+
+string escapeJson(string s) {
+    s = llReplaceSubString(s, "\\", "\\\\", 0);
+    s = llReplaceSubString(s, "\"", "\\\"", 0);
+    return s;
+}
+
+integer retryDelay(integer attempt) {
+    list schedule = [10, 30, 90, 300, 900];
+    integer idx = attempt - 1;
+    if (idx < 0) idx = 0;
+    if (idx > 4) idx = 4;
+    return llList2Integer(schedule, idx);
+}
+
+clearDepositSlot() {
+    pendingDepositAvatar    = NULL_KEY;
+    pendingDepositGroupName = "";
+    pendingDepositExpiresAt = 0;
+}
+
+clearNameInputSlot() {
+    pendingNameAvatar    = NULL_KEY;
+    pendingNameExpiresAt = 0;
+}
+
+clearDepositRetryState() {
+    depositReqId       = NULL_KEY;
+    depositPayer       = NULL_KEY;
+    depositAmount      = 0;
+    depositTxKey       = "";
+    depositGroupName   = "";
+    depositRetryCount  = 0;
+    depositNextRetryAt = 0;
+}
+
+fireDepositPost() {
+    string body = "{"
+        + "\"payerUuid\":\"" + (string)depositPayer + "\","
+        + "\"groupName\":\"" + escapeJson(depositGroupName) + "\","
+        + "\"amount\":" + (string)depositAmount + ","
+        + "\"slTransactionKey\":\"" + depositTxKey + "\","
+        + "\"terminalId\":\"" + escapeJson(TERMINAL_ID) + "\","
+        + "\"sharedSecret\":\"" + escapeJson(SHARED_SECRET) + "\""
+        + "}";
+    depositReqId = llHTTPRequest(GROUP_DEPOSIT_URL,
+        [HTTP_METHOD, "POST",
+         HTTP_MIMETYPE, "application/json",
+         HTTP_BODY_MAXLENGTH, 16384],
+        body);
+}
+
+scheduleDepositRetry() {
+    if (depositRetryCount >= 5) {
+        // Refund discipline: L$ in hand, backend unreachable. Bounce.
+        llTransferLindenDollars(depositPayer, depositAmount);
+        llOwnerSay("CRITICAL: SLParcels Group Pay: deposit from "
+            + (string)depositPayer
+            + " L$" + (string)depositAmount
+            + " to '" + depositGroupName
+            + "' not acknowledged after 5 retries; refunded payer");
+        clearDepositRetryState();
+        if (timerPhase == TIMER_DEPOSIT_RETRY) {
+            timerPhase = TIMER_SWEEP;
+            llSetTimerEvent(10.0);
+        }
+        return;
+    }
+    integer delay = retryDelay(depositRetryCount);
+    depositNextRetryAt = llGetUnixTime() + delay;
+    timerPhase = TIMER_DEPOSIT_RETRY;
+    llSetTimerEvent((float)delay);
+}
+
+// ---------------------------------------------------------------------------
+
+default {
+    state_entry() {
+        GROUP_DEPOSIT_URL = "";
+        SHARED_SECRET     = "";
+        TERMINAL_ID       = "";
+        REGION_NAME       = "";
+        DEBUG_MODE        = TRUE;
+        notecardLineRequest = NULL_KEY;
+        notecardLineNum     = 0;
+        debitGranted        = FALSE;
+        clearDepositSlot();
+        clearNameInputSlot();
+        clearDepositRetryState();
+        timerPhase = TIMER_NONE;
+
+        // Mainland-only grid guard.
+        if (llGetEnv("sim_channel") != "Second Life Server") {
+            llOwnerSay("CRITICAL: SLParcels Group Pay: not on Second Life Server grid; halting.");
+            return;
+        }
+        if (TERMINAL_ID == "") TERMINAL_ID = (string)llGetKey();
+        if (REGION_NAME == "") REGION_NAME = llGetRegionName();
+
+        // Random negative channel for our own llTextBox responses.
+        mainChan = -200000 - (integer)(llFrand(50000.0));
+        mainListenHandle = llListen(mainChan, "", NULL_KEY, "");
+
+        readNotecardLine(0);
+        llRequestPermissions(llGetOwner(), PERMISSION_DEBIT);
+
+        // 10s sweeper.
+        timerPhase = TIMER_SWEEP;
+        llSetTimerEvent(10.0);
+    }
+
+    on_rez(integer n) { llResetScript(); }
+
+    changed(integer change) {
+        if (change & CHANGED_INVENTORY) llResetScript();
+    }
+
+    run_time_permissions(integer perm) {
+        if (perm & PERMISSION_DEBIT) {
+            debitGranted = TRUE;
+        } else {
+            llOwnerSay("CRITICAL: SLParcels Group Pay: PERMISSION_DEBIT denied. "
+                + "Refunds-on-error won't work. Owner must re-grant.");
+        }
+    }
+
+    dataserver(key requested, string data) {
+        if (requested != notecardLineRequest) return;
+        if (data == EOF) {
+            if (GROUP_DEPOSIT_URL == "" || SHARED_SECRET == "" || TERMINAL_ID == "") {
+                llOwnerSay("CRITICAL: SLParcels Group Pay: incomplete config notecard.");
+                return;
+            }
+            if (DEBUG_MODE) llOwnerSay("SLParcels Group Pay: config loaded.");
+            return;
+        }
+        parseConfigLine(data);
+        readNotecardLine(notecardLineNum + 1);
+    }
+
+    link_message(integer sender, integer num, string str, key id) {
+        if (num == LM_PING) {
+            llMessageLinked(LINK_THIS, LM_PONG, "", NULL_KEY);
+            return;
+        }
+        if (num == LM_START) {
+            // Wallet says: avatar `id` picked "Pay to group". Open our
+            // text-box and remember which avatar we're waiting on.
+            if (GROUP_DEPOSIT_URL == "") {
+                llRegionSayTo(id, 0, "SLParcels Group Pay isn't configured. Try again later.");
+                return;
+            }
+            pendingNameAvatar    = id;
+            pendingNameExpiresAt = llGetUnixTime() + NAME_INPUT_TTL;
+            llTextBox(id,
+                "Type the realty group's name (the name as shown on the "
+                + "group's profile page). You then have 60 seconds to "
+                + "right-click -> Pay to deposit. Cancel = no deposit.",
+                mainChan);
+            return;
+        }
+    }
+
+    listen(integer chan, string name, key id, string msg) {
+        if (chan != mainChan) return;
+        if (pendingNameAvatar != id) return;
+        clearNameInputSlot();
+        string typed = llStringTrim(msg, STRING_TRIM);
+        if (typed == "") {
+            llRegionSayTo(id, 0, "SLParcels Group Pay: cancelled (no name typed).");
+            return;
+        }
+        if (llStringLength(typed) > GROUP_NAME_MAX_CHARS) {
+            typed = llGetSubString(typed, 0, GROUP_NAME_MAX_CHARS - 1);
+        }
+        pendingDepositAvatar    = id;
+        pendingDepositGroupName = typed;
+        pendingDepositExpiresAt = llGetUnixTime() + DEPOSIT_SLOT_TTL;
+        // Tell the wallet script to skip its personal-deposit POST when
+        // this avatar's next money() event fires.
+        llMessageLinked(LINK_THIS, LM_CLAIM, "", id);
+        llRegionSayTo(id, 0,
+            "You have 60 seconds to right-click -> Pay -> enter L$ amount "
+            + "to deposit into '" + typed + "'. The L$ is refunded if the "
+            + "group name doesn't match.");
+    }
+
+    money(key payer, integer amount) {
+        // Only handle money() if we have a fresh slot for this payer.
+        // Otherwise the wallet script handles it for personal deposit.
+        if (pendingDepositAvatar != payer) return;
+        if (pendingDepositExpiresAt < llGetUnixTime()) {
+            // Stale slot. Drop it and let wallet handle the L$ -- BUT
+            // wallet already skipped (it saw the CLAIM). Send RELEASE so
+            // wallet picks this money() up... too late, money() already
+            // fired in wallet and was skipped. The L$ is in our hands.
+            // Refund.
+            llTransferLindenDollars(payer, amount);
+            llOwnerSay("SLParcels Group Pay: slot expired before pay, refunded L$"
+                + (string)amount + " to " + (string)payer);
+            clearDepositSlot();
+            llMessageLinked(LINK_THIS, LM_RELEASE, "", payer);
+            return;
+        }
+        if (GROUP_DEPOSIT_URL == "" || SHARED_SECRET == "" || TERMINAL_ID == "") {
+            llTransferLindenDollars(payer, amount);
+            llOwnerSay("CRITICAL: SLParcels Group Pay: config incomplete, refunded L$"
+                + (string)amount);
+            clearDepositSlot();
+            llMessageLinked(LINK_THIS, LM_RELEASE, "", payer);
+            return;
+        }
+        string groupName = pendingDepositGroupName;
+        clearDepositSlot();
+        llMessageLinked(LINK_THIS, LM_RELEASE, "", payer);
+        depositPayer      = payer;
+        depositAmount     = amount;
+        depositTxKey      = (string)llGenerateKey();
+        depositGroupName  = groupName;
+        depositRetryCount = 0;
+        fireDepositPost();
+    }
+
+    http_response(key req, integer status, list meta, string body) {
+        if (req != depositReqId) return;
+        depositReqId = NULL_KEY;
+        if (status >= 200 && status < 300) {
+            string s = llJsonGetValue(body, ["status"]);
+            if (s == "OK") {
+                if (DEBUG_MODE)
+                    llOwnerSay("SLParcels Group Pay: ok L$"
+                        + (string)depositAmount + " to '" + depositGroupName + "'");
+            } else if (s == "REFUND") {
+                string reason = llJsonGetValue(body, ["reason"]);
+                llTransferLindenDollars(depositPayer, depositAmount);
+                if (DEBUG_MODE)
+                    llOwnerSay("SLParcels Group Pay: refunded (" + reason
+                        + ") L$" + (string)depositAmount + " to " + (string)depositPayer);
+            } else if (s == "ERROR") {
+                string reason = llJsonGetValue(body, ["reason"]);
+                llTransferLindenDollars(depositPayer, depositAmount);
+                if (DEBUG_MODE)
+                    llOwnerSay("SLParcels Group Pay: refunded on ERROR (" + reason
+                        + ") L$" + (string)depositAmount + " to " + (string)depositPayer);
+            }
+            clearDepositRetryState();
+            return;
+        }
+        // Transient: retry on the same slTransactionKey.
+        ++depositRetryCount;
+        if (DEBUG_MODE)
+            llOwnerSay("SLParcels Group Pay: retry " + (string)depositRetryCount
+                + "/5: status=" + (string)status);
+        scheduleDepositRetry();
+    }
+
+    timer() {
+        integer now = llGetUnixTime();
+        if (timerPhase == TIMER_DEPOSIT_RETRY && now >= depositNextRetryAt) {
+            fireDepositPost();
+            timerPhase = TIMER_SWEEP;
+            llSetTimerEvent(10.0);
+            return;
+        }
+        // Sweep: expire pending name-input + pending deposit slots.
+        if (pendingNameAvatar != NULL_KEY && pendingNameExpiresAt < now) {
+            clearNameInputSlot();
+        }
+        if (pendingDepositAvatar != NULL_KEY && pendingDepositExpiresAt < now) {
+            key staleAvatar = pendingDepositAvatar;
+            clearDepositSlot();
+            llMessageLinked(LINK_THIS, LM_RELEASE, "", staleAvatar);
+        }
+        timerPhase = TIMER_SWEEP;
+        llSetTimerEvent(10.0);
+    }
+}

--- a/lsl-scripts/slpa-terminal/README.md
+++ b/lsl-scripts/slpa-terminal/README.md
@@ -1,13 +1,16 @@
 # SLParcels Terminal (wallet model)
 
-In-world wallet kiosk for SLParcels. Up to three touch-menu options
-(Deposit-instructions, Pay to group, Withdraw) plus a lockless `money()`
-deposit handler that routes to either the personal wallet or a realty
-group wallet depending on the toucher's prior dialog selection. Also
-accepts backend-initiated PAYOUT/WITHDRAW commands via HTTP-in. The
-"Pay to group" option is hidden when `GROUP_DEPOSIT_URL` is absent from
-the config notecard, keeping pre-rollout deployments on the legacy
-2-button menu.
+In-world wallet kiosk for SLParcels. Two touch-menu options (Deposit-instructions,
+Withdraw) plus a lockless `money()` deposit handler. Also accepts
+backend-initiated PAYOUT/WITHDRAW commands via HTTP-in.
+
+When the sister [`slpa-terminal-group`](../slpa-terminal-group/) script
+is dropped into the **same prim**, the touch menu gains a third option
+"Pay to group" that routes a `money()` event into a realty group's
+wallet instead of the payer's personal wallet. The two scripts
+coordinate via `llMessageLinked` (PING/PONG/START/CLAIM/RELEASE); each
+keeps its own state and HTTP path. See the sister script's README for
+the protocol details.
 
 SL Group Verify (founder-of-an-SL-group verification, sub-project E spec
 section 7.3) is **not** on this terminal. It lives on the SLParcels
@@ -31,34 +34,13 @@ advertises "verification". See `lsl-scripts/verification-terminal/`.
   with an unhandled failure (unknown terminal id, unparseable payer uuid,
   etc). Background retry: 10s / 30s / 90s / 5m / 15m. Multiple users can
   pay simultaneously — `money()` is naturally reentrant.
-- **Touch flow:** touch → `llDialog` `[Deposit, (Pay to group,) Withdraw]`
-  (no lock acquired; "Pay to group" only appears when `GROUP_DEPOSIT_URL`
-  is configured). Deposit selection → `llRegionSayTo` instructions, no
-  state. Withdraw selection → acquire per-flow slot → text-box for amount
-  → confirm dialog → POST to `/sl/wallet/withdraw-request`. On `OK`, the
+- **Touch flow:** touch → `llDialog` `[Deposit, Withdraw]`
+  (no lock acquired). Deposit selection → `llRegionSayTo` instructions, no
+  state. Withdraw selection → acquire per-flow slot → text-box for amount →
+  confirm dialog → POST to `/sl/wallet/withdraw-request`. On `OK`, the
   backend queues a `WALLET_WITHDRAWAL` `TerminalCommand` that fires
-  asynchronously; on `REFUND_BLOCKED`, no L$ to bounce — `llRegionSayTo`
-  the reason.
-- **Group-deposit flow ("Pay to group"):** touch → "Pay to group" →
-  `llTextBox` "Type the realty group's name". The avatar types the group
-  name (matched case-insensitively against active groups on the backend)
-  → the script stores a 60-second per-avatar "pending group deposit"
-  slot keyed by `(avatarKey, groupName, expiresAt)` and instructs the
-  avatar to right-click → Pay. If `money()` fires within 60s, the script
-  routes the deposit through `POST /sl/wallet/group-deposit` (instead of
-  the personal `/sl/wallet/deposit`); if the slot is missing or expired,
-  the personal flow runs unchanged. Retry chain matches the personal
-  deposit (10s / 30s / 90s / 5m / 15m, idempotent by `slTransactionKey`).
-  On REFUND (e.g. typo → `UNKNOWN_GROUP`) / ERROR / final-retry
-  exhaustion the L$ is bounced back via `llTransferLindenDollars` — same
-  "always-refund-on-deposit-error" rule as personal. Slot eviction runs
-  on the existing 10-second sweeper alongside the withdraw-session
-  sweep. (Earlier versions fetched the eligible-groups list via
-  `/sl/wallet/avatar-groups` and rendered a paged `llDialog`; we ripped
-  that path out because the parsed JSON arrays tripped Stack-Heap
-  Collision under realistic group counts. Typing the name is the
-  trade-off: the avatar needs to know the spelling, but heap stays
-  bounded.)
+  asynchronously; on `REFUND_BLOCKED`, no L$ to bounce — `llRegionSayTo` the
+  reason.
 - **Per-flow withdraw slots:** single `llListen` opened at startup, never
   closed. Up to 4 concurrent withdraw sessions, one per avatar (per-avatar
   dedup). Strided list `[avatarKey, amountOrMinusOne, expiresAt, ...]`.
@@ -100,21 +82,6 @@ Never publish on Marketplace.
    - Right-click the prim → Pay → L$10. Confirm `deposit ok L$10 from <name>`.
    - Touch → Withdraw → enter L$5 → Yes. Confirm withdrawal arrives in your
      SL avatar within ~30s.
-   - **"Pay to group" happy path** (member-with-permission). With
-     `GROUP_DEPOSIT_URL` set: touch → Pay to group → type the group's
-     display name in the text-box → right-click → Pay → L$10 within
-     60s. Confirm `group deposit ok L$10 to <group name>` and the
-     `MEMBER_DEPOSIT` row on the group's wallet ledger.
-   - **"Pay to group" typo path.** Touch → Pay to group → type a
-     non-existent name → right-click → Pay → L$10. Confirm the L$ is
-     refunded (`REFUND/UNKNOWN_GROUP`) and no ledger row is written.
-     Permission-missing and frozen-user cases follow the same
-     refund-on-failure shape.
-   - **"Pay to group" 60-second expiry race.** Touch → Pay to group →
-     type a name → wait > 65s → right-click → Pay → L$10. Confirm the
-     deposit lands on the payer's **personal** wallet (slot expired and
-     the script fell back to `/sl/wallet/deposit`), not the group's
-     wallet.
 
 The new SLParcels Parcel Verifier Giver prim (separate; see
 `lsl-scripts/slpa-verifier-giver/`) handles parcel-verifier give-out — it is
@@ -129,7 +96,6 @@ The new SLParcels Parcel Verifier Giver prim (separate; see
 | `WITHDRAW_REQUEST_URL` | Full URL of `/api/v1/sl/wallet/withdraw-request`. Required. |
 | `PAYOUT_RESULT_URL` | Full URL of `/api/v1/sl/escrow/payout-result`. Required. |
 | `HEARTBEAT_URL` | Full URL of `/api/v1/sl/terminal/heartbeat`. Optional but recommended — see Architecture summary. |
-| `GROUP_DEPOSIT_URL` | Full URL of `/api/v1/sl/wallet/group-deposit`. Optional — when set, enables the "Pay to group" touch-menu option. Absence keeps the terminal on the legacy Deposit/Withdraw-only menu. |
 | `SHARED_SECRET` | The shared secret. **Required.** Obtain from `slpa.escrow.terminal-shared-secret`. |
 | `TERMINAL_ID` | Optional. Defaults to `(string)llGetKey()`. |
 | `REGION_NAME` | Optional. Defaults to `llGetRegionName()`. |
@@ -155,20 +121,6 @@ In steady state with `DEBUG_MODE=true`:
   backend returned a non-REFUND error code (e.g. UNKNOWN_TERMINAL); the
   script bounces the L$ regardless so the payer is never out money.
 - `SLParcels Terminal: deposit retry N/5: status=...` — transient, retrying.
-- `SLParcels Terminal: group deposit ok L$<amount> to <groupName>` —
-  successful "Pay to group" deposit; the L$ has been credited to the
-  target realty group's wallet ledger (`MEMBER_DEPOSIT` entry).
-- `SLParcels Terminal: group deposit refunded (<REASON>) L$<amount> to <payer>`
-  — backend rejected the group deposit (e.g. `PERMISSION_REVOKED`,
-  `GROUP_DISSOLVED`, `GROUP_SUSPENDED`, `AMOUNT_OUT_OF_RANGE`) and the
-  script bounced the L$ back to the payer.
-- `SLParcels Terminal: group deposit refunded on ERROR (<REASON>) L$<amount> to <payer>`
-  — backend returned a non-REFUND error code (defensive — pre-flight
-  auth should have caught this before any L$-bearing path); the script
-  bounces regardless so the payer is never out money.
-- `SLParcels Terminal: group deposit retry N/5: status=...` — transient
-  backend failure on `/sl/wallet/group-deposit`; will retry on the same
-  10s / 30s / 90s / 5m / 15m schedule as the personal deposit.
 - `SLParcels Terminal: withdraw queued L$<amount> for <payer>` — successful withdraw-request.
 - `SLParcels Terminal: HTTP-in WITHDRAW to <recipient> L$<amount> ikey=...` — backend
   dispatched a wallet-withdrawal fulfillment to this terminal.
@@ -183,17 +135,8 @@ In steady state with `DEBUG_MODE=true`:
 - `SLParcels Terminal: heartbeat ok.` — periodic 5-minute heartbeat acknowledged.
 - `SLParcels Terminal: heartbeat failed status=...` — heartbeat POST failed; will
   retry on the next interval. Not critical unless it persists.
-- `CRITICAL: SLParcels Terminal: deposit from <payer> ... not acknowledged after 5 retries; refunded payer` —
-  `/sl/wallet/deposit` exhausted its retry chain (~22 min of backend
-  unreachability). The script bounces the L$ back to the payer rather
-  than stranding it (CLAUDE.md "always refund on deposit error"), then
-  logs CRITICAL for ops reconciliation. Same posture as the
-  group-deposit exhaustion line below.
-- `CRITICAL: SLParcels Terminal: group deposit from <payer> ... not acknowledged after 5 retries; refunded payer`
-  — `/sl/wallet/group-deposit` exhausted its retry chain. The script
-  bounces the L$ back to the payer rather than stranding it, then logs
-  CRITICAL so ops can confirm. No ledger-side reconciliation needed
-  (no rows were ever written), but the avatar should be notified.
+- `CRITICAL: SLParcels Terminal: deposit ... not acknowledged after 5 retries` —
+  deposit recovery failed; manual reconciliation required.
 - `CRITICAL: unexpected REFUND HTTP-in command` — the backend dispatched a
   REFUND action; refunds should be wallet credits in the new model. Investigate.
 - `CRITICAL: PERMISSION_DEBIT denied — script halted. Owner must re-grant.` —
@@ -209,7 +152,7 @@ In steady state with `DEBUG_MODE=true`:
 | `URL_REQUEST_DENIED` | Land doesn't allow scripts to request URLs. Move the prim to a region with permissive land settings. |
 | Periodic `register retry N/5` | Backend unreachable or rejecting registration. Check `slpa.sl.trusted-owner-keys` includes this terminal's owner. |
 | `deposit retry N/5` repeatedly | Backend transient or network issue. Self-recovers in most cases. |
-| `CRITICAL: deposit not acknowledged ... refunded payer` | Backend POST never succeeded after 5 retries. The script refunded the payer; check the backend logs to find the gap, no ledger-side reconciliation needed. |
+| `CRITICAL: deposit not acknowledged` | Backend POST never succeeded after 5 retries. Manual reconciliation required. |
 | Withdraw text-box says `Terminal busy — try another nearby` | All 4 withdraw slots occupied. Walk to another terminal. (Should be vanishingly rare at SLParcels's traffic level.) |
 | Backend command dispatcher logs 403 | Shared secret mismatch. Update notecard, reset. |
 | `CRITICAL: unexpected REFUND HTTP-in command` | Stale code path or migration issue — refunds should be wallet credits. Investigate. |

--- a/lsl-scripts/slpa-terminal/config.notecard.example
+++ b/lsl-scripts/slpa-terminal/config.notecard.example
@@ -12,15 +12,6 @@ WITHDRAW_REQUEST_URL=https://slpa.app/api/v1/sl/wallet/withdraw-request
 PAYOUT_RESULT_URL=https://slpa.app/api/v1/sl/escrow/payout-result
 HEARTBEAT_URL=https://slpa.app/api/v1/sl/terminal/heartbeat
 
-# Optional URL for the "Pay to group" touch-menu option (realty-group
-# wallet deposit, sub-project H). When set, the touch menu gains a
-# "Pay to group" button that prompts the avatar to type a group name
-# and routes the next money() event to /sl/wallet/group-deposit instead
-# of the personal /sl/wallet/deposit. Absence keeps the terminal on the
-# legacy Deposit/Withdraw-only menu so not-yet-updated deployments keep
-# working.
-GROUP_DEPOSIT_URL=https://slpa.app/api/v1/sl/wallet/group-deposit
-
 # SL Group Verify (founder-of-an-SL-group verification, sub-project E spec
 # section 7.3) is NOT on this terminal -- it lives on the SLParcels
 # Verification Terminal alongside Method C user verify. See

--- a/lsl-scripts/slpa-terminal/slpa-terminal.lsl
+++ b/lsl-scripts/slpa-terminal/slpa-terminal.lsl
@@ -36,11 +36,6 @@ string  DEPOSIT_URL           = "";
 string  WITHDRAW_REQUEST_URL  = "";
 string  PAYOUT_RESULT_URL     = "";
 string  HEARTBEAT_URL         = "";
-// Optional URL for the "Pay to group" flow (sub-project H). When empty
-// the touch menu hides the "Pay to group" button (backwards compat for
-// not-yet-updated terminals -- legacy Deposit/Withdraw-only behaviour
-// is preserved).
-string  GROUP_DEPOSIT_URL     = "";
 string  SHARED_SECRET         = "";
 string  TERMINAL_ID           = "";
 string  REGION_NAME           = "";
@@ -65,6 +60,30 @@ integer registerNextRetryAt = 0;
 integer mainChan       = 0;
 integer mainListenHandle = -1;
 
+// === "Pay to group" sister-script handshake ===
+// The pay-to-group flow lives in a separate script in the same prim
+// (lsl-scripts/slpa-terminal-group/slpa-terminal-group.lsl) so its
+// state + retry chain don't pile onto this script's heap. We
+// coordinate via llMessageLinked on a small fixed protocol:
+//   PING (num=10)  wallet -> group : "are you here?" at state_entry
+//   PONG (num=11)  group  -> wallet: "yes, present"
+//   START (num=12) wallet -> group : "user X picked Pay to group"
+//   CLAIM (num=13) group  -> wallet: "user X has a pending group
+//                                     deposit; route their next
+//                                     money() to me"
+//   RELEASE(num=14) group -> wallet: "drop the claim on user X"
+// claimedAvatars is a small list of avatar keys -- when money() fires
+// for an avatar in this list, wallet skips its personal-deposit POST
+// and lets the group script handle that money() in parallel.
+integer LM_PING    = 10;
+integer LM_PONG    = 11;
+integer LM_START   = 12;
+integer LM_CLAIM   = 13;
+integer LM_RELEASE = 14;
+integer groupScriptPresent = FALSE;
+list    claimedAvatars     = [];
+integer CLAIMED_CAP        = 4;
+
 // === Per-flow withdraw slots ===
 // Strided 3-wide list: [avatarKey, amountOrMinusOne, expiresAt, ...]
 //   amountOrMinusOne: -1 = awaiting amount; >0 = awaiting confirm
@@ -72,49 +91,6 @@ list    withdrawSessions   = [];
 integer MAX_WITHDRAW_SESSIONS = 4;
 integer SESSION_TTL_SECONDS = 60;
 integer SLOT_STRIDE = 3;
-
-// === "Pay to group" pending-deposit slots ===
-// Strided 3-wide list: [avatarKey, groupNameStr, expiresAt, ...]
-//   Set when an avatar has typed a group name at the "Pay to group"
-//   text-box prompt. Consumed in money() if not expired -> POST
-//   /sl/wallet/group-deposit with groupName. Falls through to the
-//   personal-wallet deposit flow when missing or expired (preserves the
-//   existing right-click -> Pay semantics).
-//
-//   groupNameStr is the user-typed string, trimmed once before storage.
-//   Backend does a case-insensitive name match against active groups.
-list    pendingGroupDeposits   = [];
-integer MAX_GROUP_DEPOSIT_SLOTS = 4;
-integer GROUP_DEPOSIT_SLOT_TTL  = 60;
-integer GROUP_DEPOSIT_SLOT_STRIDE = 3;
-
-// === "Pay to group" pending text-box input ===
-// Single-slot scalar state. When an avatar taps "Pay to group" we open
-// llTextBox and remember which avatar is expected to type a group name
-// next. The listen handler routes the typed text into pendingGroupDeposits.
-// Single-slot rather than per-avatar list because the strided list shape
-// tripped Stack-Heap Collision on real terminals (sub-project H §8.3).
-key     pendingNameAvatar     = NULL_KEY;
-integer pendingNameExpiresAt  = 0;
-integer GROUP_NAME_INPUT_TTL  = 60;
-// Max characters accepted for a group name. The realty-group entity caps
-// names well below this; the bound keeps a runaway paste from inflating
-// the slot.
-integer GROUP_NAME_MAX_CHARS  = 64;
-
-// === In-flight /group-deposit request tracking ===
-// /group-deposit request -> mirrors paymentReqId/paymentPayer/... for the
-// existing personal deposit. Reuses the same retry schedule. Only one
-// concurrent group-deposit per terminal (mirrors the existing single-
-// concurrent personal-deposit retry slot — the rest are awaiting on the
-// 10s/30s/90s/5m/15m chain in the timer).
-key     groupDepositReqId      = NULL_KEY;
-key     groupDepositPayer      = NULL_KEY;
-integer groupDepositAmount     = 0;
-string  groupDepositTxKey      = "";
-string  groupDepositGroupName  = "";
-integer groupDepositRetryCount = 0;
-integer groupDepositNextRetryAt = 0;
 
 // === Background deposit retry (per money() event) ===
 key     paymentReqId       = NULL_KEY;
@@ -162,7 +138,6 @@ integer TIMER_SESSION_SWEEP     = 1;
 integer TIMER_PAYMENT_RETRY     = 2;
 integer TIMER_REGISTER_RETRY    = 3;
 integer TIMER_WITHDRAW_RETRY    = 4;
-integer TIMER_GROUP_DEPOSIT_RETRY = 5;
 integer timerPhase              = 0;
 
 // ---------------------------------------------------------------------------
@@ -189,7 +164,6 @@ parseConfigLine(string line) {
     else if (k == "WITHDRAW_REQUEST_URL")  WITHDRAW_REQUEST_URL  = v;
     else if (k == "PAYOUT_RESULT_URL")     PAYOUT_RESULT_URL     = v;
     else if (k == "HEARTBEAT_URL")         HEARTBEAT_URL         = v;
-    else if (k == "GROUP_DEPOSIT_URL")     GROUP_DEPOSIT_URL     = v;
     else if (k == "SHARED_SECRET")         SHARED_SECRET         = v;
     else if (k == "TERMINAL_ID")           TERMINAL_ID           = v;
     else if (k == "REGION_NAME")           REGION_NAME           = v;
@@ -297,17 +271,11 @@ firePayment() {
 
 schedulePaymentRetry() {
     if (paymentRetryCount >= 5) {
-        // Final-failure refund discipline (CLAUDE.md "always refund on
-        // deposit error"): L$ is still in the script's hands and the
-        // backend hasn't acked after ~22 minutes of retries. Bounce to
-        // the payer rather than stranding the funds, then log CRITICAL
-        // for ops reconciliation. Mirrors scheduleGroupDepositRetry.
-        llTransferLindenDollars(paymentPayer, paymentAmount);
         llOwnerSay("CRITICAL: SLParcels Terminal: deposit from "
             + (string)paymentPayer
             + " L$" + (string)paymentAmount
             + " key " + paymentTxKey
-            + " not acknowledged after 5 retries; refunded payer");
+            + " not acknowledged after 5 retries");
         paymentReqId      = NULL_KEY;
         paymentPayer      = NULL_KEY;
         paymentAmount     = 0;
@@ -442,127 +410,6 @@ sweepExpiredSlots() {
     }
 }
 
-// ---------------- Group-deposit slot helpers ----------------
-
-integer findGroupDepositSlot(key avatar) {
-    integer i;
-    integer count = llGetListLength(pendingGroupDeposits) / GROUP_DEPOSIT_SLOT_STRIDE;
-    for (i = 0; i < count; ++i) {
-        key k = llList2Key(pendingGroupDeposits, i * GROUP_DEPOSIT_SLOT_STRIDE);
-        if (k == avatar) return i;
-    }
-    return -1;
-}
-
-releaseGroupDepositSlot(key avatar) {
-    integer slotIdx = findGroupDepositSlot(avatar);
-    if (slotIdx < 0) return;
-    integer start = slotIdx * GROUP_DEPOSIT_SLOT_STRIDE;
-    pendingGroupDeposits = llDeleteSubList(pendingGroupDeposits,
-        start, start + GROUP_DEPOSIT_SLOT_STRIDE - 1);
-}
-
-// Insert a new pending group-deposit slot. Per-avatar dedup (last-write-
-// wins) and a global cap of MAX_GROUP_DEPOSIT_SLOTS — when the cap is hit
-// without an existing avatar slot, evict the oldest (head of the strided
-// list) to make room (spec §8.3).
-setGroupDepositSlot(key avatar, string groupName) {
-    releaseGroupDepositSlot(avatar);
-    integer count = llGetListLength(pendingGroupDeposits) / GROUP_DEPOSIT_SLOT_STRIDE;
-    if (count >= MAX_GROUP_DEPOSIT_SLOTS) {
-        pendingGroupDeposits = llDeleteSubList(pendingGroupDeposits,
-            0, GROUP_DEPOSIT_SLOT_STRIDE - 1);
-    }
-    pendingGroupDeposits += [
-        avatar,
-        groupName,
-        llGetUnixTime() + GROUP_DEPOSIT_SLOT_TTL
-    ];
-}
-
-sweepExpiredGroupDepositSlots() {
-    integer now = llGetUnixTime();
-    integer i = llGetListLength(pendingGroupDeposits) / GROUP_DEPOSIT_SLOT_STRIDE - 1;
-    while (i >= 0) {
-        integer expiresAt = llList2Integer(pendingGroupDeposits,
-            i * GROUP_DEPOSIT_SLOT_STRIDE + 2);
-        if (expiresAt < now) {
-            pendingGroupDeposits = llDeleteSubList(pendingGroupDeposits,
-                i * GROUP_DEPOSIT_SLOT_STRIDE,
-                i * GROUP_DEPOSIT_SLOT_STRIDE + GROUP_DEPOSIT_SLOT_STRIDE - 1);
-        }
-        --i;
-    }
-}
-
-// ---------------- Group-name input slot helpers ----------------
-
-releaseNameInputSlot() {
-    pendingNameAvatar    = NULL_KEY;
-    pendingNameExpiresAt = 0;
-}
-
-setNameInputSlot(key avatar) {
-    pendingNameAvatar    = avatar;
-    pendingNameExpiresAt = llGetUnixTime() + GROUP_NAME_INPUT_TTL;
-}
-
-sweepExpiredNameInputSlot() {
-    if (pendingNameAvatar != NULL_KEY
-            && pendingNameExpiresAt < llGetUnixTime()) {
-        releaseNameInputSlot();
-    }
-}
-
-// ---------------- /group-deposit POST + retry chain ----------------
-
-fireGroupDeposit() {
-    string body = "{"
-        + "\"payerUuid\":\"" + (string)groupDepositPayer + "\","
-        + "\"groupName\":\"" + escapeJson(groupDepositGroupName) + "\","
-        + "\"amount\":" + (string)groupDepositAmount + ","
-        + "\"slTransactionKey\":\"" + groupDepositTxKey + "\","
-        + "\"terminalId\":\"" + escapeJson(TERMINAL_ID) + "\","
-        + "\"sharedSecret\":\"" + escapeJson(SHARED_SECRET) + "\""
-        + "}";
-    groupDepositReqId = llHTTPRequest(GROUP_DEPOSIT_URL,
-        [HTTP_METHOD, "POST",
-         HTTP_MIMETYPE, "application/json",
-         HTTP_BODY_MAXLENGTH, 16384],
-        body);
-}
-
-scheduleGroupDepositRetry() {
-    if (groupDepositRetryCount >= 5) {
-        // Final-failure refund discipline: by this point L$ is still in
-        // the script's hands and the backend hasn't acked. Bounce to the
-        // payer rather than stranding the funds, then log CRITICAL for
-        // ops reconciliation.
-        llTransferLindenDollars(groupDepositPayer, groupDepositAmount);
-        llOwnerSay("CRITICAL: SLParcels Terminal: group deposit from "
-            + (string)groupDepositPayer
-            + " L$" + (string)groupDepositAmount
-            + " to group " + groupDepositGroupName
-            + " key " + groupDepositTxKey
-            + " not acknowledged after 5 retries; refunded payer");
-        groupDepositReqId      = NULL_KEY;
-        groupDepositPayer      = NULL_KEY;
-        groupDepositAmount     = 0;
-        groupDepositTxKey      = "";
-        groupDepositGroupName  = "";
-        groupDepositRetryCount = 0;
-        if (timerPhase == TIMER_GROUP_DEPOSIT_RETRY) {
-            timerPhase = TIMER_SESSION_SWEEP;
-            llSetTimerEvent(10.0);
-        }
-        return;
-    }
-    integer delay = retryDelay(groupDepositRetryCount);
-    groupDepositNextRetryAt = llGetUnixTime() + delay;
-    timerPhase = TIMER_GROUP_DEPOSIT_RETRY;
-    llSetTimerEvent((float)delay);
-}
-
 // ---------------- HTTP-in inflight ----------------
 
 addInflightCommand(key txKey, string idempotencyKey, key recipient, integer amount) {
@@ -606,7 +453,6 @@ default {
         WITHDRAW_REQUEST_URL  = "";
         PAYOUT_RESULT_URL     = "";
         HEARTBEAT_URL         = "";
-        GROUP_DEPOSIT_URL     = "";
         SHARED_SECRET         = "";
         TERMINAL_ID           = "";
         REGION_NAME           = "";
@@ -622,16 +468,6 @@ default {
         registerAttempt     = 0;
         registerNextRetryAt = 0;
         withdrawSessions    = [];
-        pendingGroupDeposits   = [];
-        pendingNameAvatar      = NULL_KEY;
-        pendingNameExpiresAt   = 0;
-        groupDepositReqId      = NULL_KEY;
-        groupDepositPayer      = NULL_KEY;
-        groupDepositAmount     = 0;
-        groupDepositTxKey      = "";
-        groupDepositGroupName  = "";
-        groupDepositRetryCount = 0;
-        groupDepositNextRetryAt = 0;
         paymentReqId        = NULL_KEY;
         paymentPayer        = NULL_KEY;
         paymentAmount       = 0;
@@ -653,6 +489,8 @@ default {
         // the heartbeat refreshes lastSeenAt on a known-good terminal.
         nextHeartbeatAt     = llGetUnixTime() + HEARTBEAT_INTERVAL_SECONDS;
         timerPhase          = TIMER_NONE;
+        groupScriptPresent  = FALSE;
+        claimedAvatars      = [];
 
         // Mainland-only grid guard
         if (llGetEnv("sim_channel") != "Second Life Server") {
@@ -677,6 +515,36 @@ default {
         // 10-second timer for session sweep + retry checks.
         timerPhase = TIMER_SESSION_SWEEP;
         llSetTimerEvent(10.0);
+
+        // Ask the sister "Pay to group" script if it's loaded in this
+        // prim. If we hear a PONG within a few ticks, we'll add the
+        // "Pay to group" button to the touch menu.
+        llMessageLinked(LINK_THIS, LM_PING, "", NULL_KEY);
+    }
+
+    link_message(integer sender, integer num, string str, key id) {
+        if (num == LM_PONG) {
+            groupScriptPresent = TRUE;
+            return;
+        }
+        if (num == LM_CLAIM) {
+            // Group script took ownership of the next money() from `id`.
+            // Track it so our own money() handler skips the personal POST.
+            integer existing = llListFindList(claimedAvatars, [id]);
+            if (existing != -1) return;
+            if (llGetListLength(claimedAvatars) >= CLAIMED_CAP) {
+                claimedAvatars = llDeleteSubList(claimedAvatars, 0, 0);
+            }
+            claimedAvatars += [id];
+            return;
+        }
+        if (num == LM_RELEASE) {
+            integer slot = llListFindList(claimedAvatars, [id]);
+            if (slot != -1) {
+                claimedAvatars = llDeleteSubList(claimedAvatars, slot, slot);
+            }
+            return;
+        }
     }
 
     on_rez(integer n) {
@@ -850,6 +718,15 @@ default {
     }
 
     money(key payer, integer amount) {
+        // If the sister "Pay to group" script has claimed this payer's next
+        // money() event, skip the personal-deposit POST and let the group
+        // script's own money() handler (running in parallel) handle the
+        // L$. The group script will refund on failure, so we don't.
+        if (llListFindList(claimedAvatars, [payer]) != -1) {
+            integer slot = llListFindList(claimedAvatars, [payer]);
+            claimedAvatars = llDeleteSubList(claimedAvatars, slot, slot);
+            return;
+        }
         // Defensive: if config is missing or DEPOSIT_URL is empty, refund
         // immediately and shout. Without this guard, llHTTPRequest("", ...)
         // would silently fail and the L$ would be stranded in the prim.
@@ -861,36 +738,6 @@ default {
             llTransferLindenDollars(payer, amount);
             return;
         }
-
-        // "Pay to group" routing: if the payer picked a group within the
-        // last GROUP_DEPOSIT_SLOT_TTL seconds, route this money() event to
-        // /sl/wallet/group-deposit instead of the personal /sl/wallet/deposit
-        // flow. The sweeper evicts expired slots out-of-band, but we still
-        // double-check expiresAt here in case money() fires between the slot
-        // expiring and the next sweeper tick.
-        integer groupSlotIdx = findGroupDepositSlot(payer);
-        if (groupSlotIdx >= 0) {
-            integer expiresAt = llList2Integer(pendingGroupDeposits,
-                groupSlotIdx * GROUP_DEPOSIT_SLOT_STRIDE + 2);
-            if (expiresAt >= llGetUnixTime()
-                    && GROUP_DEPOSIT_URL != ""
-                    && groupDepositReqId == NULL_KEY) {
-                string groupName = llList2String(pendingGroupDeposits,
-                    groupSlotIdx * GROUP_DEPOSIT_SLOT_STRIDE + 1);
-                releaseGroupDepositSlot(payer);
-                groupDepositPayer      = payer;
-                groupDepositAmount     = amount;
-                groupDepositTxKey      = (string)llGenerateKey();
-                groupDepositGroupName  = groupName;
-                groupDepositRetryCount = 0;
-                fireGroupDeposit();
-                return;
-            }
-            // Expired (or another group deposit already in flight on this
-            // terminal). Clear stale slot and fall through to personal.
-            releaseGroupDepositSlot(payer);
-        }
-
         // Lockless: every money() event is a personal-wallet deposit.
         paymentPayer      = payer;
         paymentAmount     = amount;
@@ -902,13 +749,13 @@ default {
     touch_start(integer num) {
         key toucher = llDetectedKey(0);
         // Per-toucher dialog filtered by avatar key in the listen handler.
-        // "Pay to group" appears only when GROUP_DEPOSIT_URL is configured
-        // -- pre-deploy terminals (notecard without the key) keep the
-        // legacy 2-button menu.
+        // "Pay to group" appears only when the sister script answered our
+        // startup PING -- if it's missing, the wallet keeps the legacy
+        // 2-button menu.
         list buttons = ["Deposit"];
         string prompt = "What would you like to do?\n\n"
             + "Deposit: right-click & pay (any amount)\n";
-        if (GROUP_DEPOSIT_URL != "") {
+        if (groupScriptPresent) {
             buttons += ["Pay to group"];
             prompt += "Pay to group: deposit L$ into a realty group wallet\n";
         }
@@ -920,7 +767,7 @@ default {
     listen(integer chan, string name, key id, string msg) {
         if (chan != mainChan) return;
 
-        // Top-level menu responses (Deposit / Pay to group / Withdraw)
+        // Top-level menu responses (Deposit / Withdraw)
         if (msg == "Deposit") {
             llDialog(id,
                 "To deposit: right-click this terminal → Pay → enter any L$ amount. "
@@ -929,21 +776,12 @@ default {
             return;
         }
         if (msg == "Pay to group") {
-            if (GROUP_DEPOSIT_URL == "") {
-                // Defensive: button shouldn't have been shown. Fall through
-                // silently rather than POST to an empty URL.
-                return;
-            }
-            // Single-slot last-write-wins: a second avatar starting the
-            // flow clobbers the first's pending text-box input. Acceptable
-            // -- typed-text from the first avatar just falls through to
-            // the "unrouted message" branch below and gets ignored.
-            setNameInputSlot(id);
-            llTextBox(id,
-                "Type the realty group's name (the name as shown on the "
-                + "group's profile page). You then have 60 seconds to "
-                + "right-click -> Pay to deposit.",
-                mainChan);
+            // Hand off to the sister "Pay to group" script. It owns the
+            // text-box, the slot, and the /sl/wallet/group-deposit POST.
+            // If the sister isn't loaded the message goes nowhere
+            // (groupScriptPresent stays FALSE and this button isn't
+            // shown, so this branch is unreachable in that state).
+            llMessageLinked(LINK_THIS, LM_START, "", id);
             return;
         }
         if (msg == "Withdraw") {
@@ -953,29 +791,6 @@ default {
                 return;
             }
             llTextBox(id, "Enter L$ amount to withdraw:", mainChan);
-            return;
-        }
-
-        // ---- "Pay to group" text-box response (typed group name) ----
-        // The avatar just tapped "Pay to group" and now typed a name.
-        // Trim, length-cap, and route into pendingGroupDeposits so the
-        // next money() event from this payer credits the named group.
-        if (pendingNameAvatar == id) {
-            releaseNameInputSlot();
-            string typed = llStringTrim(msg, STRING_TRIM);
-            if (typed == "") {
-                llRegionSayTo(id, 0,
-                    "Cancelled: no group name typed.");
-                return;
-            }
-            if (llStringLength(typed) > GROUP_NAME_MAX_CHARS) {
-                typed = llGetSubString(typed, 0, GROUP_NAME_MAX_CHARS - 1);
-            }
-            setGroupDepositSlot(id, typed);
-            llRegionSayTo(id, 0,
-                "You have 60 seconds to right-click -> Pay -> enter L$ amount "
-                + "to deposit into '" + typed + "'. The deposit refunds if "
-                + "the group name doesn't match a registered realty group.");
             return;
         }
 
@@ -1147,55 +962,6 @@ default {
             return;
         }
 
-        // ----- /group-deposit response -----
-        if (req == groupDepositReqId) {
-            groupDepositReqId = NULL_KEY;
-            if (status >= 200 && status < 300) {
-                string s = llJsonGetValue(body, ["status"]);
-                if (s == "OK") {
-                    if (DEBUG_MODE)
-                        llOwnerSay("SLParcels Terminal: group deposit ok L$"
-                            + (string)groupDepositAmount
-                            + " to " + groupDepositGroupName);
-                } else if (s == "REFUND") {
-                    string reason = llJsonGetValue(body, ["reason"]);
-                    llTransferLindenDollars(groupDepositPayer, groupDepositAmount);
-                    if (DEBUG_MODE)
-                        llOwnerSay("SLParcels Terminal: group deposit refunded ("
-                            + reason + ") L$" + (string)groupDepositAmount
-                            + " to " + (string)groupDepositPayer);
-                } else if (s == "ERROR") {
-                    // Mirrors the personal-deposit ERROR branch: bounce L$
-                    // defensively. By the time this endpoint runs, L$ is in
-                    // the script's hands and the payer is a real avatar
-                    // (pre-flight shared-secret / SL headers already
-                    // validated). See CLAUDE.md "always refund on deposit
-                    // error".
-                    string reason = llJsonGetValue(body, ["reason"]);
-                    llTransferLindenDollars(groupDepositPayer, groupDepositAmount);
-                    if (DEBUG_MODE)
-                        llOwnerSay("SLParcels Terminal: group deposit refunded on ERROR ("
-                            + reason + ") L$" + (string)groupDepositAmount
-                            + " to " + (string)groupDepositPayer);
-                }
-                groupDepositPayer      = NULL_KEY;
-                groupDepositAmount     = 0;
-                groupDepositTxKey      = "";
-                groupDepositGroupName  = "";
-                groupDepositRetryCount = 0;
-                return;
-            }
-            // Transient: schedule retry. Idempotent by groupDepositTxKey
-            // server-side.
-            ++groupDepositRetryCount;
-            if (DEBUG_MODE)
-                llOwnerSay("SLParcels Terminal: group deposit retry "
-                    + (string)groupDepositRetryCount + "/5: status=" + (string)status);
-            debugSayUser(groupDepositPayer, "group-deposit", status, body);
-            scheduleGroupDepositRetry();
-            return;
-        }
-
         // ----- Heartbeat ack -----
         if (req == heartbeatReqId) {
             heartbeatReqId = NULL_KEY;
@@ -1214,9 +980,8 @@ default {
     }
 
     timer() {
-        // Multi-purpose 10-second timer: sweeps expired withdraw +
-        // group-deposit + group-dialog slots, checks for due register /
-        // deposit / withdraw / group-deposit retries, then continues.
+        // Multi-purpose 10-second timer: sweeps expired withdraw slots,
+        // checks for due register/deposit/withdraw retries, then continues.
         integer now = llGetUnixTime();
 
         if (timerPhase == TIMER_REGISTER_RETRY && now >= registerNextRetryAt) {
@@ -1227,10 +992,6 @@ default {
         }
         if (timerPhase == TIMER_WITHDRAW_RETRY && now >= withdrawNextRetryAt) {
             fireWithdrawRequest();
-        }
-        if (timerPhase == TIMER_GROUP_DEPOSIT_RETRY
-                && now >= groupDepositNextRetryAt) {
-            fireGroupDeposit();
         }
 
         // Heartbeat tick (independent of timerPhase — runs on its own
@@ -1243,8 +1004,6 @@ default {
         }
 
         sweepExpiredSlots();
-        sweepExpiredGroupDepositSlots();
-        sweepExpiredNameInputSlot();
 
         // Always reschedule for the next sweep.
         timerPhase = TIMER_SESSION_SWEEP;


### PR DESCRIPTION
## Summary

Promotes PR #284 from \`dev\` to \`main\`. Final fix for the in-world Stack-Heap Collision: the Pay to group flow is split into a sister LSL script so each script gets its own 64KB heap.

See #284 for the full change set.

## What gets deployed
- **Backend** — no backend changes in this PR; \`deploy backend\` workflow won't trigger (path filter).
- **Frontend** — no frontend changes; Amplify rebuilds anyway (no path filter).
- **LSL** — script files NOT auto-deployed. After this PR merges, drop both scripts into the prim per the deployment steps in #284.

## Test plan
- [ ] After this PR merges, drop the two scripts into the prim as documented.
- [ ] Touch — menu opens (no more Stack-Heap on startup).
- [ ] Pay to group happy path + UNKNOWN_GROUP refund path + 60s expiry path.