### PR TITLE
fix(listings,auction-page): seller dashboard crash on sold auctions + legacy 14-id deeplinks

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java
@@ -72,7 +72,8 @@ public class AuctionDtoMapper {
     public record MapperBatchContext(
             Map<Long, RealtyGroup> groupsById,
             Map<Long, AuctionPhoto> primaryPhotoByAuctionId,
-            Map<Long, UUID> winnerPublicIdByAuctionId) {
+            Map<Long, UUID> winnerPublicIdByAuctionId,
+            Map<Long, String> winnerDisplayNameByAuctionId) {
 
         public static MapperBatchContext build(
                 List<Auction> auctions,
@@ -100,7 +101,8 @@ public class AuctionDtoMapper {
                     .collect(Collectors.toMap(
                             p -> p.getAuction().getId(), Function.identity()));
             Map<Long, UUID> winners = new HashMap<>(userRepo.findPublicIdsByIds(winnerIds));
-            return new MapperBatchContext(groups, primaryPhotos, winners);
+            Map<Long, String> winnerNames = new HashMap<>(userRepo.findDisplayNamesByIds(winnerIds));
+            return new MapperBatchContext(groups, primaryPhotos, winners, winnerNames);
         }
     }
 
@@ -225,6 +227,9 @@ public class AuctionDtoMapper {
                 a.getUpdatedAt(),
                 escrow == null ? null : escrow.getState(),
                 escrow == null ? null : escrow.getTransferConfirmedAt(),
+                a.getEndOutcome(),
+                a.getFinalBidAmount(),
+                resolveWinnerDisplayName(a, ctx),
                 resolveGroupAttribution(a, ctx),
                 resolveListingAgent(a));
     }
@@ -364,6 +369,27 @@ public class AuctionDtoMapper {
                     .orElse(null);
         }
         return ctx.winnerPublicIdByAuctionId().get(auction.getWinnerId());
+    }
+
+    /**
+     * Resolves the winner's display name (with username fallback) for
+     * outbound DTO emission. Returns null when the auction has no winner.
+     * Mirrors {@link #resolveWinnerPublicId}: batch callers pass a non-null
+     * context to collapse N+1 queries; single-DTO callers pass null.
+     */
+    private String resolveWinnerDisplayName(Auction auction, MapperBatchContext ctx) {
+        if (auction.getWinnerId() == null) {
+            return null;
+        }
+        if (ctx == null) {
+            return userRepo.findById(auction.getWinnerId())
+                    .map(u -> {
+                        String dn = u.getDisplayName();
+                        return (dn == null || dn.isBlank()) ? u.getUsername() : dn;
+                    })
+                    .orElse(null);
+        }
+        return ctx.winnerDisplayNameByAuctionId().get(auction.getWinnerId());
     }
 
     /**

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/dto/SellerAuctionResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/dto/SellerAuctionResponse.java
@@ -5,6 +5,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import com.slparcelauctions.backend.auction.AuctionEndOutcome;
 import com.slparcelauctions.backend.auction.AuctionStatus;
 import com.slparcelauctions.backend.auction.VerificationTier;
 import com.slparcelauctions.backend.escrow.EscrowState;
@@ -57,6 +58,25 @@ public record SellerAuctionResponse(
         OffsetDateTime updatedAt,
         EscrowState escrowState,
         OffsetDateTime transferConfirmedAt,
+        /**
+         * Populated when the auction transitions out of ACTIVE (sweeper expiry,
+         * inline buy-now close, or admin force-end). {@code null} for pre-ENDED
+         * statuses. The seller's My Listings row reads this to render
+         * "Sold for L$X to @winner" vs "Ended with no bids" vs "Reserve not met"
+         * — without it the row used to crash on the first ENDED row in the list.
+         */
+        AuctionEndOutcome endOutcome,
+        /**
+         * Final winning bid amount for SOLD / BOUGHT_NOW outcomes; null for
+         * other outcomes and pre-ENDED statuses.
+         */
+        Long finalBidAmount,
+        /**
+         * Winner's display name (or username fallback). Populated for SOLD /
+         * BOUGHT_NOW outcomes so the seller's row can show "Sold to @bob"
+         * without a follow-up profile fetch. Null for pre-ENDED or no-bid outcomes.
+         */
+        String winnerDisplayName,
         GroupAttributionDto realtyGroup,
         ListingAgentDto listingAgent) {
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java
@@ -92,6 +92,41 @@ public interface UserRepository extends JpaRepository<User, Long> {
         UUID getPublicId();
     }
 
+    /**
+     * Batch display-name lookup keyed by user id. Used by the seller-side
+     * auction DTO mapper to populate {@code winnerDisplayName} on ENDED
+     * rows so the seller's My Listings can render "Sold to @bob" without a
+     * follow-up profile fetch. Falls back to {@code username} when
+     * {@code displayName} is null so the projected value is never blank.
+     *
+     * <p>One query per call regardless of input cardinality. Empty input
+     * accepted and returns an empty map.
+     */
+    @Query("SELECT u.id AS id, u.displayName AS displayName, u.username AS username "
+         + "FROM User u WHERE u.id IN :ids")
+    List<UserIdDisplayNameProjection> findIdDisplayNameProjections(@Param("ids") Set<Long> ids);
+
+    default Map<Long, String> findDisplayNamesByIds(Set<Long> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return Map.of();
+        }
+        Map<Long, String> out = new HashMap<>(ids.size());
+        for (UserIdDisplayNameProjection p : findIdDisplayNameProjections(ids)) {
+            String name = p.getDisplayName();
+            if (name == null || name.isBlank()) {
+                name = p.getUsername();
+            }
+            out.put(p.getId(), name);
+        }
+        return out;
+    }
+
+    interface UserIdDisplayNameProjection {
+        Long getId();
+        String getDisplayName();
+        String getUsername();
+    }
+
     @Modifying
     @Transactional
     @Query("UPDATE User u SET u.role = com.slparcelauctions.backend.user.Role.ADMIN " +

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionControllerTest.java
@@ -114,6 +114,9 @@ class AuctionControllerTest {
                 false, null, null, null,
                 new java.math.BigDecimal("0.05"), null,
                 null, null, null, null,
+                /* endOutcome */ null,
+                /* finalBidAmount */ null,
+                /* winnerDisplayName */ null,
                 null, null);
     }
 

