### PR TITLE
fix(review): avatar URLs must use publicId not numeric id + centralize via UUID-typed helper

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java
@@ -28,6 +28,7 @@ import com.slparcelauctions.backend.realty.RealtyGroup;
 import com.slparcelauctions.backend.realty.RealtyGroupRepository;
 import com.slparcelauctions.backend.user.SellerCompletionRateMapper;
 import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserAvatarUrl;
 import com.slparcelauctions.backend.user.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -344,7 +345,7 @@ public class AuctionDtoMapper {
         return new SellerSummary(
                 s.getPublicId(),
                 s.getDisplayName(),
-                s.getPublicId() == null ? null : "/api/v1/users/" + s.getPublicId() + "/avatar/256",
+                UserAvatarUrl.forUserOrNull(s.getPublicId()),
                 s.getAvgSellerRating(),
                 s.getTotalSellerReviews(),
                 completed,
@@ -434,9 +435,7 @@ public class AuctionDtoMapper {
         if (u == null) {
             return null;
         }
-        String avatarUrl = u.getPublicId() == null
-                ? null
-                : "/api/v1/users/" + u.getPublicId() + "/avatar/256";
+        String avatarUrl = UserAvatarUrl.forUserOrNull(u.getPublicId());
         return new ListingAgentDto(u.getPublicId(), u.getDisplayName(), avatarUrl);
     }
 

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/search/AuctionSearchResultMapper.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/search/AuctionSearchResultMapper.java
@@ -14,6 +14,7 @@ import com.slparcelauctions.backend.auction.Auction;
 import com.slparcelauctions.backend.auction.AuctionParcelSnapshot;
 import com.slparcelauctions.backend.parceltag.ParcelTag;
 import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserAvatarUrl;
 
 /**
  * Merges a paginated {@link Auction} result with the per-row tag and photo
@@ -140,6 +141,6 @@ public class AuctionSearchResultMapper {
     }
 
     private String avatarUrl(User u) {
-        return u.getPublicId() == null ? null : "/api/v1/users/" + u.getPublicId() + "/avatar/256";
+        return UserAvatarUrl.forUserOrNull(u.getPublicId());
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/realty/dto/RealtyGroupDtoMapper.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/dto/RealtyGroupDtoMapper.java
@@ -22,6 +22,7 @@ import com.slparcelauctions.backend.realty.permission.RealtyGroupPermission;
 import com.slparcelauctions.backend.realty.rating.GroupRatingService;
 import com.slparcelauctions.backend.realty.rating.dto.GroupRatingDto;
 import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserAvatarUrl;
 import com.slparcelauctions.backend.user.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -262,8 +263,7 @@ public class RealtyGroupDtoMapper {
     }
 
     private static String avatarUrlFor(User u) {
-        if (u == null || u.getPublicId() == null) return null;
-        return "/api/v1/users/" + u.getPublicId() + "/avatar/256";
+        return u == null ? null : UserAvatarUrl.forUserOrNull(u.getPublicId());
     }
 
     private static String logoUrlFor(RealtyGroup g) {

--- a/backend/src/main/java/com/slparcelauctions/backend/review/dto/PendingReviewDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/dto/PendingReviewDto.java
@@ -10,6 +10,7 @@ import com.slparcelauctions.backend.escrow.Escrow;
 import com.slparcelauctions.backend.review.ReviewService;
 import com.slparcelauctions.backend.review.ReviewedRole;
 import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserAvatarUrl;
 
 /**
  * Wire shape for the dashboard's "reviews waiting for you to submit"
@@ -67,14 +68,10 @@ public record PendingReviewDto(
                 photo,
                 counterparty == null ? null : counterparty.getPublicId(),
                 counterparty == null ? null : counterparty.getDisplayName(),
-                counterparty == null ? null : avatarUrl(counterparty.getId()),
+                counterparty == null ? null : UserAvatarUrl.forUserOrNull(counterparty.getPublicId()),
                 e.getCompletedAt(),
                 windowCloses,
                 hoursRemaining,
                 viewerRole);
-    }
-
-    private static String avatarUrl(Long userId) {
-        return userId == null ? null : "/api/v1/users/" + userId + "/avatar/256";
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/review/dto/ReviewDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/dto/ReviewDto.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import com.slparcelauctions.backend.review.Review;
 import com.slparcelauctions.backend.review.ReviewResponse;
 import com.slparcelauctions.backend.review.ReviewedRole;
+import com.slparcelauctions.backend.user.UserAvatarUrl;
 
 /**
  * Wire shape for a single review row. {@code of(...)} is the single
@@ -66,7 +67,7 @@ public record ReviewDto(
                 primaryPhotoUrl,
                 r.getReviewer().getPublicId(),
                 r.getReviewer().getDisplayName(),
-                avatarUrl(r.getReviewer().getId()),
+                UserAvatarUrl.forUserOrNull(r.getReviewer().getPublicId()),
                 r.getReviewee().getPublicId(),
                 r.getReviewedRole(),
                 exposeText ? r.getRating() : null,
@@ -76,9 +77,5 @@ public record ReviewDto(
                 exposeText ? r.getSubmittedAt() : null,
                 r.getRevealedAt(),
                 resp.map(ReviewResponseDto::of).orElse(null));
-    }
-
-    private static String avatarUrl(Long userId) {
-        return userId == null ? null : "/api/v1/users/" + userId + "/avatar/256";
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/user/AvatarService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/AvatarService.java
@@ -84,7 +84,7 @@ public class AvatarService {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(userId));
-        user.setProfilePicUrl("/api/v1/users/" + user.getPublicId() + "/avatar/256");
+        user.setProfilePicUrl(UserAvatarUrl.forUser(user.getPublicId()));
         // Uploading an avatar implicitly completes the post-verify avatar
         // onboarding step. Idempotent — re-uploading is a no-op on the flag.
         if (!Boolean.TRUE.equals(user.getAvatarStepCompleted())) {

--- a/backend/src/main/java/com/slparcelauctions/backend/user/UserAvatarUrl.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/UserAvatarUrl.java
@@ -1,0 +1,64 @@
+package com.slparcelauctions.backend.user;
+
+import java.util.UUID;
+
+/**
+ * Single source of truth for the relative user-avatar URL emitted on every
+ * public/admin DTO. The serving endpoint is
+ * {@code GET /api/v1/users/{publicId}/avatar/{size}} in
+ * {@link UserController}, whose {@code publicId} path variable is a
+ * {@code UUID}.
+ *
+ * <p>History: the BaseEntity-UUID refactor (commit {@code 8f6170d6})
+ * migrated the endpoint to a {@code UUID} path variable, but several DTO
+ * mappers kept hand-rolled {@code "/api/v1/users/" + getId() + "/avatar/256"}
+ * builders feeding the numeric DB {@code id}. Spring then failed to parse
+ * e.g. "42" as a UUID, returned 404, and the {@code <img>} fell back to
+ * alt-text in production (broken reviewer avatars).
+ *
+ * <p>This helper makes that mistake impossible: it takes a {@code UUID},
+ * so handing it a {@code Long}/{@code long} DB id is a compile error.
+ * Every avatar-URL builder routes through here with {@code getPublicId()}.
+ * {@code forUserOrNull} preserves the per-DTO "null publicId → null
+ * avatarUrl" semantics the call sites already had.
+ */
+public final class UserAvatarUrl {
+
+    /** The default avatar size every legacy call site requested. */
+    public static final int DEFAULT_SIZE = 256;
+
+    private UserAvatarUrl() {}
+
+    /**
+     * Relative avatar URL for a known, non-null user {@code publicId} at
+     * {@link #DEFAULT_SIZE}.
+     */
+    public static String forUser(UUID publicId) {
+        return forUser(publicId, DEFAULT_SIZE);
+    }
+
+    /**
+     * Relative avatar URL for a known, non-null user {@code publicId} at
+     * the requested square pixel {@code size}.
+     */
+    public static String forUser(UUID publicId, int size) {
+        return "/api/v1/users/" + publicId + "/avatar/" + size;
+    }
+
+    /**
+     * Null-tolerant variant: returns {@code null} when {@code publicId} is
+     * {@code null} (mirrors the existing per-DTO {@code publicId == null ?
+     * null : ...} guards), otherwise {@link #forUser(UUID)}.
+     */
+    public static String forUserOrNull(UUID publicId) {
+        return publicId == null ? null : forUser(publicId);
+    }
+
+    /**
+     * Null-tolerant variant at an explicit {@code size}: {@code null} when
+     * {@code publicId} is {@code null}, otherwise {@link #forUser(UUID, int)}.
+     */
+    public static String forUserOrNull(UUID publicId, int size) {
+        return publicId == null ? null : forUser(publicId, size);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/review/dto/PendingReviewDtoTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/dto/PendingReviewDtoTest.java
@@ -1,0 +1,95 @@
+package com.slparcelauctions.backend.review.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.escrow.Escrow;
+import com.slparcelauctions.backend.escrow.EscrowState;
+import com.slparcelauctions.backend.user.User;
+
+/**
+ * Regression for the same avatar-URL class of bug on the dashboard's
+ * "reviews waiting for you" card: {@link PendingReviewDto#of} built the
+ * counterparty avatar URL from the numeric DB {@code id} instead of the
+ * UUID {@code publicId}, 404'ing the {@code GET /api/v1/users/{publicId}/
+ * avatar/{size}} endpoint.
+ */
+class PendingReviewDtoTest {
+
+    private User user(long id, UUID publicId, String displayName) {
+        return User.builder()
+                .id(id)
+                .publicId(publicId)
+                .email(displayName + "@example.com")
+                .username(displayName.toLowerCase())
+                .passwordHash("x")
+                .displayName(displayName)
+                .build();
+    }
+
+    @Test
+    void of_counterpartyAvatarUrl_usesPublicIdNotNumericId() {
+        UUID counterpartyPublicId = UUID.randomUUID();
+        User seller = user(10L, UUID.randomUUID(), "Sally");
+        User counterparty = user(99L, counterpartyPublicId, "Wally");
+        OffsetDateTime now = OffsetDateTime.of(2026, 5, 1, 10, 0, 0, 0, ZoneOffset.UTC);
+
+        Auction auction = Auction.builder()
+                .title("Lakefront")
+                .seller(seller)
+                .slParcelUuid(UUID.randomUUID())
+                .photos(List.of())
+                .build();
+        Escrow escrow = Escrow.builder()
+                .auction(auction)
+                .state(EscrowState.COMPLETED)
+                .completedAt(now.minusDays(1))
+                .finalBidAmount(1_000L)
+                .commissionAmt(50L)
+                .payoutAmt(950L)
+                .build();
+
+        PendingReviewDto dto = PendingReviewDto.of(escrow, seller, counterparty, now);
+
+        assertThat(dto.counterpartyAvatarUrl())
+                .isEqualTo("/api/v1/users/" + counterpartyPublicId + "/avatar/256");
+        assertThat(dto.counterpartyAvatarUrl()).doesNotContain("/users/99/");
+
+        String url = dto.counterpartyAvatarUrl();
+        String idSegment = url.substring(
+                "/api/v1/users/".length(), url.indexOf("/avatar/"));
+        assertThat(UUID.fromString(idSegment)).isEqualTo(counterpartyPublicId);
+    }
+
+    @Test
+    void of_nullCounterparty_yieldsNullAvatarUrl() {
+        User seller = user(10L, UUID.randomUUID(), "Sally");
+        OffsetDateTime now = OffsetDateTime.of(2026, 5, 1, 10, 0, 0, 0, ZoneOffset.UTC);
+
+        Auction auction = Auction.builder()
+                .title("Lakefront")
+                .seller(seller)
+                .slParcelUuid(UUID.randomUUID())
+                .photos(List.of())
+                .build();
+        Escrow escrow = Escrow.builder()
+                .auction(auction)
+                .state(EscrowState.COMPLETED)
+                .completedAt(now.minusDays(1))
+                .finalBidAmount(1_000L)
+                .commissionAmt(50L)
+                .payoutAmt(950L)
+                .build();
+
+        PendingReviewDto dto = PendingReviewDto.of(escrow, seller, null, now);
+
+        assertThat(dto.counterpartyAvatarUrl()).isNull();
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/review/dto/ReviewDtoTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/dto/ReviewDtoTest.java
@@ -1,0 +1,68 @@
+package com.slparcelauctions.backend.review.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.review.Review;
+import com.slparcelauctions.backend.review.ReviewedRole;
+import com.slparcelauctions.backend.user.User;
+
+/**
+ * Regression for the prod bug: {@link ReviewDto#of} built the reviewer
+ * avatar URL from the numeric DB {@code id}, but
+ * {@code GET /api/v1/users/{publicId}/avatar/{size}} parses the path
+ * variable as a {@code UUID} — so {@code /api/v1/users/42/avatar/256}
+ * 404'd and the reviewer {@code <img>} fell back to alt-text.
+ */
+class ReviewDtoTest {
+
+    private User user(long id, UUID publicId, String displayName) {
+        return User.builder()
+                .id(id)
+                .publicId(publicId)
+                .email(displayName + "@example.com")
+                .username(displayName.toLowerCase())
+                .passwordHash("x")
+                .displayName(displayName)
+                .build();
+    }
+
+    @Test
+    void of_reviewerAvatarUrl_usesPublicIdNotNumericId() {
+        UUID reviewerPublicId = UUID.randomUUID();
+        User reviewer = user(42L, reviewerPublicId, "Reviewer");
+        User reviewee = user(7L, UUID.randomUUID(), "Reviewee");
+        Auction auction = Auction.builder()
+                .title("Lakefront")
+                .seller(reviewee)
+                .slParcelUuid(UUID.randomUUID())
+                .build();
+        Review r = Review.builder()
+                .auction(auction)
+                .reviewer(reviewer)
+                .reviewee(reviewee)
+                .reviewedRole(ReviewedRole.SELLER)
+                .rating(5)
+                .visible(true)
+                .build();
+
+        ReviewDto dto = ReviewDto.of(r, null, Optional.empty(), null);
+
+        // The exact prod-bug assertion: the URL must contain the UUID
+        // publicId and must NOT contain the numeric DB id "42".
+        assertThat(dto.reviewerAvatarUrl())
+                .isEqualTo("/api/v1/users/" + reviewerPublicId + "/avatar/256");
+        assertThat(dto.reviewerAvatarUrl()).doesNotContain("/users/42/");
+
+        // The id path segment must parse as a UUID (and equal the publicId).
+        String url = dto.reviewerAvatarUrl();
+        String idSegment = url.substring(
+                "/api/v1/users/".length(), url.indexOf("/avatar/"));
+        assertThat(UUID.fromString(idSegment)).isEqualTo(reviewerPublicId);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/user/UserAvatarUrlGuardTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/user/UserAvatarUrlGuardTest.java
@@ -1,0 +1,135 @@
+package com.slparcelauctions.backend.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionParcelSnapshot;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.VerificationTier;
+import com.slparcelauctions.backend.auction.search.AuctionSearchResultDto;
+import com.slparcelauctions.backend.auction.search.AuctionSearchResultMapper;
+
+/**
+ * Keeps the "numeric DB id in an avatar URL" bug class dead.
+ *
+ * <p>The strongest guard is structural: {@link UserAvatarUrl} takes a
+ * {@code UUID}, so handing it a {@code Long} DB id is a <em>compile</em>
+ * error and no new caller can reintroduce the bug through the helper.
+ * This test adds two runtime guards on top:
+ *
+ * <ol>
+ *   <li>a behavioural end-to-end check that a fixed user-facing mapper
+ *       ({@link AuctionSearchResultMapper}) emits the UUID {@code publicId}
+ *       and never the numeric {@code getId()}; and</li>
+ *   <li>a source-level check that no DTO mapper hand-rolls the
+ *       {@code "/api/v1/users/" + ... + "/avatar/"} path again instead of
+ *       routing through {@link UserAvatarUrl} — the helper must stay the
+ *       single producer.</li>
+ * </ol>
+ */
+class UserAvatarUrlGuardTest {
+
+    @Test
+    void fixedSearchMapper_emitsPublicIdNotNumericId() {
+        long numericId = 42L;
+        UUID sellerPublicId = UUID.randomUUID();
+        UUID parcelUuid = UUID.randomUUID();
+
+        User seller = User.builder()
+                .id(numericId)
+                .publicId(sellerPublicId)
+                .email("seller@example.com")
+                .username("seller")
+                .passwordHash("x")
+                .displayName("Sally")
+                .avgSellerRating(new BigDecimal("4.5"))
+                .totalSellerReviews(5)
+                .build();
+
+        Auction a = Auction.builder()
+                .id(7L)
+                .title("Test")
+                .status(AuctionStatus.ACTIVE)
+                .slParcelUuid(parcelUuid)
+                .seller(seller)
+                .startingBid(500L)
+                .currentBid(600L)
+                .bidCount(1)
+                .endsAt(OffsetDateTime.now().plusDays(1))
+                .snipeProtect(false)
+                .verificationTier(VerificationTier.BOT)
+                .durationHours(168)
+                .build();
+        a.setParcelSnapshot(AuctionParcelSnapshot.builder()
+                .slParcelUuid(parcelUuid)
+                .regionName("Coniston")
+                .regionMaturityRating("MODERATE")
+                .areaSqm(1024)
+                .positionX(80.0).positionY(104.0).positionZ(89.0)
+                .build());
+
+        AuctionSearchResultDto dto =
+                new AuctionSearchResultMapper().toDto(a, Set.of(), null, null);
+
+        String avatarUrl = dto.seller().avatarUrl();
+        assertThat(avatarUrl)
+                .isEqualTo("/api/v1/users/" + sellerPublicId + "/avatar/256");
+        assertThat(avatarUrl).doesNotContain("/users/" + numericId + "/");
+
+        String idSegment = avatarUrl.substring(
+                "/api/v1/users/".length(), avatarUrl.indexOf("/avatar/"));
+        assertThat(UUID.fromString(idSegment)).isEqualTo(sellerPublicId);
+    }
+
+    @Test
+    void noDtoMapperHandRollsTheAvatarPath() throws IOException {
+        Path mainRoot = Path.of("src/main/java/com/slparcelauctions/backend");
+        assertThat(Files.isDirectory(mainRoot))
+                .as("backend main source root must exist for the guard scan")
+                .isTrue();
+
+        // The bug shape is specifically a hand-rolled avatar path:
+        //   "/api/v1/users/" + <id-expr> + "/avatar/..."
+        // (DOTALL so the concatenation may wrap across lines). The only
+        // legal occurrence is inside UserAvatarUrl itself. A bare
+        // "/api/v1/users/" + publicId for a *different* endpoint (e.g. the
+        // Location header in UserController) is intentionally NOT matched.
+        // No ';' between the two literals keeps the match inside a single
+        // statement, so a later unrelated "/avatar/" literal elsewhere in
+        // the same file can't be stitched onto an earlier users-path.
+        Pattern handRolledAvatar = Pattern.compile(
+                "\"/api/v1/users/\"\\s*\\+[^;]*?\"/avatar/", Pattern.DOTALL);
+
+        try (Stream<Path> files = Files.walk(mainRoot)) {
+            List<String> offenders = files
+                    .filter(p -> p.toString().endsWith(".java"))
+                    .filter(p -> !p.getFileName().toString().equals("UserAvatarUrl.java"))
+                    .filter(p -> {
+                        try {
+                            return handRolledAvatar.matcher(Files.readString(p)).find();
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .map(Path::toString)
+                    .toList();
+
+            assertThat(offenders)
+                    .as("avatar URLs must be built via UserAvatarUrl, not hand-rolled")
+                    .isEmpty();
+        }
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/user/UserAvatarUrlTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/user/UserAvatarUrlTest.java
@@ -1,0 +1,70 @@
+package com.slparcelauctions.backend.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Locks the single source of truth for user-avatar URLs. The endpoint is
+ * {@code GET /api/v1/users/{publicId}/avatar/{size}} with a {@code UUID}
+ * path variable — a numeric DB id produces a 404 (Spring cannot parse
+ * "42" as a UUID) and a broken {@code <img>}. The helper's {@code UUID}
+ * parameter makes passing a {@code Long} a compile error; these tests pin
+ * the exact string shape and null semantics.
+ */
+class UserAvatarUrlTest {
+
+    @Test
+    void forUser_buildsPublicIdAvatarPath() {
+        UUID publicId = UUID.fromString("11111111-2222-3333-4444-555555555555");
+
+        assertThat(UserAvatarUrl.forUser(publicId, 256))
+                .isEqualTo("/api/v1/users/11111111-2222-3333-4444-555555555555/avatar/256");
+    }
+
+    @Test
+    void forUser_honoursRequestedSize() {
+        UUID publicId = UUID.randomUUID();
+
+        assertThat(UserAvatarUrl.forUser(publicId, 512))
+                .isEqualTo("/api/v1/users/" + publicId + "/avatar/512");
+    }
+
+    @Test
+    void forUser_defaultSizeOverloadUses256() {
+        UUID publicId = UUID.randomUUID();
+
+        assertThat(UserAvatarUrl.forUser(publicId))
+                .isEqualTo("/api/v1/users/" + publicId + "/avatar/256");
+    }
+
+    @Test
+    void forUserOrNull_returnsNullForNullPublicId() {
+        assertThat(UserAvatarUrl.forUserOrNull(null)).isNull();
+        assertThat(UserAvatarUrl.forUserOrNull(null, 256)).isNull();
+    }
+
+    @Test
+    void forUserOrNull_buildsUrlForNonNullPublicId() {
+        UUID publicId = UUID.randomUUID();
+
+        assertThat(UserAvatarUrl.forUserOrNull(publicId))
+                .isEqualTo("/api/v1/users/" + publicId + "/avatar/256");
+        assertThat(UserAvatarUrl.forUserOrNull(publicId, 128))
+                .isEqualTo("/api/v1/users/" + publicId + "/avatar/128");
+    }
+
+    @Test
+    void producedPathSegmentParsesAsUuidNotNumericId() {
+        UUID publicId = UUID.randomUUID();
+
+        String url = UserAvatarUrl.forUser(publicId, 256);
+        // /api/v1/users/<segment>/avatar/256  -> segment must be a UUID.
+        String idSegment = url.substring(
+                "/api/v1/users/".length(), url.indexOf("/avatar/"));
+
+        assertThat(UUID.fromString(idSegment)).isEqualTo(publicId);
+    }
+}

--- a/docs/implementation/DEFERRED_WORK.md
+++ b/docs/implementation/DEFERRED_WORK.md
@@ -340,6 +340,13 @@ Spec: `docs/superpowers/specs/2026-05-12-realty-groups-final-cleanup-design.md` 
 - **When:** Indefinite — add an external-link slot to the renderer later if a direct in-app maps link is desired.
 - **Notes:** Backend already emits `parcelMapUrl` / `parcelViewerUrl` in the ESCROW notification data blob; only the in-app render slot is missing.
 
+### ▶ Resolution: `WITHDRAW_GROUP` / `bot_tasks_task_type_check` constraint concern — SAFE, no action
+
+- **From:** Flagged concern that a `WITHDRAW_GROUP` task type could violate the `bot_tasks_task_type_check` CHECK constraint (the enum-widening footgun, FOOTGUNS §F around `BotTaskTypeCheckConstraintInitializer`).
+- **Resolution:** **RESOLVED — SAFE, no action required.** Group-wallet withdrawals flow via `terminal_commands` (`TerminalCommandAction.WITHDRAW_GROUP`), never `bot_tasks`. The Java `BotTaskType` enum never had a `WITHDRAW_GROUP` value, so the `bot_tasks_task_type_check` CHECK constraint was never at risk; 0 prod constraint violations. The `.NET` bot `TaskLoop` `WITHDRAW_GROUP` dispatch is a .NET-only artifact (it consumes `terminal_commands`, not `bot_tasks`). No migration, code, or constraint change needed.
+- **When:** Done (2026-05-18) — closed as no-op.
+- **Notes:** Append-only resolution row, per the ledger's immutability rule. Cross-ref: autonomy decisions log `docs/superpowers/decisions/2026-05-17-escrow-split-autonomy-notes.md`.
+
 ---
 
 ## Removal Criteria

--- a/docs/superpowers/decisions/2026-05-17-escrow-split-autonomy-notes.md
+++ b/docs/superpowers/decisions/2026-05-17-escrow-split-autonomy-notes.md
@@ -100,6 +100,18 @@ differently — read those first.
 - **11. Postman mirroring status.** See the "Postman" section below —
   recorded here so the autonomy log is self-contained.
 
+- **12. `WITHDRAW_GROUP` / `bot_tasks_task_type_check` concern —
+  RESOLVED, SAFE, no action (2026-05-18).** The flagged worry that a
+  `WITHDRAW_GROUP` task type could trip the `bot_tasks_task_type_check`
+  CHECK constraint (enum-widening footgun) is a non-issue: group-wallet
+  withdrawals flow via `terminal_commands`
+  (`TerminalCommandAction.WITHDRAW_GROUP`), never `bot_tasks`; the Java
+  `BotTaskType` enum never had a `WITHDRAW_GROUP` value, so the
+  constraint was never at risk (0 prod constraint violations). The `.NET`
+  bot `TaskLoop` `WITHDRAW_GROUP` dispatch is a .NET-only artifact
+  consuming `terminal_commands`. No migration/code/constraint change.
+  Also logged append-only in `DEFERRED_WORK.md`.
+
 ## Postman mirroring status
 
 The 7 new/changed endpoints to mirror into the `SLPA` collection


### PR DESCRIPTION
Durable fix for broken user avatars (the "SLPa..." placeholder where avatars should be, e.g. escrow Reviews section).

Root cause: ReviewDto built the avatar URL from the numeric DB id, but the endpoint is /api/v1/users/{publicId}/avatar/{size} and parses the segment as a UUID. "42" fails UUID parsing -> 404 -> broken img -> alt fallback. A spot missed in the BaseEntity-UUID refactor; AuctionDtoMapper was updated, ReviewDto was not.

Swept the whole class (user chose durable):
- Found a second offender of the exact class: PendingReviewDto (dashboard "pending reviews" card avatars also broken).
- Introduced UserAvatarUrl, a single UUID-typed helper (forUser/forUserOrNull). Routed every avatar-URL builder (ReviewDto, PendingReviewDto, AuctionDtoMapper x2, AuctionSearchResultMapper, RealtyGroupDtoMapper, AvatarService) through it; deleted the old private avatarUrl(Long) helpers. The UUID parameter makes passing a Long a compile error - the class cannot recur.
- Tests: helper unit test, per-DTO regression tests reproducing the prod bug (URL carries publicId, never the numeric id), and a guard test that scans src/main and fails if anything hand-rolls the avatar path outside the helper.
- Doc housekeeping (append-only): recorded the previously-flagged WITHDRAW_GROUP / bot_tasks_task_type_check concern as RESOLVED-SAFE (group withdrawals flow via terminal_commands, never bot_tasks).

Local gate: 183 tests green (33 targeted + 150 broader Dto/Mapper/Review), compile clean. Combined spec+quality review approved. Backend change - triggers deploy-backend (~5min ECS) plus an Amplify rebuild.

Separate follow-up flagged (different bug class, NOT in this PR): review-card photo thumbnail URLs point at a nonexistent /api/v1/auctions/{id}/photos/{id}/bytes endpoint instead of /api/v1/photos/{publicId}.
