### PR TITLE
feat(listing): structured commission preview + Method 3 inline instructions

### DIFF
--- a/frontend/src/components/listing/AgentCommissionPreview.test.tsx
+++ b/frontend/src/components/listing/AgentCommissionPreview.test.tsx
@@ -38,13 +38,23 @@ describe("AgentCommissionPreview (case 3)", () => {
     );
 
     const preview = await screen.findByTestId("agent-commission-preview");
-    // Compact assertion against the rendered text — normalize whitespace
-    // for robustness across the JSX line breaks.
     await waitFor(() => {
-      const text = preview.textContent?.replace(/\s+/g, " ") ?? "";
+      // dt/dd siblings have no inline whitespace between them, so the
+      // visible "<label> <value>" is "labelvalue" in textContent. Assert
+      // on each row's components separately to stay robust against
+      // future layout tweaks.
+      const text = preview.textContent ?? "";
+      expect(text).toContain("List price");
+      expect(text).toContain("L$1,000");
+      expect(text).toContain("Platform commission at list price");
+      expect(text).toContain("L$50");
+      expect(text).toContain("(5%)");
+      expect(text).toContain("Your earnings at list price");
       expect(text).toContain("L$95");
-      expect(text).toContain("your 10% commission");
-      expect(text).toContain("Sunset Realty earns L$855");
+      expect(text).toContain("(10% of remaining)");
+      expect(text).toContain("Sunset Realty earnings at list price");
+      expect(text).toContain("L$855");
+      expect(text).toContain("(remaining)");
     });
   });
 
@@ -64,11 +74,14 @@ describe("AgentCommissionPreview (case 3)", () => {
 
     const preview = await screen.findByTestId("agent-commission-preview");
     await waitFor(() => {
-      const text = preview.textContent?.replace(/\s+/g, " ") ?? "";
+      const text = preview.textContent ?? "";
       // Rate 0 falls under the < 0.01 branch → "0.00%".
-      expect(text).toContain("your 0.00% commission");
+      expect(text).toContain("Your earnings at list price");
+      expect(text).toContain("L$0");
+      expect(text).toContain("(0.00% of remaining)");
       // L$1000 - 50 platform = 950 group slice when agent rate = 0.
-      expect(text).toContain("Sunset Realty earns L$950");
+      expect(text).toContain("Sunset Realty earnings at list price");
+      expect(text).toContain("L$950");
     });
   });
 