--- a/frontend/src/app/auction/[publicId]/escrow/page.tsx
+++ b/frontend/src/app/auction/[publicId]/escrow/page.tsx
@@ -41,7 +41,13 @@ export default async function EscrowStatusPage({ params }: Props) {
   try {
     auction = await getAuction(publicId);
   } catch (err) {
-    if (isApiError(err) && err.status === 404) notFound();
+    // 404 = auction missing. 400 = the route param wasn't a valid UUID
+    // (e.g. a legacy notification deeplink that carried the internal
+    // Long auctionId — /auction/14/escrow). Both render as a clean 404
+    // rather than crashing the page into the Next.js error boundary.
+    if (isApiError(err) && (err.status === 404 || err.status === 400)) {
+      notFound();
+    }
     throw err;
   }
   if (!auction) notFound();

--- a/frontend/src/app/auction/[publicId]/page.tsx
+++ b/frontend/src/app/auction/[publicId]/page.tsx
@@ -97,7 +97,12 @@ export default async function AuctionPage({ params }: Props) {
       getBidHistory(publicId, { page: 0, size: 20 }),
     ]);
   } catch (err) {
-    if (isApiError(err) && err.status === 404) notFound();
+    // 404 = auction missing. 400 = the route param wasn't a valid UUID
+    // (e.g. a legacy notification deeplink like /auction/14). Both render
+    // as a clean 404 instead of crashing into the Next.js error boundary.
+    if (isApiError(err) && (err.status === 404 || err.status === 400)) {
+      notFound();
+    }
     throw err;
   }
 

--- a/frontend/src/components/listing/ListingSummaryRow.test.tsx
+++ b/frontend/src/components/listing/ListingSummaryRow.test.tsx
@@ -245,6 +245,28 @@ describe("ListingSummaryRow", () => {
     expect(screen.queryByText(/^Ended/)).not.toBeInTheDocument();
   });
 
