### PR TITLE
fix(sl): recover parcel owner UUID from body link when meta is empty

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/sl/SlWorldApiClient.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/sl/SlWorldApiClient.java
@@ -60,6 +60,9 @@ public class SlWorldApiClient {
     private static final Pattern RESIDENT_UUID_FROM_HREF = Pattern.compile(
             "/resident/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})");
 
+    private static final Pattern GROUP_UUID_FROM_HREF = Pattern.compile(
+            "/group/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})");
+
     private final WebClient webClient;
     private final int retryAttempts;
     private final long retryBackoffMs;
@@ -159,10 +162,22 @@ public class SlWorldApiClient {
     private ParcelPageData parseParcelHtml(UUID parcelUuid, String html) {
         Document doc = Jsoup.parse(html);
         String[] xyz = parseLocation(meta(doc, "name", "location"));
+        String ownerType = meta(doc, "name", "ownertype");
+        // Linden populates the <meta name="ownerid"> tag asynchronously --
+        // for a few minutes after a deed/sale, the meta tag is empty even
+        // though `ownertype` already says "group" and the body's <a class
+        // ="person" href="/group/<UUID>"> link carries the real owner UUID.
+        // Fall back to the body link when the meta is missing, so the
+        // listing-eligibility filter doesn't black-hole the picker during
+        // the propagation window.
+        UUID ownerUuid = optionalUuid(meta(doc, "name", "ownerid"));
+        if (ownerUuid == null && "group".equalsIgnoreCase(ownerType)) {
+            ownerUuid = parseOwnerGroupUuidFromBody(doc);
+        }
         ParcelMetadata parcel = new ParcelMetadata(
                 parcelUuid,
-                optionalUuid(meta(doc, "name", "ownerid")),
-                meta(doc, "name", "ownertype"),
+                ownerUuid,
+                ownerType,
                 meta(doc, "name", "owner"),
                 meta(doc, "name", "parcel"),
                 meta(doc, "name", "region"),
@@ -297,6 +312,29 @@ public class SlWorldApiClient {
         } catch (IllegalArgumentException e) {
             throw new ParcelIngestException(
                     "region link UUID failed to parse: " + m.group(1), e);
+        }
+    }
+
+    /**
+     * Fallback owner-UUID resolution for group-owned parcels when the
+     * {@code <meta name="ownerid">} tag is empty (Linden's "Loading..."
+     * propagation window). The rendered body always carries
+     * {@code <a class="person" href="/group/<UUID>">Loading...</a>} as
+     * soon as the deed is recorded -- only the meta tag and display name
+     * lag. We return {@code null} (not throw) when the link is also
+     * missing, so the caller keeps surfacing "owner unknown" rather than
+     * breaking the lookup entirely.
+     */
+    private UUID parseOwnerGroupUuidFromBody(Document doc) {
+        Element link = doc.selectFirst("a.person[href^=/group/]");
+        if (link == null) return null;
+        String href = link.attr("href");
+        Matcher m = GROUP_UUID_FROM_HREF.matcher(href);
+        if (!m.find()) return null;
+        try {
+            return UUID.fromString(m.group(1));
+        } catch (IllegalArgumentException e) {
+            return null;
         }
     }
 

--- a/backend/src/test/java/com/slparcelauctions/backend/sl/SlWorldApiClientTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/sl/SlWorldApiClientTest.java
@@ -112,10 +112,9 @@ class SlWorldApiClientTest {
     }
 
     @Test
-    void fetchParcel_groupOwnedParcel_ownerUuidIsNull() {
-        // Group-owned parcels: SL omits a parseable ownerid (the field renders
-        // empty or with a non-UUID placeholder). Parser must tolerate this so
-        // the lookup succeeds; ownership is settled later at script verify time.
+    void fetchParcel_groupOwnedParcel_emptyMetaAndNoBodyLink_ownerUuidIsNull() {
+        // No body link either -- truly unknown owner. Parser must tolerate this
+        // so the lookup succeeds; the caller decides whether to bail.
         UUID parcelUuid = UUID.randomUUID();
         String html = fixtureHtml(parcelUuid, "group", "");
         wireMock.stubFor(get(urlPathMatching("/place/.*"))
@@ -128,6 +127,45 @@ class SlWorldApiClientTest {
         assertThat(result.ownerType()).isEqualTo("group");
         assertThat(result.ownerUuid()).isNull();
         assertThat(result.regionName()).isEqualTo("Tula");
+    }
+
+    @Test
+    void fetchParcel_groupOwnedParcel_emptyMetaButOwnerLinkInBody_recoversFromLink() {
+        // Linden's loading state: <meta name="ownerid"> is empty for the first
+        // few minutes after a deed/sale but the body's <a class="person"
+        // href="/group/<UUID>"> link carries the real owner UUID immediately.
+        // Without this fallback the listing-eligible-groups picker silently
+        // returns empty during the propagation window.
+        UUID parcelUuid = UUID.randomUUID();
+        UUID ownerUuid = UUID.fromString("f66a4677-bef1-be1a-cd7c-64c2cb037ba8");
+        String html = """
+                <html><head>
+                <meta name="region" content="Tula">
+                <meta name="parcel" content="Cheap Land">
+                <meta name="parcelid" content="%s">
+                <meta name="area" content="512">
+                <meta name="ownerid" content="">
+                <meta name="ownertype" content="group">
+                <meta name="owner" content="Loading...">
+                <meta name="location" content="80/104/0">
+                </head><body>
+                  <div class="info">
+                    <span class="syscat">Owner:</span>
+                    <a href="/group/%s" class="person" style="display:inline;">Loading...</a>
+                  </div>
+                  <p class="desc">A rectangle.</p>
+                  <a href="/region/f54a1a30-2dbf-4922-8871-3e5b3de81fcf">Tula</a>
+                </body></html>
+                """.formatted(parcelUuid, ownerUuid);
+        wireMock.stubFor(get(urlPathMatching("/place/.*"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "text/html").withBody(html)));
+
+        client = newClient();
+        ParcelMetadata result = client.fetchParcelPage(parcelUuid).block().parcel();
+
+        assertThat(result).isNotNull();
+        assertThat(result.ownerType()).isEqualTo("group");
+        assertThat(result.ownerUuid()).isEqualTo(ownerUuid);
     }
 
     @Test


### PR DESCRIPTION
Linden's parcel page populates `<meta name="ownerid">` asynchronously after a deed. For a few minutes the meta tag is empty even though `ownertype=group` is set and the body's `<a class="person" href="/group/<UUID>">` link carries the real owner UUID. Our parser only read the meta, so the listing-eligible-groups picker silently returned empty during the propagation window.

Falls back to scanning the body link when the meta is empty. Returns null (not throw) when neither mechanism resolves -- caller keeps its existing 'no eligible groups' behaviour. Regression test mirrors the exact HTML shape observed on parcel `abac26ab-dde0-db22-7c78-92d48a103f7b`.

8/8 SlWorldApiClientTest green.