### PR TITLE
fix(escrow): surface winner SL avatar name + copy button in TRANSFER_PENDING seller card

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
@@ -454,8 +454,20 @@ public class EscrowService {
 
     private EscrowStatusResponse toStatusResponse(Escrow escrow) {
         List<EscrowTimelineEntry> timeline = buildTimeline(escrow);
+        // Look up the winner's SL avatar name so the seller's
+        // TRANSFER_PENDING card can show it next to a copy button. One
+        // extra query per escrow GET is acceptable for this single-row
+        // endpoint. Null when no winner is resolved yet (pre-FUNDED).
+        String winnerSlAvatarName = null;
+        Long winnerUserId = escrow.getAuction().getWinnerUserId();
+        if (winnerUserId != null) {
+            winnerSlAvatarName = userRepo.findById(winnerUserId)
+                    .map(User::getSlAvatarName)
+                    .orElse(null);
+        }
         return new EscrowStatusResponse(
-                escrow.getPublicId(), escrow.getAuction().getPublicId(), escrow.getState(),
+                escrow.getPublicId(), escrow.getAuction().getPublicId(),
+                winnerSlAvatarName, escrow.getState(),
                 escrow.getFinalBidAmount(), escrow.getCommissionAmt(), escrow.getPayoutAmt(),
                 escrow.getTransferDeadline(),
                 escrow.getFundedAt(), escrow.getTransferConfirmedAt(), escrow.getCompletedAt(),

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/dto/EscrowStatusResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/dto/EscrowStatusResponse.java
@@ -17,6 +17,14 @@ import com.slparcelauctions.backend.escrow.EscrowState;
 public record EscrowStatusResponse(
         UUID escrowPublicId,
         UUID auctionPublicId,
+        /**
+         * Winner's SL avatar name. Shown to the seller in the
+         * TRANSFER_PENDING card so they can paste it into the SL viewer's
+         * About Land → Sell Land → "Sell to" field. Null only for
+         * pre-FUNDED states (no winner resolved yet) — should be present
+         * whenever an escrow row exists.
+         */
+        String winnerSlAvatarName,
         EscrowState state,
         Long finalBidAmount,
         Long commissionAmt,

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowControllerSliceTest.java
@@ -98,7 +98,8 @@ class EscrowControllerSliceTest {
         // Wallet-only escrow funding (spec 2026-05-16): paymentDeadline
         // is gone from EscrowStatusResponse; transferDeadline replaces it.
         return new EscrowStatusResponse(
-                ESCROW_PUBLIC_ID, AUCTION_PUBLIC_ID, state,
+                ESCROW_PUBLIC_ID, AUCTION_PUBLIC_ID,
+                "Winner Resident", state,
                 5_000L, 250L, 4_750L,
                 null, null, null, null,
                 null, null, null,

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowDisputeIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowDisputeIntegrationTest.java
@@ -200,6 +200,9 @@ class EscrowDisputeIntegrationTest {
                 List.of());
 
         assertThat(resp.state()).isEqualTo(EscrowState.DISPUTED);
+        // The status DTO should surface the winner's SL avatar name so the
+        // seller's TRANSFER_PENDING card can show it next to a copy button.
+        assertThat(resp.winnerSlAvatarName()).isEqualTo("Dispute Winner Resident");
 
         Escrow persisted = escrowRepo.findById(seededEscrowId).orElseThrow();
         assertThat(persisted.getState()).isEqualTo(EscrowState.DISPUTED);
@@ -258,6 +261,7 @@ class EscrowDisputeIntegrationTest {
                     .passwordHash("$2a$10$dummy.hash.value.for.test.only.aaaaaaaaaaaaaaaaaaaa")
                     .displayName("Escrow Dispute Bidder")
                     .slAvatarUuid(UUID.randomUUID())
+                    .slAvatarName("Dispute Winner Resident")
                     .verified(true)
                     .build());
             UUID parcelUuid = UUID.randomUUID();

--- a/frontend/src/components/escrow/state/TransferPendingStateCard.test.tsx
+++ b/frontend/src/components/escrow/state/TransferPendingStateCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { renderWithProviders, screen } from "@/test/render";
+import { renderWithProviders, screen, fireEvent, waitFor } from "@/test/render";
 import { TransferPendingStateCard } from "./TransferPendingStateCard";
 import { fakeEscrow } from "@/test/fixtures/escrow";
 
@@ -61,6 +61,70 @@ describe("TransferPendingStateCard", () => {
       );
       const link = screen.getByRole("link", { name: /file a dispute/i });
       expect(link).toHaveAttribute("href", "/auction/00000000-0000-0000-0000-00000000002a/escrow/dispute");
+    });
+
+    it("renders the winner's SL avatar name with a copy button", async () => {
+      // Real timers for this test so waitFor + the promise-resolution
+      // microtask the copy handler awaits can actually progress.
+      vi.useRealTimers();
+      const writeTextMock = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText: writeTextMock },
+        writable: true,
+        configurable: true,
+      });
+
+      renderWithProviders(
+        <TransferPendingStateCard
+          escrow={fakeEscrow({
+            state: "TRANSFER_PENDING",
+            fundedAt: "2026-04-30T12:00:00Z",
+            transferConfirmedAt: null,
+            transferDeadline: "2026-05-03T12:00:00Z",
+            winnerSlAvatarName: "Alice Bidder Resident",
+          })}
+          role="seller"
+        />,
+      );
+
+      expect(screen.getByTestId("winner-sl-avatar-name")).toHaveTextContent(
+        "Alice Bidder Resident",
+      );
+      const copyBtn = screen.getByTestId("copy-winner-sl-avatar-name-btn");
+      expect(copyBtn).toBeInTheDocument();
+
+      fireEvent.click(copyBtn);
+      await waitFor(() => {
+        expect(writeTextMock).toHaveBeenCalledWith("Alice Bidder Resident");
+      });
+      await waitFor(() => {
+        expect(copyBtn).toHaveTextContent(/copied/i);
+      });
+    });
+
+    it("falls back to generic step 3 copy when winnerSlAvatarName is null", () => {
+      renderWithProviders(
+        <TransferPendingStateCard
+          escrow={fakeEscrow({
+            state: "TRANSFER_PENDING",
+            fundedAt: "2026-04-30T12:00:00Z",
+            transferConfirmedAt: null,
+            transferDeadline: "2026-05-03T12:00:00Z",
+            winnerSlAvatarName: null,
+          })}
+          role="seller"
+        />,
+      );
+
+      expect(
+        screen.queryByTestId("winner-sl-avatar-name"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("copy-winner-sl-avatar-name-btn"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText(/winner's avatar name/i),
+      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/escrow/state/TransferPendingStateCard.tsx
+++ b/frontend/src/components/escrow/state/TransferPendingStateCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/Button";
 import { EscrowDeadlineBadge } from "@/components/escrow/EscrowDeadlineBadge";
@@ -10,10 +11,11 @@ import type { StateCardProps } from "./types";
  * into two sub-phases:
  *
  *  - Pre-confirmation: seller sees a numbered SL-viewer recipe for
- *    transferring the parcel at L$0 to the winner's avatar (plus a
- *    clipboard copy button for the winner's avatar name). Winner sees a
- *    waiting banner with guidance thresholds and an inert "Message seller"
- *    placeholder (real messaging is future work).
+ *    transferring the parcel at L$0 to the winner's avatar. Step 3 renders
+ *    the winner's avatar name in monospace with a "Copy" button next to it
+ *    so the seller can paste it straight into the SL viewer's "Sell to"
+ *    field. Winner sees a waiting banner with guidance thresholds and an
+ *    inert "Message seller" placeholder (real messaging is future work).
  *  - Post-confirmation ("payout pending"): both roles see the same
  *    role-neutral acknowledgement; no dispute link because the backend is
  *    about to flip the escrow to COMPLETED. See spec §3.3.
@@ -73,7 +75,20 @@ function SellerPreConfirmation({
         <li>Right-click the parcel in-world and open About Land.</li>
         <li>Click Sell Land.</li>
         <li>
-          Set &quot;Sell to:&quot; to the winner&apos;s avatar name.
+          {escrow.winnerSlAvatarName ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <span>Set &quot;Sell to:&quot; to:</span>
+              <code
+                data-testid="winner-sl-avatar-name"
+                className="rounded bg-bg-subtle px-1.5 py-0.5 font-mono text-xs text-fg"
+              >
+                {escrow.winnerSlAvatarName}
+              </code>
+              <CopyAvatarNameButton name={escrow.winnerSlAvatarName} />
+            </div>
+          ) : (
+            <>Set &quot;Sell to:&quot; to the winner&apos;s avatar name.</>
+          )}
         </li>
         <li>Set the price to L$ 0 (SLParcels has already escrowed payment).</li>
         <li>Confirm the sale in the SL viewer dialog.</li>
@@ -171,4 +186,33 @@ function formatTimestamp(iso: string): string {
     dateStyle: "medium",
     timeStyle: "short",
   });
+}
+
+/**
+ * Small inline button that copies the winner's SL avatar name to the
+ * clipboard. Shows a brief "Copied" confirmation for ~1.5s after a
+ * successful copy; clipboard rejection is non-fatal because the name is
+ * also visible on screen.
+ */
+function CopyAvatarNameButton({ name }: { name: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(name);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard rejection is non-fatal; the name is also visible on screen.
+    }
+  };
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="text-xs font-medium text-brand hover:underline"
+      data-testid="copy-winner-sl-avatar-name-btn"
+    >
+      {copied ? "Copied" : "Copy"}
+    </button>
+  );
 }

--- a/frontend/src/test/fixtures/escrow.ts
+++ b/frontend/src/test/fixtures/escrow.ts
@@ -11,6 +11,7 @@ export function fakeEscrow(
   const base: EscrowStatusResponse = {
     escrowPublicId: "00000000-0000-0000-0000-000000000001",
     auctionPublicId: "00000000-0000-0000-0000-000000000007",
+    winnerSlAvatarName: "Winner Resident",
     state: "ESCROW_PENDING",
     finalBidAmount: 5000,
     commissionAmt: 250,

--- a/frontend/src/types/escrow.ts
+++ b/frontend/src/types/escrow.ts
@@ -37,6 +37,13 @@ export type EscrowFreezeReason =
 export interface EscrowStatusResponse {
   escrowPublicId: string;
   auctionPublicId: string;
+  /**
+   * Winner's SL avatar name. Shown to the seller in the TRANSFER_PENDING
+   * card so they can paste it into the SL viewer's About Land → Sell Land →
+   * "Sell to" field. Null only for pre-FUNDED states (no winner resolved
+   * yet) — should be present whenever an escrow row exists post-FUNDED.
+   */
+  winnerSlAvatarName: string | null;
   state: EscrowState;
   finalBidAmount: number;
   commissionAmt: number;


### PR DESCRIPTION
## Summary
- Add `winnerSlAvatarName` to `EscrowStatusResponse`, populated via `UserRepository.findById` inside `EscrowService.toStatusResponse`.
- Show the winner's avatar name inline in step 3 of the seller's "Transfer the parcel" recipe, alongside a small "Copy" button (writes to clipboard, briefly flips to "Copied"). Falls back to the original generic text if the field is null.
- Mirror the new field in the frontend `EscrowStatusResponse` type and update fixtures.

## Test plan
- [x] `EscrowControllerSliceTest` / `EscrowDisputeIntegrationTest` / `EscrowEndToEndIntegrationTest` / `EscrowPaymentIntegrationTest` / `EscrowCreateOnAuctionEndIntegrationTest` / `EscrowCreateOnBuyNowIntegrationTest` -- 22 backend tests green.
- [x] Added backend assertion that `winnerSlAvatarName` round-trips through a TRANSFER_PENDING dispute.
- [x] `vitest run src/components/escrow` -- 80 frontend tests green; new cases cover the rendered name, the copy button, the clipboard call, and the null fallback.
- [x] `tsc --noEmit` clean except the pre-existing `useBulkCommissionEdit.test.tsx` error.