### PR TITLE
fix(migration): V36 constraint ordering — drop V12 CHECK before UPDATEs

### DIFF
--- a/backend/src/main/resources/db/migration/V36__rewire_auction_status.sql
+++ b/backend/src/main/resources/db/migration/V36__rewire_auction_status.sql
@@ -5,6 +5,14 @@
 
 BEGIN;
 
+-- Drop the V12 auctions_status_check CHECK constraint FIRST so the
+-- translation UPDATEs below can set rows to 'FROZEN' (a new value not in
+-- the V12 constraint). The new constraint is re-added at the bottom of
+-- the migration with the post-rewire value set. Both ends run inside the
+-- same transaction so no window exists where the column is unconstrained
+-- from other writers' perspective.
+ALTER TABLE auctions DROP CONSTRAINT IF EXISTS auctions_status_check;
+
 -- ENDED + COMPLETED escrow -> COMPLETED
 UPDATE auctions a
 SET status = 'COMPLETED'
@@ -59,12 +67,10 @@ UPDATE auctions
 SET status = 'TRANSFER_PENDING'
 WHERE status IN ('ESCROW_PENDING', 'ESCROW_FUNDED');
 
--- Rewire the auctions_status_check CHECK constraint defined in V12.
--- ENDED / ESCROW_PENDING / ESCROW_FUNDED are dropped from AuctionStatus;
--- FROZEN is added. The translation UPDATEs above already moved every
--- existing row off the dropped values, so the new constraint can be
--- enforced without violations.
-ALTER TABLE auctions DROP CONSTRAINT IF EXISTS auctions_status_check;
+-- Re-add the auctions_status_check CHECK constraint with the post-rewire
+-- value set. ENDED / ESCROW_PENDING / ESCROW_FUNDED are dropped; FROZEN
+-- is added. The translation UPDATEs above moved every existing row off
+-- the dropped values, so the new constraint enforces cleanly.
 ALTER TABLE auctions ADD CONSTRAINT auctions_status_check CHECK (status IN (
     'DRAFT', 'DRAFT_PAID', 'VERIFICATION_PENDING', 'VERIFICATION_FAILED',
     'ACTIVE', 'TRANSFER_PENDING', 'DISPUTED',


### PR DESCRIPTION
PR #322's deploy failed on V36 because the CHECK constraint replacement ran AFTER the UPDATE statements. Postgres validates CHECK at row update time, so 'ENDED + escrow FROZEN → status=FROZEN' violated the old V12 constraint (which doesn't include FROZEN).

Reorder: DROP V12 constraint at the top of the V36 transaction, run all UPDATEs unconstrained, ADD the new constraint at the end. Whole migration is one transaction so no observable window where the column is unconstrained.

\`flyway_schema_history\` confirmed clean (no failed V36 row — Postgres rolled the entire transaction back), so the next deploy attempt runs V36 fresh.

## Test plan
- [ ] Backend deploy fires + V36 applies cleanly
- [ ] Auction 17 (\`f47aeeea-…\`) transitions to FROZEN
- [ ] Parcel \`abac26ab-…\` becomes re-listable