### PR TITLE
fix(escrow,bot): correct ParcelFlags.ForSale + fast retry on transient bot errors

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskResultService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskResultService.java
@@ -1,6 +1,7 @@
 package com.slparcelauctions.backend.bot;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
@@ -51,15 +52,22 @@ import lombok.extern.slf4j.Slf4j;
  *   <li>{@code ACCESS_DENIED}/{@code BOT_ERROR} → increment
  *       {@code consecutiveSellToBotFailures}, no attempt consumed, clear
  *       {@code manualVerifyPending}; at threshold open an idempotent
- *       {@code EscrowManualReview(BOT_PERSISTENT_FAILURE)}; reschedule.</li>
+ *       {@code EscrowManualReview(BOT_PERSISTENT_FAILURE)}; reschedule on the
+ *       fast {@code sellToBotRetryBackoff} (the parcel is fine — the bot just
+ *       couldn't observe it, so a 30m wait needlessly stalls a healthy
+ *       transfer).</li>
  *   <li>{@code PARCEL_NOT_FOUND} → same streak; at threshold
- *       {@link EscrowService#freezeForFraud}{@code (PARCEL_DELETED)}.</li>
+ *       {@link EscrowService#freezeForFraud}{@code (PARCEL_DELETED)};
+ *       reschedule on the normal {@code sellToBotRecurrence}.</li>
  * </ul>
  *
- * <p>Reschedule = {@code nextRunAt = now + sellToBotRecurrence} only while
+ * <p>Reschedule = {@code nextRunAt = now + backoff} only while
  * {@code transferDeadline} is in the future; once the deadline has elapsed
  * the recurring task is {@code CANCELLED} (the timeout job expires/refunds
- * the escrow — no point re-checking a parcel whose deadline has passed).
+ * the escrow — no point re-checking a parcel whose deadline has passed). The
+ * backoff is {@code sellToBotRetryBackoff} for transient infra failures
+ * ({@code BOT_ERROR}/{@code ACCESS_DENIED}) and {@code sellToBotRecurrence}
+ * for definitive negatives and {@code PARCEL_NOT_FOUND}.
  */
 @Service
 @RequiredArgsConstructor
@@ -132,7 +140,7 @@ public class BotTaskResultService {
             escrow.setManualVerifyPending(false);
         }
         escrowRepo.save(escrow);
-        reschedule(task, escrow, now);
+        reschedule(task, escrow, now, props.sellToBotRecurrence());
     }
 
     private void infraFailure(BotTask task, Escrow escrow, SellToOutcome outcome,
@@ -162,7 +170,15 @@ public class BotTaskResultService {
             }
             openManualReviewIfAbsent(escrow);
         }