+  it("renders a graceful 'Auction ended' fallback when ENDED row arrives without endOutcome (legacy backend)", () => {
+    // Regression guard: prior versions threw an Error from EndedBidSummary
+    // when endOutcome was null on an ENDED row, which React-errored the
+    // entire My Listings page out into the Next.js error boundary the
+    // first time a seller's auction reached ENDED before the backend
+    // projection was widened. The fallback prevents a single-row data
+    // gap from nuking the whole dashboard.
+    renderWithProviders(
+      <ListingSummaryRow
+        auction={baseAuction({
+          status: "ENDED",
+          bidCount: 0,
+          // Deliberately do NOT set endOutcome — exercises the fallback path.
+        })}
+      />,
+      { auth: "authenticated" },
+    );
+    expect(screen.getByText(/Auction ended/i)).toBeInTheDocument();
+    // Must NOT crash the row; status badge and primary actions still render.
+    expect(screen.getByTestId(/^listing-row-/)).toBeInTheDocument();
+  });
+
   it("renders Sold for ENDED + SOLD when DTO explicitly sets endOutcome", () => {
     renderWithProviders(
       <ListingSummaryRow

--- a/frontend/src/components/listing/ListingSummaryRow.tsx
+++ b/frontend/src/components/listing/ListingSummaryRow.tsx
@@ -256,24 +256,18 @@ function EndedBidSummary({
   auction: ListingRowAuction;
   highBid: number | null;
 }) {
-  // Backend always projects endOutcome on ENDED auctions post Epic 05
-  // sub-spec 1. If this field is ever null on an ENDED auction, it's a
-  // backend invariant violation — let it surface rather than papering
-  // over it with a heuristic.
-  if (auction.endOutcome == null) {
-    throw new Error(
-      `ListingSummaryRow rendered ENDED auction ${auction.publicId} with null endOutcome — ` +
-        "backend enrichment invariant violated (Epic 05 sub-spec 1).",
-    );
-  }
-  const outcome: AuctionEndOutcome = auction.endOutcome;
-
   // Winner display-name fallback mirrors AuctionEndedPanel. The query runs
   // only when we have a winnerId but no inline display name. Same cache key
   // as AuctionEndedPanel so the two share any pre-fetched profile data.
+  //
+  // Hook must be called unconditionally (rules-of-hooks): the
+  // null-endOutcome fallback below cannot short-circuit before this
+  // call. The query's {@code enabled} flag already gates the actual
+  // fetch on the conditions that matter (outcome is SOLD/BOUGHT_NOW,
+  // winnerPublicId present, inline display name missing).
   const winnerPublicId = auction.winnerPublicId;
   const needWinnerFetch =
-    (outcome === "SOLD" || outcome === "BOUGHT_NOW") &&
+    (auction.endOutcome === "SOLD" || auction.endOutcome === "BOUGHT_NOW") &&
     winnerPublicId != null &&
     (auction.winnerDisplayName == null || auction.winnerDisplayName === "");
   const winnerQuery = useQuery<PublicUserProfile>({
@@ -282,6 +276,30 @@ function EndedBidSummary({
     enabled: needWinnerFetch,
     staleTime: 60_000,
   });
+
+  // Backend always projects endOutcome on ENDED auctions post Epic 05
+  // sub-spec 1. If this field is ever null on an ENDED auction, it is a
+  // backend enrichment regression — log loudly so we notice in dev, but
+  // render a graceful fallback rather than throwing. A throw here crashes
+  // the entire My Listings page for every seller as soon as ONE row is
+  // missing the field, which is precisely what happened the first time a
+  // seller's auction reached ENDED before the SellerAuctionResponse
+  // projection was widened to include endOutcome.
+  if (auction.endOutcome == null) {
+    if (typeof console !== "undefined") {
+      console.warn(
+        `ListingSummaryRow: ENDED auction ${auction.publicId} arrived with null endOutcome — ` +
+          "backend enrichment may be stale. Rendering fallback.",
+      );
+    }
+    return (
+      <p className="text-xs text-fg-muted">
+        Auction ended
+      </p>
+    );
+  }
+  const outcome: AuctionEndOutcome = auction.endOutcome;
+
   const winnerDisplayName =
     auction.winnerDisplayName ??
     winnerQuery.data?.displayName ??

--- a/frontend/src/types/auction.ts
+++ b/frontend/src/types/auction.ts
@@ -118,6 +118,12 @@ export interface SellerAuctionResponse {
   // and an escrow row exists; null otherwise.
   escrowState?: EscrowState | null;
   transferConfirmedAt?: string | null;
+  // ENDED-state enrichment. Populated once the auction transitions out of
+  // ACTIVE; null for pre-ENDED statuses. ListingSummaryRow reads these to
+  // render "Sold for L$X to @winner" without a follow-up profile fetch.
+  endOutcome?: AuctionEndOutcome | null;
+  finalBidAmount?: number | null;
+  winnerDisplayName?: string | null;
   // Realty group attribution — present when the listing was created under a group.
   realtyGroup?: GroupAttribution | null;
   listingAgent?: ListingAgent | null;


### PR DESCRIPTION
## Summary

- **Dashboard /listings 500 for sellers with a sold auction.** \`SellerAuctionResponse\` never projected \`endOutcome\` / \`finalBidAmount\` / \`winnerDisplayName\`, but the frontend's \`ListingSummaryRow.EndedBidSummary\` THREW on null \`endOutcome\` — crashing the entire My Listings page the first time any seller's auction reached ENDED. Backend now populates the three fields (with a batched \`UserRepository.findDisplayNamesByIds\` for the display-name resolution to avoid N+1). Frontend stops throwing and renders \"Auction ended\" as a graceful fallback for any future regression.
- **Legacy /auction/14/escrow 500.** Notification rows written before yesterday's \`auctionPublicId\` fix have only the internal Long \`auctionId\` in their data blob. Clicking those legacy deeplinks routes to \`/auction/14/escrow\`; backend correctly returns 400 Invalid UUID; auction-page + escrow-page server components now treat 400 as \`notFound()\` (alongside the existing 404 handling) so legacy deeplinks degrade to a clean 404 page.

## Test plan

- [x] Backend: 2352 / 2352
- [x] Frontend: 1964 / 1964 (+ ListingSummaryRow regression test for null-endOutcome fallback)
- [x] Lint 0 errors, all guards pass
- [ ] Post-deploy: seller of a sold auction can load /dashboard/listings; clicking a legacy /auction/14/escrow link shows a 404 page, not "This page couldn't load"