### PR TITLE
chore(ci): run CI on main only for now

### DIFF
--- a/.github/workflows/bot-ci.yml
+++ b/.github/workflows/bot-ci.yml
@@ -3,14 +3,17 @@ name: bot CI
 
 on:
   push:
-    branches: [dev, main]
+    # CI is main-only for now. To re-enable pre-merge CI, restore the dev
+    # branch below and uncomment the pull_request block.
+    # branches: [dev, main]
+    branches: [main]
     paths:
       - 'bot/**'
       - '.github/workflows/bot-ci.yml'
-  pull_request:
-    paths:
-      - 'bot/**'
-      - '.github/workflows/bot-ci.yml'
+  # pull_request:
+  #   paths:
+  #     - 'bot/**'
+  #     - '.github/workflows/bot-ci.yml'
 
 jobs:
   test:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,9 +1,11 @@
 # .github/workflows/frontend-ci.yml
 #
-# Lint + test + production build + design-system guard scripts. Runs on every
-# push to dev/main and every PR that touches frontend/** so a failing typecheck
-# is caught before the merge to main triggers an Amplify build (which costs
-# minutes and a failed deployment slot).
+# Lint + test + production build + design-system guard scripts. Currently
+# main-only (push to main touching frontend/**) — the dev-push and
+# pull_request triggers are temporarily commented out below. Restore them to
+# bring back pre-merge CI that catches a failing typecheck before the merge to
+# main triggers an Amplify build (which costs minutes and a failed deployment
+# slot).
 #
 # `npm run build` is what catches typecheck regressions — `next build` runs
 # tsc as part of the production build pipeline. We don't run `tsc --noEmit`
@@ -14,14 +16,17 @@ name: frontend CI
 
 on:
   push:
-    branches: [dev, main]
+    # CI is main-only for now. To re-enable pre-merge CI, restore the dev
+    # branch below and uncomment the pull_request block.
+    # branches: [dev, main]
+    branches: [main]
     paths:
       - 'frontend/**'
       - '.github/workflows/frontend-ci.yml'
-  pull_request:
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-ci.yml'
+  # pull_request:
+  #   paths:
+  #     - 'frontend/**'
+  #     - '.github/workflows/frontend-ci.yml'
 
 jobs:
   check:


### PR DESCRIPTION
Comment out the dev-push and pull_request triggers on bot-ci and frontend-ci so CI only fires on push to main. The dev branch and pull_request blocks are preserved as comments for trivial restore.

deploy-backend / deploy-bot already trigger on main only and are deploy pipelines, not CI, so they are unchanged.