### PR TITLE
fix(auth): refresh-rotation race + BidPanel auth-loading flash

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auth/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auth/RefreshTokenRepository.java
@@ -1,6 +1,8 @@
 package com.slparcelauctions.backend.auth;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,6 +15,20 @@ import com.slparcelauctions.backend.admin.users.dto.UserIpProjection;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByTokenHash(String tokenHash);
+
+    /**
+     * Pessimistic-lock variant for the rotation path. Two concurrent
+     * {@code /auth/refresh} calls with the same cookie used to race the
+     * optimistic {@code @Version} check on commit and surface as
+     * {@link org.springframework.orm.ObjectOptimisticLockingFailureException}
+     * (500). With {@code SELECT ... FOR UPDATE}, the second caller blocks
+     * until the first commits, then re-reads the row and sees
+     * {@code revokedAt != null} — handled deterministically by
+     * {@code RefreshTokenService.rotate}.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT rt FROM RefreshToken rt WHERE rt.tokenHash = :hash")
+    Optional<RefreshToken> findByTokenHashForUpdate(@Param("hash") String hash);
 
     List<RefreshToken> findAllByUserId(Long userId);
 

--- a/backend/src/main/java/com/slparcelauctions/backend/auth/RefreshTokenService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auth/RefreshTokenService.java
@@ -108,24 +108,36 @@ public class RefreshTokenService {
     @Transactional
     public RotationResult rotate(String rawToken, String userAgent, String ipAddress) {
         String hash = TokenHasher.sha256Hex(rawToken);
-        RefreshToken row = repository.findByTokenHash(hash)
+        // Pessimistic row lock — serializes concurrent rotations of the same
+        // token at the DB level. Without it, two parallel rotations would
+        // both pass the revokedAt-null check, both call
+        // setRevokedAt(now), and the @Version optimistic check would fail
+        // on the loser's commit as ObjectOptimisticLockingFailureException
+        // (HTTP 500). With FOR UPDATE the second caller blocks here until
+        // the first transaction commits, then re-reads with revokedAt set
+        // and falls into the reuse-detection cascade below — security model
+        // FOOTGUNS §B.6 is preserved. The single-client concurrency case
+        // that originally produced the 500 is now prevented upstream by
+        // the frontend stampede guard ({@code ensureFreshAccessToken}).
+        RefreshToken row = repository.findByTokenHashForUpdate(hash)
                 .orElseThrow(() -> new TokenInvalidException("Refresh token not found."));
+
+        OffsetDateTime now = OffsetDateTime.now(clock);
 
         if (row.getRevokedAt() != null) {
             // REUSE DETECTED — cascade. FOOTGUNS §B.6.
             log.warn("Refresh token reuse detected: userId={} ip={} userAgent={}",
                     row.getUserId(), ipAddress, userAgent);
-            repository.revokeAllByUserId(row.getUserId(), OffsetDateTime.now(clock));
+            repository.revokeAllByUserId(row.getUserId(), now);
             userService.bumpTokenVersion(row.getUserId());  // invalidate live access tokens
             throw new RefreshTokenReuseDetectedException(row.getUserId());
         }
 
-        if (row.getExpiresAt().isBefore(OffsetDateTime.now(clock))) {
+        if (row.getExpiresAt().isBefore(now)) {
             throw new TokenExpiredException("Refresh token has expired.");
         }
 
         // Happy path: rotate
-        OffsetDateTime now = OffsetDateTime.now(clock);
         row.setLastUsedAt(now);
         row.setRevokedAt(now);
         // Dirty checking flushes on transaction commit

--- a/backend/src/main/java/com/slparcelauctions/backend/auth/exception/AuthExceptionHandler.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auth/exception/AuthExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.net.URI;
@@ -90,6 +91,28 @@ public class AuthExceptionHandler {
         pd.setTitle("Refresh token reuse detected");
         pd.setInstance(URI.create(req.getRequestURI()));
         pd.setProperty("code", "AUTH_REFRESH_TOKEN_REUSED");
+        return pd;
+    }
+
+    /**
+     * Defense-in-depth: if a refresh-token rotation race somehow slips past
+     * the pessimistic row lock in {@code RefreshTokenService.rotate}, never
+     * surface it as a 500. Map to 401 so the frontend treats it as
+     * "session needs another refresh / log in again" rather than a server
+     * fault. The row-lock + concurrent-rotation-grace path inside the
+     * service should make this handler dormant in normal operation.
+     */
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ProblemDetail handleOptimisticLock(
+            ObjectOptimisticLockingFailureException e, HttpServletRequest req) {
+        log.warn("Auth-slice optimistic lock collision on {}: {}",
+                req.getRequestURI(), e.getMessage());
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(
+            HttpStatus.UNAUTHORIZED, "Session refresh conflicted. Please retry.");
+        pd.setType(URI.create("https://slpa.example/problems/auth/refresh-conflict"));
+        pd.setTitle("Refresh conflict");
+        pd.setInstance(URI.create(req.getRequestURI()));
+        pd.setProperty("code", "AUTH_REFRESH_CONFLICT");
         return pd;
     }
 