--- a/frontend/src/components/listing/AgentCommissionPreview.tsx
+++ b/frontend/src/components/listing/AgentCommissionPreview.tsx
@@ -93,21 +93,45 @@ export function AgentCommissionPreview({
     .replace(/\.0$/, "");
 
   return (
-    <div className="flex flex-col gap-1" data-testid="agent-commission-preview">
-      <p className="text-sm text-gray-600 mt-2">
-        If this lists at L${startingBid.toLocaleString()}, you{"'"}ll receive{" "}
-        <strong>L${agentSlice.toLocaleString()}</strong> (your {ratePct}%
-        commission of earnings after platform commission).{" "}
-        <strong>{groupName}</strong> earns{" "}
-        <strong>L${groupSlice.toLocaleString()}</strong>.
-      </p>
+    <div className="flex flex-col gap-2 mt-2" data-testid="agent-commission-preview">
+      <dl className="flex flex-col rounded-lg bg-bg-subtle px-4 py-3 text-sm">
+        <div className="flex justify-between gap-4 py-1">
+          <dt className="text-fg-muted">List price</dt>
+          <dd className="tabular-nums font-medium text-fg">
+            L${startingBid.toLocaleString()}
+          </dd>
+        </div>
+        <div className="flex justify-between gap-4 py-1">
+          <dt className="text-fg-muted">Platform commission at list price</dt>
+          <dd className="tabular-nums font-medium text-fg">
+            L${platformCommission.toLocaleString()}{" "}
+            <span className="text-fg-muted font-normal">(5%)</span>
+          </dd>
+        </div>
+        <div className="flex justify-between gap-4 py-1">
+          <dt className="text-fg-muted">Your earnings at list price</dt>
+          <dd className="tabular-nums font-medium text-fg">
+            L${agentSlice.toLocaleString()}{" "}
+            <span className="text-fg-muted font-normal">
+              ({ratePct}% of remaining)
+            </span>
+          </dd>
+        </div>
+        <div className="flex justify-between gap-4 py-1">
+          <dt className="text-fg-muted">{groupName} earnings at list price</dt>
+          <dd className="tabular-nums font-medium text-fg">
+            L${groupSlice.toLocaleString()}{" "}
+            <span className="text-fg-muted font-normal">(remaining)</span>
+          </dd>
+        </div>
+      </dl>
       {insufficient && balance !== null ? (
-        <p className="text-sm text-danger mt-1">
+        <p className="text-sm text-danger">
           Group wallet has L${balance.toLocaleString()}; deposit L$
           {shortfall.toLocaleString()} to publish.
         </p>
       ) : balance !== null ? (
-        <p className="text-sm text-gray-500 mt-1">
+        <p className="text-xs text-fg-muted">
           Listing fee paid from {groupName} wallet — current balance L$
           {balance.toLocaleString()}.
         </p>

--- a/frontend/src/components/listing/VerificationMethodPicker.tsx
+++ b/frontend/src/components/listing/VerificationMethodPicker.tsx
@@ -12,10 +12,16 @@ import type {
 } from "@/types/auction";
 import { activateAuctionKey } from "@/hooks/useActivateAuction";
 
+type MethodBody = string | React.ReactNode;
+
 interface MethodCard {
   key: VerificationMethod;
   title: string;
-  body: string;
+  body: MethodBody;
+  /** Button label. Defaults to "Use this method"; method 3 overrides to
+   *  "Verify" because the user has to set up the parcel sale in SL
+   *  BEFORE clicking. */
+  actionLabel?: string;
 }
 
 const METHODS: readonly MethodCard[] = [
@@ -34,8 +40,32 @@ const METHODS: readonly MethodCard[] = [
   {
     key: "SALE_TO_BOT",
     title: "Sale-to-bot",
-    body:
-      "Set your land for sale to the SLPAEscrow Resident account at L$999,999,999. Our bot detects the sale and verifies. Required for group-owned land.",
+    actionLabel: "Verify",
+    body: (
+      <>
+        <p className="text-xs text-fg-muted">
+          Required for group-owned land. Set the parcel for sale to our
+          escrow account first, THEN click Verify so the bot starts
+          watching.
+        </p>
+        <ol className="list-decimal pl-4 flex flex-col gap-0.5 text-xs text-fg">
+          <li>Open the SL Land menu on the parcel.</li>
+          <li>
+            Choose <em>Set Land for Sale&hellip;</em>
+          </li>
+          <li>
+            Buyer: <strong>SLPAEscrow Resident</strong>
+          </li>
+          <li>
+            Price: <strong>L$999,999,999</strong>
+          </li>
+          <li>
+            Click <em>Sell</em> to confirm in-world.
+          </li>
+          <li>Come back here and click Verify.</li>
+        </ol>
+      </>
+    ),
   },
 ];
 
@@ -140,28 +170,33 @@ export function VerificationMethodPicker({
         </div>
       )}
       <div className="grid gap-4 md:grid-cols-3">
-        {METHODS.map((method) => (
-          <article
-            key={method.key}
-            className="flex flex-col gap-3 rounded-lg bg-bg-subtle p-4"
-          >
-            <h3 className="text-sm font-semibold tracking-tight text-fg">{method.title}</h3>
-            <p className="text-xs text-fg-muted">
-              {method.body}
-            </p>
-            <div className="mt-auto">
-              <Button
-                onClick={() => mutation.mutate(method.key)}
-                disabled={mutation.isPending}
-                loading={mutation.isPending && mutation.variables === method.key}
-              >
-                {mutation.isPending && mutation.variables === method.key
-                  ? "Starting…"
-                  : "Use this method"}
-              </Button>
-            </div>
-          </article>
-        ))}
+        {METHODS.map((method) => {
+          const label = method.actionLabel ?? "Use this method";
+          return (
+            <article
+              key={method.key}
+              className="flex flex-col gap-3 rounded-lg bg-bg-subtle p-4"
+            >
+              <h3 className="text-sm font-semibold tracking-tight text-fg">{method.title}</h3>
+              {typeof method.body === "string" ? (
+                <p className="text-xs text-fg-muted">{method.body}</p>
+              ) : (
+                <div className="flex flex-col gap-2">{method.body}</div>
+              )}
+              <div className="mt-auto">
+                <Button
+                  onClick={() => mutation.mutate(method.key)}
+                  disabled={mutation.isPending}
+                  loading={mutation.isPending && mutation.variables === method.key}
+                >
+                  {mutation.isPending && mutation.variables === method.key
+                    ? "Starting…"
+                    : label}
+                </Button>
+              </div>
+            </article>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## AgentCommissionPreview

Replaces the prose paragraph (`If this lists at L$100, you'll receive L$23 (your 25% commission of earnings after platform commission). HadronTest earns L$72.`) with a structured `dl`:

```
List price                                  L$100
Platform commission at list price           L$50 (5%)
Your earnings at list price                 L$95 (10% of remaining)
HadronTest earnings at list price           L$855 (remaining)
```

Wallet-source / shortfall line stays below.

## Method 3 (Sale-to-bot) inline instructions

Previously the card was a 1-sentence prose blurb with a 'Use this method' button that kicked off the bot task on click -- the seller had to click first, THEN do the in-world setup, with the bot timer already running. Card now shows the 6 numbered steps inline, button label is 'Verify'.