### PR TITLE
release: review thumbnail 404 fix (centralized PhotoUrl)

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationStatusService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationStatusService.java
@@ -1,7 +1,5 @@
 package com.slparcelauctions.backend.auction;
 
-import java.util.Comparator;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -105,11 +103,8 @@ public class CancellationStatusService {
     private String resolvePrimaryPhotoUrl(Auction auction) {
         // Photos are eagerly hydrated by the {@code @EntityGraph} on
         // {@link CancellationLogRepository#findBySellerId} (one LEFT JOIN per
-        // page, not per row), so we read straight off the entity collection
-        // and project to the flat photo URL served by {@link PhotoController}.
-        return auction.getPhotos().stream()
-                .min(Comparator.comparing(AuctionPhoto::getSortOrder))
-                .map(p -> "/api/v1/photos/" + p.getPublicId())
-                .orElse(null);
+        // page, not per row), so we read straight off the entity collection.
+        // Single producer of the flat photo URL lives in {@link PhotoUrl}.
+        return PhotoUrl.primaryForAuction(auction);
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/PhotoUrl.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/PhotoUrl.java
@@ -1,0 +1,65 @@
+package com.slparcelauctions.backend.auction;
+
+import java.util.Comparator;
+import java.util.UUID;
+
+/**
+ * Single source of truth for the relative photo-byte URL emitted on every
+ * public/admin DTO. The serving endpoint is the flat
+ * {@code GET /api/v1/photos/{publicId}} in {@link PhotoController}, whose
+ * {@code publicId} path variable is a {@code UUID}.
+ *
+ * <p>History (mirrors the {@code UserAvatarUrl} fix): two review-side
+ * builders ({@code PendingReviewDto.of} and
+ * {@code ReviewService.resolvePrimaryPhotoUrl}) hand-rolled
+ * {@code "/api/v1/auctions/" + auction.getId() + "/photos/" + photo.getId()
+ * + "/bytes"} — a route that <em>does not exist</em> (only
+ * POST/DELETE/PATCH live under {@code /api/v1/auctions/{id}/photos}) and
+ * fed numeric DB ids besides. Every review thumbnail (dashboard
+ * pending-reviews card, auction-detail review list, profile Reviews tab)
+ * 404'd in production.
+ *
+ * <p>This helper makes that mistake impossible: it takes a {@code UUID},
+ * so handing it a {@code Long}/{@code long} DB id is a compile error.
+ * Every photo-URL builder routes through here with {@code getPublicId()}.
+ * {@link #primaryForAuction(Auction)} centralises the previously-triplicated
+ * "first photo by sortOrder, else null" projection so there is exactly one
+ * producer of an auction's primary-photo URL.
+ */
+public final class PhotoUrl {
+
+    private PhotoUrl() {}
+
+    /**
+     * Relative photo-byte URL for a known, non-null photo {@code publicId}.
+     */
+    public static String forPhoto(UUID publicId) {
+        return "/api/v1/photos/" + publicId;
+    }
+
+    /**
+     * Null-tolerant variant: {@code null} when {@code publicId} is
+     * {@code null}, otherwise {@link #forPhoto(UUID)}. Used by the
+     * primary-photo paths (no photos → {@code null} URL) and by the
+     * suggest repository, which projects a nullable {@code public_id}
+     * straight off a {@code LEFT JOIN}.
+     */
+    public static String forPhotoOrNull(UUID publicId) {
+        return publicId == null ? null : forPhoto(publicId);
+    }
+
+    /**
+     * The auction's primary-photo URL: first {@link AuctionPhoto} by
+     * {@code sortOrder}, mapped to {@link #forPhoto(UUID)} on its
+     * {@code publicId}; {@code null} when the auction has no photos.
+     * Single producer for the dashboard pending-reviews card, the
+     * auction-detail review list, the profile Reviews tab, and the
+     * cancellation-history list.
+     */
+    public static String primaryForAuction(Auction auction) {
+        return auction.getPhotos().stream()
+                .min(Comparator.comparing(AuctionPhoto::getSortOrder))
+                .map(p -> forPhoto(p.getPublicId()))
+                .orElse(null);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/dto/AuctionPhotoResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/dto/AuctionPhotoResponse.java
@@ -4,6 +4,7 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 
 import com.slparcelauctions.backend.auction.AuctionPhoto;
+import com.slparcelauctions.backend.auction.PhotoUrl;
 
 public record AuctionPhotoResponse(
         UUID publicId,
@@ -14,7 +15,7 @@ public record AuctionPhotoResponse(
         OffsetDateTime uploadedAt) {
 
     public static AuctionPhotoResponse from(AuctionPhoto p) {
-        String url = "/api/v1/photos/" + p.getPublicId();
+        String url = PhotoUrl.forPhoto(p.getPublicId());
         return new AuctionPhotoResponse(p.getPublicId(), url, p.getContentType(),
                 p.getSizeBytes(), p.getSortOrder(), p.getUploadedAt());
     }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/search/suggest/SearchSuggestRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/search/suggest/SearchSuggestRepository.java
@@ -6,6 +6,8 @@ import java.util.UUID;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
+import com.slparcelauctions.backend.auction.PhotoUrl;
+
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -105,6 +107,10 @@ public class SearchSuggestRepository {
     }
 
     private static String photoUrl(String publicId) {
-        return publicId == null ? null : "/api/v1/photos/" + publicId;
+        // The LEFT JOIN projects a nullable public_id (UUID text). Parse
+        // back to UUID so the canonical URL is produced by the single
+        // {@link PhotoUrl} producer rather than hand-rolled here.
+        return publicId == null ? null
+                : PhotoUrl.forPhotoOrNull(UUID.fromString(publicId));
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/review/ReviewService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/ReviewService.java
@@ -3,7 +3,6 @@ package com.slparcelauctions.backend.review;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,8 +18,8 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import com.slparcelauctions.backend.auction.Auction;
-import com.slparcelauctions.backend.auction.AuctionPhoto;
 import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.PhotoUrl;
 import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
 import com.slparcelauctions.backend.escrow.Escrow;
 import com.slparcelauctions.backend.escrow.EscrowRepository;
@@ -449,17 +448,15 @@ public class ReviewService {
     }
 
     /**
-     * Mirrors the listing-detail primary-photo fallback: first photo by
-     * {@code sortOrder}, else the parcel's {@code snapshotUrl}. Returned
-     * URL is the public {@code /api/v1/auctions/{id}/photos/{photoId}/bytes}
-     * proxy path so renderers do not need to know S3 object keys.
+     * The auction's primary-photo URL (first photo by {@code sortOrder},
+     * else {@code null} when there are no photos). Delegates to
+     * {@link PhotoUrl#primaryForAuction(Auction)} so the canonical flat
+     * {@code GET /api/v1/photos/{publicId}} path is produced in exactly one
+     * place — see {@link PhotoUrl} for the history of the
+     * nonexistent-route / numeric-id bug this method used to carry.
      */
     private String resolvePrimaryPhotoUrl(Auction auction) {
-        return auction.getPhotos().stream()
-                .sorted(Comparator.comparing(AuctionPhoto::getSortOrder))
-                .findFirst()
-                .map(p -> "/api/v1/auctions/" + auction.getId() + "/photos/" + p.getId() + "/bytes")
-                .orElse(null);
+        return PhotoUrl.primaryForAuction(auction);
     }
 
     /**

--- a/backend/src/main/java/com/slparcelauctions/backend/review/dto/PendingReviewDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/review/dto/PendingReviewDto.java
@@ -2,10 +2,9 @@ package com.slparcelauctions.backend.review.dto;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.util.Comparator;
 import java.util.UUID;
 
-import com.slparcelauctions.backend.auction.AuctionPhoto;
+import com.slparcelauctions.backend.auction.PhotoUrl;
 import com.slparcelauctions.backend.escrow.Escrow;
 import com.slparcelauctions.backend.review.ReviewService;
 import com.slparcelauctions.backend.review.ReviewedRole;
@@ -55,12 +54,7 @@ public record PendingReviewDto(
 
         ReviewedRole viewerRole = viewerIsSeller ? ReviewedRole.SELLER : ReviewedRole.BUYER;
 
-        String photo = e.getAuction().getPhotos().stream()
-                .sorted(Comparator.comparing(AuctionPhoto::getSortOrder))
-                .findFirst()
-                .map(p -> "/api/v1/auctions/" + e.getAuction().getId()
-                        + "/photos/" + p.getId() + "/bytes")
-                .orElse(null);
+        String photo = PhotoUrl.primaryForAuction(e.getAuction());
 
         return new PendingReviewDto(
                 e.getAuction().getPublicId(),

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/PhotoUrlGuardTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/PhotoUrlGuardTest.java
@@ -1,0 +1,101 @@
+package com.slparcelauctions.backend.auction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Keeps the "review thumbnail points at a nonexistent route / numeric DB
+ * id" bug class dead.
+ *
+ * <p>The strongest guard is structural: {@link PhotoUrl} takes a
+ * {@code UUID}, so handing it a {@code Long} DB id is a <em>compile</em>
+ * error and no caller can reintroduce the numeric-id bug through the
+ * helper. This test adds source-level guards so a future caller cannot
+ * re-introduce a hand-rolled photo URL <em>around</em> the helper:
+ *
+ * <ol>
+ *   <li>nobody hand-rolls the legacy-broken
+ *       {@code "/api/v1/auctions/" + ... + "/photos/" + ... + "/bytes"}
+ *       shape (a route that never existed); and</li>
+ *   <li>nobody hand-rolls a {@code "/api/v1/photos/" + ...} Java
+ *       concatenation outside {@link PhotoUrl} — the helper must stay the
+ *       single Java producer.</li>
+ * </ol>
+ *
+ * <p>The native-SQL projection in {@code AuctionPhotoBatchRepositoryImpl}
+ * ({@code '/api/v1/photos/' || public_id}) is intentionally NOT matched:
+ * it is a SQL {@code ||} concat (not a Java {@code +} expression), it
+ * already emits the UUID {@code public_id}, and a Java helper cannot run
+ * inside a SQL string. The regexes bind to the Java {@code "..." +}
+ * shape so that site is correctly out of scope.
+ */
+class PhotoUrlGuardTest {
+
+    private static final Path MAIN_ROOT =
+            Path.of("src/main/java/com/slparcelauctions/backend");
+
+    @Test
+    void noFileHandRollsTheLegacyBrokenAuctionPhotosBytesPath() throws IOException {
+        assertThat(Files.isDirectory(MAIN_ROOT))
+                .as("backend main source root must exist for the guard scan")
+                .isTrue();
+
+        // The legacy bug shape, exactly:
+        //   "/api/v1/auctions/" + <expr> + "/photos/" + <expr> + "/bytes"
+        // DOTALL so the concatenation may wrap across lines. No ';' between
+        // the literals keeps the match inside a single statement so an
+        // unrelated later literal can't be stitched onto an earlier one.
+        Pattern legacyBroken = Pattern.compile(
+                "\"/api/v1/auctions/\"\\s*\\+[^;]*?\"/bytes\"", Pattern.DOTALL);
+
+        assertThat(offenders(legacyBroken, "PhotoUrl.java"))
+                .as("the /api/v1/auctions/{id}/photos/{id}/bytes route does "
+                        + "not exist — build photo URLs via PhotoUrl")
+                .isEmpty();
+    }
+
+    @Test
+    void noFileHandRollsTheFlatPhotosPathOutsidePhotoUrl() throws IOException {
+        assertThat(Files.isDirectory(MAIN_ROOT)).isTrue();
+
+        // A hand-rolled Java concatenation of the flat photo path:
+        //   "/api/v1/photos/" + <expr>
+        // The ONLY legal occurrence is inside PhotoUrl itself. The SQL
+        // projection uses '||' not '+' (and single quotes), so it does not
+        // match. PhotoController's @GetMapping("/{publicId}") is a mapping
+        // annotation, not a "/api/v1/photos/" + concat, so it does not
+        // match either — only PhotoUrl.java is excluded.
+        Pattern handRolledFlat = Pattern.compile(
+                "\"/api/v1/photos/\"\\s*\\+", Pattern.DOTALL);
+
+        assertThat(offenders(handRolledFlat, "PhotoUrl.java"))
+                .as("photo URLs must be built via PhotoUrl, not hand-rolled")
+                .isEmpty();
+    }
+
+    private List<String> offenders(Pattern pattern, String excludedFileName)
+            throws IOException {
+        try (Stream<Path> files = Files.walk(MAIN_ROOT)) {
+            return files
+                    .filter(p -> p.toString().endsWith(".java"))
+                    .filter(p -> !p.getFileName().toString().equals(excludedFileName))
+                    .filter(p -> {
+                        try {
+                            return pattern.matcher(Files.readString(p)).find();
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .map(Path::toString)
+                    .toList();
+        }
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/PhotoUrlTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/PhotoUrlTest.java
@@ -1,0 +1,83 @@
+package com.slparcelauctions.backend.auction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Locks the single source of truth for photo-byte URLs. The serving
+ * endpoint is {@code GET /api/v1/photos/{publicId}} in
+ * {@link PhotoController}, whose path variable is a {@code UUID} — a
+ * numeric DB id produces a 404 (Spring cannot parse "42" as a UUID) and a
+ * broken {@code <img>}. The helper's {@code UUID} parameter makes passing
+ * a {@code Long} a compile error; these tests pin the exact string shape,
+ * the primary-photo selection, and the null semantics.
+ */
+class PhotoUrlTest {
+
+    @Test
+    void forPhoto_buildsFlatPhotoPath() {
+        UUID publicId = UUID.fromString("11111111-2222-3333-4444-555555555555");
+
+        assertThat(PhotoUrl.forPhoto(publicId))
+                .isEqualTo("/api/v1/photos/11111111-2222-3333-4444-555555555555");
+    }
+
+    @Test
+    void forPhoto_producedSegmentParsesAsUuidNotNumericId() {
+        UUID publicId = UUID.randomUUID();
+
+        String url = PhotoUrl.forPhoto(publicId);
+        // /api/v1/photos/<segment> -> segment must be a UUID.
+        String idSegment = url.substring("/api/v1/photos/".length());
+
+        assertThat(UUID.fromString(idSegment)).isEqualTo(publicId);
+        assertThat(url).doesNotContain("/auctions/");
+        assertThat(url).doesNotContain("/bytes");
+    }
+
+    @Test
+    void forPhotoOrNull_returnsNullForNullPublicId() {
+        assertThat(PhotoUrl.forPhotoOrNull(null)).isNull();
+    }
+
+    @Test
+    void forPhotoOrNull_buildsUrlForNonNullPublicId() {
+        UUID publicId = UUID.randomUUID();
+
+        assertThat(PhotoUrl.forPhotoOrNull(publicId))
+                .isEqualTo("/api/v1/photos/" + publicId);
+    }
+
+    @Test
+    void primaryForAuction_returnsFirstPhotoBySortOrder() {
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+        AuctionPhoto p2 = AuctionPhoto.builder().publicId(second).sortOrder(2).build();
+        AuctionPhoto p0 = AuctionPhoto.builder().publicId(first).sortOrder(0).build();
+
+        Auction auction = Auction.builder()
+                .title("Lakefront")
+                .slParcelUuid(UUID.randomUUID())
+                // Intentionally out of order — helper must sort by sortOrder.
+                .photos(List.of(p2, p0))
+                .build();
+
+        assertThat(PhotoUrl.primaryForAuction(auction))
+                .isEqualTo("/api/v1/photos/" + first);
+    }
+
+    @Test
+    void primaryForAuction_emptyPhotos_returnsNull() {
+        Auction auction = Auction.builder()
+                .title("Lakefront")
+                .slParcelUuid(UUID.randomUUID())
+                .photos(List.of())
+                .build();
+
+        assertThat(PhotoUrl.primaryForAuction(auction)).isNull();
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServicePhotoUrlTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/ReviewServicePhotoUrlTest.java
@@ -1,0 +1,180 @@
+package com.slparcelauctions.backend.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionPhoto;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.escrow.Escrow;
+import com.slparcelauctions.backend.escrow.EscrowRepository;
+import com.slparcelauctions.backend.escrow.EscrowState;
+import com.slparcelauctions.backend.notification.NotificationPublisher;
+import com.slparcelauctions.backend.review.broadcast.ReviewBroadcastPublisher;
+import com.slparcelauctions.backend.review.dto.AuctionReviewsResponse;
+import com.slparcelauctions.backend.review.dto.ReviewDto;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Regression for the prod bug: {@link ReviewService#resolvePrimaryPhotoUrl}
+ * built the review-list thumbnail as
+ * {@code "/api/v1/auctions/" + auction.getId() + "/photos/" + photo.getId()
+ * + "/bytes"} — a route that does not exist (only POST/DELETE/PATCH live
+ * under {@code /api/v1/auctions/{id}/photos}) and fed numeric DB ids. The
+ * auction-detail review list and the profile Reviews tab 404'd. The fix
+ * routes through {@code PhotoUrl} so every review thumbnail is the canonical
+ * {@code /api/v1/photos/{publicId}}.
+ */
+@ExtendWith(MockitoExtension.class)
+class ReviewServicePhotoUrlTest {
+
+    private static final Instant FIXED_NOW = Instant.parse("2026-05-01T10:00:00Z");
+    private static final OffsetDateTime NOW =
+            OffsetDateTime.ofInstant(FIXED_NOW, ZoneOffset.UTC);
+
+    @Mock ReviewRepository reviewRepo;
+    @Mock ReviewResponseRepository responseRepo;
+    @Mock ReviewFlagRepository flagRepo;
+    @Mock AuctionRepository auctionRepo;
+    @Mock EscrowRepository escrowRepo;
+    @Mock UserRepository userRepo;
+    @Mock ReviewBroadcastPublisher broadcastPublisher;
+    @Mock NotificationPublisher notificationPublisher;
+    @Mock ApplicationEventPublisher eventPublisher;
+
+    ReviewService service;
+
+    User seller;
+    User winner;
+    Auction auction;
+    Escrow escrow;
+    AuctionPhoto photo;
+
+    private static final long AUCTION_NUMERIC_ID = 555L;
+    private static final long PHOTO_NUMERIC_ID = 4242L;
+    private final UUID photoPublicId = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+        service = new ReviewService(reviewRepo, responseRepo, flagRepo, auctionRepo,
+                escrowRepo, userRepo, broadcastPublisher, notificationPublisher,
+                eventPublisher, clock);
+
+        seller = User.builder().id(10L).email("seller@example.com")
+                .username("seller").passwordHash("x").displayName("Sally").build();
+        winner = User.builder().id(20L).email("winner@example.com")
+                .username("winner").passwordHash("x").displayName("Willy").build();
+
+        photo = AuctionPhoto.builder().publicId(photoPublicId).sortOrder(0).build();
+        setEntityId(photo, PHOTO_NUMERIC_ID);
+
+        auction = Auction.builder()
+                .title("Lakefront")
+                .seller(seller)
+                .slParcelUuid(UUID.randomUUID())
+                .winnerUserId(winner.getId())
+                .photos(List.of(photo))
+                .build();
+        setEntityId(auction, AUCTION_NUMERIC_ID);
+
+        escrow = Escrow.builder()
+                .auction(auction)
+                .state(EscrowState.COMPLETED)
+                .completedAt(NOW.minusDays(1))
+                .finalBidAmount(1_000L)
+                .commissionAmt(50L)
+                .payoutAmt(950L)
+                .build();
+    }
+
+    private Review visibleReview(long id) {
+        Review r = Review.builder()
+                .auction(auction)
+                .reviewer(winner)
+                .reviewee(seller)
+                .reviewedRole(ReviewedRole.SELLER)
+                .rating(5)
+                .visible(true)
+                .build();
+        setEntityId(r, id);
+        r.setSubmittedAt(NOW.minusDays(10));
+        r.setRevealedAt(NOW.minusDays(5));
+        return r;
+    }
+
+    private void assertCanonicalPhotoUrl(String url) {
+        assertThat(url).isEqualTo("/api/v1/photos/" + photoPublicId);
+        // Exact prod-bug assertions — all would FAIL under the old code.
+        assertThat(url).doesNotContain("/auctions/");
+        assertThat(url).doesNotContain("/bytes");
+        assertThat(url).doesNotContain("/photos/" + PHOTO_NUMERIC_ID);
+        assertThat(url).doesNotContain("/" + AUCTION_NUMERIC_ID + "/");
+    }
+
+    @Test
+    void listForAuction_thumbnailUsesFlatPhotosEndpointWithPublicId() {
+        Review r = visibleReview(1L);
+        when(auctionRepo.findById(AUCTION_NUMERIC_ID)).thenReturn(Optional.of(auction));
+        when(escrowRepo.findByAuctionId(AUCTION_NUMERIC_ID))
+                .thenReturn(Optional.of(escrow));
+        when(reviewRepo.findByAuctionIdAndVisibleTrue(AUCTION_NUMERIC_ID))
+                .thenReturn(List.of(r));
+        when(responseRepo.findByReviewId(1L)).thenReturn(Optional.empty());
+
+        AuctionReviewsResponse resp = service.listForAuction(AUCTION_NUMERIC_ID, null);
+
+        assertThat(resp.reviews()).hasSize(1);
+        assertCanonicalPhotoUrl(resp.reviews().get(0).auctionPrimaryPhotoUrl());
+    }
+
+    @Test
+    void listForUser_thumbnailUsesFlatPhotosEndpointWithPublicId() {
+        Review r = visibleReview(5L);
+        Page<Review> pageResult =
+                new PageImpl<>(List.of(r), PageRequest.of(0, 10), 1);
+        when(reviewRepo.findByRevieweeIdAndReviewedRoleAndVisibleTrue(
+                eq(seller.getId()), eq(ReviewedRole.SELLER), any(Pageable.class)))
+                .thenReturn(pageResult);
+        when(responseRepo.findByReviewId(5L)).thenReturn(Optional.empty());
+
+        Page<ReviewDto> result = service.listForUser(seller.getId(),
+                ReviewedRole.SELLER, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).hasSize(1);
+        assertCanonicalPhotoUrl(result.getContent().get(0).auctionPrimaryPhotoUrl());
+    }
+
+    private static void setEntityId(Object entity, long id) {
+        try {
+            java.lang.reflect.Field f = com.slparcelauctions.backend.common
+                    .BaseEntity.class.getDeclaredField("id");
+            f.setAccessible(true);
+            f.set(entity, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/review/dto/PendingReviewDtoTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/review/dto/PendingReviewDtoTest.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionPhoto;
 import com.slparcelauctions.backend.escrow.Escrow;
 import com.slparcelauctions.backend.escrow.EscrowState;
 import com.slparcelauctions.backend.user.User;
@@ -66,6 +67,93 @@ class PendingReviewDtoTest {
         String idSegment = url.substring(
                 "/api/v1/users/".length(), url.indexOf("/avatar/"));
         assertThat(UUID.fromString(idSegment)).isEqualTo(counterpartyPublicId);
+    }
+
+    @Test
+    void of_primaryPhotoUrl_pointsAtFlatPhotosEndpointWithPublicId() {
+        // Regression for the prod bug: PendingReviewDto.of built the
+        // thumbnail as "/api/v1/auctions/" + auction.getId() + "/photos/"
+        // + photo.getId() + "/bytes" — a route that does not exist, fed
+        // numeric DB ids. The dashboard pending-reviews card 404'd.
+        UUID photoPublicId = UUID.randomUUID();
+        long auctionNumericId = 555L;
+        long photoNumericId = 4242L;
+
+        User seller = user(10L, UUID.randomUUID(), "Sally");
+        User counterparty = user(99L, UUID.randomUUID(), "Wally");
+        OffsetDateTime now = OffsetDateTime.of(2026, 5, 1, 10, 0, 0, 0, ZoneOffset.UTC);
+
+        AuctionPhoto photo = AuctionPhoto.builder()
+                .publicId(photoPublicId)
+                .sortOrder(0)
+                .build();
+        setEntityId(photo, photoNumericId);
+
+        Auction auction = Auction.builder()
+                .title("Lakefront")
+                .seller(seller)
+                .slParcelUuid(UUID.randomUUID())
+                .photos(List.of(photo))
+                .build();
+        setEntityId(auction, auctionNumericId);
+
+        Escrow escrow = Escrow.builder()
+                .auction(auction)
+                .state(EscrowState.COMPLETED)
+                .completedAt(now.minusDays(1))
+                .finalBidAmount(1_000L)
+                .commissionAmt(50L)
+                .payoutAmt(950L)
+                .build();
+
+        PendingReviewDto dto = PendingReviewDto.of(escrow, seller, counterparty, now);
+
+        assertThat(dto.primaryPhotoUrl())
+                .isEqualTo("/api/v1/photos/" + photoPublicId);
+        // The exact prod-bug assertions — all would FAIL under old code.
+        assertThat(dto.primaryPhotoUrl()).doesNotContain("/auctions/");
+        assertThat(dto.primaryPhotoUrl()).doesNotContain("/bytes");
+        assertThat(dto.primaryPhotoUrl())
+                .doesNotContain("/photos/" + photoNumericId);
+        assertThat(dto.primaryPhotoUrl())
+                .doesNotContain("/" + auctionNumericId + "/");
+    }
+
+    @Test
+    void of_noPhotos_yieldsNullPrimaryPhotoUrl() {
+        User seller = user(10L, UUID.randomUUID(), "Sally");
+        User counterparty = user(99L, UUID.randomUUID(), "Wally");
+        OffsetDateTime now = OffsetDateTime.of(2026, 5, 1, 10, 0, 0, 0, ZoneOffset.UTC);
+
+        Auction auction = Auction.builder()
+                .title("Lakefront")
+                .seller(seller)
+                .slParcelUuid(UUID.randomUUID())
+                .photos(List.of())
+                .build();
+        Escrow escrow = Escrow.builder()
+                .auction(auction)
+                .state(EscrowState.COMPLETED)
+                .completedAt(now.minusDays(1))
+                .finalBidAmount(1_000L)
+                .commissionAmt(50L)
+                .payoutAmt(950L)
+                .build();
+
+        PendingReviewDto dto = PendingReviewDto.of(escrow, seller, counterparty, now);
+
+        assertThat(dto.primaryPhotoUrl()).isNull();
+    }
+
+    private static void setEntityId(Object entity, long id) {
+        try {
+            java.lang.reflect.Field f = com.slparcelauctions.backend.common
+                    .BaseEntity.class.getDeclaredField("id");
+            f.setAccessible(true);
+            f.set(entity, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes broken review parcel-thumbnails (404 -> blank) on the dashboard pending-reviews card, auction-detail review list, and profile Reviews tab. PendingReviewDto/ReviewService built the URL as /api/v1/auctions/{numericId}/photos/{numericId}/bytes (nonexistent endpoint); the only photo-byte endpoint is /api/v1/photos/{publicId}.

Durable fix: new UUID-typed PhotoUrl helper as the single source of truth (passing a numeric Long is now a compile error); every photo-byte URL producer routed through it; regression tests + a source-scan guard test (verified it catches reintroduction) so the class cannot recur. Backend-only - frontend already wraps the backend URL via apiUrl().

Parcel images elsewhere were never affected (they use the correct builder), matching the reported observation. Local gate green (287 tests, compile clean). Combined spec+quality review approved. Triggers deploy-backend (~5min ECS) + Amplify rebuild. Separate inert FE-fixture cleanup flagged as a follow-up.