-        reschedule(task, escrow, now);
+        // PARCEL_NOT_FOUND keeps the slow recurrence (deliberate negative —
+        // a missing parcel won't reappear in 2 minutes). BOT_ERROR /
+        // ACCESS_DENIED are transient: the parcel is fine, the bot just
+        // couldn't observe it, so retry fast instead of stalling a healthy
+        // transfer for a full recurrence interval.
+        Duration backoff = parcelGone
+                ? props.sellToBotRecurrence()
+                : props.sellToBotRetryBackoff();
+        reschedule(task, escrow, now, backoff);
     }
 
     private void openManualReviewIfAbsent(Escrow escrow) {
@@ -189,13 +205,17 @@ public class BotTaskResultService {
     }
 
     /**
-     * Reschedule the recurring task only while the transfer deadline is in
-     * the future; otherwise cancel it (the timeout job expires/refunds).
+     * Reschedule the recurring task {@code backoff} from now, but only while
+     * the transfer deadline is in the future; otherwise cancel it (the
+     * timeout job expires/refunds). Callers pass {@code sellToBotRetryBackoff}
+     * for transient infra failures and {@code sellToBotRecurrence} for
+     * definitive negatives and {@code PARCEL_NOT_FOUND}.
      */
-    private void reschedule(BotTask task, Escrow escrow, OffsetDateTime now) {
+    private void reschedule(BotTask task, Escrow escrow, OffsetDateTime now,
+                            Duration backoff) {
         OffsetDateTime deadline = escrow.getTransferDeadline();
         if (deadline != null && deadline.isAfter(now)) {
-            task.setNextRunAt(now.plus(props.sellToBotRecurrence()));
+            task.setNextRunAt(now.plus(backoff));
             task.setStatus(BotTaskStatus.PENDING);
             botTaskRepo.save(task);
         } else {

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/terminal/EscrowConfigProperties.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/terminal/EscrowConfigProperties.java
@@ -18,6 +18,7 @@ public record EscrowConfigProperties(
         Integer ownershipApiFailureThreshold,
         Duration ownershipReminderDelay,
         Duration sellToBotRecurrence,
+        Duration sellToBotRetryBackoff,
         Integer sellToBotFailureThreshold,
         Duration buyParcelFastCadence,
         Duration buyParcelFastWindow,
@@ -31,6 +32,7 @@ public record EscrowConfigProperties(
         if (ownershipApiFailureThreshold == null) ownershipApiFailureThreshold = 5;
         if (ownershipReminderDelay == null) ownershipReminderDelay = Duration.ofHours(24);
         if (sellToBotRecurrence == null) sellToBotRecurrence = Duration.ofMinutes(30);
+        if (sellToBotRetryBackoff == null) sellToBotRetryBackoff = Duration.ofMinutes(2);
         if (sellToBotFailureThreshold == null) sellToBotFailureThreshold = 5;
         if (buyParcelFastCadence == null) buyParcelFastCadence = Duration.ofMinutes(5);
         if (buyParcelFastWindow == null) buyParcelFastWindow = Duration.ofHours(1);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -156,6 +156,11 @@ slpa:
     ownership-api-failure-threshold: 5
     ownership-reminder-delay: PT24H
     sell-to-bot-recurrence: PT30M
+    # Fast retry for transient bot outcomes (BOT_ERROR / ACCESS_DENIED) only —
+    # the parcel is fine, the bot just couldn't observe it, so re-check soon
+    # instead of waiting a full recurrence interval. PARCEL_NOT_FOUND and
+    # definitive negatives stay on sell-to-bot-recurrence.
+    sell-to-bot-retry-backoff: PT2M
     sell-to-bot-failure-threshold: 5
     buy-parcel-fast-cadence: PT5M
     buy-parcel-fast-window: PT1H

--- a/backend/src/test/java/com/slparcelauctions/backend/bot/BotTaskResultServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/bot/BotTaskResultServiceTest.java
@@ -78,6 +78,7 @@ class BotTaskResultServiceTest {
         service = new BotTaskResultService(
                 botTaskRepo, escrowRepo, escrowService, manualReviewRepo, props, fixed);
         lenient().when(props.sellToBotRecurrence()).thenReturn(Duration.ofMinutes(30));
+        lenient().when(props.sellToBotRetryBackoff()).thenReturn(Duration.ofMinutes(2));
         lenient().when(props.sellToBotFailureThreshold()).thenReturn(THRESHOLD);
         lenient().when(botTaskRepo.save(any(BotTask.class)))
                 .thenAnswer(inv -> inv.getArgument(0));
@@ -167,7 +168,7 @@ class BotTaskResultServiceTest {
     // ---- infra failures ----
 
     @Test
-    void botError_incrementsStreak_noAttempt_clearsPending_belowThreshold_reschedules() {
+    void botError_incrementsStreak_noAttempt_clearsPending_belowThreshold_fastRetry() {
         BotTask task = pendingTask();
         Escrow escrow = transferPending(now.plusHours(70));
         escrow.setManualVerifyPending(true);
@@ -181,8 +182,38 @@ class BotTaskResultServiceTest {
         assertThat(escrow.getSellToVerifyAttempts()).isZero();
         assertThat(escrow.getManualVerifyPending()).isFalse();
         assertThat(task.getStatus()).isEqualTo(BotTaskStatus.PENDING);
-        assertThat(task.getNextRunAt()).isEqualTo(now.plusMinutes(30));
+        // Transient infra failure retries on the fast backoff, not the 30m
+        // recurrence — the parcel is fine, the bot just couldn't observe it.
+        assertThat(task.getNextRunAt()).isEqualTo(now.plusMinutes(2));
         verify(manualReviewRepo, never()).save(any());
+    }
+
+    @Test
+    void accessDenied_belowThreshold_fastRetry() {
+        BotTask task = pendingTask();
+        Escrow escrow = transferPending(now.plusHours(70));
+        escrow.setConsecutiveSellToBotFailures(0);
+        primeLoad(task, escrow);
+
+        service.apply(TASK_ID, req(SellToOutcome.ACCESS_DENIED));
+
+        assertThat(escrow.getConsecutiveSellToBotFailures()).isEqualTo(1);
+        assertThat(task.getStatus()).isEqualTo(BotTaskStatus.PENDING);
+        assertThat(task.getNextRunAt()).isEqualTo(now.plusMinutes(2));
+        verify(manualReviewRepo, never()).save(any());
+    }
+
+    @Test
+    void botError_pastDeadline_cancelsTask_noFastRetry() {
+        BotTask task = pendingTask();
+        Escrow escrow = transferPending(now.minusHours(1)); // deadline elapsed
+        escrow.setConsecutiveSellToBotFailures(0);
+        primeLoad(task, escrow);
+
+        service.apply(TASK_ID, req(SellToOutcome.BOT_ERROR));
+
+        assertThat(escrow.getConsecutiveSellToBotFailures()).isEqualTo(1);
+        assertThat(task.getStatus()).isEqualTo(BotTaskStatus.CANCELLED);
     }
 
     @Test
@@ -245,6 +276,8 @@ class BotTaskResultServiceTest {
         assertThat(escrow.getConsecutiveSellToBotFailures()).isEqualTo(1);
         verify(escrowService, never()).freezeForFraud(any(), any(), any(), any());
         assertThat(task.getStatus()).isEqualTo(BotTaskStatus.PENDING);
+        // PARCEL_NOT_FOUND keeps the existing 30m recurrence — the fast
+        // retry is scoped to BOT_ERROR/ACCESS_DENIED only.
         assertThat(task.getNextRunAt()).isEqualTo(now.plusMinutes(30));
     }
 

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/config/EscrowStartupValidatorTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/config/EscrowStartupValidatorTest.java
@@ -30,12 +30,13 @@ class EscrowStartupValidatorTest {
                 Duration.ofMinutes(5),
                 5,
                 Duration.ofHours(24),
-                null,
-                null,
-                null,
-                null,
-                null,
-                null);
+                null, // sellToBotRecurrence
+                null, // sellToBotRetryBackoff
+                null, // sellToBotFailureThreshold
+                null, // buyParcelFastCadence
+                null, // buyParcelFastWindow
+                null, // buyParcelSlowCadence
+                null); // manualVerifyAttempts
     }
 
     @Test

--- a/bot/src/Slpa.Bot/Sl/LibreMetaverseBotSession.cs
+++ b/bot/src/Slpa.Bot/Sl/LibreMetaverseBotSession.cs
@@ -446,11 +446,17 @@ public sealed class LibreMetaverseBotSession : IBotSession
             return null;
         }
 
+        // SalePrice persists after a sale, so "is this parcel for sale" must
+        // be read from the ForSale flag bit, not inferred from the price.
+        // ParcelFlags.ForSale is 1<<2 — distinct from ForSaleObjects (1<<7).
+        bool forSale = parcel.Flags.HasFlag(OpenMetaverse.ParcelFlags.ForSale);
+
         _log.LogInformation(
             "ReadParcel resolved LocalID {LocalId} at ({X},{Y}) in {Sim}: " +
-            "name='{Name}' owner={Owner} authBuyer={AuthBuyer} salePrice={Price}",
+            "name='{Name}' owner={Owner} authBuyer={AuthBuyer} salePrice={Price} " +
+            "forSale={ForSale}",
             localId, x, y, sim.Name, parcel.Name, parcel.OwnerID,
-            parcel.AuthBuyerID, parcel.SalePrice);
+            parcel.AuthBuyerID, parcel.SalePrice, forSale);
 
         return new ParcelSnapshot(
             OwnerId: Guid.Parse(parcel.OwnerID.ToString()),
@@ -458,6 +464,7 @@ public sealed class LibreMetaverseBotSession : IBotSession
             IsGroupOwned: parcel.IsGroupOwned,
             AuthBuyerId: Guid.Parse(parcel.AuthBuyerID.ToString()),
             SalePrice: parcel.SalePrice,
+            ForSale: forSale,
             Name: parcel.Name ?? string.Empty,
             Description: parcel.Desc ?? string.Empty,
             AreaSqm: parcel.Area,

--- a/bot/src/Slpa.Bot/Sl/ParcelSnapshot.cs
+++ b/bot/src/Slpa.Bot/Sl/ParcelSnapshot.cs
@@ -11,6 +11,7 @@ public sealed record ParcelSnapshot(
     bool IsGroupOwned,
     Guid AuthBuyerId,
     long SalePrice,
+    bool ForSale,
     string Name,
     string Description,
     int AreaSqm,

--- a/bot/src/Slpa.Bot/Sl/ParcelSnapshot.cs
+++ b/bot/src/Slpa.Bot/Sl/ParcelSnapshot.cs
@@ -2,8 +2,9 @@ namespace Slpa.Bot.Sl;
 
 /// <summary>
 /// Snapshot of ParcelProperties the bot can observe via
-/// <see cref="IBotSession.ReadParcelAsync"/>. Retained as session
-/// infrastructure for future task types — no current handler consumes it.
+/// <see cref="IBotSession.ReadParcelAsync"/>. Consumed by
+/// <see cref="Slpa.Bot.Tasks.VerifySellToHandler"/> to verify the seller's
+/// "Sell To" configuration; also available to future task types.
 /// </summary>
 public sealed record ParcelSnapshot(
     Guid OwnerId,

--- a/bot/src/Slpa.Bot/Tasks/VerifySellToHandler.cs
+++ b/bot/src/Slpa.Bot/Tasks/VerifySellToHandler.cs
@@ -11,15 +11,17 @@ namespace Slpa.Bot.Tasks;
 /// the expected winner, and POSTs a <see cref="SellToOutcome"/> back to the
 /// backend via <see cref="IBackendClient.ReportTaskResultAsync"/>. The
 /// backend's escrow state machine owns the consequences; the bot only
-/// observes + reports. ForSale flag bit = LibreMetaverse
-/// <c>ParcelFlags.ForSale</c> = 0x00000080.
+/// observes + reports. The for-sale signal is read from the strongly-typed
+/// <c>OpenMetaverse.ParcelFlags.ForSale</c> bit (1&lt;&lt;2) in
+/// <see cref="IBotSession.ReadParcelAsync"/> and surfaced as
+/// <see cref="ParcelSnapshot.ForSale"/> — note this is distinct from
+/// <c>ParcelFlags.ForSaleObjects</c> (1&lt;&lt;7, 0x00000080).
 /// </summary>
 public sealed class VerifySellToHandler
 {
     private readonly IBotSession _session;
     private readonly IBackendClient _backend;
     private readonly ILogger<VerifySellToHandler> _log;
-    private const uint ForSaleFlag = 0x00000080;
 
     public VerifySellToHandler(IBotSession session, IBackendClient backend,
         ILogger<VerifySellToHandler> log)
@@ -65,7 +67,7 @@ public sealed class VerifySellToHandler
                 owner = snap.OwnerId;
                 auth = snap.AuthBuyerId;
                 price = snap.SalePrice;
-                forSale = (snap.Flags & ForSaleFlag) != 0;
+                forSale = snap.ForSale;
                 if (snap.OwnerId == task.ExpectedWinnerUuid.Value)
                     outcome = SellToOutcome.OWNER_ALREADY_WINNER;
                 else if (forSale != true || snap.AuthBuyerId == Guid.Empty)

--- a/bot/tests/Slpa.Bot.Tests/ParcelReaderTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/ParcelReaderTests.cs
@@ -27,7 +27,7 @@ public sealed class ParcelReaderTests
     {
         var expected = new ParcelSnapshot(
             Guid.NewGuid(), Guid.Empty, false, Guid.NewGuid(), 999_999_999,
-            "Test Parcel", "desc", 1024, 117, 0, Guid.Empty, 0);
+            true, "Test Parcel", "desc", 1024, 117, 0, Guid.Empty, 0);
         var session = new FakeBotSession { ReadPolicy = (_, _) => expected };
         var snap = await session.ReadParcelAsync(128, 128, default);
         snap.Should().BeEquivalentTo(expected);

--- a/bot/tests/Slpa.Bot.Tests/TaskLoopTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/TaskLoopTests.cs
@@ -193,6 +193,7 @@ public sealed class TaskLoopTests
             IsGroupOwned: false,
             AuthBuyerId: winner,
             SalePrice: 0,
+            ForSale: true,
             Name: "P",
             Description: "",
             AreaSqm: 1024,

--- a/bot/tests/Slpa.Bot.Tests/VerifySellToHandlerTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/VerifySellToHandlerTests.cs
@@ -13,12 +13,13 @@ namespace Slpa.Bot.Tests;
 /// Spec §5 — VERIFY_SELL_TO handler. Drives the teleport → read-parcel →
 /// classify → report path via the in-test <see cref="FakeBotSession"/>
 /// (TeleportPolicy / ReadPolicy) + a mocked <see cref="IBackendClient"/>;
-/// never touches GridClient. ForSale flag bit = 0x00000080.
+/// never touches GridClient. The for-sale signal is the typed
+/// <c>ParcelSnapshot.ForSale</c> bool (sourced from
+/// <c>OpenMetaverse.ParcelFlags.ForSale</c> in the real session), not the
+/// raw <c>Flags</c> bitfield.
 /// </summary>
 public sealed class VerifySellToHandlerTests
 {
-    private const uint ForSaleFlag = 0x00000080;
-
     private readonly Mock<IBackendClient> _backend = new();
     private readonly FakeBotSession _session = new();
 
@@ -123,6 +124,33 @@ public sealed class VerifySellToHandlerTests
         _captured.ObservedAuthBuyerUuid.Should().Be(winner);
     }
 
+    /// <summary>
+    /// Regression for the prod incident: a correctly group-owned, for-sale,
+    /// L$0, sell-to-winner parcel must classify as SELL_TO_OK. The bot log
+    /// showed owner=&lt;group&gt; authBuyer=&lt;winner&gt; salePrice=0 →
+    /// SELL_TO_NOT_SET because the old code ANDed the raw Flags bitfield with
+    /// 0x00000080 (ParcelFlags.ForSaleObjects, NOT ForSale). The snapshot
+    /// factory deliberately leaves Flags=0 so this would still be
+    /// SELL_TO_NOT_SET under the buggy code, and SELL_TO_OK now that the
+    /// handler reads the typed ParcelSnapshot.ForSale.
+    /// </summary>
+    [Fact]
+    public async Task GroupOwnedForSaleZeroPriceToWinner_ReportsSellToOk_ProdRegression()
+    {
+        var winner = Guid.NewGuid();
+        var group = Guid.NewGuid(); // group owner UUID, distinct from winner
+        _session.ReadPolicy = (_, _) => Snapshot(
+            owner: group, authBuyer: winner, price: 0, forSale: true);
+        var task = BuildVerifySellToTask(winner);
+
+        await NewHandler().HandleAsync(task, CancellationToken.None);
+
+        Reported().Should().Be(SellToOutcome.SELL_TO_OK);
+        _captured!.ObservedForSale.Should().BeTrue();
+        _captured.ObservedSalePrice.Should().Be(0);
+        _captured.ObservedAuthBuyerUuid.Should().Be(winner);
+    }
+
     [Fact]
     public async Task TeleportAccessDenied_ReportsAccessDenied_NoReadParcel()
     {
@@ -169,13 +197,14 @@ public sealed class VerifySellToHandlerTests
         IsGroupOwned: false,
         AuthBuyerId: authBuyer,
         SalePrice: price,
+        ForSale: forSale,
         Name: "P",
         Description: "",
         AreaSqm: 1024,
         MaxPrims: 234,
         Category: 0,
         SnapshotId: Guid.NewGuid(),
-        Flags: forSale ? ForSaleFlag : 0u);
+        Flags: 0u);
 
     private static BotTaskResponse BuildVerifySellToTask(Guid winner) => new(
         Id: 99,


### PR DESCRIPTION
@
Production hotfix for two bugs found right after the escrow-split release.

**B — false SELL_TO_NOT_SET (blocker).** `VerifySellToHandler` bit-tested `0x00000080` for "for sale", but `0x80` (1<<7) is `ParcelFlags.ForSaleObjects`, not `ParcelFlags.ForSale` (1<<2). A correctly-listed parcel (proven in prod: authBuyer==winner, salePrice=0, group-owned, actively for sale) read `forSale=false` → false negative. Fix: compute `ForSale` from the typed `parcel.Flags.HasFlag(OpenMetaverse.ParcelFlags.ForSale)` in `ReadParcelAsync`, expose `ParcelSnapshot.ForSale`, handler uses it. No magic literal anywhere. Regression test mirrors the exact prod scenario (factory sets raw Flags=0 so it fails under the old code).

**C — slow recovery from transient bot errors.** A transient `BOT_ERROR`/`ACCESS_DENIED` (degraded bot SL connection) rescheduled the task on the full 30-min `sellToBotRecurrence`. Fix: only `BOT_ERROR`/`ACCESS_DENIED` reschedule on a new `sell-to-bot-retry-backoff` (PT2M, configurable); `PARCEL_NOT_FOUND`, definitive negatives, and the past-deadline cancel guard are unchanged.

Local gate: bot `dotnet test` 73/0; backend `Bot*`/`EscrowStartupValidatorTest` green; `mvn compile` clean. Combined spec+quality review: ✅.
@