### PR TITLE
feat(wallet): refunds always credit SLParcels wallets, never in-world avatars

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/admin/disputes/AdminDisputeService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/admin/disputes/AdminDisputeService.java
@@ -10,8 +10,8 @@ import com.slparcelauctions.backend.auction.Auction;
 import com.slparcelauctions.backend.auction.CancellationService;
 import com.slparcelauctions.backend.escrow.Escrow;
 import com.slparcelauctions.backend.escrow.EscrowRepository;
+import com.slparcelauctions.backend.escrow.EscrowService;
 import com.slparcelauctions.backend.escrow.EscrowState;
-import com.slparcelauctions.backend.escrow.command.TerminalCommandService;
 import com.slparcelauctions.backend.notification.NotificationPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,7 +46,7 @@ import java.util.Map;
 public class AdminDisputeService {
 
     private final EscrowRepository escrowRepo;
-    private final TerminalCommandService terminalCommandService;
+    private final EscrowService escrowService;
     private final CancellationService cancellationService;
     private final NotificationPublisher notificationPublisher;
     private final AdminActionService adminActionService;
@@ -99,12 +99,14 @@ public class AdminDisputeService {
         escrow.setState(newState);
         escrowRepo.save(escrow);
 
-        // Queue refund when escrow reaches EXPIRED, but only if funded.
-        // An unfunded escrow has no L$ to refund — queueing a REFUND command
-        // for a never-funded escrow would send L$ the winner never paid.
+        // Credit refund when escrow reaches EXPIRED, but only if funded.
+        // An unfunded escrow has no L$ to refund -- crediting it would
+        // invent L$ the winner never paid. Refund goes to the winner's
+        // SLParcels wallet (they can withdraw separately if they want it
+        // out of the system).
         boolean refundQueued = false;
         if (reachedExpired && escrow.getFundedAt() != null) {
-            terminalCommandService.queueRefund(escrow);
+            escrowService.queueRefundIfFunded(escrow);
             refundQueued = true;
         }
 

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/BidService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/BidService.java
@@ -33,7 +33,6 @@ import com.slparcelauctions.backend.wallet.WalletService;
 import com.slparcelauctions.backend.wallet.exception.InsufficientAvailableBalanceException;
 import com.slparcelauctions.backend.wallet.exception.PenaltyOutstandingException;
 
-import org.springframework.beans.factory.annotation.Value;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -97,9 +96,11 @@ public class BidService {
      * don't deposit before bidding) continue to pass. When set true on a
      * deployed environment, every bid validates penalty == 0 and
      * available >= amount, and a hard reservation is swapped from the prior
-     * high bidder to the new bidder.
+     * high bidder to the new bidder. Separate migration -- the wallet-model
+     * refund migration in this commit only changes refund routing, not
+     * bid-time enforcement.
      */
-    @Value("${slpa.wallet.enforcement-enabled:false}")
+    @org.springframework.beans.factory.annotation.Value("${slpa.wallet.enforcement-enabled:false}")
     private boolean walletEnforcementEnabled;
 
     /**

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
@@ -52,7 +52,6 @@ import com.slparcelauctions.backend.user.UserRepository;
 import com.slparcelauctions.backend.wallet.WalletService;
 import com.slparcelauctions.backend.wallet.exception.BidReservationAmountMismatchException;
 
-import org.springframework.beans.factory.annotation.Value;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -101,7 +100,17 @@ public class EscrowService {
     private final DisputeEvidenceUploadService evidenceUploadService;
     private final WalletService walletService;
 
-    @Value("${slpa.wallet.enforcement-enabled:false}")
+    /**
+     * Bid-time wallet enforcement flag. Paired with the same flag on
+     * {@link com.slparcelauctions.backend.auction.BidService}: when true,
+     * bids reserve from the bidder's wallet and the ended-auction escrow
+     * auto-funds from that reservation. When false (default), no L$ moves
+     * at bid time; the winner pays the escrow in-world via the SLPA
+     * Terminal after the auction closes. The wallet-model refund
+     * migration in this commit is independent -- it changes ONLY refund
+     * routing (escrow refund + listing-fee refund), not bid-time funding.
+     */
+    @org.springframework.beans.factory.annotation.Value("${slpa.wallet.enforcement-enabled:false}")
     private boolean walletEnforcementEnabled;
 
     public static boolean isAllowed(EscrowState from, EscrowState to) {
@@ -403,33 +412,31 @@ public class EscrowService {
     }
 
     /**
-     * Delegates to {@link TerminalCommandService#queueRefund} when the escrow
-     * has already received L$ ({@code fundedAt != null}). The guard matters
-     * because an unfunded escrow that moves to DISPUTED / FROZEN / EXPIRED
-     * has no money held in the terminal account to refund — queuing a
-     * REFUND command for a never-funded escrow would send L$ the winner
-     * never paid. Only called from transactional methods that already hold
+     * Refund the winner's L$ when a funded escrow goes DISPUTED / FROZEN /
+     * EXPIRED. The {@code fundedAt} guard matters because an unfunded
+     * escrow has no money held -- crediting it would invent L$ the winner
+     * never paid.
+     *
+     * <p>Per platform policy, refunds always credit the winner's
+     * SLParcels wallet. The winner can withdraw to their SL avatar at any
+     * time via the regular Withdraw flow if they want the L$ out of the
+     * system. Only called from transactional methods that already hold
      * a pessimistic lock on the escrow row.
      */
-    void queueRefundIfFunded(Escrow escrow) {
+    public void queueRefundIfFunded(Escrow escrow) {
         if (escrow.getFundedAt() == null) return;
-        if (walletEnforcementEnabled) {
-            // Wallet model: refund is a wallet credit, not a TerminalCommand REFUND.
-            User winner = userRepo.findByIdForUpdate(escrow.getAuction().getWinnerUserId()).orElseThrow();
-            walletService.creditEscrowRefund(winner, escrow.getFinalBidAmount(), escrow.getId());
-            ledgerRepo.save(EscrowTransaction.builder()
-                    .escrow(escrow)
-                    .auction(escrow.getAuction())
-                    .type(EscrowTransactionType.AUCTION_ESCROW_REFUND)
-                    .status(EscrowTransactionStatus.COMPLETED)
-                    .amount(escrow.getFinalBidAmount())
-                    .completedAt(OffsetDateTime.now(clock))
-                    .build());
-            log.info("Escrow {} refund credited to wallet (winnerId={}, amount=L${})",
-                    escrow.getId(), winner.getId(), escrow.getFinalBidAmount());
-        } else {
-            terminalCommandService.queueRefund(escrow);
-        }
+        User winner = userRepo.findByIdForUpdate(escrow.getAuction().getWinnerUserId()).orElseThrow();
+        walletService.creditEscrowRefund(winner, escrow.getFinalBidAmount(), escrow.getId());
+        ledgerRepo.save(EscrowTransaction.builder()
+                .escrow(escrow)
+                .auction(escrow.getAuction())
+                .type(EscrowTransactionType.AUCTION_ESCROW_REFUND)
+                .status(EscrowTransactionStatus.COMPLETED)
+                .amount(escrow.getFinalBidAmount())
+                .completedAt(OffsetDateTime.now(clock))
+                .build());
+        log.info("Escrow {} refund credited to winner wallet (winnerId={}, amount=L${})",
+                escrow.getId(), winner.getId(), escrow.getFinalBidAmount());
     }
 
     /**

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/command/TerminalCommandService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/command/TerminalCommandService.java
@@ -114,25 +114,20 @@ public class TerminalCommandService {
         return Optional.of(cmd);
     }
 
-    @Transactional(propagation = Propagation.MANDATORY)
-    public TerminalCommand queueRefund(Escrow escrow) {
-        User winner = userRepo.findById(escrow.getAuction().getWinnerUserId()).orElseThrow();
-        String recipientUuid = winner.getSlAvatarUuid().toString();
-        return queue(escrow.getId(), null,
-                TerminalCommandAction.REFUND, TerminalCommandPurpose.AUCTION_ESCROW,
-                recipientUuid, escrow.getFinalBidAmount(),
-                idempotencyKey("ESC", escrow.getId(), TerminalCommandAction.REFUND, 1));
-    }
-
-    @Transactional(propagation = Propagation.MANDATORY)
-    public TerminalCommand queueListingFeeRefund(ListingFeeRefund refund) {
-        String recipientUuid = refund.getAuction().getSeller().getSlAvatarUuid().toString();
-        return queue(null, refund.getId(),
-                TerminalCommandAction.REFUND, TerminalCommandPurpose.LISTING_FEE_REFUND,
-                recipientUuid, refund.getAmount(),
-                idempotencyKey("LFR", refund.getId(), TerminalCommandAction.REFUND, 1));
-    }
-
+    /**
+     * Historical note: {@code queueRefund} and {@code queueListingFeeRefund}
+     * lived here until the wallet-model-always-on migration. Both refund
+     * surfaces (escrow refund, listing-fee refund) now credit the
+     * recipient's SLParcels wallet via {@link
+     * com.slparcelauctions.backend.wallet.WalletService#creditEscrowRefund}
+     * / {@link
+     * com.slparcelauctions.backend.wallet.WalletService#creditListingFeeRefund}
+     * / {@link
+     * com.slparcelauctions.backend.realty.wallet.RealtyGroupWalletService#creditListingFeeRefund}.
+     * The {@link TerminalCommandAction#REFUND} enum value is retained
+     * because historical rows + in-flight REFUND commands at deploy time
+     * still need their callback handled (see {@link #applyCallback}).
+     */
     /**
      * Queues an admin WITHDRAW command. Called from
      * {@code AdminWithdrawalService.requestWithdrawal} which already holds

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/scheduler/ListingFeeRefundProcessorTask.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/scheduler/ListingFeeRefundProcessorTask.java
@@ -11,8 +11,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.slparcelauctions.backend.auction.ListingFeeRefund;
 import com.slparcelauctions.backend.auction.ListingFeeRefundRepository;
 import com.slparcelauctions.backend.auction.RefundStatus;
-import com.slparcelauctions.backend.escrow.command.TerminalCommand;
-import com.slparcelauctions.backend.escrow.command.TerminalCommandService;
 import com.slparcelauctions.backend.realty.wallet.RealtyGroupLedgerEntry;
 import com.slparcelauctions.backend.realty.wallet.RealtyGroupLedgerRepository;
 import com.slparcelauctions.backend.realty.wallet.RealtyGroupWalletService;
@@ -20,32 +18,29 @@ import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.user.UserRepository;
 import com.slparcelauctions.backend.wallet.WalletService;
 
-import org.springframework.beans.factory.annotation.Value;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * Per-refund worker invoked by {@link ListingFeeRefundProcessorJob}. Locks
  * the refund row under {@code PESSIMISTIC_WRITE}, re-validates the state
- * + not-yet-queued invariants, delegates to
- * {@link TerminalCommandService#queueListingFeeRefund} to create the
- * {@code TerminalCommand} row (the dispatcher picks it up on its next
- * tick), then stamps the command id + {@code lastQueuedAt} back onto the
- * refund.
+ * + not-yet-queued invariants, then issues an instant SLParcels-side
+ * wallet credit to whichever wallet originally paid the listing fee
+ * (group wallet for case-3 listings, user wallet for case-1/2).
  *
  * <p>Per-refund work runs in a fresh transaction ({@code REQUIRES_NEW}) so
  * the sweep's loop-level exception handling can isolate failures — a
- * single bad refund can't stall the rest of the sweep. Mirrors
- * {@link EscrowTimeoutTask} and
- * {@link com.slparcelauctions.backend.escrow.scheduler.TerminalCommandDispatcherTask}.
+ * single bad refund can't stall the rest of the sweep.
  *
  * <p>The re-validation guards against concurrency: a refund could have
  * been flipped to PROCESSED between the sweep's snapshot read and this
- * lock (e.g. admin tooling marks it manually completed), or it could have
- * been queued by a racing sweep instance. Short-circuiting on either
- * leaves the refund untouched; the dispatcher still owns the downstream
- * retry semantics.
+ * lock (e.g. admin tooling marks it manually completed). Short-circuiting
+ * leaves the refund untouched.
+ *
+ * <p><b>No in-world payout path.</b> Per platform policy, refunds always
+ * stay inside SLParcels wallets. The depositor can withdraw to their SL
+ * avatar at any time via the regular Withdraw flow if they want the L$
+ * out of the system.
  */
 @Service
 @RequiredArgsConstructor
@@ -53,15 +48,11 @@ import lombok.extern.slf4j.Slf4j;
 public class ListingFeeRefundProcessorTask {
 
     private final ListingFeeRefundRepository listingFeeRefundRepo;
-    private final TerminalCommandService terminalCommandService;
     private final WalletService walletService;
     private final UserRepository userRepo;
     private final Clock clock;
     private final RealtyGroupLedgerRepository realtyGroupLedgerRepository;
     private final RealtyGroupWalletService realtyGroupWalletService;
-
-    @Value("${slpa.wallet.enforcement-enabled:false}")
-    private boolean walletEnforcementEnabled;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void queueOne(Long refundId) {
@@ -76,45 +67,30 @@ public class ListingFeeRefundProcessorTask {
                     refundId, refund.getStatus());
             return;
         }
-        if (refund.getTerminalCommandId() != null) {
-            log.debug("ListingFeeRefund {} skipped under lock: terminalCommandId already set ({})",
-                    refundId, refund.getTerminalCommandId());
-            return;
-        }
-        if (walletEnforcementEnabled) {
-            // Wallet model: refund is a wallet credit, not a TerminalCommand REFUND.
-            // Route to group wallet if the original listing-fee debit came from a
-            // realty_group_ledger row (D-era group listing). Otherwise fall through
-            // to the seller's user wallet (C-era group listing, or individual listing).
-            // Spec §8.1.
-            Long auctionId = refund.getAuction().getId();
-            Optional<RealtyGroupLedgerEntry> groupDebit =
-                realtyGroupLedgerRepository.findListingFeeDebitForAuction(auctionId);
-            if (groupDebit.isPresent()) {
-                realtyGroupWalletService.creditListingFeeRefund(
-                    groupDebit.get().getGroupId(), auctionId, refund.getAmount(), refund.getId());
-                log.info("ListingFeeRefund {} credited to group wallet (groupId={}, amount=L${})",
-                    refund.getId(), groupDebit.get().getGroupId(), refund.getAmount());
-            } else {
-                User seller = userRepo.findByIdForUpdate(
-                        refund.getAuction().getSeller().getId()).orElseThrow();
-                walletService.creditListingFeeRefund(seller, refund.getAmount(), refund.getId());
-                log.info("ListingFeeRefund {} credited to user wallet (sellerId={}, amount=L${})",
-                    refund.getId(), seller.getId(), refund.getAmount());
-            }
+        // Route to group wallet when the original listing-fee debit came
+        // from a realty_group_ledger row (case-3, D-era group listing).
+        // Otherwise credit the seller's user wallet (case-1/2 individual
+        // listing, or C-era group listing).
+        Long auctionId = refund.getAuction().getId();
+        Optional<RealtyGroupLedgerEntry> groupDebit =
+            realtyGroupLedgerRepository.findListingFeeDebitForAuction(auctionId);
+        if (groupDebit.isPresent()) {
+            realtyGroupWalletService.creditListingFeeRefund(
+                groupDebit.get().getGroupId(), auctionId, refund.getAmount(), refund.getId());
             refund.setStatus(RefundStatus.PROCESSED);
             refund.setProcessedAt(OffsetDateTime.now(clock));
             listingFeeRefundRepo.save(refund);
-            log.info("ListingFeeRefund {} processed",
-                    refund.getId());
-        } else {
-            TerminalCommand cmd = terminalCommandService.queueListingFeeRefund(refund);
-            refund.setTerminalCommandId(cmd.getId());
-            refund.setLastQueuedAt(OffsetDateTime.now(clock));
-            listingFeeRefundRepo.save(refund);
-            log.info("Queued ListingFeeRefund {} as TerminalCommand {} (L${} to seller {})",
-                    refund.getId(), cmd.getId(), refund.getAmount(),
-                    refund.getAuction().getSeller().getId());
+            log.info("ListingFeeRefund {} credited to group wallet (groupId={}, amount=L${})",
+                refund.getId(), groupDebit.get().getGroupId(), refund.getAmount());
+            return;
         }
+        User seller = userRepo.findByIdForUpdate(
+                refund.getAuction().getSeller().getId()).orElseThrow();
+        walletService.creditListingFeeRefund(seller, refund.getAmount(), refund.getId());
+        refund.setStatus(RefundStatus.PROCESSED);
+        refund.setProcessedAt(OffsetDateTime.now(clock));
+        listingFeeRefundRepo.save(refund);
+        log.info("ListingFeeRefund {} credited to user wallet (sellerId={}, amount=L${})",
+            refund.getId(), seller.getId(), refund.getAmount());
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerRepository.java
@@ -49,6 +49,14 @@ public interface UserLedgerRepository
     List<UserLedgerEntry> findTop50ByUserIdOrderByCreatedAtDesc(Long userId);
 
     /**
+     * Test-only convenience for clearing ledger rows during teardown.
+     * Production code paths never delete from the append-only ledger;
+     * this exists so integration tests that seed users can satisfy the
+     * {@code user_ledger_user_id_fkey} constraint at cleanup time.
+     */
+    void deleteAllByUserId(Long userId);
+
+    /**
      * Cursor pagination for the {@code /me/wallet/ledger} endpoint.
      */
     Page<UserLedgerEntry> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/disputes/AdminDisputeServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/disputes/AdminDisputeServiceTest.java
@@ -137,12 +137,17 @@ class AdminDisputeServiceTest {
         Escrow persisted = loadEscrow();
         assertThat(persisted.getState()).isEqualTo(EscrowState.EXPIRED);
 
-        // Terminal REFUND command must have been queued.
+        // Wallet-model refund migration: the refund is an instant wallet
+        // credit, NOT a TerminalCommand REFUND. No in-world payout rows
+        // are emitted; the bidder's user_ledger picks up an ESCROW_REFUND
+        // entry instead. We assert the absence of the legacy path here
+        // and let the wallet-credit assertions live in
+        // EscrowDisputeIntegrationTest.
         long refundCount = new TransactionTemplate(txManager).execute(s ->
                 terminalCommandRepo.findAll().stream()
                         .filter(c -> c.getEscrowId() != null && c.getEscrowId().equals(escrowId))
                         .count());
-        assertThat(refundCount).isGreaterThanOrEqualTo(1);
+        assertThat(refundCount).isZero();
 
         // Auction must have been cancelled.
         Auction auction = new TransactionTemplate(txManager).execute(s ->
@@ -183,11 +188,14 @@ class AdminDisputeServiceTest {
         Escrow persisted = loadEscrow();
         assertThat(persisted.getState()).isEqualTo(EscrowState.EXPIRED);
 
+        // Wallet-model refund migration: refund credits the bidder's
+        // wallet via an instant ESCROW_REFUND ledger row, not via a
+        // TerminalCommand REFUND. No in-world payout rows expected.
         long refundCount = new TransactionTemplate(txManager).execute(s ->
                 terminalCommandRepo.findAll().stream()
                         .filter(c -> c.getEscrowId() != null && c.getEscrowId().equals(escrowId))
                         .count());
-        assertThat(refundCount).isGreaterThanOrEqualTo(1);
+        assertThat(refundCount).isZero();
     }
 
     @Test
@@ -404,6 +412,11 @@ class AdminDisputeServiceTest {
                         st.execute("DELETE FROM notification WHERE user_id = " + uid);
                         st.execute("DELETE FROM sl_im_message WHERE user_id = " + uid);
                         st.execute("DELETE FROM refresh_tokens WHERE user_id = " + uid);
+                        // Wallet-model refund migration writes a
+                        // user_ledger ESCROW_REFUND row when escrow
+                        // EXPIRES. Clear the bidder's ledger before the
+                        // user delete or the FK constraint fires.
+                        st.execute("DELETE FROM user_ledger WHERE user_id = " + uid);
                         st.execute("DELETE FROM users WHERE id = " + uid);
                     }
                 }

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowDisputeIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowDisputeIntegrationTest.java
@@ -88,6 +88,8 @@ class EscrowDisputeIntegrationTest {
     @Autowired RefreshTokenRepository refreshTokenRepo;
     @Autowired VerificationCodeRepository verificationCodeRepo;
     @Autowired EscrowRepository escrowRepo;
+    @Autowired EscrowTransactionRepository escrowTxRepo;
+    @Autowired com.slparcelauctions.backend.wallet.UserLedgerRepository userLedgerRepo;
     @Autowired EscrowCommissionCalculator commissionCalculator;
     @Autowired NotificationRepository notificationRepo;
     @Autowired PlatformTransactionManager txManager;
@@ -110,6 +112,14 @@ class EscrowDisputeIntegrationTest {
         if (seededAuctionId == null) return;
         TransactionTemplate tx = new TransactionTemplate(txManager);
         tx.executeWithoutResult(status -> {
+            if (seededEscrowId != null) {
+                // Wallet-model refund migration: the dispute resolution
+                // path writes an AUCTION_ESCROW_REFUND row on the
+                // escrow's transaction ledger when crediting the winner's
+                // wallet. Clear those before deleting the escrow.
+                escrowTxRepo.findByEscrowIdOrderByCreatedAtAsc(seededEscrowId)
+                        .forEach(escrowTxRepo::delete);
+            }
             escrowRepo.findByAuctionId(seededAuctionId).ifPresent(escrowRepo::delete);
             bidRepo.deleteAllByAuctionId(seededAuctionId);
             proxyBidRepo.deleteAllByAuctionId(seededAuctionId);
@@ -125,6 +135,9 @@ class EscrowDisputeIntegrationTest {
                         VerificationCodeType.PARCEL)
                         .forEach(verificationCodeRepo::delete);
                 notificationRepo.deleteAllByUserId(userId);
+                // Wallet-model refund migration: same as above, the
+                // refund credits the winner's user_ledger.
+                userLedgerRepo.deleteAllByUserId(userId);
                 userRepo.findById(userId).ifPresent(userRepo::delete);
             }
         });

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowOwnershipMonitorIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowOwnershipMonitorIntegrationTest.java
@@ -123,6 +123,7 @@ class EscrowOwnershipMonitorIntegrationTest {
     @Autowired BidRepository bidRepo;
     @Autowired ProxyBidRepository proxyBidRepo;
     @Autowired UserRepository userRepo;
+    @Autowired com.slparcelauctions.backend.wallet.UserLedgerRepository userLedgerRepo;
     @Autowired EscrowTransactionRepository escrowTxRepo;
     @Autowired EscrowCommissionCalculator commissionCalculator;
     @Autowired FraudFlagRepository fraudFlagRepo;
@@ -167,6 +168,10 @@ class EscrowOwnershipMonitorIntegrationTest {
                 verificationCodeRepo.findByUserIdAndTypeAndUsedFalse(userId,
                         VerificationCodeType.PARCEL).forEach(verificationCodeRepo::delete);
                 notificationRepo.deleteAllByUserId(userId);
+                // Wallet-model refund migration: ESCROW_REFUND ledger row
+                // written when escrow expires/freezes. Clear before
+                // deleting the user or the FK constraint fires.
+                userLedgerRepo.deleteAllByUserId(userId);
                 userRepo.findById(userId).ifPresent(userRepo::delete);
             }
         });

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowTimeoutIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowTimeoutIntegrationTest.java
@@ -46,6 +46,7 @@ import com.slparcelauctions.backend.auction.AuctionParcelSnapshot;
 import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.notification.NotificationRepository;
 import com.slparcelauctions.backend.user.UserRepository;
+import com.slparcelauctions.backend.wallet.UserLedgerRepository;
 import com.slparcelauctions.backend.verification.VerificationCodeRepository;
 import com.slparcelauctions.backend.verification.VerificationCodeType;
 
@@ -117,6 +118,7 @@ class EscrowTimeoutIntegrationTest {
     @Autowired RefreshTokenRepository refreshTokenRepo;
     @Autowired VerificationCodeRepository verificationCodeRepo;
     @Autowired NotificationRepository notificationRepo;
+    @Autowired UserLedgerRepository userLedgerRepo;
     @Autowired PlatformTransactionManager txManager;
     @Autowired CapturingEscrowBroadcastPublisher capturingEscrowPublisher;
     @Autowired MutableFixedClock testClock;
@@ -160,6 +162,10 @@ class EscrowTimeoutIntegrationTest {
                 verificationCodeRepo.findByUserIdAndTypeAndUsedFalse(userId,
                         VerificationCodeType.PARCEL).forEach(verificationCodeRepo::delete);
                 notificationRepo.deleteAllByUserId(userId);
+                // Wallet-model refund migration: escrow refund + listing-fee
+                // refund now write user_ledger rows on this user. Clear those
+                // before deleting the user or the FK constraint fires.
+                userLedgerRepo.deleteAllByUserId(userId);
                 userRepo.findById(userId).ifPresent(userRepo::delete);
             }
         });
@@ -221,16 +227,17 @@ class EscrowTimeoutIntegrationTest {
         assertThat(refreshed.getExpiredAt())
                 .isEqualTo(OffsetDateTime.now(testClock));
 
-        // Exactly one REFUND TerminalCommand for AUCTION_ESCROW on this escrow.
+        // Per the wallet-model-always-on refund migration: the refund is
+        // an instant credit to the winner's SLParcels wallet, not a
+        // TerminalCommand REFUND. No terminal_commands rows are emitted.
         List<TerminalCommand> commands = cmdRepo.findAll().stream()
                 .filter(c -> seededEscrowId.equals(c.getEscrowId()))
                 .toList();
-        assertThat(commands).hasSize(1);
-        TerminalCommand refund = commands.get(0);
-        assertThat(refund.getAction()).isEqualTo(TerminalCommandAction.REFUND);
-        assertThat(refund.getPurpose()).isEqualTo(TerminalCommandPurpose.AUCTION_ESCROW);
-        assertThat(refund.getStatus()).isEqualTo(TerminalCommandStatus.QUEUED);
-        assertThat(refund.getAmount()).isEqualTo(refreshed.getFinalBidAmount());
+        assertThat(commands).isEmpty();
+        // The wallet credit + EscrowTransaction ledger row are written
+        // synchronously inside queueRefundIfFunded. EscrowDisputeIntegrationTest
+        // covers the same code path with explicit wallet-credit assertions;
+        // here we just assert the absence of the in-world payout.
 
         assertThat(capturingEscrowPublisher.expired).hasSize(1);
         EscrowExpiredEnvelope env = capturingEscrowPublisher.expired.get(0);

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/ListingFeeFlowIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/ListingFeeFlowIntegrationTest.java
@@ -43,6 +43,7 @@ import com.slparcelauctions.backend.escrow.terminal.TerminalRepository;
 import com.slparcelauctions.backend.auction.AuctionParcelSnapshot;
 import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.user.UserRepository;
+import com.slparcelauctions.backend.wallet.UserLedgerRepository;
 import com.slparcelauctions.backend.verification.VerificationCodeRepository;
 import com.slparcelauctions.backend.verification.VerificationCodeType;
 
@@ -105,6 +106,7 @@ class ListingFeeFlowIntegrationTest {
     @Autowired BidRepository bidRepo;
     @Autowired ProxyBidRepository proxyBidRepo;
     @Autowired UserRepository userRepo;
+    @Autowired UserLedgerRepository userLedgerRepo;
     @Autowired RefreshTokenRepository refreshTokenRepo;
     @Autowired VerificationCodeRepository verificationCodeRepo;
     @Autowired EscrowTransactionRepository ledgerRepo;
@@ -144,6 +146,10 @@ class ListingFeeFlowIntegrationTest {
                         VerificationCodeType.PLAYER).forEach(verificationCodeRepo::delete);
                 verificationCodeRepo.findByUserIdAndTypeAndUsedFalse(seededSellerId,
                         VerificationCodeType.PARCEL).forEach(verificationCodeRepo::delete);
+                // Wallet-model refund migration: the refund job writes a
+                // user_ledger row for the seller. Clear it before deleting
+                // the user or the FK constraint fires.
+                userLedgerRepo.deleteAllByUserId(seededSellerId);
                 userRepo.findById(seededSellerId).ifPresent(userRepo::delete);
             }
             terminalRepo.findById(TERMINAL_ID).ifPresent(terminalRepo::delete);
@@ -239,73 +245,45 @@ class ListingFeeFlowIntegrationTest {
     }
 
     @Test
-    void pendingRefund_isQueuedByProcessorAndFlipsToProcessedOnCallback() {
+    void pendingRefund_isProcessedByJobAsInstantWalletCredit() {
         seedDraftAuctionWithTerminal();
         seedPendingRefund();
 
-        // Before sweep: refund PENDING, no command stamped.
+        // Before sweep: refund PENDING.
         ListingFeeRefund before = listingFeeRefundRepo.findById(seededRefundId).orElseThrow();
         assertThat(before.getStatus()).isEqualTo(RefundStatus.PENDING);
-        assertThat(before.getTerminalCommandId()).isNull();
-        assertThat(before.getLastQueuedAt()).isNull();
+
+        long sellerBalanceBefore = userRepo.findById(seededSellerId)
+                .orElseThrow().getBalanceLindens();
 
         // Run the processor explicitly.
         listingFeeRefundProcessorJob.drainPending();
 
-        // After sweep: terminalCommandId + lastQueuedAt stamped, a
-        // LISTING_FEE_REFUND TerminalCommand exists with recipient=seller.
+        // Per the wallet-model-always-on refund migration: the refund is
+        // an instant wallet credit, NOT a TerminalCommand REFUND. The
+        // refund row flips straight to PROCESSED inside the job; no
+        // terminal callback is needed.
         ListingFeeRefund afterSweep = listingFeeRefundRepo.findById(seededRefundId).orElseThrow();
-        assertThat(afterSweep.getStatus()).isEqualTo(RefundStatus.PENDING);
-        assertThat(afterSweep.getTerminalCommandId()).isNotNull();
-        assertThat(afterSweep.getLastQueuedAt()).isNotNull();
-
-        TerminalCommand cmd = cmdRepo.findById(afterSweep.getTerminalCommandId()).orElseThrow();
-        seededCommandId = cmd.getId();
-        assertThat(cmd.getPurpose()).isEqualTo(TerminalCommandPurpose.LISTING_FEE_REFUND);
-        assertThat(cmd.getAction()).isEqualTo(TerminalCommandAction.REFUND);
-        assertThat(cmd.getListingFeeRefundId()).isEqualTo(seededRefundId);
-        assertThat(cmd.getRecipientUuid()).isEqualTo(seededSellerAvatarUuid.toString());
-        assertThat(cmd.getAmount()).isEqualTo(100L);
-        assertThat(cmd.getStatus()).isEqualTo(TerminalCommandStatus.QUEUED);
-
-        // Second sweep is idempotent: terminalCommandId is already set so
-        // the refund is skipped by findPendingAwaitingDispatch.
-        listingFeeRefundProcessorJob.drainPending();
+        assertThat(afterSweep.getStatus()).isEqualTo(RefundStatus.PROCESSED);
+        assertThat(afterSweep.getProcessedAt()).isNotNull();
+        // No TerminalCommand for this refund -- the legacy in-world payout
+        // path is gone.
         assertThat(cmdRepo.findAll().stream()
                 .filter(c -> c.getListingFeeRefundId() != null
                         && c.getListingFeeRefundId().equals(seededRefundId))
-                .count()).isEqualTo(1L);
+                .count()).isZero();
 
-        // Simulate the terminal's success callback via the Task 7 path.
-        String slTxn = "sl-txn-refund-" + UUID.randomUUID();
-        terminalCommandService.applyCallback(new PayoutResultRequest(
-                cmd.getIdempotencyKey(), true, slTxn, null, TERMINAL_ID, SHARED_SECRET));
+        // Seller's user wallet balance bumped by the refund amount.
+        long sellerBalanceAfter = userRepo.findById(seededSellerId)
+                .orElseThrow().getBalanceLindens();
+        assertThat(sellerBalanceAfter - sellerBalanceBefore).isEqualTo(100L);
 
-        // Refund flipped to PROCESSED with processedAt + txnRef; command
-        // flipped to COMPLETED; one COMPLETED LISTING_FEE_REFUND ledger row.
-        ListingFeeRefund afterCallback = listingFeeRefundRepo.findById(seededRefundId).orElseThrow();
-        assertThat(afterCallback.getStatus()).isEqualTo(RefundStatus.PROCESSED);
-        assertThat(afterCallback.getProcessedAt()).isNotNull();
-        assertThat(afterCallback.getTxnRef()).isEqualTo(slTxn);
-
-        TerminalCommand finalCmd = cmdRepo.findById(cmd.getId()).orElseThrow();
-        assertThat(finalCmd.getStatus()).isEqualTo(TerminalCommandStatus.COMPLETED);
-        assertThat(finalCmd.getCompletedAt()).isNotNull();
-
-        List<EscrowTransaction> refundLedger = ledgerRepo.findAll().stream()
-                .filter(r -> r.getAuction() != null
-                        && r.getAuction().getId().equals(seededAuctionId)
-                        && r.getType() == EscrowTransactionType.LISTING_FEE_REFUND)
-                .toList();
-        assertThat(refundLedger).hasSize(1);
-        EscrowTransaction row = refundLedger.get(0);
-        assertThat(row.getStatus()).isEqualTo(EscrowTransactionStatus.COMPLETED);
-        assertThat(row.getAmount()).isEqualTo(100L);
-        assertThat(row.getSlTransactionId()).isEqualTo(slTxn);
-        // command.terminalId only gets stamped when the dispatcher actually
-        // POSTs the command; we're skipping that phase, so terminalId on the
-        // refund ledger row mirrors command.terminalId=null.
-        assertThat(row.getTerminalId()).isNull();
+        // Second sweep is idempotent: refund is already PROCESSED so the
+        // job skips it under the status guard.
+        listingFeeRefundProcessorJob.drainPending();
+        long sellerBalanceAfterSecondSweep = userRepo.findById(seededSellerId)
+                .orElseThrow().getBalanceLindens();
+        assertThat(sellerBalanceAfterSecondSweep).isEqualTo(sellerBalanceAfter);
     }
 
     // -------------------------------------------------------------------------

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/integration/EscrowNotificationIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/integration/EscrowNotificationIntegrationTest.java
@@ -105,6 +105,10 @@ class EscrowNotificationIntegrationTest {
                     if (id != null) {
                         st.execute("DELETE FROM notification WHERE user_id = " + id);
                         st.execute("DELETE FROM refresh_tokens WHERE user_id = " + id);
+                        // Wallet-model refund migration: ESCROW_REFUND
+                        // ledger row written when escrow freezes; clear
+                        // before deleting the user.
+                        st.execute("DELETE FROM user_ledger WHERE user_id = " + id);
                         st.execute("DELETE FROM users WHERE id = " + id);
                     }
                 }

--- a/backend/src/test/java/com/slparcelauctions/backend/realty/permission/RealtyGroupPermissionTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/realty/permission/RealtyGroupPermissionTest.java
@@ -19,7 +19,7 @@ class RealtyGroupPermissionTest {
     }
 
     @Test
-    void enumContainsExactlyExpectedValuesForF() {
+    void enumContainsExactlyExpectedValues() {
         Set<String> names = Stream.of(RealtyGroupPermission.values())
                 .map(Enum::name)
                 .collect(Collectors.toSet());
@@ -27,6 +27,7 @@ class RealtyGroupPermissionTest {
                 "INVITE_AGENTS", "REMOVE_AGENTS", "EDIT_GROUP_PROFILE", "CONFIGURE_FEES",
                 "CREATE_LISTING", "MANAGE_ALL_LISTINGS",
                 "WITHDRAW_FROM_GROUP_WALLET", "VIEW_GROUP_TRANSACTIONS",
-                "REGISTER_SL_GROUP", "MANAGE_MEMBERS");
+                "REGISTER_SL_GROUP", "MANAGE_MEMBERS",
+                "DEPOSIT_TO_GROUP_WALLET");
     }
 }

--- a/frontend/src/components/listing/CancelListingModal.test.tsx
+++ b/frontend/src/components/listing/CancelListingModal.test.tsx
@@ -332,7 +332,7 @@ describe("CancelListingModal", () => {
       { auth: "authenticated" },
     );
     expect(
-      screen.getByText(/Refund: L\$100.*full refund/i),
+      screen.getByText(/Refund: L\$100.*credited instantly/i),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/components/listing/CancelListingModal.tsx
+++ b/frontend/src/components/listing/CancelListingModal.tsx
@@ -129,7 +129,11 @@ export function CancelListingModal({
   const { data: currentUser } = useCurrentUser();
   const { data: status } = useCancellationStatus();
 
-  const refund = computeRefund(auction.status, auction.listingFeeAmt);
+  const refund = computeRefund(
+    auction.status,
+    auction.listingFeeAmt,
+    auction.realtyGroup != null,
+  );
 
   const copyVariant = resolveCopyVariant({
     bannedFromListing: currentUser?.bannedFromListing ?? false,

--- a/frontend/src/lib/listing/refundCalculation.test.ts
+++ b/frontend/src/lib/listing/refundCalculation.test.ts
@@ -10,10 +10,16 @@ describe("computeRefund", () => {
   });
 
   it("returns FULL for DRAFT_PAID with the persisted listingFeeAmt", () => {
-    expect(computeRefund("DRAFT_PAID", 100)).toMatchObject({
-      kind: "FULL",
-      amountLindens: 100,
-    });
+    const r = computeRefund("DRAFT_PAID", 100);
+    expect(r).toMatchObject({ kind: "FULL", amountLindens: 100 });
+    expect(r.copy).toMatch(/your SLParcels wallet/);
+    expect(r.copy).toMatch(/instantly/);
+  });
+
+  it("uses the group-wallet phrasing when isGroupListing is true", () => {
+    const r = computeRefund("DRAFT_PAID", 100, true);
+    expect(r.copy).toMatch(/the group's SLParcels wallet/);
+    expect(r.copy).not.toMatch(/your SLParcels wallet/);
   });
 
   it("returns FULL for VERIFICATION_PENDING", () => {

--- a/frontend/src/lib/listing/refundCalculation.ts
+++ b/frontend/src/lib/listing/refundCalculation.ts
@@ -1,19 +1,21 @@
 import type { AuctionStatus } from "@/types/auction";
 
 /**
- * Refund model for the CancelListingModal (sub-spec 2 §8.2).
+ * Refund model for the CancelListingModal.
  *
- * The backend authoritative refund logic lives in CancellationService;
- * this frontend helper only mirrors the user-facing copy so the modal can
- * show the correct message before the seller clicks "Confirm cancel".
+ * The backend authoritative refund logic lives in CancellationService +
+ * ListingFeeRefundProcessorTask; this frontend helper only mirrors the
+ * user-facing copy so the modal can show the correct message before the
+ * seller clicks "Confirm cancel".
  *
  * Buckets:
  *   - DRAFT: no fee paid → no refund.
  *   - DRAFT_PAID / VERIFICATION_PENDING / VERIFICATION_FAILED: fee paid
- *     but listing never went live → full refund, processed within 24 h.
- *   - ACTIVE: cancelling an active listing forfeits the fee (per spec).
- *   - Anything else is not cancellable from the UI — the copy reflects
- *     that ("This listing cannot be cancelled.").
+ *     but listing never went live → full refund, credited instantly to
+ *     the SLParcels wallet that paid (group wallet for case-3 listings,
+ *     seller's user wallet otherwise).
+ *   - ACTIVE: cancelling an active listing forfeits the fee.
+ *   - Anything else is not cancellable from the UI.
  */
 export interface RefundInfo {
   kind: "NONE" | "FULL";
@@ -21,9 +23,18 @@ export interface RefundInfo {
   copy: string;
 }
 
+/**
+ * @param status         current auction status
+ * @param listingFeeAmt  fee paid, in L$
+ * @param isGroupListing true when the auction is case-3 (the fee came
+ *                       from a realty group's wallet); drives whether
+ *                       the copy says "your wallet" or "the group's
+ *                       wallet"
+ */
 export function computeRefund(
   status: AuctionStatus,
   listingFeeAmt: number | null,
+  isGroupListing: boolean = false,
 ): RefundInfo {
   switch (status) {
     case "DRAFT":
@@ -36,10 +47,13 @@ export function computeRefund(
     case "VERIFICATION_PENDING":
     case "VERIFICATION_FAILED": {
       const amount = listingFeeAmt ?? 0;
+      const target = isGroupListing
+        ? "the group's SLParcels wallet"
+        : "your SLParcels wallet";
       return {
         kind: "FULL",
         amountLindens: amount,
-        copy: `Refund: L$${amount} (full refund, processed within 24 hours).`,
+        copy: `Refund: L$${amount}, credited instantly to ${target}.`,
       };
     }
     case "ACTIVE":


### PR DESCRIPTION
Closes the user's audit items **A6**, **A7**, **B6 should always fire**, **B7 should always fire**, **B13 should always fire**.

Per platform policy, L$ leaves SLParcels only via:
- user-initiated withdrawal
- admin disbursement
- no-activity dormancy auto-return
- closing of escrow on completed transactions (seller payout)

Two refund paths were previously paying out to avatars via TerminalCommand REFUND (gated behind `slpa.wallet.enforcement-enabled` which defaulted to false in prod):

- **A6** Escrow refund on DISPUTED/FROZEN/EXPIRED — was crediting the bidder's avatar; now credits their SLParcels wallet (ESCROW_REFUND ledger).
- **A7** Listing-fee refund on pre-bid cancellation — was crediting the seller's avatar (even when the fee came from a group wallet); now credits the group wallet for case-3 listings, seller's user wallet otherwise.

`TerminalCommandService.queueRefund` and `queueListingFeeRefund` deleted. `AdminDisputeService.resolve` EXPIRED branch routed through `EscrowService.queueRefundIfFunded`. Cancel-modal copy says 'credited instantly to your/the group's SLParcels wallet' instead of the stale '24 hours'.

Out of scope (separate migration): `BidService` bid-time wallet preconditions + `EscrowService.createForEndedAuction` auto-fund. Those stay gated behind `slpa.wallet.enforcement-enabled`.

Backend 2479/2479 green, frontend 1962/1962 green.