### PR TITLE
fix(parcel-lock): ENDED auctions release parcel when escrow is terminal

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionRepository.java
@@ -51,6 +51,32 @@ public interface AuctionRepository extends JpaRepository<Auction, Long>, JpaSpec
             UUID slParcelUuid, Collection<AuctionStatus> statuses);
 
     /**
+     * Second parcel-lock check used alongside {@link #existsBySlParcelUuidAndStatusInAndIdNot}.
+     * ENDED auctions are not unconditionally locking — once their escrow reaches a
+     * terminal state ({@code COMPLETED}, {@code FROZEN}, {@code EXPIRED}) the parcel
+     * is releasable, and ENDED auctions with no escrow row at all ({@code NO_BIDS} /
+     * {@code RESERVE_NOT_MET}) never locked the parcel in the first place. This
+     * query identifies the case that DOES still lock: an ENDED auction whose escrow
+     * is mid-flight (any state where transfer to the winner is still expected).
+     * Returns the blocking auction id when one is found.
+     */
+    @Query("""
+            SELECT a.id FROM Auction a
+            WHERE a.slParcelUuid = :slParcelUuid
+              AND a.status = com.slparcelauctions.backend.auction.AuctionStatus.ENDED
+              AND a.id <> :excludeAuctionId
+              AND EXISTS (
+                SELECT 1 FROM Escrow e
+                WHERE e.auction.id = a.id
+                  AND e.state IN :activeStates
+              )
+            """)
+    Optional<Long> findFirstEndedWithActiveEscrowByParcel(
+            @Param("slParcelUuid") UUID slParcelUuid,
+            @Param("excludeAuctionId") Long excludeAuctionId,
+            @Param("activeStates") Collection<com.slparcelauctions.backend.escrow.EscrowState> activeStates);
+
+    /**
      * Eagerly fetches {@code parcel} + {@code tags} — see class-level note on
      * {@link #findBySellerIdOrderByCreatedAtDesc}.
      */

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionStatusConstants.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionStatusConstants.java
@@ -10,12 +10,18 @@ import java.util.Set;
 public final class AuctionStatusConstants {
 
     /**
-     * Statuses that block another auction on the same parcel from transitioning
-     * to ACTIVE. See spec §8.3.
+     * Statuses that unconditionally block another auction on the same parcel
+     * from transitioning to ACTIVE. Originally included ENDED, but a freshly-
+     * ENDED auction is not a definitive parcel-lock: its escrow may have
+     * reached a terminal state ({@code COMPLETED}, {@code FROZEN}, or
+     * {@code EXPIRED}) — at which point the parcel is releasable — or there
+     * may be no escrow at all ({@code NO_BIDS} / {@code RESERVE_NOT_MET}).
+     * The ENDED-with-active-escrow case is enforced separately via
+     * {@code AuctionRepository#findFirstEndedWithActiveEscrowByParcel} so it
+     * can consult the escrow row. See spec §8.3.
      */
     public static final Set<AuctionStatus> LOCKING_STATUSES = Set.of(
             AuctionStatus.ACTIVE,
-            AuctionStatus.ENDED,
             AuctionStatus.ESCROW_PENDING,
             AuctionStatus.ESCROW_FUNDED,
             AuctionStatus.TRANSFER_PENDING,

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionVerificationService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionVerificationService.java
@@ -217,21 +217,55 @@ public class AuctionVerificationService {
 
     /**
      * Throws {@link ParcelAlreadyListedException} if any other auction on the
-     * same parcel is in a {@link AuctionStatusConstants#LOCKING_STATUSES locking
-     * status}. Excludes the candidate auction itself (which is still
-     * DRAFT_PAID / VERIFICATION_FAILED at this point and therefore not
-     * locking).
+     * same parcel holds the parcel lock. Excludes the candidate auction itself
+     * (which is still DRAFT_PAID / VERIFICATION_FAILED at this point and
+     * therefore not locking).
+     *
+     * <p>Two-pass check:
+     * <ol>
+     *   <li>Hard-locking statuses ({@link AuctionStatusConstants#LOCKING_STATUSES})
+     *       — currently {@code ACTIVE} plus the unwired escrow-stage statuses.
+     *       Any match unconditionally blocks.</li>
+     *   <li>ENDED auctions with an in-flight escrow. ENDED itself is not a
+     *       hard lock because the escrow may have reached a terminal state
+     *       ({@code COMPLETED} / {@code FROZEN} / {@code EXPIRED}) or never
+     *       opened at all ({@code NO_BIDS} / {@code RESERVE_NOT_MET}), all of
+     *       which release the parcel. Only ENDED auctions whose escrow is in
+     *       {@code ESCROW_PENDING}, {@code FUNDED}, {@code TRANSFER_PENDING},
+     *       or {@code DISPUTED} still hold the parcel — the escrow is
+     *       expected to transfer the parcel to the winner imminently.</li>
+     * </ol>
      */
     private void assertParcelNotLocked(Auction candidate) {
         UUID slParcelUuid = candidate.getSlParcelUuid();
-        boolean exists = auctionRepo.existsBySlParcelUuidAndStatusInAndIdNot(
-                slParcelUuid, AuctionStatusConstants.LOCKING_STATUSES, candidate.getId());
-        if (!exists) return;
 
-        Long blockingId = auctionRepo
-                .findFirstBySlParcelUuidAndStatusIn(slParcelUuid, AuctionStatusConstants.LOCKING_STATUSES)
-                .map(Auction::getId)
-                .orElse(-1L);
-        throw new ParcelAlreadyListedException(candidate.getId(), blockingId);
+        boolean hardLocked = auctionRepo.existsBySlParcelUuidAndStatusInAndIdNot(
+                slParcelUuid, AuctionStatusConstants.LOCKING_STATUSES, candidate.getId());
+        if (hardLocked) {
+            Long blockingId = auctionRepo
+                    .findFirstBySlParcelUuidAndStatusIn(slParcelUuid, AuctionStatusConstants.LOCKING_STATUSES)
+                    .map(Auction::getId)
+                    .orElse(-1L);
+            throw new ParcelAlreadyListedException(candidate.getId(), blockingId);
+        }
+
+        Long endedBlockingId = auctionRepo
+                .findFirstEndedWithActiveEscrowByParcel(
+                        slParcelUuid, candidate.getId(), ACTIVE_ESCROW_STATES)
+                .orElse(null);
+        if (endedBlockingId != null) {
+            throw new ParcelAlreadyListedException(candidate.getId(), endedBlockingId);
+        }
     }
+
+    /**
+     * Escrow states that keep an ENDED auction's parcel locked. Anything outside
+     * this set ({@code COMPLETED}, {@code FROZEN}, {@code EXPIRED}, or no escrow
+     * row at all) releases the parcel for re-listing.
+     */
+    private static final Set<com.slparcelauctions.backend.escrow.EscrowState> ACTIVE_ESCROW_STATES = Set.of(
+            com.slparcelauctions.backend.escrow.EscrowState.ESCROW_PENDING,
+            com.slparcelauctions.backend.escrow.EscrowState.FUNDED,
+            com.slparcelauctions.backend.escrow.EscrowState.TRANSFER_PENDING,
+            com.slparcelauctions.backend.escrow.EscrowState.DISPUTED);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/config/ParcelLockingIndexInitializer.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/config/ParcelLockingIndexInitializer.java
@@ -32,10 +32,16 @@ public class ParcelLockingIndexInitializer {
             DROP INDEX IF EXISTS uq_auctions_parcel_locked_status
             """;
 
+    // ENDED intentionally not in the index WHERE clause. An ENDED auction is
+    // not a hard parcel-lock — its escrow may have settled to a terminal
+    // state (COMPLETED, FROZEN, EXPIRED) or never opened at all (NO_BIDS /
+    // RESERVE_NOT_MET), in which cases the parcel is free to re-list. The
+    // service-layer assertParcelNotLocked() consults the escrow row for the
+    // ENDED-with-active-escrow case. See AuctionStatusConstants javadoc.
     private static final String DDL = """
             CREATE UNIQUE INDEX IF NOT EXISTS uq_auctions_parcel_locked_status
               ON auctions(sl_parcel_uuid)
-              WHERE status IN ('ACTIVE', 'ENDED', 'ESCROW_PENDING',
+              WHERE status IN ('ACTIVE', 'ESCROW_PENDING',
                                'ESCROW_FUNDED', 'TRANSFER_PENDING', 'DISPUTED')
             """;
 

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/ParcelLockingRaceIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/ParcelLockingRaceIntegrationTest.java
@@ -198,6 +198,131 @@ class ParcelLockingRaceIntegrationTest {
     }
 
     // -------------------------------------------------------------------------
+    // ENDED auction with a terminal-state escrow releases the parcel lock so
+    // the seller can re-list. Mirrors the prod incident on auction 17 (BOUGHT_NOW
+    // close, escrow FROZEN with UNKNOWN_OWNER) where the parcel stayed locked
+    // forever despite the sale never completing.
+    // -------------------------------------------------------------------------
+
+    @Test
+    void endedAuction_withFrozenEscrow_releasesParcelLock() throws Exception {
+        stubWorldApiOwnership(sellerAvatar, "agent");
+        AuctionRef a1 = seedDraftPaidAuction();
+        AuctionRef a2 = seedDraftPaidAuction();
+
+        // A1 -> ACTIVE
+        mockMvc.perform(put("/api/v1/auctions/" + a1.publicId() + "/verify")
+                .header("Authorization", "Bearer " + sellerAccessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"method\":\"UUID_ENTRY\"}"))
+                .andExpect(status().isOk());
+
+        // Drive A1 to ENDED with a FROZEN escrow row using direct DB updates —
+        // the production BidService + EscrowService path involves wallet seeding
+        // and is over-scoped for this lock-release assertion.
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("UPDATE auctions SET status = 'ENDED' WHERE id = " + a1.id());
+                stmt.execute(
+                    "INSERT INTO escrows (auction_id, state, final_bid_amount, commission_amt, "
+                    + "payout_amt, consecutive_world_api_failures, frozen_at, freeze_reason, "
+                    + "public_id, created_at, updated_at, version) VALUES ("
+                    + a1.id() + ", 'FROZEN', 1000, 50, 950, 0, NOW(), 'UNKNOWN_OWNER', "
+                    + "gen_random_uuid(), NOW(), NOW(), 0)");
+            }
+        }
+
+        // A2 verify -> succeeds because A1's escrow is in a terminal failure
+        // state. The parcel is releasable.
+        mockMvc.perform(put("/api/v1/auctions/" + a2.publicId() + "/verify")
+                .header("Authorization", "Bearer " + sellerAccessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"method\":\"UUID_ENTRY\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ACTIVE"));
+
+        // Tidy up the escrow row so cleanUp()'s auction delete doesn't trip on the FK.
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("DELETE FROM escrows WHERE auction_id = " + a1.id());
+            }
+        }
+    }
+
+    @Test
+    void endedAuction_withTransferPendingEscrow_stillHoldsParcelLock() throws Exception {
+        stubWorldApiOwnership(sellerAvatar, "agent");
+        AuctionRef a1 = seedDraftPaidAuction();
+        AuctionRef a2 = seedDraftPaidAuction();
+
+        mockMvc.perform(put("/api/v1/auctions/" + a1.publicId() + "/verify")
+                .header("Authorization", "Bearer " + sellerAccessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"method\":\"UUID_ENTRY\"}"))
+                .andExpect(status().isOk());
+
+        // A1 ENDED with TRANSFER_PENDING escrow — sale is still mid-flight.
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("UPDATE auctions SET status = 'ENDED' WHERE id = " + a1.id());
+                stmt.execute(
+                    "INSERT INTO escrows (auction_id, state, final_bid_amount, commission_amt, "
+                    + "payout_amt, consecutive_world_api_failures, funded_at, transfer_deadline, "
+                    + "public_id, created_at, updated_at, version) VALUES ("
+                    + a1.id() + ", 'TRANSFER_PENDING', 1000, 50, 950, 0, NOW(), "
+                    + "NOW() + INTERVAL '72 hours', gen_random_uuid(), NOW(), NOW(), 0)");
+            }
+        }
+
+        mockMvc.perform(put("/api/v1/auctions/" + a2.publicId() + "/verify")
+                .header("Authorization", "Bearer " + sellerAccessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"method\":\"UUID_ENTRY\"}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("PARCEL_ALREADY_LISTED"))
+                .andExpect(jsonPath("$.blockingAuctionId").value(a1.id()));
+
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("DELETE FROM escrows WHERE auction_id = " + a1.id());
+            }
+        }
+    }
+
+    @Test
+    void endedAuction_withNoEscrowRow_releasesParcelLock() throws Exception {
+        // Mirrors NO_BIDS / RESERVE_NOT_MET outcomes: auction ENDED, no escrow
+        // ever opened, parcel should be free to re-list.
+        stubWorldApiOwnership(sellerAvatar, "agent");
+        AuctionRef a1 = seedDraftPaidAuction();
+        AuctionRef a2 = seedDraftPaidAuction();
+
+        mockMvc.perform(put("/api/v1/auctions/" + a1.publicId() + "/verify")
+                .header("Authorization", "Bearer " + sellerAccessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"method\":\"UUID_ENTRY\"}"))
+                .andExpect(status().isOk());
+
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("UPDATE auctions SET status = 'ENDED' WHERE id = " + a1.id());
+            }
+        }
+
+        mockMvc.perform(put("/api/v1/auctions/" + a2.publicId() + "/verify")
+                .header("Authorization", "Bearer " + sellerAccessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"method\":\"UUID_ENTRY\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ACTIVE"));
+    }
+
+    // -------------------------------------------------------------------------
     // Concurrent race: two parallel verify calls, only one wins.
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Surfaced when a seller couldn't re-list a parcel after their previous group auction (auction 17, BOUGHT_NOW close) was case-3-frozen by the bug fixed in PR #317. Even after the fraud flag was manually resolved, the parcel was still locked — the auction sat at status=ENDED, and ENDED was in \`LOCKING_STATUSES\`, so every parcel-lock check rejected new auctions on the same parcel.

Same trap quietly applied to every NO_BIDS / RESERVE_NOT_MET ending and to any completed sale where the winner wanted to re-list.

## Fix

- Drop \`ENDED\` from \`AuctionStatusConstants.LOCKING_STATUSES\` and from the partial unique index in \`ParcelLockingIndexInitializer\`. ENDED is no longer a hard lock.
- Add a second pass in \`AuctionVerificationService.assertParcelNotLocked\`: an ENDED auction still holds the lock only when its escrow is in \`ESCROW_PENDING\` / \`FUNDED\` / \`TRANSFER_PENDING\` / \`DISPUTED\` (transfer is still expected). Terminal escrow states (\`COMPLETED\` / \`FROZEN\` / \`EXPIRED\`) and ENDED auctions with no escrow at all release the parcel.
- The unique index is recreated on boot by the existing idempotent DROP + CREATE initializer — no Flyway migration.

## Test plan

- [x] \`ParcelLockingRaceIntegrationTest\` — 6 tests, 3 new (ENDED+FROZEN unlocks, ENDED+TRANSFER_PENDING still blocks, ENDED-no-escrow unlocks)
- [x] \`AuctionControllerTest\`, \`AuctionDtoMapperTest\`, \`EscrowOwnershipCheckTaskTest\` — all green
- [ ] Post-deploy: seller's stuck auction (auction 17 ENDED+FROZEN) should now let auction 20 activate against the same parcel