### PR TITLE
fix(auction): unbreak prod build — drop reserve row from BidPanel loading variant

### DIFF
--- a/frontend/src/components/auction/BidPanel.tsx
+++ b/frontend/src/components/auction/BidPanel.tsx
@@ -267,10 +267,6 @@ function BidPanelAuthLoading({
     >
       <CurrentBidDisplay auction={auction} />
 
-      {auction.reservePrice != null ? (
-        <ReserveStatusIndicator auction={auction} />
-      ) : null}
-
       {auction.buyNowPrice != null ? (
         <div
           data-testid="bid-panel-auth-loading-buy-now"


### PR DESCRIPTION
## Summary

Quick follow-up to #306 / #307: the new \`BidPanelAuthLoading\` component referenced \`auction.reservePrice\` directly, but that field is only on \`SellerAuctionResponse\` (not the public DTO). \`npx vitest run\` passed because the test fixture used the seller shape, but Next.js prod typecheck failed on the union narrowing.

The bidder variant elsewhere in this file already handles the dual shape via a \`"reservePrice" in auction\` discriminator. For the brief auth-bootstrap loading state, the reserve row is non-essential — dropping it.

## Test plan

- [x] \`npx tsc --noEmit\` clean (only the pre-existing \`useBulkCommissionEdit\` error remains)
- [x] \`npx vitest run src/components/auction/BidPanel.test.tsx\` — 15/15 pass
- [ ] Frontend CI pipeline turns green on this PR