### PR TITLE
feat(auction): group-flavoured seller card on group-listed auctions

### DIFF
--- a/frontend/src/app/auction/[publicId]/AuctionDetailClient.tsx
+++ b/frontend/src/app/auction/[publicId]/AuctionDetailClient.tsx
@@ -24,6 +24,8 @@ import {
   SellerProfileCard,
   type SellerProfileCardSeller,
 } from "@/components/auction/SellerProfileCard";
+import { GroupSellerProfileCard } from "@/components/auction/GroupSellerProfileCard";
+import { useRealtyGroup } from "@/hooks/realty/useRealtyGroups";
 import { VisitInSecondLifeBlock } from "@/components/auction/VisitInSecondLifeBlock";
 import { BidPanel } from "@/components/auction/BidPanel";
 import { BidHistoryList } from "@/components/auction/BidHistoryList";
@@ -408,7 +410,17 @@ export function AuctionDetailClient({ initialAuction, initialBidPage }: Props) {
           ) : null}
           <ParcelLayoutMapPlaceholder />
           <BidHistoryList auctionPublicId={publicId} />
-          <SellerProfileCard seller={sellerCardData} />
+          {auction.realtyGroup &&
+          !auction.realtyGroup.dissolved &&
+          auction.listingAgent ? (
+            <GroupSellerProfileCardContainer
+              group={auction.realtyGroup}
+              agent={auction.listingAgent}
+              fallbackSeller={sellerCardData}
+            />
+          ) : (
+            <SellerProfileCard seller={sellerCardData} />
+          )}
         </div>
         <aside className="hidden lg:block lg:col-span-4">
           <div
@@ -453,6 +465,42 @@ export function AuctionDetailClient({ initialAuction, initialBidPage }: Props) {
         </BidSheet>
       </div>
     </main>
+  );
+}
+
+/**
+ * Lazily fetches the group profile so the seller card can show group-
+ * level rating, lifetime sales, and founded-at without making the parent
+ * suspend on it. While the fetch is in flight (or on error) the card
+ * still renders — with the attribution data we already have from
+ * {@code auction.realtyGroup} — so layout doesn't shift on resolve.
+ */
+function GroupSellerProfileCardContainer({
+  group,
+  agent,
+  fallbackSeller,
+}: {
+  group: NonNullable<PublicAuctionResponse["realtyGroup"]>;
+  agent: NonNullable<PublicAuctionResponse["listingAgent"]>;
+  fallbackSeller: SellerProfileCardSeller;
+}) {
+  const groupQuery = useRealtyGroup(group.publicId);
+  if (groupQuery.isError) {
+    // Group fetch failed — fall back to the individual seller card so
+    // the page still shows something meaningful. The attribution line
+    // at the top still tells the buyer it's a group listing.
+    return <SellerProfileCard seller={fallbackSeller} />;
+  }
+  const profile = groupQuery.data;
+  return (
+    <GroupSellerProfileCard
+      group={group}
+      agent={agent}
+      averageRating={profile?.rating?.averageRating ?? null}
+      reviewCount={profile?.rating?.reviewCount ?? 0}
+      completedSales={profile?.completedSalesCount ?? 0}
+      foundedAt={profile?.memberSince ?? null}
+    />
   );
 }
 

--- a/frontend/src/app/listings/(verified)/[publicId]/activate/DraftEditorClient.tsx
+++ b/frontend/src/app/listings/(verified)/[publicId]/activate/DraftEditorClient.tsx
@@ -14,6 +14,8 @@ import {
   SellerProfileCard,
   type SellerProfileCardSeller,
 } from "@/components/auction/SellerProfileCard";
+import { GroupSellerProfileCard } from "@/components/auction/GroupSellerProfileCard";
+import { useRealtyGroup } from "@/hooks/realty/useRealtyGroups";
 import { EditablePhotoGallery } from "@/components/listing/draft-editor/EditablePhotoGallery";
 import { BidPanelPreview } from "@/components/listing/draft-editor/BidPanelPreview";
 import { DraftActionBar } from "@/components/listing/draft-editor/DraftActionBar";
