### PR TITLE
fix(escrow,auction): group escrow freeze, duplicate buy-now notif, buyer-side ended-page 500

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java
@@ -168,6 +168,10 @@ public class AuctionDtoMapper {
                 sellerSummary(a.getSeller()),
                 escrow == null ? null : escrow.getState(),
                 escrow == null ? null : escrow.getTransferConfirmedAt(),
+                a.getEndOutcome(),
+                a.getFinalBidAmount(),
+                resolveWinnerPublicId(a, ctx),
+                resolveWinnerDisplayName(a, ctx),
                 resolveGroupAttribution(a, ctx),
                 resolveListingAgent(a));
     }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/dto/PublicAuctionResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/dto/PublicAuctionResponse.java
@@ -6,6 +6,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import com.slparcelauctions.backend.auction.AuctionEndOutcome;
 import com.slparcelauctions.backend.auction.VerificationTier;
 import com.slparcelauctions.backend.escrow.EscrowState;
 import com.slparcelauctions.backend.parcel.dto.ParcelResponse;
@@ -32,6 +33,15 @@ import com.slparcelauctions.backend.parceltag.dto.ParcelTagResponse;
  * page's seller card. {@code completionRate} is server-computed by
  * {@code SellerCompletionRateMapper} so the private {@code cancelledWithBids}
  * and {@code escrowExpiredUnfulfilled} counters never appear in the response.
