### PR TITLE
fix(activate): method-3 setup step + group-wallet balance on draft

### DIFF
--- a/frontend/src/app/listings/(verified)/[publicId]/activate/ActivateClient.test.tsx
+++ b/frontend/src/app/listings/(verified)/[publicId]/activate/ActivateClient.test.tsx
@@ -173,6 +173,85 @@ describe("ActivateClient", () => {
     );
   });
 
+  it("DRAFT_PAID + Sale-to-bot → shows the setup panel, NOT an immediate verify", async () => {
+    let verifyCalls = 0;
+    server.use(
+      http.get("*/api/v1/auctions/00000000-0000-0000-0000-00000000002a", () =>
+        HttpResponse.json(auctionBase({ status: "DRAFT_PAID" })),
+      ),
+      http.put("*/api/v1/auctions/00000000-0000-0000-0000-00000000002a/verify", () => {
+        verifyCalls += 1;
+        return HttpResponse.json(
+          auctionBase({
+            status: "VERIFICATION_PENDING",
+            verificationMethod: "SALE_TO_BOT",
+            pendingVerification: null,
+          }),
+        );
+      }),
+    );
+    renderWithProviders(
+      <ActivateClient auctionPublicId="00000000-0000-0000-0000-00000000002a" />,
+      { auth: "authenticated" },
+    );
+    const useThisMethodButtons = await screen.findAllByRole("button", {
+      name: /Use this method/i,
+    });
+    // Sale-to-bot is the third card.
+    await userEvent.click(useThisMethodButtons[2]);
+    // Setup panel mounts with the steps + a Verify button; no verify call yet.
+    expect(
+      await screen.findByTestId("sale-to-bot-setup-panel"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("sale-to-bot-setup-verify")).toBeInTheDocument();
+    expect(verifyCalls).toBe(0);
+  });
+
+  it("Sale-to-bot setup panel → clicking Verify fires triggerVerify with SALE_TO_BOT", async () => {
+    let received: string | null = null;
+    let auctionCalls = 0;
+    server.use(
+      http.get("*/api/v1/auctions/00000000-0000-0000-0000-00000000002a", () => {
+        auctionCalls += 1;
+        if (auctionCalls < 2) {
+          return HttpResponse.json(auctionBase({ status: "DRAFT_PAID" }));
+        }
+        return HttpResponse.json(
+          auctionBase({
+            status: "VERIFICATION_PENDING",
+            verificationMethod: "SALE_TO_BOT",
+            pendingVerification: null,
+          }),
+        );
+      }),
+      http.put(
+        "*/api/v1/auctions/00000000-0000-0000-0000-00000000002a/verify",
+        async ({ request }) => {
+          const body = (await request.json()) as { method: string };
+          received = body.method;
+          return HttpResponse.json(
+            auctionBase({
+              status: "VERIFICATION_PENDING",
+              verificationMethod: "SALE_TO_BOT",
+              pendingVerification: null,
+            }),
+          );
+        },
+      ),
+    );
+    renderWithProviders(
+      <ActivateClient auctionPublicId="00000000-0000-0000-0000-00000000002a" />,
+      { auth: "authenticated" },
+    );
+    const useThisMethodButtons = await screen.findAllByRole("button", {
+      name: /Use this method/i,
+    });
+    await userEvent.click(useThisMethodButtons[2]);
+    await screen.findByTestId("sale-to-bot-setup-panel");
+    await userEvent.click(screen.getByTestId("sale-to-bot-setup-verify"));
+    await waitFor(() => expect(received).toBe("SALE_TO_BOT"));
+  });
+
   it("VERIFICATION_FAILED renders the retry banner with the failure notes", async () => {
     server.use(
       http.get("*/api/v1/auctions/00000000-0000-0000-0000-00000000002a", () =>

--- a/frontend/src/app/listings/(verified)/[publicId]/activate/ActivateClient.tsx
+++ b/frontend/src/app/listings/(verified)/[publicId]/activate/ActivateClient.tsx
@@ -10,6 +10,7 @@ import { CheckCircle2 } from "@/components/ui/icons";
 import { useToast } from "@/components/ui/Toast";
 import { ActivateStatusStepper } from "@/components/listing/ActivateStatusStepper";
 import { CancelListingModal } from "@/components/listing/CancelListingModal";
+import { SaleToBotSetupPanel } from "@/components/listing/SaleToBotSetupPanel";
 import { VerificationInProgressPanel } from "@/components/listing/VerificationInProgressPanel";
 import { VerificationMethodPicker } from "@/components/listing/VerificationMethodPicker";
 import { useActivateAuction } from "@/hooks/useActivateAuction";
@@ -51,6 +52,7 @@ export function ActivateClient({ auctionPublicId }: ActivateClientProps) {
   const router = useRouter();
   const toast = useToast();
   const [cancelOpen, setCancelOpen] = useState(false);
+  const [saleSetupPending, setSaleSetupPending] = useState(false);
   const { data: auction, isLoading, error } = useActivateAuction(auctionPublicId);
   const status = auction?.status;
 
@@ -129,11 +131,24 @@ export function ActivateClient({ auctionPublicId }: ActivateClientProps) {
     return <DraftEditorClient auction={auction} />;
   }
 
+  const inMethodPick =
+    auction.status === "DRAFT_PAID" ||
+    auction.status === "VERIFICATION_FAILED";
+  // The sale-setup interstitial only applies when status is DRAFT_PAID.
+  // On VERIFICATION_FAILED we always show the picker (with the failure
+  // banner) — the seller may want to retry a different method without
+  // being dropped back into a stale setup panel from a prior attempt.
+  const showSaleSetup =
+    saleSetupPending && auction.status === "DRAFT_PAID";
+  const showPicker = inMethodPick && !showSaleSetup;
+
   return (
     <div className="mx-auto flex max-w-3xl flex-col gap-6 p-6">
-      <ActivateStatusStepper status={auction.status} />
-      {(auction.status === "DRAFT_PAID" ||
-        auction.status === "VERIFICATION_FAILED") && (
+      <ActivateStatusStepper
+        status={auction.status}
+        saleSetupPending={showSaleSetup}
+      />
+      {showPicker && (
         <VerificationMethodPicker
           auctionPublicId={auction.publicId}
           lastFailureNotes={
@@ -141,6 +156,13 @@ export function ActivateClient({ auctionPublicId }: ActivateClientProps) {
               ? auction.verificationNotes
               : null
           }
+          onSelectSaleToBot={() => setSaleSetupPending(true)}
+        />
+      )}
+      {showSaleSetup && (
+        <SaleToBotSetupPanel
+          auctionPublicId={auction.publicId}
+          onBack={() => setSaleSetupPending(false)}
         />
       )}
       {auction.status === "VERIFICATION_PENDING" && (

--- a/frontend/src/app/listings/(verified)/[publicId]/activate/DraftEditorClient.tsx
+++ b/frontend/src/app/listings/(verified)/[publicId]/activate/DraftEditorClient.tsx
@@ -29,6 +29,10 @@ import { auctionKey } from "@/hooks/useAuction";
 import { activateAuctionKey } from "@/hooks/useActivateAuction";
 import { useListingFeeConfig } from "@/hooks/useListingFeeConfig";
 import { useWallet, walletQueryKey } from "@/lib/wallet/use-wallet";
+import {
+  useGroupWallet,
+  useInvalidateGroupWallet,
+} from "@/hooks/realty/useGroupWallet";
 import { payListingFee } from "@/lib/api/wallet";
 import type {
   AuctionDurationHours,
@@ -58,7 +62,16 @@ export function DraftEditorClient({ auction }: DraftEditorClientProps) {
   const m = useDraftEditorMutations(auction.publicId);
   const reorder = useReorderAuctionPhotos(auction.publicId);
   const feeQ = useListingFeeConfig();
-  const walletQ = useWallet(true);
+  const groupPublicId = auction.realtyGroup?.publicId ?? null;
+  const isGroupListing = groupPublicId !== null;
+  // Only one of these is meaningfully populated: the user wallet drives
+  // personal listings, the group wallet drives group-attributed ones.
+  // Backend MeWalletController.payListingFee routes the debit the same
+  // way (auction.realtyGroupId → group wallet, else user wallet) so this
+  // mirrors the source of truth.
+  const walletQ = useWallet(!isGroupListing);
+  const groupWalletQ = useGroupWallet(groupPublicId ?? "");
+  const invalidateGroupWallet = useInvalidateGroupWallet(groupPublicId ?? "");
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [confirmListOpen, setConfirmListOpen] = useState(false);
 
@@ -66,7 +79,11 @@ export function DraftEditorClient({ auction }: DraftEditorClientProps) {
     mutationFn: () => payListingFee(auction.publicId, genIdempotencyKey()),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: activateAuctionKey(auction.publicId) });
-      qc.invalidateQueries({ queryKey: walletQueryKey });
+      if (isGroupListing) {
+        invalidateGroupWallet();
+      } else {
+        qc.invalidateQueries({ queryKey: walletQueryKey });
+      }
       toast.success("Listing fee paid. Choose a verification method next.");
       setConfirmListOpen(false);
     },
@@ -77,21 +94,53 @@ export function DraftEditorClient({ auction }: DraftEditorClientProps) {
           ? e.message
           : "Could not list this parcel.";
       toast.error(detail);
-      qc.invalidateQueries({ queryKey: walletQueryKey });
+      if (isGroupListing) {
+        invalidateGroupWallet();
+      } else {
+        qc.invalidateQueries({ queryKey: walletQueryKey });
+      }
     },
   });
 
-  if (feeQ.isLoading || walletQ.isLoading || !feeQ.data || !walletQ.data) {
+  const walletLoading = isGroupListing ? groupWalletQ.isLoading : walletQ.isLoading;
+  const walletData = isGroupListing ? groupWalletQ.data : walletQ.data;
+  const walletError = isGroupListing ? groupWalletQ.error : walletQ.error;
+  if (feeQ.isLoading || walletLoading || !feeQ.data) {
     return (
       <div className="mx-auto max-w-3xl p-6">
         <LoadingSpinner label="Loading listing details…" />
       </div>
     );
   }
+  if (!walletData) {
+    // Group-listed drafts require the seller to be able to read the
+    // group wallet — leader auto-passes; agents need VIEW_GROUP_TRANSACTIONS.
+    // Surface the failure rather than spinning forever.
+    const detail = isApiError(walletError)
+      ? walletError.problem.detail ??
+        walletError.problem.title ??
+        "Could not load wallet."
+      : walletError instanceof Error
+        ? walletError.message
+        : isGroupListing
+          ? "Could not load the group wallet. You may need VIEW_GROUP_TRANSACTIONS permission to list under this group."
+          : "Could not load wallet.";
+    return (
+      <div className="mx-auto max-w-3xl p-6 text-sm text-danger">
+        {detail}
+      </div>
+    );
+  }
 
   const fee = feeQ.data.amountLindens;
-  const wallet = walletQ.data;
-  const insufficientFunds = wallet.available < fee || wallet.penaltyOwed > 0;
+  const availableBalance = walletData.available;
+  // Group wallet has no penalty concept — only the user wallet does.
+  // For group listings we gate purely on balance; for user listings we
+  // also block when the user has an outstanding penalty.
+  const personalPenaltyOwed = isGroupListing
+    ? 0
+    : (walletQ.data?.penaltyOwed ?? 0);
+  const insufficientFunds = availableBalance < fee || personalPenaltyOwed > 0;
 
   const settings: DraftSettings = {
     startingBid: auction.startingBid,
@@ -128,7 +177,8 @@ export function DraftEditorClient({ auction }: DraftEditorClientProps) {
     <div data-testid="draft-editor-client" className="flex flex-col gap-3">
       <DraftActionBar
         listingFee={fee}
-        walletBalance={wallet.available}
+        walletBalance={availableBalance}
+        isGroupListing={isGroupListing}
         isListing={listMutation.isPending}
         insufficientFunds={insufficientFunds}
         onListParcel={() => setConfirmListOpen(true)}
@@ -203,7 +253,8 @@ export function DraftEditorClient({ auction }: DraftEditorClientProps) {
         onClose={() => setConfirmListOpen(false)}
         onConfirm={() => listMutation.mutate()}
         listingFee={fee}
-        walletBalance={wallet.available}
+        walletBalance={availableBalance}
+        isGroupListing={isGroupListing}
         isListing={listMutation.isPending}
       />
     </div>

--- a/frontend/src/components/listing/ActivateStatusStepper.tsx
+++ b/frontend/src/components/listing/ActivateStatusStepper.tsx
@@ -13,19 +13,35 @@ const LABELS = ["Draft", "Paid", "Verifying", "Active"] as const;
  * VERIFICATION_FAILED pins the indicator back to Paid so the UI shows
  * "you're back on step 2" rather than still showing "Verifying" — this
  * is the "regression" visual in spec §5.1.
+ *
+ * Sale-to-bot setup override: while the seller is on the SaleToBotSetupPanel
+ * (after picking the method but before clicking Verify), the parent
+ * advances the indicator to "Verifying" so the flow reads top-down even
+ * though backend status is still DRAFT_PAID.
  */
-export function statusToStepperIndex(status: AuctionStatus): number {
+export function statusToStepperIndex(
+  status: AuctionStatus,
+  saleSetupPending: boolean = false,
+): number {
   if (status === "DRAFT") return 0;
-  if (status === "DRAFT_PAID" || status === "VERIFICATION_FAILED") return 1;
+  if (status === "DRAFT_PAID" || status === "VERIFICATION_FAILED") {
+    return saleSetupPending ? 2 : 1;
+  }
   if (status === "VERIFICATION_PENDING") return 2;
   return 3;
 }
 
-export function ActivateStatusStepper({ status }: { status: AuctionStatus }) {
+export function ActivateStatusStepper({
+  status,
+  saleSetupPending = false,
+}: {
+  status: AuctionStatus;
+  saleSetupPending?: boolean;
+}) {
   return (
     <Stepper
       steps={LABELS as unknown as string[]}
-      currentIndex={statusToStepperIndex(status)}
+      currentIndex={statusToStepperIndex(status, saleSetupPending)}
     />
   );
 }

--- a/frontend/src/components/listing/SaleToBotSetupPanel.test.tsx
+++ b/frontend/src/components/listing/SaleToBotSetupPanel.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/test/render";
+import { server } from "@/test/msw/server";
+import { SaleToBotSetupPanel } from "./SaleToBotSetupPanel";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/listings/42/activate",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+describe("SaleToBotSetupPanel", () => {
+  it("renders the setup steps and the Verify button", () => {
+    renderWithProviders(
+      <SaleToBotSetupPanel
+        auctionPublicId="00000000-0000-0000-0000-00000000002a"
+        onBack={vi.fn()}
+      />,
+      { auth: "authenticated" },
+    );
+    expect(
+      screen.getByRole("heading", {
+        name: /Set your land for sale to SLPAEscrow Resident/i,
+      }),
+    ).toBeInTheDocument();
+    // The heading and the buyer step both mention SLPAEscrow Resident.
+    expect(screen.getAllByText(/SLPAEscrow Resident/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/L\$999,999,999/)).toBeInTheDocument();
+    expect(screen.getByTestId("sale-to-bot-setup-verify")).toBeInTheDocument();
+    expect(screen.getByTestId("sale-to-bot-setup-back")).toBeInTheDocument();
+  });
+
+  it("clicking Verify fires triggerVerify with SALE_TO_BOT", async () => {
+    let received: string | null = null;
+    server.use(
+      http.put(
+        "*/api/v1/auctions/00000000-0000-0000-0000-00000000002a/verify",
+        async ({ request }) => {
+          const body = (await request.json()) as { method: string };
+          received = body.method;
+          return HttpResponse.json({
+            id: 42,
+            status: "VERIFICATION_PENDING",
+            verificationMethod: body.method,
+            pendingVerification: null,
+            parcel: {},
+          });
+        },
+      ),
+    );
+    renderWithProviders(
+      <SaleToBotSetupPanel
+        auctionPublicId="00000000-0000-0000-0000-00000000002a"
+        onBack={vi.fn()}
+      />,
+      { auth: "authenticated" },
+    );
+    await userEvent.click(screen.getByTestId("sale-to-bot-setup-verify"));
+    await waitFor(() => expect(received).toBe("SALE_TO_BOT"));
+  });
+
+  it("clicking the back button calls onBack and does NOT fire verify", async () => {
+    let verifyCalls = 0;
+    server.use(
+      http.put(
+        "*/api/v1/auctions/00000000-0000-0000-0000-00000000002a/verify",
+        () => {
+          verifyCalls += 1;
+          return HttpResponse.json({});
+        },
+      ),
+    );
+    const onBack = vi.fn();
+    renderWithProviders(
+      <SaleToBotSetupPanel
+        auctionPublicId="00000000-0000-0000-0000-00000000002a"
+        onBack={onBack}
+      />,
+      { auth: "authenticated" },
+    );
+    await userEvent.click(screen.getByTestId("sale-to-bot-setup-back"));
+    expect(onBack).toHaveBeenCalledTimes(1);
+    expect(verifyCalls).toBe(0);
+  });
+});

--- a/frontend/src/components/listing/SaleToBotSetupPanel.tsx
+++ b/frontend/src/components/listing/SaleToBotSetupPanel.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/Button";
+import { ApiError, isApiError } from "@/lib/api";
+import { triggerVerify } from "@/lib/api/auctions";
+import type { SellerAuctionResponse } from "@/types/auction";
+import { activateAuctionKey } from "@/hooks/useActivateAuction";
+
+export interface SaleToBotSetupPanelProps {
+  auctionPublicId: number | string;
+  /**
+   * Returns the seller to the method picker so they can pick a different
+   * verification method without firing the SALE_TO_BOT mutation.
+   */
+  onBack: () => void;
+}
+
+/**
+ * Step-3 setup panel for the Sale-to-bot verification method. Renders the
+ * in-world steps the seller must complete (Set Land for Sale to
+ * SLPAEscrow Resident at L$999,999,999) and a Verify button that fires
+ * {@code PUT /auctions/{id}/verify} with method=SALE_TO_BOT only after
+ * the seller has had a chance to set up the sale.
+ *
+ * Spec context: previously the picker fired verify immediately on click,
+ * which raced the bot ahead of the seller setting the parcel for sale.
+ * Splitting picker → setup → in-progress gives the seller a stable view
+ * to follow the steps on before the bot starts watching.
+ */
+export function SaleToBotSetupPanel({
+  auctionPublicId,
+  onBack,
+}: SaleToBotSetupPanelProps) {
+  const qc = useQueryClient();
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation<SellerAuctionResponse, unknown, void>({
+    mutationFn: () => triggerVerify(auctionPublicId, { method: "SALE_TO_BOT" }),
+    onMutate: () => setError(null),
+    onSuccess: (auction) => {
+      qc.setQueryData(activateAuctionKey(auctionPublicId), auction);
+    },
+    onError: (e) => {
+      if (e instanceof ApiError || isApiError(e)) {
+        setError(
+          e.problem.detail ??
+            e.problem.title ??
+            "Verification could not be started.",
+        );
+        return;
+      }
+      setError(
+        e instanceof Error ? e.message : "Verification could not be started.",
+      );
+    },
+  });
+
+  return (
+    <section
+      aria-labelledby="sale-to-bot-setup-heading"
+      data-testid="sale-to-bot-setup-panel"
+      className="flex flex-col gap-4 rounded-lg bg-bg-subtle p-6"
+    >
+      <h3
+        id="sale-to-bot-setup-heading"
+        className="text-sm font-semibold tracking-tight text-fg"
+      >
+        Set your land for sale to SLPAEscrow Resident
+      </h3>
+      <p className="text-xs text-fg-muted">
+        Complete these steps in-world first. Then click Verify so our bot
+        starts watching for the sale event.
+      </p>
+      <ol className="list-decimal list-inside flex flex-col gap-1 text-sm text-fg">
+        <li>Open the SL Land menu on the parcel.</li>
+        <li>
+          Choose <em>Set Land for Sale&hellip;</em>
+        </li>
+        <li>
+          Buyer: <strong>SLPAEscrow Resident</strong>
+        </li>
+        <li>
+          Price: <strong>L$999,999,999</strong>
+        </li>
+        <li>
+          Click <em>Sell</em> to confirm in-world.
+        </li>
+      </ol>
+      {error && (
+        <div
+          role="alert"
+          className="rounded-lg bg-danger-bg px-4 py-3 text-xs font-medium text-danger"
+        >
+          {error}
+        </div>
+      )}
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <Button
+          variant="secondary"
+          onClick={onBack}
+          disabled={mutation.isPending}
+          data-testid="sale-to-bot-setup-back"
+        >
+          Choose a different method
+        </Button>
+        <Button
+          onClick={() => mutation.mutate()}
+          disabled={mutation.isPending}
+          loading={mutation.isPending}
+          data-testid="sale-to-bot-setup-verify"
+        >
+          {mutation.isPending ? "Starting…" : "Verify"}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/listing/VerificationMethodPicker.test.tsx
+++ b/frontend/src/components/listing/VerificationMethodPicker.test.tsx
@@ -57,6 +57,45 @@ describe("VerificationMethodPicker", () => {
     ).toBeInTheDocument();
   });
 
+  it("does NOT show the inline sale-to-bot steps on the picker card", () => {
+    renderWithProviders(
+      <VerificationMethodPicker auctionPublicId="00000000-0000-0000-0000-00000000002a" />,
+      { auth: "authenticated" },
+    );
+    // The steps moved to the dedicated SaleToBotSetupPanel — the picker
+    // card now carries only a short description, not the numbered list.
+    expect(screen.queryByText(/Set Land for Sale/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/L\$999,999,999/i)).not.toBeInTheDocument();
+  });
+
+  it("clicking Sale-to-bot fires onSelectSaleToBot and skips the verify call", async () => {
+    let verifyCalls = 0;
+    server.use(
+      http.put(
+        "*/api/v1/auctions/00000000-0000-0000-0000-00000000002a/verify",
+        () => {
+          verifyCalls += 1;
+          return HttpResponse.json({});
+        },
+      ),
+    );
+    const onSelectSaleToBot = vi.fn();
+    renderWithProviders(
+      <VerificationMethodPicker
+        auctionPublicId="00000000-0000-0000-0000-00000000002a"
+        onSelectSaleToBot={onSelectSaleToBot}
+      />,
+      { auth: "authenticated" },
+    );
+    // Sale-to-bot is the third card; click its "Use this method" button.
+    const buttons = await screen.findAllByRole("button", {
+      name: /Use this method/i,
+    });
+    await userEvent.click(buttons[2]);
+    expect(onSelectSaleToBot).toHaveBeenCalledTimes(1);
+    expect(verifyCalls).toBe(0);
+  });
+
   it("remaps a 422 error to the group-owned prescriptive message", async () => {
     server.use(
       http.put("*/api/v1/auctions/00000000-0000-0000-0000-00000000002a/verify", () =>

--- a/frontend/src/components/listing/VerificationMethodPicker.tsx
+++ b/frontend/src/components/listing/VerificationMethodPicker.tsx
@@ -12,16 +12,10 @@ import type {
 } from "@/types/auction";
 import { activateAuctionKey } from "@/hooks/useActivateAuction";
 
-type MethodBody = string | React.ReactNode;
-
 interface MethodCard {
   key: VerificationMethod;
   title: string;
-  body: MethodBody;
-  /** Button label. Defaults to "Use this method"; method 3 overrides to
-   *  "Verify" because the user has to set up the parcel sale in SL
-   *  BEFORE clicking. */
-  actionLabel?: string;
+  body: string;
 }
 
 const METHODS: readonly MethodCard[] = [
@@ -40,32 +34,8 @@ const METHODS: readonly MethodCard[] = [
   {
     key: "SALE_TO_BOT",
     title: "Sale-to-bot",
-    actionLabel: "Verify",
-    body: (
-      <>
-        <p className="text-xs text-fg-muted">
-          Required for group-owned land. Set the parcel for sale to our
-          escrow account first, THEN click Verify so the bot starts
-          watching.
-        </p>
-        <ol className="list-decimal pl-4 flex flex-col gap-0.5 text-xs text-fg">
-          <li>Open the SL Land menu on the parcel.</li>
-          <li>
-            Choose <em>Set Land for Sale&hellip;</em>
-          </li>
-          <li>
-            Buyer: <strong>SLPAEscrow Resident</strong>
-          </li>
-          <li>
-            Price: <strong>L$999,999,999</strong>
-          </li>
-          <li>
-            Click <em>Sell</em> to confirm in-world.
-          </li>
-          <li>Come back here and click Verify.</li>
-        </ol>
-      </>
-    ),
+    body:
+      "Required for group-owned land. You'll be shown the steps to set the parcel for sale to our escrow account before verification starts.",
   },
 ];
 
@@ -76,6 +46,14 @@ export interface VerificationMethodPickerProps {
    * failed. Null/undefined hides the banner.
    */
   lastFailureNotes?: string | null;
+  /**
+   * When provided, picking the SALE_TO_BOT card calls this callback
+   * INSTEAD of firing the verify mutation directly. The parent uses
+   * this to navigate the seller to the setup panel so they can put
+   * the parcel up for sale before the bot starts watching. UUID_ENTRY
+   * and REZZABLE remain immediate.
+   */
+  onSelectSaleToBot?: () => void;
 }
 
 /**
@@ -97,6 +75,7 @@ export interface VerificationMethodPickerProps {
 export function VerificationMethodPicker({
   auctionPublicId,
   lastFailureNotes,
+  onSelectSaleToBot,
 }: VerificationMethodPickerProps) {
   const qc = useQueryClient();
   const [error, setError] = useState<string | null>(null);
@@ -171,27 +150,29 @@ export function VerificationMethodPicker({
       )}
       <div className="grid gap-4 md:grid-cols-3">
         {METHODS.map((method) => {
-          const label = method.actionLabel ?? "Use this method";
+          const handleClick = () => {
+            if (method.key === "SALE_TO_BOT" && onSelectSaleToBot) {
+              onSelectSaleToBot();
+              return;
+            }
+            mutation.mutate(method.key);
+          };
+          const isPendingThis =
+            mutation.isPending && mutation.variables === method.key;
           return (
             <article
               key={method.key}
               className="flex flex-col gap-3 rounded-lg bg-bg-subtle p-4"
             >
               <h3 className="text-sm font-semibold tracking-tight text-fg">{method.title}</h3>
-              {typeof method.body === "string" ? (
-                <p className="text-xs text-fg-muted">{method.body}</p>
-              ) : (
-                <div className="flex flex-col gap-2">{method.body}</div>
-              )}
+              <p className="text-xs text-fg-muted">{method.body}</p>
               <div className="mt-auto">
                 <Button
-                  onClick={() => mutation.mutate(method.key)}
+                  onClick={handleClick}
                   disabled={mutation.isPending}
-                  loading={mutation.isPending && mutation.variables === method.key}
+                  loading={isPendingThis}
                 >
-                  {mutation.isPending && mutation.variables === method.key
-                    ? "Starting…"
-                    : label}
+                  {isPendingThis ? "Starting…" : "Use this method"}
                 </Button>
               </div>
             </article>

--- a/frontend/src/components/listing/draft-editor/ConfirmListParcelModal.test.tsx
+++ b/frontend/src/components/listing/draft-editor/ConfirmListParcelModal.test.tsx
@@ -38,6 +38,27 @@ describe("ConfirmListParcelModal", () => {
     expect(onConfirm).toHaveBeenCalled();
   });
 
+  it("uses group-wallet language when isGroupListing is true", () => {
+    renderWithProviders(
+      <ConfirmListParcelModal
+        open
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        listingFee={100}
+        walletBalance={5000}
+        isGroupListing
+      />,
+    );
+    expect(screen.getByText(/Group wallet balance/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/group's SLParcels wallet/i),
+    ).toBeInTheDocument();
+    // The personal-wallet variant copy must NOT appear in the group case.
+    expect(
+      screen.queryByText(/from your SLParcels wallet/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("disables both buttons while isListing", () => {
     renderWithProviders(
       <ConfirmListParcelModal

--- a/frontend/src/components/listing/draft-editor/ConfirmListParcelModal.tsx
+++ b/frontend/src/components/listing/draft-editor/ConfirmListParcelModal.tsx
@@ -9,6 +9,12 @@ export interface ConfirmListParcelModalProps {
   onConfirm: () => void;
   listingFee: number;
   walletBalance: number;
+  /**
+   * Renders the balance + copy in group-wallet language. Set when the
+   * draft auction was created under a realty group — the backend
+   * debits the group wallet for the listing fee in that case.
+   */
+  isGroupListing?: boolean;
   /** Pending = button shows spinner + close is disabled. */
   isListing?: boolean;
 }
@@ -27,9 +33,14 @@ export function ConfirmListParcelModal({
   onConfirm,
   listingFee,
   walletBalance,
+  isGroupListing = false,
   isListing = false,
 }: ConfirmListParcelModalProps) {
   const balanceAfter = walletBalance - listingFee;
+  const description = isGroupListing
+    ? "Listing this parcel debits the listing fee from the group's SLParcels wallet and starts the verification flow. The fee is non-refundable once the listing reaches buyers."
+    : "Listing your parcel debits the listing fee from your SLParcels wallet and starts the verification flow. The fee is non-refundable once the listing reaches buyers.";
+  const balanceLabel = isGroupListing ? "Group wallet balance" : "Wallet balance";
 
   return (
     <Dialog
@@ -49,11 +60,7 @@ export function ConfirmListParcelModal({
           <DialogTitle className="text-base font-bold tracking-tight text-fg">
             List this parcel?
           </DialogTitle>
-          <p className="text-sm text-fg-muted">
-            Listing your parcel debits the listing fee from your SLParcels
-            wallet and starts the verification flow. The fee is non-refundable
-            once the listing reaches buyers.
-          </p>
+          <p className="text-sm text-fg-muted">{description}</p>
           <dl className="flex flex-col gap-2 rounded-lg bg-surface-raised p-4 text-sm">
             <div className="flex items-baseline justify-between">
               <dt className="text-fg-muted">Listing fee</dt>
@@ -62,7 +69,7 @@ export function ConfirmListParcelModal({
               </dd>
             </div>
             <div className="flex items-baseline justify-between">
-              <dt className="text-fg-muted">Wallet balance</dt>
+              <dt className="text-fg-muted">{balanceLabel}</dt>
               <dd className="font-medium text-fg">
                 L${walletBalance.toLocaleString()}
               </dd>

--- a/frontend/src/components/listing/draft-editor/DraftActionBar.test.tsx
+++ b/frontend/src/components/listing/draft-editor/DraftActionBar.test.tsx
@@ -30,6 +30,40 @@ describe("DraftActionBar", () => {
     expect(screen.getByTestId("draft-action-bar-list")).toBeDisabled();
   });
 
+  it("labels the balance as 'Group wallet' when isGroupListing is true", () => {
+    renderWithProviders(
+      <DraftActionBar
+        listingFee={100}
+        walletBalance={5000}
+        isGroupListing
+        onListParcel={vi.fn()}
+        onDeleteDraft={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("draft-action-bar-wallet")).toHaveTextContent(
+      /Group wallet:/i,
+    );
+    expect(screen.getByTestId("draft-action-bar-wallet")).not.toHaveTextContent(
+      /^Wallet:/,
+    );
+  });
+
+  it("low-funds copy reflects the group wallet when isGroupListing", () => {
+    renderWithProviders(
+      <DraftActionBar
+        listingFee={100}
+        walletBalance={50}
+        insufficientFunds
+        isGroupListing
+        onListParcel={vi.fn()}
+        onDeleteDraft={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByTestId("draft-action-bar-low-funds"),
+    ).toHaveTextContent(/Top up group wallet to list/i);
+  });
+
   it("disables List Parcel and shows low-funds hint when insufficientFunds", () => {
     renderWithProviders(
       <DraftActionBar

--- a/frontend/src/components/listing/draft-editor/DraftActionBar.tsx
+++ b/frontend/src/components/listing/draft-editor/DraftActionBar.tsx
@@ -4,6 +4,13 @@ import { Button } from "@/components/ui/Button";
 export interface DraftActionBarProps {
   listingFee: number;
   walletBalance: number;
+  /**
+   * Labels the balance as the group wallet rather than the user's
+   * personal wallet. Toggle on when the draft auction was created
+   * under a realty group — the backend debits the group wallet for
+   * the listing fee in that case (see MeWalletController.payListingFee).
+   */
+  isGroupListing?: boolean;
   isListing?: boolean;
   insufficientFunds?: boolean;
   onListParcel: () => void;
@@ -19,11 +26,16 @@ export interface DraftActionBarProps {
 export function DraftActionBar({
   listingFee,
   walletBalance,
+  isGroupListing = false,
   isListing = false,
   insufficientFunds = false,
   onListParcel,
   onDeleteDraft,
 }: DraftActionBarProps) {
+  const walletLabel = isGroupListing ? "Group wallet" : "Wallet";
+  const lowFundsLabel = isGroupListing
+    ? "Top up group wallet to list"
+    : "Top up wallet to list";
   return (
     <div
       data-testid="draft-action-bar"
@@ -37,15 +49,15 @@ export function DraftActionBar({
           </span>
         </span>
         <span aria-hidden="true">·</span>
-        <span>
-          Wallet:{" "}
+        <span data-testid="draft-action-bar-wallet">
+          {walletLabel}:{" "}
           <span className="font-medium text-fg">
             L${walletBalance.toLocaleString()}
           </span>
         </span>
         {insufficientFunds && (
           <span className="text-xs text-danger" data-testid="draft-action-bar-low-funds">
-            Top up wallet to list
+            {lowFundsLabel}
           </span>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Split Sale-to-bot verification into an explicit setup step. The picker card now reads "Use this method" with a short description (no inline numbered steps); clicking advances to a new `SaleToBotSetupPanel` that carries the in-world steps and a single Verify button that fires `triggerVerify(SALE_TO_BOT)`. The stepper advances to "Verifying" while the seller is on the setup panel.
- Route the listing-fee wallet readout to the group wallet when the draft is attributed to a realty group. `DraftActionBar` and `ConfirmListParcelModal` both swap to group-wallet language + balance. Mirrors the backend's `MeWalletController.payListingFee` routing.

## Test plan
- [x] `npx vitest run` — 1971/1971 (gained tests for the new panel + group-wallet variants)
- [x] `npm run lint` — 0 errors
- [x] Frontend guards — `verify-no-dark-variants`, `verify-no-hex-colors`, `verify-no-inline-styles` all pass
- [ ] In-world smoke: create a group-attributed draft on a HadronTest parcel, confirm the activate page top banner reads "Group wallet: L\$…"
- [ ] In-world smoke: click List parcel, confirm the modal says "Group wallet balance" and the description mentions "the group's SLParcels wallet"
- [ ] In-world smoke: on DRAFT_PAID, click the third method card; the setup panel appears with the steps and a Verify button that doesn't fire until clicked