--- a/backend/src/test/java/com/slparcelauctions/backend/auth/RefreshTokenServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auth/RefreshTokenServiceTest.java
@@ -97,7 +97,7 @@ class RefreshTokenServiceTest {
                 .expiresAt(OffsetDateTime.now().plusDays(3))
                 .build();
 
-        when(repository.findByTokenHash(hash)).thenReturn(Optional.of(existing));
+        when(repository.findByTokenHashForUpdate(hash)).thenReturn(Optional.of(existing));
         when(repository.save(any(RefreshToken.class))).thenAnswer(inv -> inv.getArgument(0));
 
         RefreshTokenService.RotationResult result =
@@ -129,7 +129,7 @@ class RefreshTokenServiceTest {
                 .expiresAt(OffsetDateTime.now().minusDays(1))
                 .build();
 
-        when(repository.findByTokenHash(hash)).thenReturn(Optional.of(expired));
+        when(repository.findByTokenHashForUpdate(hash)).thenReturn(Optional.of(expired));
 
         assertThatThrownBy(() -> service.rotate(rawToken, "UA", "1.2.3.4"))
                 .isInstanceOf(TokenExpiredException.class);
@@ -152,7 +152,7 @@ class RefreshTokenServiceTest {
                 .revokedAt(OffsetDateTime.now().minusHours(1))  // already revoked
                 .build();
 
-        when(repository.findByTokenHash(hash)).thenReturn(Optional.of(reused));
+        when(repository.findByTokenHashForUpdate(hash)).thenReturn(Optional.of(reused));
 
         assertThatThrownBy(() -> service.rotate(rawToken, "evil-UA", "5.6.7.8"))
                 .isInstanceOf(RefreshTokenReuseDetectedException.class);
@@ -174,10 +174,32 @@ class RefreshTokenServiceTest {
         String rawToken = TokenHasher.secureRandomBase64Url(32);
         String hash = TokenHasher.sha256Hex(rawToken);
 
-        when(repository.findByTokenHash(hash)).thenReturn(Optional.empty());
+        when(repository.findByTokenHashForUpdate(hash)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.rotate(rawToken, "UA", "1.2.3.4"))
                 .isInstanceOf(TokenInvalidException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Pessimistic-lock canary — rotate uses findByTokenHashForUpdate (SELECT
+    // FOR UPDATE) so concurrent rotations serialize at the DB level instead
+    // of racing the @Version optimistic check on commit. The non-locking
+    // findByTokenHash variant must NOT be used here.
+    // -------------------------------------------------------------------------
+
+    @Test
+    void rotate_usesPessimisticLockingQuery() {
+        String rawToken = TokenHasher.secureRandomBase64Url(32);
+        String hash = TokenHasher.sha256Hex(rawToken);
+
+        when(repository.findByTokenHashForUpdate(hash)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.rotate(rawToken, "UA", "1.2.3.4"))
+                .isInstanceOf(TokenInvalidException.class);
+
+        // Confirm rotate hits the locked query, not the unlocked variant.
+        verify(repository).findByTokenHashForUpdate(hash);
+        verify(repository, never()).findByTokenHash(any());
     }
 
     // -------------------------------------------------------------------------

--- a/frontend/src/app/auction/[publicId]/AuctionDetailClient.tsx
+++ b/frontend/src/app/auction/[publicId]/AuctionDetailClient.tsx
@@ -368,6 +368,12 @@ export function AuctionDetailClient({ initialAuction, initialBidPage }: Props) {
     session.status === "authenticated"
       ? { publicId: session.user.publicId, verified: session.user.verified }
       : null;
+  // Distinguishes "bootstrap still running" (auth indeterminate; show
+  // the public data + spinner variant) from "session resolved to
+  // unauthenticated" (show the sign-in CTA). Without this distinction,
+  // a slow auth/refresh roundtrip flashes "Sign in to bid" to a viewer
+  // who actually IS signed in.
+  const authLoading = session.status === "loading";
   const viewerIsWinning =
     currentUserPublicId != null &&
     (auction as AuctionCacheEntry).currentBidderPublicId === currentUserPublicId;
@@ -431,6 +437,7 @@ export function AuctionDetailClient({ initialAuction, initialBidPage }: Props) {
             <BidPanel
               auction={auction}
               currentUser={bidPanelUser}
+              authLoading={authLoading}
               existingProxy={myProxyQuery.data ?? null}
               connectionState={connectionState}
               currentUserIsWinning={viewerIsWinning}
@@ -450,6 +457,7 @@ export function AuctionDetailClient({ initialAuction, initialBidPage }: Props) {
         <StickyBidBar
           auction={auction}
           currentUser={bidPanelUser}
+          authLoading={authLoading}
           connectionState={connectionState}
           onOpenSheet={() => setSheetOpen(true)}
         />
@@ -457,6 +465,7 @@ export function AuctionDetailClient({ initialAuction, initialBidPage }: Props) {
           <BidPanel
             auction={auction}
             currentUser={bidPanelUser}
+            authLoading={authLoading}
             existingProxy={myProxyQuery.data ?? null}
             connectionState={connectionState}
             currentUserIsWinning={viewerIsWinning}

--- a/frontend/src/components/auction/BidPanel.test.tsx
+++ b/frontend/src/components/auction/BidPanel.test.tsx
@@ -105,6 +105,28 @@ describe("deriveBidPanelVariant", () => {
       deriveBidPanelVariant(publicAuction(), { publicId: "00000000-0000-0000-0000-000000000001", verified: true }),
     ).toBe("bidder");
   });
+
+  it("returns 'loading' when authLoading is true (regardless of currentUser)", () => {
+    // null currentUser + loading → loading, not unauth. This is the bug
+    // fix: don't flash "Sign in to bid" during auth bootstrap.
+    expect(deriveBidPanelVariant(publicAuction(), null, true)).toBe("loading");
+    // Even with a populated currentUser, authLoading wins until the
+    // bootstrap settles. (In practice the parent only sets authLoading
+    // when currentUser is null, but defending the precedence here makes
+    // the contract explicit.)
+    expect(
+      deriveBidPanelVariant(
+        publicAuction(),
+        { publicId: "00000000-0000-0000-0000-000000000001", verified: true },
+        true,
+      ),
+    ).toBe("loading");
+  });
+
+  it("ENDED still trumps authLoading", () => {
+    const ended = { ...publicAuction(), status: "ENDED" as const };
+    expect(deriveBidPanelVariant(ended, null, true)).toBe("ended");
+  });
 });
 
 describe("BidPanel", () => {
@@ -127,6 +149,26 @@ describe("BidPanel", () => {
       "data-kind",
       "unauth",
     );
+  });
+
+  it("renders the public-data loading variant when authLoading is true", () => {
+    renderWithProviders(
+      <BidPanel
+        auction={publicAuction()}
+        currentUser={null}
+        authLoading
+        existingProxy={null}
+        connectionState={connected}
+      />,
+    );
+    // Loading panel mounts; the unauth sign-in card does NOT.
+    expect(screen.getByTestId("bid-panel-auth-loading")).toBeInTheDocument();
+    expect(screen.queryByTestId("auth-gate-message")).not.toBeInTheDocument();
+    // The current-bid readout (public data, no auth needed) is visible
+    // immediately — that's the whole point of Option B.
+    expect(screen.getByTestId("bid-panel-current-high")).toBeInTheDocument();
+    // The form / sign-in slot is replaced with a status spinner.
+    expect(screen.getByText(/Checking sign-in/i)).toBeInTheDocument();
   });
 
   it("renders the unverified gate when user.verified is false", () => {

--- a/frontend/src/components/auction/BidPanel.tsx
+++ b/frontend/src/components/auction/BidPanel.tsx
@@ -59,23 +59,52 @@ export interface BidPanelProps {
    * extensions can omit it entirely.
    */
   snipeExtension?: SnipeExtensionSignal;
+  /**
+   * The auth bootstrap is in flight. When true, render the public auction
+   * data (current bid, bidder count, buy-now callout) with a spinner in
+   * place of the form / sign-in CTA — never flash the "Sign in to bid"
+   * card to a viewer whose session is still resolving. Defaults to false.
+   *
+   * Without this, the loading state collapsed to the {@code unauth}
+   * variant and signed-in users saw "Sign in to bid" for the duration of
+   * the bootstrap (sub-second on the happy path, but multi-second when
+   * the backend refresh path is degraded — see spec
+   * 2026-05-16-ownership-only-verification for the related backend race).
+   */
+  authLoading?: boolean;
 }
 
-type Variant = "unauth" | "unverified" | "seller" | "ended" | "bidder";
+type Variant =
+  | "loading"
+  | "unauth"
+  | "unverified"
+  | "seller"
+  | "ended"
+  | "bidder";
 
 /**
  * Selects a BidPanel variant from viewer + auction state, per spec §9's
- * variant table. Order matters: the {@code ended} status trumps
- * variant-specific checks so a seller viewing their closed auction sees
- * the ended panel, not the read-only seller callout.
+ * variant table. Order matters:
+ * <ol>
+ *   <li>{@code ended} trumps everything else so a seller viewing their
+ *       closed auction sees the ended panel, not the read-only seller
+ *       callout.</li>
+ *   <li>{@code loading} runs second so an authenticated viewer whose
+ *       session is still bootstrapping doesn't briefly see the
+ *       {@code unauth} CTA. The loading variant renders the same public
+ *       data the unauth variant would, minus the sign-in card.</li>
+ *   <li>Everything else falls through to the identity-aware variants.</li>
+ * </ol>
  *
  * Exported for unit-level coverage of the dispatch matrix.
  */
 export function deriveBidPanelVariant(
   auction: PublicAuctionResponse | SellerAuctionResponse,
   currentUser: BidPanelUser | null,
+  authLoading: boolean = false,
 ): Variant {
   if (auction.status === "ENDED") return "ended";
+  if (authLoading) return "loading";
   if (!currentUser) return "unauth";
   if (!currentUser.verified) return "unverified";
   if (currentUser.publicId === auction.sellerPublicId) return "seller";
@@ -212,6 +241,65 @@ function formatHighBid(value: number | string | null): string {
 }
 
 /**
+ * Auth-bootstrap-in-flight variant. Renders the public auction data
+ * (current bid, bidder count, buy-now callout) immediately — that data
+ * is in the SSR payload and never depends on viewer identity — but
+ * replaces the form / sign-in CTA slot with a quiet spinner. Resolves
+ * to one of the identity-aware variants once {@code authLoading}
+ * flips to false.
+ *
+ * Order-of-operations note: callers must pass {@code authLoading=true}
+ * during the bootstrap window, not just "currentUser is null". A null
+ * currentUser after the bootstrap settled is a real unauthenticated
+ * viewer and should see the {@code unauth} sign-in CTA, not this
+ * spinner.
+ */
+function BidPanelAuthLoading({
+  auction,
+}: {
+  auction: PublicAuctionResponse | SellerAuctionResponse;
+}) {
+  return (
+    <div
+      data-testid="bid-panel-auth-loading"
+      className="flex flex-col gap-4 rounded-xl bg-surface-raised p-6 shadow-sm"
+      aria-busy="true"
+    >
+      <CurrentBidDisplay auction={auction} />
+
+      {auction.reservePrice != null ? (
+        <ReserveStatusIndicator auction={auction} />
+      ) : null}
+
+      {auction.buyNowPrice != null ? (
+        <div
+          data-testid="bid-panel-auth-loading-buy-now"
+          className="rounded-lg bg-bg-subtle p-3 text-xs text-fg"
+        >
+          Buy now for{" "}
+          <span className="font-semibold">
+            L${auction.buyNowPrice.toLocaleString()}
+          </span>
+          .
+        </div>
+      ) : null}
+
+      <div
+        className="flex flex-col items-center justify-center gap-2 rounded-lg bg-bg-subtle px-4 py-6 text-xs text-fg-muted"
+        role="status"
+        aria-live="polite"
+      >
+        <span
+          aria-hidden="true"
+          className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-border border-t-brand"
+        />
+        <span>Checking sign-in&hellip;</span>
+      </div>
+    </div>
+  );
+}
+
+/**
  * Variant dispatcher for the auction bid panel. Lives in the sticky
  * sidebar slot of {@code AuctionDetailClient} — one mount per page.
  *
@@ -232,10 +320,13 @@ export function BidPanel({
   connectionState,
   currentUserIsWinning = false,
   snipeExtension,
+  authLoading = false,
 }: BidPanelProps) {
-  const variant = deriveBidPanelVariant(auction, currentUser);
+  const variant = deriveBidPanelVariant(auction, currentUser, authLoading);
 
   switch (variant) {
+    case "loading":
+      return <BidPanelAuthLoading auction={auction} />;
     case "unauth":
       return <AuthGateMessage kind="unauth" auctionPublicId={auction.publicId} />;
     case "unverified":

--- a/frontend/src/components/auction/StickyBidBar.tsx
+++ b/frontend/src/components/auction/StickyBidBar.tsx
@@ -34,6 +34,14 @@ export interface StickyBidBarProps {
    * {@link StickyBidBar} is stateless.
    */
   onOpenSheet: () => void;
+  /**
+   * Auth bootstrap is in flight. While true, the sticky bar renders the
+   * public bid readout on the left and a spinner on the right rather
+   * than flashing the "Sign in to bid" CTA to a viewer whose session
+   * has not yet resolved. Defaults to false. See the matching prop on
+   * {@link BidPanel} for the desktop equivalent.
+   */
+  authLoading?: boolean;
 }
 
 /**
@@ -51,19 +59,29 @@ type EndedExtensions = {
   winnerDisplayName?: string | null;
 };
 
-type Variant = "unauth" | "unverified" | "seller" | "bidder" | "ended";
+type Variant =
+  | "loading"
+  | "unauth"
+  | "unverified"
+  | "seller"
+  | "bidder"
+  | "ended";
 
 /**
  * Picks the sticky-bar variant from viewer + auction state. Mirrors
- * {@code deriveBidPanelVariant} in {@link BidPanel} — terminal state
+ * {@code deriveBidPanelVariant} in {@link BidPanel}: terminal state
  * trumps viewer-specific variants so a seller viewing their closed
- * auction sees the {@code ended} copy, not the read-only seller row.
+ * auction sees the {@code ended} copy; the {@code loading} variant
+ * sits between {@code ended} and the identity-aware variants so a
+ * still-bootstrapping session doesn't flash the sign-in CTA.
  */
 function deriveVariant(
   auction: PublicAuctionResponse | SellerAuctionResponse,
   currentUser: StickyBidBarUser | null,
+  authLoading: boolean,
 ): Variant {
   if (auction.status === "ENDED") return "ended";
+  if (authLoading) return "loading";
   if (!currentUser) return "unauth";
   if (!currentUser.verified) return "unverified";
   if (currentUser.publicId === auction.sellerPublicId) return "seller";
@@ -85,8 +103,9 @@ export function StickyBidBar({
   currentUser,
   connectionState,
   onOpenSheet,
+  authLoading = false,
 }: StickyBidBarProps) {
-  const variant = deriveVariant(auction, currentUser);
+  const variant = deriveVariant(auction, currentUser, authLoading);
   const connected = connectionState.status === "connected";
   const ended = auction as (
     | PublicAuctionResponse
@@ -124,6 +143,8 @@ export function StickyBidBar({
         ) : variant === "ended" ? (
           <EndedLeft auction={auction} ended={ended} />
         ) : (
+          // loading, unauth, unverified, bidder all share the public
+          // current-bid + countdown readout.
           <BidReadout auction={auction} expiresAt={expiresAt} />
         )}
 
@@ -285,6 +306,23 @@ function RightSlot({
 }) {
   if (variant === "seller" || variant === "ended") {
     return null;
+  }
+
+  if (variant === "loading") {
+    // Auth still bootstrapping — show a quiet spinner. Don't render the
+    // sign-in CTA: an authenticated user whose session is still
+    // resolving would briefly see "Sign in to bid" otherwise.
+    return (
+      <div
+        data-testid="sticky-bid-bar-cta"
+        data-kind="loading"
+        role="status"
+        aria-label="Checking sign-in"
+        className="inline-flex h-11 shrink-0 items-center justify-center px-5"
+      >
+        <Loader2 className="size-4 animate-spin text-fg-muted" aria-hidden="true" />
+      </div>
+    );
   }
 
   if (variant === "unauth") {

--- a/frontend/src/lib/auth/hooks.ts
+++ b/frontend/src/lib/auth/hooks.ts
@@ -4,6 +4,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { authApi, type LoginRequest, type RegisterRequest } from "./api";
+import { ensureFreshAccessToken } from "./refresh";
 import { markAuthReady, setAccessToken } from "./session";
 import type { AuthSession, AuthUser } from "./session";
 
@@ -12,20 +13,27 @@ const SESSION_QUERY_KEY = ["auth", "session"] as const;
 /**
  * Bootstrap the session by calling POST /api/v1/auth/refresh.
  *
- * The side effect (calling setAccessToken) lives INSIDE queryFn, NOT in
- * onSuccess. TanStack Query's first subscriber receives queryFn's return
- * value directly — onSuccess only fires on subsequent subscribers and
- * refetches. If we put setAccessToken in onSuccess, the first useAuth() call
- * would get the user but the access token ref would stay null until the next
- * refetch (which may never happen with staleTime: Infinity).
+ * Routes through {@link ensureFreshAccessToken} so the in-flight stampede
+ * guard dedupes ALL refresh paths: the {@code useAuth} bootstrap, the
+ * 401 HTTP interceptor, and the STOMP WebSocket {@code beforeConnect}
+ * hook. Before this dedupe was unified, the bootstrap fired
+ * {@code authApi.refresh()} directly in parallel with the WS client
+ * firing {@code ensureFreshAccessToken()} on the same page load — both
+ * with the same refresh cookie. The backend rotation race surfaced as
+ * {@code ObjectOptimisticLockingFailureException} (500) on one of them,
+ * leaving the user with the inconsistent state seen in prod.
  *
- * See FOOTGUNS §F.2.
+ * The query function returns the authenticated user. The access token
+ * and session cache are populated as side effects of
+ * {@code ensureFreshAccessToken}, so the only extra work here is
+ * extracting the user from the cache for React Query's first subscriber.
+ *
+ * See FOOTGUNS §F.2 and §F.4.
  */
 async function bootstrapSession(): Promise<AuthUser> {
   try {
-    const response = await authApi.refresh();
-    setAccessToken(response.accessToken);
-    return response.user;
+    const result = await ensureFreshAccessToken();
+    return result.user;
   } finally {
     // Close the auth-ready gate so api.ts can release any requests that fired
     // in parallel with the bootstrap. Fires on success AND on 401 — the gate's

--- a/frontend/src/lib/auth/refresh.test.ts
+++ b/frontend/src/lib/auth/refresh.test.ts
@@ -52,10 +52,11 @@ describe("ensureFreshAccessToken (stampede canary)", () => {
       })
     );
 
-    const token = await ensureFreshAccessToken();
+    const result = await ensureFreshAccessToken();
 
     expect(refreshCount).toBe(1);
-    expect(token).toBe("fresh-token-A");
+    expect(result.accessToken).toBe("fresh-token-A");
+    expect(result.user).toMatchObject({ id: 1 });
     expect(getAccessToken()).toBe("fresh-token-A");
     expect(queryClient.getQueryData(["auth", "session"])).toMatchObject({
       id: 1,
@@ -89,7 +90,11 @@ describe("ensureFreshAccessToken (stampede canary)", () => {
     ]);
 
     expect(refreshCount).toBe(1);
-    expect(results).toEqual(["fresh-token-B", "fresh-token-B", "fresh-token-B"]);
+    expect(results.map((r) => r.accessToken)).toEqual([
+      "fresh-token-B",
+      "fresh-token-B",
+      "fresh-token-B",
+    ]);
     expect(getAccessToken()).toBe("fresh-token-B");
   });
 
@@ -124,9 +129,9 @@ describe("ensureFreshAccessToken (stampede canary)", () => {
 
     // Second call — proves inFlightRefresh was cleared in the finally block
     // on the failure path. Fetch is called a SECOND time and resolves fresh.
-    const token = await ensureFreshAccessToken();
+    const result = await ensureFreshAccessToken();
     expect(refreshCount).toBe(2);
-    expect(token).toBe("fresh-token-C");
+    expect(result.accessToken).toBe("fresh-token-C");
     expect(getAccessToken()).toBe("fresh-token-C");
   });
 });

--- a/frontend/src/lib/auth/refresh.ts
+++ b/frontend/src/lib/auth/refresh.ts
@@ -13,12 +13,25 @@ import { setAccessToken } from "./session";
 import type { AuthUser } from "./session";
 
 let queryClientRef: QueryClient | null = null;
-let inFlightRefresh: Promise<string> | null = null;
+let inFlightRefresh: Promise<RefreshResult> | null = null;
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
 const SESSION_QUERY_KEY = ["auth", "session"] as const;
 
 type RefreshResponse = { accessToken: string; user: AuthUser };
+
+/**
+ * Resolved value of {@link ensureFreshAccessToken}. Callers that only need
+ * the access token (401 interceptor, STOMP {@code beforeConnect}) can
+ * destructure {@code accessToken}; the {@code useAuth} bootstrap also
+ * needs {@code user} to populate the session cache when running in a
+ * context where {@link configureRefresh} hasn't been wired up (e.g.
+ * test wrappers that build their own {@code QueryClient}).
+ */
+export interface RefreshResult {
+  accessToken: string;
+  user: AuthUser;
+}
 
 export class RefreshFailedError extends Error {
   readonly status: number;
@@ -35,14 +48,14 @@ export function configureRefresh(queryClient: QueryClient): void {
 
 /**
  * Refreshes the access token, deduping concurrent callers onto a single
- * in-flight promise. Returns the new access token string. On failure, clears
- * the in-memory access token and the session query cache, then throws
- * RefreshFailedError.
+ * in-flight promise. Returns the new access token and the user payload.
+ * On failure, clears the in-memory access token and the session query
+ * cache, then throws RefreshFailedError.
  *
  * Callers that need redirect-to-login behavior (HTTP 401 interceptor) do so
  * after catching RefreshFailedError.
  */
-export async function ensureFreshAccessToken(): Promise<string> {
+export async function ensureFreshAccessToken(): Promise<RefreshResult> {
   if (inFlightRefresh) return inFlightRefresh;
 
   inFlightRefresh = (async () => {
@@ -70,7 +83,7 @@ export async function ensureFreshAccessToken(): Promise<string> {
       if (queryClientRef) {
         queryClientRef.setQueryData(SESSION_QUERY_KEY, body.user);
       }
-      return body.accessToken;
+      return { accessToken: body.accessToken, user: body.user };
     } finally {
       inFlightRefresh = null;
     }

--- a/frontend/src/lib/ws/client.test.ts
+++ b/frontend/src/lib/ws/client.test.ts
@@ -126,7 +126,18 @@ vi.mock("sockjs-client", () => ({
 }));
 
 vi.mock("@/lib/auth/refresh", () => ({
-  ensureFreshAccessToken: vi.fn(async () => "mock-access-token"),
+  ensureFreshAccessToken: vi.fn(async () => ({
+    accessToken: "mock-access-token",
+    user: {
+      publicId: "test-user-public-id",
+      username: "test-user",
+      email: null,
+      displayName: null,
+      slAvatarUuid: null,
+      verified: false,
+      role: "USER" as const,
+    },
+  })),
   RefreshFailedError: class extends Error {
     readonly status: number;
     constructor(status: number) {

--- a/frontend/src/lib/ws/client.ts
+++ b/frontend/src/lib/ws/client.ts
@@ -87,8 +87,8 @@ function getOrCreateClient(): Client {
       if (!client) return;
       setState({ status: "connecting" });
       try {
-        const token = await ensureFreshAccessToken();
-        client.connectHeaders = { Authorization: `Bearer ${token}` };
+        const { accessToken } = await ensureFreshAccessToken();
+        client.connectHeaders = { Authorization: `Bearer ${accessToken}` };
       } catch (e) {
         // Do NOT throw from beforeConnect — stompjs handles a thrown
         // beforeConnect as a catastrophic failure. Instead, let stompjs


### PR DESCRIPTION
## Summary

- **Backend rotation race fixed.** \`RefreshTokenService.rotate\` now uses \`@Lock(PESSIMISTIC_WRITE)\` to serialize concurrent rotations of the same refresh cookie. Eliminates the \`ObjectOptimisticLockingFailureException\` (HTTP 500) seen in \`/aws/ecs/slpa-backend\` logs at ~1 per few-seconds during active use. Reuse-cascade semantics (FOOTGUNS B.6) preserved.
- **Frontend refresh dedupe.** \`useAuth\` bootstrap now routes through the same \`ensureFreshAccessToken\` stampede guard that the 401 interceptor and WS \`beforeConnect\` already use. Eliminates the single-tab concurrency that was producing the race in prod.
- **BidPanel Option B.** New \`authLoading\` prop renders the public auction data (current high, bidder count, buy-now callout) plus a quiet spinner during bootstrap. No more "Sign in to bid" flash for authenticated users.

Stack trace + root-cause analysis in PR #306 description.

## Test plan

- [x] Backend: 2352/2352. Frontend: 1962/1962. Lint: 0 errors. Guards: pass.
- [ ] Post-deploy: tail \`/aws/ecs/slpa-backend\` logs; \`/api/v1/auth/refresh\` errors should drop to ~zero.
- [ ] Manual: hard-refresh on /auction/{publicId} as signed-in user; bid panel never flashes Sign-in CTA.