+ *
+ * <p>{@code endOutcome}, {@code finalBidAmount}, {@code winnerPublicId}, and
+ * {@code winnerDisplayName} are populated on the public DTO once the auction
+ * has ended -- the outcome + winning bid + winner identity are all already
+ * derivable from the public bid history, so emitting them inline lets the
+ * detail page render the ended-state panel without a follow-up profile
+ * fetch. {@code null} for pre-ENDED statuses. Without these the buyer view
+ * of an ENDED listing throws inside AuctionEndedPanel
+ * ({@code endOutcome} invariant), surfacing as an SSR 500.
  */
 public record PublicAuctionResponse(
         UUID publicId,
@@ -60,6 +70,10 @@ public record PublicAuctionResponse(
         SellerSummary seller,
         EscrowState escrowState,
         OffsetDateTime transferConfirmedAt,
+        AuctionEndOutcome endOutcome,
+        Long finalBidAmount,
+        UUID winnerPublicId,
+        String winnerDisplayName,
         GroupAttributionDto realtyGroup,
         ListingAgentDto listingAgent) {
 

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.web.multipart.MultipartFile;
 
 import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionEndOutcome;
 import com.slparcelauctions.backend.auction.fraud.FraudFlag;
 import com.slparcelauctions.backend.auction.fraud.FraudFlagReason;
 import com.slparcelauctions.backend.auction.fraud.FraudFlagRepository;
@@ -198,13 +199,20 @@ public class EscrowService {
                 .completedAt(endedAt)
                 .build());
 
-        // Notify seller of funded state
-        notificationPublisher.escrowFunded(
-                auction.getSeller().getId(),
-                auction.getId(),
-                saved.getId(),
-                auction.getTitle(),
-                saved.getTransferDeadline());
+        // Notify seller of funded state — except on the buy-now close path,
+        // where BidService.acceptBid has already published a dedicated
+        // AUCTION_ENDED_BOUGHT_NOW notification with the same L$ amount.
+        // Both reaching the seller as separate rows is duplicate noise (one
+        // event, one notification). Natural auction-end paths still fire
+        // escrowFunded since they don't have a BOUGHT_NOW counterpart.
+        if (auction.getEndOutcome() != AuctionEndOutcome.BOUGHT_NOW) {
+            notificationPublisher.escrowFunded(
+                    auction.getSeller().getId(),
+                    auction.getId(),
+                    saved.getId(),
+                    auction.getTitle(),
+                    saved.getTransferDeadline());
+        }
 
         final Escrow finalEscrow = saved;
         final EscrowFundedEnvelope fundedEnvelope = EscrowFundedEnvelope.of(finalEscrow, endedAt);

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/scheduler/EscrowOwnershipCheckTask.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/scheduler/EscrowOwnershipCheckTask.java
@@ -17,6 +17,8 @@ import com.slparcelauctions.backend.escrow.EscrowService;
 import com.slparcelauctions.backend.escrow.EscrowState;
 import com.slparcelauctions.backend.escrow.FreezeReason;
 import com.slparcelauctions.backend.escrow.terminal.EscrowConfigProperties;
+import com.slparcelauctions.backend.realty.slgroup.RealtyGroupSlGroup;
+import com.slparcelauctions.backend.realty.slgroup.RealtyGroupSlGroupRepository;
 import com.slparcelauctions.backend.sl.SlWorldApiClient;
 import com.slparcelauctions.backend.sl.dto.ParcelMetadata;
 import com.slparcelauctions.backend.sl.exception.ExternalApiTimeoutException;
@@ -75,6 +77,7 @@ public class EscrowOwnershipCheckTask {
     private final EscrowService escrowService;
     private final SlWorldApiClient worldApi;
     private final UserRepository userRepo;
+    private final RealtyGroupSlGroupRepository slGroupRepo;
     private final EscrowConfigProperties props;
     private final Clock clock;
 
@@ -108,25 +111,44 @@ public class EscrowOwnershipCheckTask {
             UUID ownerUuid = result.ownerUuid();
             User winner = userRepo.findById(escrow.getAuction().getWinnerUserId()).orElseThrow();
             UUID winnerUuid = winner.getSlAvatarUuid();
-            UUID sellerUuid = escrow.getAuction().getSeller().getSlAvatarUuid();
+            // Pre-transfer expected owner is the seller side: the seller's
+            // avatar for individual listings, or the registered SL group for
+            // case-3 group listings (mirrors OwnershipCheckTask.doCheck).
+            // Without the group branch, a group-owned parcel reports the
+            // group UUID and gets misclassified as UNKNOWN_OWNER on the
+            // first sweep, freezing a perfectly healthy escrow.
+            UUID expectedPreTransfer;
+            String expectedPreTransferLabel;
+            if (escrow.getAuction().getRealtyGroupSlGroupId() != null) {
+                RealtyGroupSlGroup reg = slGroupRepo
+                        .findById(escrow.getAuction().getRealtyGroupSlGroupId())
+                        .orElse(null);
+                expectedPreTransfer = (reg == null) ? null : reg.getSlGroupUuid();
+                expectedPreTransferLabel = "expectedGroupUuid";
+            } else {
+                expectedPreTransfer = escrow.getAuction().getSeller().getSlAvatarUuid();
+                expectedPreTransferLabel = "expectedSellerUuid";
+            }
 
             if (winnerUuid != null && winnerUuid.equals(ownerUuid)) {
                 escrowService.confirmTransfer(escrow, now);
                 return;
             }
-            if (sellerUuid != null && sellerUuid.equals(ownerUuid)) {
+            if (expectedPreTransfer != null && expectedPreTransfer.equals(ownerUuid)) {
                 escrowService.stampChecked(escrow, now);
                 maybeLogReminder(escrow, now);
                 return;
             }
 
-            // Owner is an unknown third party (or a group, or a null-owner
-            // parcel that reparented to somebody else). Freeze the escrow
-            // and let the admin review queue decide the refund path.
+            // Owner is an unknown third party — neither the winner nor the
+            // pre-transfer expected owner (seller avatar or registered group).
+            // Freeze the escrow and let the admin review queue decide the
+            // refund path.
             Map<String, Object> evidence = new HashMap<>();
             evidence.put("observedOwnerUuid", ownerUuid == null ? "<null>" : ownerUuid.toString());
             evidence.put("expectedWinnerUuid", winnerUuid == null ? "<null>" : winnerUuid.toString());
-            evidence.put("expectedSellerUuid", sellerUuid == null ? "<null>" : sellerUuid.toString());
+            evidence.put(expectedPreTransferLabel,
+                    expectedPreTransfer == null ? "<null>" : expectedPreTransfer.toString());
             evidence.put("observedOwnerType", result.ownerType() == null ? "<null>" : result.ownerType());
             escrowService.freezeForFraud(escrow, FreezeReason.UNKNOWN_OWNER, evidence, now);
 

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowCreateOnBuyNowIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowCreateOnBuyNowIntegrationTest.java
@@ -199,6 +199,27 @@ class EscrowCreateOnBuyNowIntegrationTest {
         assertThat(env.state()).isEqualTo(EscrowState.ESCROW_PENDING);
     }
 
+    @Test
+    void buyNow_doesNotPublishEscrowFundedNotification_forSeller() {
+        // On the buy-now path BidService.acceptBid publishes a dedicated
+        // AUCTION_ENDED_BOUGHT_NOW notification to the seller; the same
+        // transaction's wallet auto-fund used to also publish ESCROW_FUNDED,
+        // landing two near-duplicate seller rows ("Buy-now exercised" +
+        // "Buyer funded escrow on …") for a single event. Only the
+        // BOUGHT_NOW notification should fire on this path.
+        long bidAmount = 10_000L;
+        seedActiveAuction(bidAmount);
+
+        bidService.placeBid(seededAuctionId, seededBidderId, bidAmount, "1.2.3.4");
+
+        java.util.List<com.slparcelauctions.backend.notification.Notification> sellerNotifs =
+                notificationRepo.findAllByUserId(seededSellerId);
+        assertThat(sellerNotifs)
+                .extracting(com.slparcelauctions.backend.notification.Notification::getCategory)
+                .contains(com.slparcelauctions.backend.notification.NotificationCategory.AUCTION_ENDED_BOUGHT_NOW)
+                .doesNotContain(com.slparcelauctions.backend.notification.NotificationCategory.ESCROW_FUNDED);
+    }
+
     // -------------------------------------------------------------------------
     // Seeding
     // -------------------------------------------------------------------------

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/scheduler/EscrowOwnershipCheckTaskTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/scheduler/EscrowOwnershipCheckTaskTest.java
@@ -37,6 +37,8 @@ import com.slparcelauctions.backend.escrow.EscrowState;
 import com.slparcelauctions.backend.escrow.FreezeReason;
 import com.slparcelauctions.backend.escrow.terminal.EscrowConfigProperties;
 import com.slparcelauctions.backend.auction.AuctionParcelSnapshot;
+import com.slparcelauctions.backend.realty.slgroup.RealtyGroupSlGroup;
+import com.slparcelauctions.backend.realty.slgroup.RealtyGroupSlGroupRepository;
 import com.slparcelauctions.backend.sl.SlWorldApiClient;
 import com.slparcelauctions.backend.region.dto.RegionPageData;
 import com.slparcelauctions.backend.sl.dto.ParcelMetadata;
@@ -66,12 +68,15 @@ class EscrowOwnershipCheckTaskTest {
     private static final UUID SELLER_AVATAR = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     private static final UUID WINNER_AVATAR = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
     private static final UUID STRANGER_AVATAR = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID GROUP_UUID = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static final Long REALTY_GROUP_SL_GROUP_ID = 99L;
     private static final int FAILURE_THRESHOLD = 5;
 
     @Mock EscrowRepository escrowRepo;
     @Mock EscrowService escrowService;
     @Mock SlWorldApiClient worldApi;
     @Mock UserRepository userRepo;
+    @Mock RealtyGroupSlGroupRepository slGroupRepo;
     @Mock EscrowConfigProperties props;
 
     EscrowOwnershipCheckTask task;
@@ -80,7 +85,8 @@ class EscrowOwnershipCheckTaskTest {
     @BeforeEach
     void setUp() {
         fixed = Clock.fixed(Instant.parse("2026-04-20T12:00:00Z"), ZoneOffset.UTC);
-        task = new EscrowOwnershipCheckTask(escrowRepo, escrowService, worldApi, userRepo, props, fixed);
+        task = new EscrowOwnershipCheckTask(
+                escrowRepo, escrowService, worldApi, userRepo, slGroupRepo, props, fixed);
         lenient().when(props.ownershipApiFailureThreshold()).thenReturn(FAILURE_THRESHOLD);
         lenient().when(props.ownershipReminderDelay()).thenReturn(Duration.ofHours(24));
     }
@@ -254,6 +260,82 @@ class EscrowOwnershipCheckTaskTest {
     }
 
     @Test
+    void groupStillOwns_case3_stampsChecked_noFreeze() {
+        // Case 3: group listing. The parcel is owned by the registered SL
+        // group (not the seller's avatar). Pre-transfer ownership should
+        // match the group UUID and the escrow should stay TRANSFER_PENDING
+        // rather than freezing on the first sweep.
+        Escrow escrow = buildPendingGroup();
+        escrow.setFundedAt(OffsetDateTime.now(fixed).minusHours(2));
+        when(escrowRepo.findByIdForUpdate(ESCROW_ID)).thenReturn(Optional.of(escrow));
+        when(worldApi.fetchParcelPage(PARCEL_UUID))
+                .thenReturn(Mono.just(new ParcelPageData(
+                        meta(GROUP_UUID, "group"), java.util.UUID.randomUUID())));
+        RealtyGroupSlGroup reg = RealtyGroupSlGroup.builder()
+                .id(REALTY_GROUP_SL_GROUP_ID)
+                .slGroupUuid(GROUP_UUID)
+                .build();
+        when(slGroupRepo.findById(REALTY_GROUP_SL_GROUP_ID)).thenReturn(Optional.of(reg));
+        stubWinner();
+
+        task.checkOne(ESCROW_ID);
+
+        verify(escrowService).stampChecked(escrow, OffsetDateTime.now(fixed));
+        verify(escrowService, never()).confirmTransfer(any(), any());
+        verify(escrowService, never()).freezeForFraud(any(), any(), any(), any());
+    }
+
+    @Test
+    void groupListing_winnerNowOwns_delegatesToConfirmTransfer() {
+        // Case 3: group listing where the parcel has already been deeded to
+        // the winning avatar. Should complete the escrow regardless of the
+        // group branch taking precedence in expected-owner resolution.
+        Escrow escrow = buildPendingGroup();
+        when(escrowRepo.findByIdForUpdate(ESCROW_ID)).thenReturn(Optional.of(escrow));
+        when(worldApi.fetchParcelPage(PARCEL_UUID))
+                .thenReturn(Mono.just(new ParcelPageData(
+                        meta(WINNER_AVATAR, "agent"), java.util.UUID.randomUUID())));
+        stubWinner();
+
+        task.checkOne(ESCROW_ID);
+
+        verify(escrowService).confirmTransfer(escrow, OffsetDateTime.now(fixed));
+        verify(escrowService, never()).freezeForFraud(any(), any(), any(), any());
+        verify(escrowService, never()).stampChecked(any(), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void groupListing_unknownThirdParty_freezesWithGroupEvidence() {
+        // Case 3: group listing, but parcel reparented to a stranger.
+        // Evidence carries the expected GROUP uuid (not the seller's avatar)
+        // so incident review reflects what the check actually compared.
+        Escrow escrow = buildPendingGroup();
+        when(escrowRepo.findByIdForUpdate(ESCROW_ID)).thenReturn(Optional.of(escrow));
+        when(worldApi.fetchParcelPage(PARCEL_UUID))
+                .thenReturn(Mono.just(new ParcelPageData(
+                        meta(STRANGER_AVATAR, "agent"), java.util.UUID.randomUUID())));
+        RealtyGroupSlGroup reg = RealtyGroupSlGroup.builder()
+                .id(REALTY_GROUP_SL_GROUP_ID)
+                .slGroupUuid(GROUP_UUID)
+                .build();
+        when(slGroupRepo.findById(REALTY_GROUP_SL_GROUP_ID)).thenReturn(Optional.of(reg));
+        stubWinner();
+
+        task.checkOne(ESCROW_ID);
+
+        ArgumentCaptor<Map<String, Object>> ev = ArgumentCaptor.forClass(Map.class);
+        verify(escrowService).freezeForFraud(
+                eq(escrow), eq(FreezeReason.UNKNOWN_OWNER), ev.capture(),
+                eq(OffsetDateTime.now(fixed)));
+        assertThat(ev.getValue())
+                .containsEntry("observedOwnerUuid", STRANGER_AVATAR.toString())
+                .containsEntry("expectedWinnerUuid", WINNER_AVATAR.toString())
+                .containsEntry("expectedGroupUuid", GROUP_UUID.toString())
+                .doesNotContainKey("expectedSellerUuid");
+    }
+
+    @Test
     void lockEntryPath_usesFindByIdForUpdate_notFindById() {
         Escrow escrow = buildPending();
         when(escrowRepo.findByIdForUpdate(ESCROW_ID)).thenReturn(Optional.of(escrow));
@@ -321,6 +403,12 @@ class EscrowOwnershipCheckTaskTest {
                 .fundedAt(OffsetDateTime.now(fixed).minusHours(2))
                 .consecutiveWorldApiFailures(0)
                 .build();
+    }
+
+    private Escrow buildPendingGroup() {
+        Escrow base = buildPending();
+        base.getAuction().setRealtyGroupSlGroupId(REALTY_GROUP_SL_GROUP_ID);
+        return base;
     }
 
     private ParcelMetadata meta(UUID owner, String ownerType) {

--- a/frontend/src/types/auction.ts
+++ b/frontend/src/types/auction.ts
@@ -224,6 +224,17 @@ export interface PublicAuctionResponse {
   // and an escrow row exists; null otherwise.
   escrowState?: EscrowState | null;
   transferConfirmedAt?: string | null;
+  /**
+   * Ended-state enrichment. All four are populated once the auction reaches
+   * ENDED; null for pre-ENDED statuses. Without these the buyer/anonymous
+   * view of an ENDED listing throws inside AuctionEndedPanel — the
+   * SellerAuctionResponse already carries them, and the public DTO mirrors
+   * the shape so the detail page renders identically for either viewer.
+   */
+  endOutcome?: AuctionEndOutcome | null;
+  finalBidAmount?: number | null;
+  winnerPublicId?: string | null;
+  winnerDisplayName?: string | null;
   // Realty group attribution — present when the listing was created under a group.
   realtyGroup?: GroupAttribution | null;
   listingAgent?: ListingAgent | null;


### PR DESCRIPTION
## Summary

Three regressions surfaced in prod after the wallet-only escrow funding rollout (PR #316):

- **C — case-3 escrow freeze (critical).** Group-listed escrows flipped to FROZEN + auto-refunded on the first ownership sweep because `EscrowOwnershipCheckTask` only compared the observed parcel owner against `seller.slAvatarUuid` and `winner.slAvatarUuid`. For SL-group listings the observed owner is the group UUID, matching neither — so a perfectly healthy escrow was misclassified as UNKNOWN_OWNER. Mirror the case-3 branch from `OwnershipCheckTask`: when `auction.realtyGroupSlGroupId` is set, the pre-transfer expected owner is the registered SL group's UUID. Winner-match path unchanged; freeze evidence carries `expectedGroupUuid` for case-3 incidents.
- **B — duplicate buy-now seller notification.** On a buy-now close the seller received both `AUCTION_ENDED_BOUGHT_NOW` ("Buy-now exercised") and `ESCROW_FUNDED` ("Buyer funded escrow on …"). Both reach the seller via the same transaction. `escrowFunded` is now suppressed when `endOutcome == BOUGHT_NOW` — natural-end paths still emit it since they don't have a BOUGHT_NOW counterpart.
- **A — buyer view of ended listing returns SSR 500.** `AuctionEndedPanel` enforces a non-null `endOutcome` invariant. `PublicAuctionResponse` didn't carry `endOutcome`, `finalBidAmount`, `winnerPublicId`, `winnerDisplayName`, so anonymous and buyer viewers crashed the SSR render on any ENDED listing. The seller's view worked because `SellerAuctionResponse` already had the fields. Public DTO now mirrors the shape — the outcome / winning bid / winner identity are all already derivable from the public bid history, so emitting them inline doesn't widen the trust surface.

## Test plan

- [x] `EscrowOwnershipCheckTaskTest` — 13 tests, 3 new for case-3 (group still owns → stamp, winner now owns → confirm, stranger → freeze with `expectedGroupUuid` evidence)
- [x] `EscrowCreateOnBuyNowIntegrationTest` — new test asserts seller gets `AUCTION_ENDED_BOUGHT_NOW` but not `ESCROW_FUNDED` on buy-now
- [x] `EscrowCreateOnAuctionEndIntegrationTest` — natural-end path unchanged (`ESCROW_FUNDED` still fires)
- [x] `AuctionControllerTest` / `AuctionDtoMapperTest` — public DTO arity bump compiles + behaves
- [x] Notification + escrow integration sweep — 17/17 green (`AuctionEndNotificationIntegrationTest`, `BidNotificationIntegrationTest`, `EscrowNotificationIntegrationTest`, `EscrowEndToEndIntegrationTest`, `EscrowOwnershipMonitorIntegrationTest`, etc.)
- [x] Frontend vitest full suite — 1956/1956 green
- [ ] Manual prod smoke after deploy: place buy-now bid on a group listing, confirm buyer sees the ended panel without a 500, seller receives one notification (not two), escrow stays TRANSFER_PENDING through at least one ownership-monitor sweep