@@ -64,6 +66,10 @@ export function DraftEditorClient({ auction }: DraftEditorClientProps) {
   const feeQ = useListingFeeConfig();
   const groupPublicId = auction.realtyGroup?.publicId ?? null;
   const isGroupListing = groupPublicId !== null;
+  // Fetch the group profile so the seller-card preview shows the buyer
+  // view: group as primary seller with group stats. The hook is gated by
+  // groupPublicId so user-listed drafts never fire it.
+  const groupProfileQ = useRealtyGroup(groupPublicId ?? undefined);
   // Only one of these is meaningfully populated: the user wallet drives
   // personal listings, the group wallet drives group-attributed ones.
   // Backend MeWalletController.payListingFee routes the debit the same
@@ -225,7 +231,20 @@ export function DraftEditorClient({ auction }: DraftEditorClientProps) {
             />
             <ParcelLayoutMapPlaceholder />
             <BidHistoryList auctionPublicId={auction.publicId} />
-            <SellerProfileCard seller={sellerCardData} />
+            {auction.realtyGroup &&
+            !auction.realtyGroup.dissolved &&
+            auction.listingAgent ? (
+              <GroupSellerProfileCard
+                group={auction.realtyGroup}
+                agent={auction.listingAgent}
+                averageRating={groupProfileQ.data?.rating?.averageRating ?? null}
+                reviewCount={groupProfileQ.data?.rating?.reviewCount ?? 0}
+                completedSales={groupProfileQ.data?.completedSalesCount ?? 0}
+                foundedAt={groupProfileQ.data?.memberSince ?? null}
+              />
+            ) : (
+              <SellerProfileCard seller={sellerCardData} />
+            )}
           </div>
           <aside className="hidden lg:block lg:col-span-4">
             <div className="sticky top-24">

--- a/frontend/src/components/auction/GroupSellerProfileCard.test.tsx
+++ b/frontend/src/components/auction/GroupSellerProfileCard.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { renderWithProviders, screen, within } from "@/test/render";
+import type { GroupAttribution, ListingAgent } from "@/types/auction";
+import { GroupSellerProfileCard } from "./GroupSellerProfileCard";
+
+function makeGroup(overrides: Partial<GroupAttribution> = {}): GroupAttribution {
+  return {
+    publicId: "00000000-0000-0000-0000-0000000000aa",
+    name: "Hadron Realty",
+    slug: "hadron-realty",
+    logoUrl: null,
+    dissolved: false,
+    ...overrides,
+  };
+}
+
+function makeAgent(overrides: Partial<ListingAgent> = {}): ListingAgent {
+  return {
+    publicId: "00000000-0000-0000-0000-0000000000bb",
+    displayName: "Carol Agent",
+    avatarUrl: null,
+    ...overrides,
+  };
+}
+
+describe("GroupSellerProfileCard", () => {
+  it("renders the group name as the primary heading, linking to /groups/{slug}", () => {
+    renderWithProviders(
+      <GroupSellerProfileCard
+        group={makeGroup()}
+        agent={makeAgent()}
+        averageRating={4.5}
+        reviewCount={10}
+        completedSales={5}
+        foundedAt="2025-09-12"
+      />,
+    );
+    const nameLink = screen.getByTestId("group-seller-profile-card-name");
+    expect(nameLink).toHaveTextContent("Hadron Realty");
+    expect(nameLink).toHaveAttribute("href", "/groups/hadron-realty");
+  });
+
+  it("renders 'Listed by <agent>' linking to the agent's profile", () => {
+    renderWithProviders(
+      <GroupSellerProfileCard
+        group={makeGroup()}
+        agent={makeAgent()}
+        averageRating={null}
+        reviewCount={0}
+        completedSales={0}
+      />,
+    );
+    const listedBy = screen.getByTestId("group-seller-profile-card-listed-by");
+    expect(listedBy).toHaveTextContent(/^Listed by/);
+    const agentLink = within(listedBy).getByTestId(
+      "group-seller-profile-card-agent-link",
+    );
+    expect(agentLink).toHaveTextContent("Carol Agent");
+    expect(agentLink).toHaveAttribute(
+      "href",
+      "/users/00000000-0000-0000-0000-0000000000bb",
+    );
+  });
+
+  it("does NOT render the 'Member since' line that the individual card uses", () => {
+    renderWithProviders(
+      <GroupSellerProfileCard
+        group={makeGroup()}
+        agent={makeAgent()}
+        completedSales={5}
+        foundedAt="2025-09-12"
+      />,
+    );
+    expect(screen.queryByText(/Member since/i)).not.toBeInTheDocument();
+    // Group-flavored equivalent renders instead.
+    expect(
+      screen.getByTestId("group-seller-profile-card-founded"),
+    ).toHaveTextContent(/Founded Sep 2025/);
+  });
+
+  it("renders group rating + completed-sales count (not the agent's stats)", () => {
+    renderWithProviders(
+      <GroupSellerProfileCard
+        group={makeGroup()}
+        agent={makeAgent()}
+        averageRating={4.2}
+        reviewCount={7}
+        completedSales={12}
+      />,
+    );
+    expect(screen.getByText("4.2")).toBeInTheDocument();
+    expect(screen.getByText("(7 reviews)")).toBeInTheDocument();
+    expect(screen.getByText("12 completed sales")).toBeInTheDocument();
+  });
+
+  it("'View group profile' link points at /groups/{slug}", () => {
+    renderWithProviders(
+      <GroupSellerProfileCard
+        group={makeGroup({ slug: "hadron realty" })}
+        agent={makeAgent()}
+        completedSales={5}
+      />,
+    );
+    const link = screen.getByTestId("group-seller-profile-card-link");
+    // Slug is URL-encoded so a space-containing slug still produces a
+    // well-formed path.
+    expect(link).toHaveAttribute("href", "/groups/hadron%20realty");
+    expect(link).toHaveTextContent(/View group profile/i);
+  });
+
+  it("renders the New Group badge when no reviews + completed sales >= 3", () => {
+    renderWithProviders(
+      <GroupSellerProfileCard
+        group={makeGroup()}
+        agent={makeAgent()}
+        averageRating={null}
+        reviewCount={0}
+        completedSales={5}
+      />,
+    );
+    expect(screen.getByText(/New Group/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/auction/GroupSellerProfileCard.tsx
+++ b/frontend/src/components/auction/GroupSellerProfileCard.tsx
@@ -1,0 +1,171 @@
+/* eslint-disable @next/next/no-img-element -- group logo + agent avatar are API-served binary content */
+import Link from "next/link";
+import { ArrowRight } from "@/components/ui/icons";
+import { Avatar } from "@/components/ui/Avatar";
+import { StatusBadge } from "@/components/ui/StatusBadge";
+import { NewSellerBadge } from "@/components/user/NewSellerBadge";
+import { ReputationStars } from "@/components/user/ReputationStars";
+import { apiUrl } from "@/lib/api/url";
+import { cn } from "@/lib/cn";
+import type { GroupAttribution, ListingAgent } from "@/types/auction";
+
+/**
+ * Group-flavoured seller card for the auction detail page. Rendered in
+ * place of {@link SellerProfileCard} when the listing was created under
+ * a non-dissolved realty group. The group is the public "seller"; the
+ * agent who placed the listing appears as a subline link.
+ *
+ * Layout mirrors {@link SellerProfileCard} (logo on the left, stats
+ * block, view-profile pill) so the surrounding page composition is
+ * unchanged. The outer card is NOT a single anchor — the agent's name
+ * is a distinct link inside the card, which means we can't nest it in
+ * an outer anchor without producing invalid HTML. Click targets:
+ *   - Group logo + group name → /groups/{slug}
+ *   - Agent name              → /users/{agentPublicId}
+ *   - "View group profile"    → /groups/{slug}
+ */
+export interface GroupSellerProfileCardProps {
+  group: GroupAttribution;
+  agent: ListingAgent;
+  /** Aggregated group rating; null/undefined renders the "no reviews" state. */
+  averageRating?: number | string | null;
+  reviewCount?: number | null;
+  completedSales: number;
+  /**
+   * ISO date string for the group's foundedAt (server emits
+   * {@code memberSince}). Rendered as "Founded {Mon YYYY}" if present.
+   */
+  foundedAt?: string | null;
+  className?: string;
+}
+
+function formatFoundedAt(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  const month = d.toLocaleString("en-US", { month: "short", timeZone: "UTC" });
+  const year = d.getUTCFullYear();
+  return `Founded ${month} ${year}`;
+}
+
+function normaliseRating(value: number | string | null | undefined): number | null {
+  if (value == null) return null;
+  const n = typeof value === "string" ? Number(value) : value;
+  if (!Number.isFinite(n)) return null;
+  return n;
+}
+
+export function GroupSellerProfileCard({
+  group,
+  agent,
+  averageRating,
+  reviewCount,
+  completedSales,
+  foundedAt,
+  className,
+}: GroupSellerProfileCardProps) {
+  const rating = normaliseRating(averageRating);
+  const totalReviews = reviewCount ?? 0;
+  const foundedLabel = formatFoundedAt(foundedAt ?? null);
+  const groupHref = `/groups/${encodeURIComponent(group.slug)}`;
+  const agentHref = `/users/${encodeURIComponent(agent.publicId)}`;
+  const resolvedLogo = apiUrl(group.logoUrl ?? null);
+  const resolvedAvatar = apiUrl(agent.avatarUrl ?? null);
+
+  return (
+    <section
+      aria-label="Seller group"
+      data-testid="group-seller-profile-card"
+      className={cn(
+        "rounded-lg bg-surface-raised p-6 flex flex-col gap-4",
+        className,
+      )}
+    >
+      <header className="flex items-start gap-4">
+        <Link
+          href={groupHref}
+          aria-label={`View ${group.name}'s profile`}
+          className="shrink-0 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+        >
+          {resolvedLogo ? (
+            <img
+              src={resolvedLogo}
+              alt={group.name}
+              className="size-12 rounded object-cover"
+              loading="lazy"
+            />
+          ) : (
+            <Avatar
+              src={undefined}
+              alt={group.name}
+              name={group.name}
+              size="lg"
+            />
+          )}
+        </Link>
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <h2 className="text-base font-bold tracking-tight text-fg truncate">
+            <Link
+              href={groupHref}
+              className="hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand rounded"
+              data-testid="group-seller-profile-card-name"
+            >
+              {group.name}
+            </Link>
+          </h2>
+          <p
+            className="text-[11px] font-medium text-fg-muted flex items-center gap-1.5"
+            data-testid="group-seller-profile-card-listed-by"
+          >
+            <span>Listed by</span>
+            {resolvedAvatar && (
+              <img
+                src={resolvedAvatar}
+                alt=""
+                aria-hidden="true"
+                className="size-4 rounded-full object-cover"
+                loading="lazy"
+              />
+            )}
+            <Link
+              href={agentHref}
+              className="font-semibold text-fg hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand rounded"
+              data-testid="group-seller-profile-card-agent-link"
+            >
+              {agent.displayName}
+            </Link>
+          </p>
+          {foundedLabel && (
+            <p
+              className="text-[11px] font-medium text-fg-muted"
+              data-testid="group-seller-profile-card-founded"
+            >
+              {foundedLabel}
+            </p>
+          )}
+        </div>
+      </header>
+
+      <div className="flex flex-col gap-2">
+        <ReputationStars rating={rating} reviewCount={totalReviews} />
+        <p className="text-xs text-fg-muted">
+          {completedSales} completed sale{completedSales === 1 ? "" : "s"}
+        </p>
+        {completedSales < 3 ? (
+          <NewSellerBadge completedSales={completedSales} />
+        ) : totalReviews === 0 ? (
+          <StatusBadge tone="warning">New Group</StatusBadge>
+        ) : null}
+      </div>
+
+      <Link
+        href={groupHref}
+        className="inline-flex items-center gap-1 text-brand text-sm font-medium self-start rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+        data-testid="group-seller-profile-card-link"
+      >
+        View group profile
+        <ArrowRight className="size-4" aria-hidden="true" />
+      </Link>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- New `GroupSellerProfileCard` for the bottom-of-page seller surface on `/auction/{id}` when the listing was created under a non-dissolved realty group: group name + logo as the primary heading, "Listed by <agent>" subline with the agent name linking to `/users/{agentPublicId}`, group's aggregated rating + completed sales, "View group profile" pill linking to `/groups/{slug}`.
- Lazy group-profile fetch (`useRealtyGroup`) supplies the rating/sales/foundedAt stats; on error the page falls back to the individual `SellerProfileCard` so the section never blanks.
- Same swap applied to the activate-page draft preview so the seller sees the buyer's view.

## Test plan
- [x] `npx vitest run` — 1978/1978 (6 new tests for `GroupSellerProfileCard`)
- [x] `npm run lint` — 0 errors
- [x] Frontend guards — no-dark-variants, no-hex-colors, no-inline-styles all pass
- [ ] In-world smoke: visit `/auction/{publicId}` for a group-attributed listing; confirm the bottom card shows the group name + logo, agent appears under "Listed by", and "View group profile" navigates to `/groups/{slug}`