### PR TITLE
fix(auction): unbreak prod build — drop reserve row from BidPanel loading variant

### DIFF
--- a/frontend/src/components/auction/BidPanel.tsx
+++ b/frontend/src/components/auction/BidPanel.tsx
@@ -267,10 +267,6 @@ function BidPanelAuthLoading({
     >
       <CurrentBidDisplay auction={auction} />
 
-      {auction.reservePrice != null ? (
-        <ReserveStatusIndicator auction={auction} />
-      ) : null}
-
       {auction.buyNowPrice != null ? (
         <div
           data-testid="bid-panel-auth-loading-buy-now"


### PR DESCRIPTION
## Summary

Follow-up to the auth-fix PR — Next.js prod typecheck failed on \`auction.reservePrice\` because the field is only on \`SellerAuctionResponse\`, not the public DTO. Dropping the reserve row from the brief auth-bootstrap loading variant unblocks the deploy. Current bid + bidder count + buy-now still render.

## Test plan

- [x] Backend: 2352/2352 (untouched).
- [x] Frontend: targeted test class 15/15. \`npx tsc --noEmit\` clean.
- [ ] Post-deploy: frontend CI pipeline green.