### PR TITLE
release: em/en-dash sweep of user-facing copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ SLParcels is a player-to-player land auction platform for Second Life. It bridge
 ```
 Frontend (Next.js 16 / React 19 / TypeScript 5 / Tailwind CSS 4)
     ↕ REST API + WebSocket (STOMP)
-Backend (Spring Boot 4 / Java 26 / PostgreSQL / Redis / MinIO)
+Backend (Spring Boot 4 / Java 24 / PostgreSQL / Redis / MinIO)
     ↕ HTTP (llHTTPRequest / HTTP-in)         ↕ shared-secret HTTP
 In-World (Second Life LSL Scripts)      Bot (.NET 8 / LibreMetaverse)
 ```
@@ -67,7 +67,7 @@ Requires real SL credentials in `.env.bot-N`. No mock mode. See `bot/README.md`.
 ## Framework Version Warnings
 
 - **Next.js 16.2.3** has breaking changes from earlier versions. Read `frontend/node_modules/next/dist/docs/` before writing frontend code. See `frontend/AGENTS.md`.
-- **Spring Boot 4.0.5** with **Java 26** - use latest conventions.
+- **Spring Boot 4.0.5** targeting **Java 24** (`backend/pom.xml` `<java.version>24</java.version>`). The installed JDK at `JAVA_HOME` is newer (openjdk-26), which is fine; do not override `JAVA_HOME` inline. Use latest conventions.
 - **Tailwind CSS 4** uses the new `@tailwindcss/postcss` plugin (not the legacy `tailwindcss` PostCSS plugin).
 
 ## Key Directories
@@ -86,7 +86,7 @@ Requires real SL credentials in `.env.bot-N`. No mock mode. See `bot/README.md`.
 - **ORM**: Spring Data JPA / Hibernate with Lombok for boilerplate
 - **Database migrations**: `application.yml` sets `ddl-auto: update`, but **Spring Boot 4 silently sets `hibernate.hbm2ddl.auto=none` whenever Flyway is on the classpath** — Flyway is the actual schema manager and Hibernate fills no gaps. The "no migrations until users" intent isn't realised today: entity changes still need a paired Flyway migration (`backend/src/main/resources/db/migration/V<N>__*.sql`). To make the original intent real, set `spring.flyway.enabled: false` and rebuild — until then, write a migration when you change an entity.
 
-  **DB wipe procedure (prod).** RDS is in a private subnet, so `psql -h <rds>` from a dev box can't reach it. Use a one-shot Fargate task with the `postgres:16` image inside the same VPC:
+  **DB wipe procedure (prod).** RDS is in a private subnet, so `psql -h <rds>` from a dev box can't reach it. Use a one-shot Fargate task with the `postgres:17` image inside the same VPC (prod RDS is PostgreSQL 17.x; `docker-compose.yml` also uses `postgres:17-alpine`):
 
   ```bash
   # Task def already lives at .scratch/wipe-task-def.json (subnets + sg of the
@@ -150,7 +150,7 @@ Once L$ has reached an SLParcels Terminal script (the `money()` event has fired)
 - **AWS CLI is on PATH.** Run `aws` directly. (Earlier Claude Code sessions inherited a stale PATH from IntelliJ-spawned shells started before the install — if `aws` ever doesn't resolve in a tool call, restart the parent terminal so the new env propagates.)
 - **Profile**: `slpa-prod` (IAM Identity Center user `heath`, account `486208158127`, region `us-east-1`).
 - **ECS**: cluster `slpa-prod`. Services: `slpa-prod-backend`, `slpa-prod-bot-1`, `slpa-prod-bot-2`. ECS Exec is enabled on the backend service.
-- **CloudWatch logs**: `/aws/ecs/slpa-backend` for backend stdout. Tail with `aws --profile slpa-prod logs tail /aws/ecs/slpa-backend --since 5m --format short`.
+- **CloudWatch logs**: `/aws/ecs/slpa-backend` (backend stdout), `/aws/ecs/slpa-bot-1` and `/aws/ecs/slpa-bot-2` (per-bot worker stdout), `/aws/amplify/dil6fhehya5jf` (frontend build), `/aws/rds/instance/slpa-prod-postgres/postgresql` (RDS). Tail with `aws --profile slpa-prod logs tail /aws/ecs/slpa-backend --since 5m --format short`. NOTE (Windows): Git Bash rewrites a leading `/aws/...` arg into a `C:/Program Files/Git/aws/...` path, so the CLI fails the log-group regex and the call silently returns nothing. Run any `aws logs` command via the PowerShell tool (or prefix `MSYS_NO_PATHCONV=1`).
 - **Amplify**: app id `dil6fhehya5jf`, branch `main`. List recent jobs with `aws --profile slpa-prod amplify list-jobs --app-id dil6fhehya5jf --branch-name main --max-items 5`. Amplify rebuilds on every push to `main` regardless of which paths changed.
 - **RDS**: `slpa-prod-postgres.celewqkic6r2.us-east-1.rds.amazonaws.com`, db `slpa`, user `slpa`. **Private subnet — not reachable from a dev box.** Use the one-shot Fargate task pattern for any psql operation.
 - **SSM Parameter Store** (encrypted, region us-east-1): `/slpa/prod/rds/{username,password}`, `/slpa/prod/jwt/secret`, `/slpa/prod/redis/auth-token`, `/slpa/prod/escrow/terminal-shared-secret`, `/slpa/prod/sl/{primary-escrow-uuid,trusted-owner-keys}`, `/slpa/prod/bot-N/{username,password,uuid}`, `/slpa/prod/notifications/sl-im/dispatcher-secret`. Read with `aws --profile slpa-prod ssm get-parameter --name /slpa/prod/... --with-decryption --query 'Parameter.Value' --output text`. Secrets Manager is empty — everything lives in SSM.
@@ -158,7 +158,9 @@ Once L$ has reached an SLParcels Terminal script (the `money()` event has fired)
 ## Deploy pipelines
 
 - **Backend**: GitHub Actions workflow `.github/workflows/deploy-backend.yml`. Triggers on push to `main` with `paths: backend/**`. Builds + pushes the image to ECR, updates the ECS service. Tail with `gh run list --branch main --workflow 'deploy backend' --limit 3 --json status,conclusion`.
-- **Frontend**: Amplify on its own webhook. Triggers on every push to `main` regardless of paths. Independent of the backend pipeline — frontend can finish *before* the backend is up, which causes "build hits old API shape, fails prerender" timing bugs. Forcing pages to `dynamic = "force-dynamic"` (see Frontend SSR caveats above) is the durable fix; if you need to retrigger Amplify without a code change, use `aws --profile slpa-prod amplify start-job --app-id dil6fhehya5jf --branch-name main --job-type RELEASE`.
+- **Bot**: GitHub Actions workflow `.github/workflows/deploy-bot.yml`. Triggers on push to `main` with `paths: bot/**` (or the workflow file itself). Builds + pushes the bot image to ECR, then fans a task-def revision + service update across every active `slpa-prod-bot-*` service and waits for them to stabilize. Bot ECS services use `deployment_minimum_healthy_percent = 0` so the old task drains fully before the new one starts (named SL creds cannot double-login); a brief per-bot downtime per deploy is expected. Tail with `gh run list --branch main --workflow 'deploy bots' --limit 3 --json status,conclusion`.
+- **Frontend**: Amplify on its own webhook. Triggers on every push to `main` regardless of paths. Independent of the backend pipeline; the frontend can finish *before* the backend is up, which causes "build hits old API shape, fails prerender" timing bugs. Forcing pages to `dynamic = "force-dynamic"` (see Frontend SSR caveats above) is the durable fix; if you need to retrigger Amplify without a code change, use `aws --profile slpa-prod amplify start-job --app-id dil6fhehya5jf --branch-name main --job-type RELEASE`.
+- **CI**: `.github/workflows/frontend-ci.yml` (lint + test + build + verify guards) and `.github/workflows/bot-ci.yml` (dotnet build + test) run **only on push to `main`** (the dev/PR triggers are commented out). There is no backend test CI workflow. Run `./mvnw test`, `npm run lint|test|build|verify`, and `dotnet test` locally before pushing (see memory `project_ci_main_only_temporarily`).
 
 ## Branch / PR workflow
 

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java
@@ -262,8 +262,8 @@ public class NotificationPublisherImpl implements NotificationPublisher {
     @Override
     public void escrowSellToSet(long buyerUserId, long auctionId, long escrowId, String parcelName) {
         String title = "Parcel set for sale to you: " + parcelName;
-        String body = "The seller has set the parcel for sale to you. Buy it now — "
-            + "only if the price is L$0.";
+        String body = "The seller has set the parcel for sale to you. Buy it now, "
+            + "but only if the price is L$0.";
         notificationService.publish(new NotificationEvent(
             buyerUserId, NotificationCategory.ESCROW_SELL_TO_SET, title, body,
             withParcelSlurl(withAuctionPublicId(NotificationDataBuilder.escrowSellToSet(auctionId, escrowId, parcelName), auctionId), auctionId),

--- a/frontend/src/app/admin/escrow-reviews/[publicId]/AdminEscrowReviewDetailPage.tsx
+++ b/frontend/src/app/admin/escrow-reviews/[publicId]/AdminEscrowReviewDetailPage.tsx
@@ -105,7 +105,7 @@ export function AdminEscrowReviewDetailPage({
             <dl className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs">
               <Field
                 label="Sell-To last result"
-                value={data.sellToLastResult ?? "—"}
+                value={data.sellToLastResult ?? "(none)"}
               />
               <Field
                 label="Sell-To last checked"
@@ -138,7 +138,7 @@ export function AdminEscrowReviewDetailPage({
             <section className="bg-bg-muted rounded p-4 space-y-2">
               <div className="text-[10px] uppercase opacity-60">Resolution</div>
               <dl className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs">
-                <Field label="Resolution" value={data.resolution ?? "—"} />
+                <Field label="Resolution" value={data.resolution ?? "(none)"} />
                 <Field label="Resolved at" value={fmt(data.resolvedAt)} />
               </dl>
               {data.adminNotes && (
@@ -175,5 +175,5 @@ function Field({ label, value }: { label: string; value: string }) {
 }
 
 function fmt(value: string | null) {
-  return value ? new Date(value).toLocaleString() : "—";
+  return value ? new Date(value).toLocaleString() : "(none)";
 }

--- a/frontend/src/app/admin/escrow-reviews/[publicId]/ReviewResolutionPanel.tsx
+++ b/frontend/src/app/admin/escrow-reviews/[publicId]/ReviewResolutionPanel.tsx
@@ -18,7 +18,7 @@ const ACTIONS: {
     value: "FORCE_CONFIRM_SELL_TO",
     label: "Force confirm Sell To",
     subtitle:
-      "Same path as the bot SELL_TO_OK outcome — advances escrow to the Buy-Parcel step.",
+      "Same path as the bot SELL_TO_OK outcome. Advances escrow to the Buy-Parcel step.",
   },
   {
     value: "FORCE_COMPLETE_TRANSFER",

--- a/frontend/src/app/dashboard/(verified)/avatar/page.tsx
+++ b/frontend/src/app/dashboard/(verified)/avatar/page.tsx
@@ -171,7 +171,7 @@ export default function AvatarOnboardingPage() {
           {source.kind === "ready" ? "Upload a different image" : "Upload an image"}
         </Button>
         <Button variant="tertiary" onClick={handleSkip} disabled={saving}>
-          Skip — no avatar
+          Skip (no avatar)
         </Button>
       </div>
     </div>

--- a/frontend/src/components/admin/bans/UserSearchAutocomplete.tsx
+++ b/frontend/src/components/admin/bans/UserSearchAutocomplete.tsx
@@ -67,7 +67,7 @@ export function UserSearchAutocomplete({ onSelect, placeholder = "Search by name
               <span className="text-sm font-medium text-fg">
                 {user.displayName ?? user.username}
               </span>
-              <span className="text-[11px] text-fg-muted">{user.email ?? "—"}</span>
+              <span className="text-[11px] text-fg-muted">{user.email ?? "(none)"}</span>
             </li>
           ))}
         </ul>

--- a/frontend/src/components/admin/ledger/AdminLedgerStatusBadge.tsx
+++ b/frontend/src/components/admin/ledger/AdminLedgerStatusBadge.tsx
@@ -19,7 +19,7 @@ function chipClass(status: string): string {
 }
 
 export function AdminLedgerStatusBadge({ status }: { status: string | null }) {
-  if (!status) return <span className="text-fg-muted/50">—</span>;
+  if (!status) return <span className="text-fg-muted/50">(none)</span>;
   return (
     <span
       className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${chipClass(status)}`}

--- a/frontend/src/components/admin/ledger/AdminLedgerTable.tsx
+++ b/frontend/src/components/admin/ledger/AdminLedgerTable.tsx
@@ -109,7 +109,7 @@ export function AdminLedgerTable({ rows, sort, onSortChange }: Props) {
                       {row.username ?? row.userPublicId.slice(0, 8) + "…"}
                     </Link>
                   ) : (
-                    <span className="text-fg-muted/50">—</span>
+                    <span className="text-fg-muted/50">(none)</span>
                   )}
                 </td>
                 <td className={`px-3 py-2.5 text-right font-mono text-[11px] ${row.amountLindens < 0 ? "text-danger" : "text-fg"}`}>
@@ -130,7 +130,7 @@ export function AdminLedgerTable({ rows, sort, onSortChange }: Props) {
                       {row.counterpartyUsername ?? row.counterpartyPublicId.slice(0, 8) + "…"}
                     </Link>
                   ) : (
-                    <span className="text-fg-muted/50">—</span>
+                    <span className="text-fg-muted/50">(none)</span>
                   )}
                 </td>
                 <td className="px-3 py-2.5 text-[11px] text-fg-muted">
@@ -138,10 +138,10 @@ export function AdminLedgerTable({ rows, sort, onSortChange }: Props) {
                     <span>
                       {row.refType}{row.refId != null ? ` · ${row.refId}` : ""}
                     </span>
-                  ) : <span className="text-fg-muted/50">—</span>}
+                  ) : <span className="text-fg-muted/50">(none)</span>}
                 </td>
                 <td className="px-3 py-2.5 text-[11px] text-fg-muted max-w-[420px] truncate" title={row.description ?? ""}>
-                  {row.description ?? <span className="text-fg-muted/50">—</span>}
+                  {row.description ?? <span className="text-fg-muted/50">(none)</span>}
                 </td>
                 <td className="px-3 py-2.5 text-right">
                   {drill ? (
@@ -153,7 +153,7 @@ export function AdminLedgerTable({ rows, sort, onSortChange }: Props) {
                       →
                     </Link>
                   ) : (
-                    <span className="text-fg-muted/30">—</span>
+                    <span className="text-fg-muted/30">(none)</span>
                   )}
                 </td>
               </tr>

--- a/frontend/src/components/admin/listings/AdminListingsTable.tsx
+++ b/frontend/src/components/admin/listings/AdminListingsTable.tsx
@@ -19,7 +19,7 @@ type Props = {
 };
 
 function formatDate(iso: string | null): string {
-  if (!iso) return "—";
+  if (!iso) return "(none)";
   return new Date(iso).toLocaleDateString("en-US", {
     month: "short", day: "numeric", year: "2-digit",
   });
@@ -30,8 +30,8 @@ function formatLindens(amount: number): string {
 }
 
 function formatTimeRemaining(endsAt: string | null, status: string): string {
-  if (!endsAt) return "—";
-  if (status !== "ACTIVE") return "—";
+  if (!endsAt) return "(none)";
+  if (status !== "ACTIVE") return "(none)";
   const ends = new Date(endsAt).getTime();
   const now = Date.now();
   const ms = ends - now;
@@ -161,7 +161,7 @@ export function AdminListingsTable({ rows, sort, onSortChange }: Props) {
                         Yes
                       </span>
                     ) : (
-                      <span className="text-[11px] text-fg-muted">—</span>
+                      <span className="text-[11px] text-fg-muted">(none)</span>
                     )}
                   </td>
                   <td className="px-3 py-2.5">
@@ -174,7 +174,7 @@ export function AdminListingsTable({ rows, sort, onSortChange }: Props) {
                         Featured
                       </span>
                     ) : (
-                      <span className="text-[11px] text-fg-muted">—</span>
+                      <span className="text-[11px] text-fg-muted">(none)</span>
                     )}
                   </td>
                   <td className="px-3 py-2.5 text-fg-muted text-[11px]">{formatDate(row.createdAt)}</td>
@@ -186,7 +186,7 @@ export function AdminListingsTable({ rows, sort, onSortChange }: Props) {
                     {formatTimeRemaining(row.endsAt, row.status)}
                   </td>
                   <td className="px-3 py-2.5 text-fg-muted text-[11px]">
-                    {row.region ?? <span className="text-fg-muted/50">—</span>}
+                    {row.region ?? <span className="text-fg-muted/50">(none)</span>}
                   </td>
                   <td className="px-3 py-2.5 text-right" onClick={(e) => e.stopPropagation()}>
                     <RowActionMenu

--- a/frontend/src/components/admin/listings/ListingActionModal.tsx
+++ b/frontend/src/components/admin/listings/ListingActionModal.tsx
@@ -28,7 +28,7 @@ const CONFIG: Record<AdminListingAction, ActionConfig> = {
     variant: "destructive",
     body: "The seller will receive a warning notification. The listing remains active.",
     placeholder:
-      'e.g. "Please update your description — the title doesn\'t match the parcel size shown in your photos."',
+      'e.g. "Please update your description. The title doesn\'t match the parcel size shown in your photos."',
   },
   suspend: {
     title: "Suspend listing",
@@ -44,7 +44,7 @@ const CONFIG: Record<AdminListingAction, ActionConfig> = {
     variant: "destructive",
     body: "**This is permanent.** The listing will be terminated and cannot be reinstated. All bidders will be notified. Use Suspend if you may want to reinstate later.",
     placeholder:
-      'e.g. "Cancelled — parcel ownership has changed and seller no longer controls it."',
+      'e.g. "Cancelled. Parcel ownership has changed and seller no longer controls it."',
   },
   reinstate: {
     title: "Reinstate listing",
@@ -58,7 +58,7 @@ const CONFIG: Record<AdminListingAction, ActionConfig> = {
     title: "Feature listing",
     primaryLabel: "Feature listing",
     variant: "primary",
-    body: "The listing will appear on the homepage Featured rail. Optional expiry — leave blank for permanent.",
+    body: "The listing will appear on the homepage Featured rail. Optional expiry; leave blank for permanent.",
     placeholder: "",
   },
   unfeature: {
@@ -209,7 +209,7 @@ export function ListingActionModal({ open, action, row, onClose }: Props) {
               action === "feature" ? (
                 <div className="flex flex-col gap-1">
                   <label htmlFor="featured-until" className="text-xs font-medium text-fg">
-                    Featured until (optional — blank = permanent)
+                    Featured until (optional; blank = permanent)
                   </label>
                   <input
                     id="featured-until"

--- a/frontend/src/components/admin/realty-groups/AdminGroupAuditTab.tsx
+++ b/frontend/src/components/admin/realty-groups/AdminGroupAuditTab.tsx
@@ -13,9 +13,9 @@ export interface AdminGroupAuditTabProps {
 }
 
 function formatTimestamp(iso: string | null | undefined): string {
-  if (!iso) return "—";
+  if (!iso) return "(none)";
   const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "—";
+  if (Number.isNaN(d.getTime())) return "(none)";
   return d.toLocaleString();
 }
 
@@ -104,7 +104,7 @@ export function AdminGroupAuditTab({ groupPublicId }: AdminGroupAuditTabProps) {
                         {formatTimestamp(row.createdAt)}
                       </td>
                       <td className="py-2 pr-3 text-xs text-fg">
-                        {row.adminDisplayName ?? "—"}
+                        {row.adminDisplayName ?? "(none)"}
                       </td>
                       <td className="py-2 pr-3 text-xs text-fg font-mono">
                         {row.actionType}

--- a/frontend/src/components/admin/realty-groups/AdminGroupReportDetailPage.tsx
+++ b/frontend/src/components/admin/realty-groups/AdminGroupReportDetailPage.tsx
@@ -41,7 +41,7 @@ function statusPillClasses(status: RealtyGroupReportStatus): string {
 }
 
 function formatTimestamp(iso: string | null): string {
-  if (!iso) return "—";
+  if (!iso) return "(none)";
   const d = new Date(iso);
   if (!Number.isFinite(d.getTime())) return iso;
   return d.toLocaleString();

--- a/frontend/src/components/admin/realty-groups/AdminGroupReportsTab.tsx
+++ b/frontend/src/components/admin/realty-groups/AdminGroupReportsTab.tsx
@@ -38,9 +38,9 @@ function statusTone(status: RealtyGroupReportStatus | string): "warning" | "succ
 }
 
 function formatTimestamp(iso: string | null | undefined): string {
-  if (!iso) return "—";
+  if (!iso) return "(none)";
   const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "—";
+  if (Number.isNaN(d.getTime())) return "(none)";
   return d.toLocaleString();
 }
 

--- a/frontend/src/components/admin/realty-groups/AdminGroupSuspensionsTab.tsx
+++ b/frontend/src/components/admin/realty-groups/AdminGroupSuspensionsTab.tsx
@@ -47,9 +47,9 @@ function statusLabel(value: SuspensionStatus | string | null | undefined): strin
 }
 
 function formatTimestamp(iso: string | null | undefined): string {
-  if (!iso) return "—";
+  if (!iso) return "(none)";
   const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "—";
+  if (Number.isNaN(d.getTime())) return "(none)";
   return d.toLocaleString();
 }
 
@@ -221,7 +221,7 @@ export function AdminGroupSuspensionsTab({
                             Lift
                           </Button>
                         ) : (
-                          <span className="text-xs text-fg-muted">—</span>
+                          <span className="text-xs text-fg-muted">(none)</span>
                         )}
                       </td>
                     </tr>

--- a/frontend/src/components/admin/realty-groups/AdminSlGroupDriftRow.tsx
+++ b/frontend/src/components/admin/realty-groups/AdminSlGroupDriftRow.tsx
@@ -33,7 +33,7 @@ function driftLabel(value: SlGroupDriftReason | string | null | undefined): stri
 }
 
 function truncateUuid(uuid: string | null | undefined): string {
-  if (!uuid) return "—";
+  if (!uuid) return "(none)";
   if (uuid.length <= 12) return uuid;
   return `${uuid.slice(0, 8)}…${uuid.slice(-4)}`;
 }
@@ -216,7 +216,7 @@ export function AdminSlGroupDriftRow({
         <td className="py-2 pr-3 text-xs text-fg-muted">
           {row.consecutiveFetchFailures > 0
             ? `${row.consecutiveFetchFailures} fetch failure${row.consecutiveFetchFailures === 1 ? "" : "s"}`
-            : "—"}
+            : "(none)"}
         </td>
         <td className="py-2 text-right">
           <div className="flex flex-col items-end gap-1">

--- a/frontend/src/components/admin/realty-groups/AdminSlGroupDriftRow.tsx
+++ b/frontend/src/components/admin/realty-groups/AdminSlGroupDriftRow.tsx
@@ -216,7 +216,7 @@ export function AdminSlGroupDriftRow({
         <td className="py-2 pr-3 text-xs text-fg-muted">
           {row.consecutiveFetchFailures > 0
             ? `${row.consecutiveFetchFailures} fetch failure${row.consecutiveFetchFailures === 1 ? "" : "s"}`
-            : "(none)"}
+            : "0 failures"}
         </td>
         <td className="py-2 text-right">
           <div className="flex flex-col items-end gap-1">

--- a/frontend/src/components/admin/users/wallet/AdjustBalanceModal.tsx
+++ b/frontend/src/components/admin/users/wallet/AdjustBalanceModal.tsx
@@ -162,7 +162,7 @@ export function AdjustBalanceModal({
                   className="mt-0.5"
                 />
                 <span>
-                  Override reservation floor — I understand this will leave the user&apos;s
+                  Override reservation floor. I understand this will leave the user&apos;s
                   bid reservations under-funded.
                 </span>
               </label>

--- a/frontend/src/components/admin/users/wallet/WalletTab.tsx
+++ b/frontend/src/components/admin/users/wallet/WalletTab.tsx
@@ -10,7 +10,7 @@ import type { AdminWalletPendingWithdrawal } from "@/lib/admin/types";
 const PAGE_SIZE = 25;
 
 function formatDateTime(iso: string | null): string {
-  if (!iso) return "—";
+  if (!iso) return "(none)";
   return new Date(iso).toLocaleString("en-US", {
     month: "short", day: "numeric", year: "numeric",
     hour: "2-digit", minute: "2-digit",
@@ -86,7 +86,7 @@ export function WalletTab({ publicId }: Props) {
         )}
         {wallet.walletTermsAcceptedAt ? (
           <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-info-bg text-info">
-            Terms v{wallet.walletTermsVersion ?? "—"}
+            Terms v{wallet.walletTermsVersion ?? "(none)"}
           </span>
         ) : (
           <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-bg-hover text-fg-muted">
@@ -144,7 +144,7 @@ export function WalletTab({ publicId }: Props) {
                           disabled={!w.canForceFinalize}
                           onClick={() => setPendingAction({ withdrawal: w, mode: "complete" })}
                           data-testid={`force-complete-${w.terminalCommandId}`}
-                          title={!w.canForceFinalize ? "Bot is mid-payout — wait for callback or lease expiry" : undefined}
+                          title={!w.canForceFinalize ? "Bot is mid-payout. Wait for callback or lease expiry." : undefined}
                         >
                           Force complete
                         </Button>
@@ -154,7 +154,7 @@ export function WalletTab({ publicId }: Props) {
                           disabled={!w.canForceFinalize}
                           onClick={() => setPendingAction({ withdrawal: w, mode: "fail" })}
                           data-testid={`force-fail-${w.terminalCommandId}`}
-                          title={!w.canForceFinalize ? "Bot is mid-payout — wait for callback or lease expiry" : undefined}
+                          title={!w.canForceFinalize ? "Bot is mid-payout. Wait for callback or lease expiry." : undefined}
                         >
                           Force fail
                         </Button>
@@ -198,9 +198,9 @@ export function WalletTab({ publicId }: Props) {
                         {row.amount >= 0 ? "+" : ""}{formatLindens(row.amount)}
                       </td>
                       <td className="px-3 py-2.5 text-right font-mono text-fg">{formatLindens(row.balanceAfter)}</td>
-                      <td className="px-3 py-2.5 text-fg-muted text-[11px]">{row.description ?? "—"}</td>
+                      <td className="px-3 py-2.5 text-fg-muted text-[11px]">{row.description ?? "(none)"}</td>
                       <td className="px-3 py-2.5 text-fg-muted text-[11px]">
-                        {row.createdByAdminId ? `#${row.createdByAdminId}` : "—"}
+                        {row.createdByAdminId ? `#${row.createdByAdminId}` : "(none)"}
                       </td>
                     </tr>
                   ))}

--- a/frontend/src/components/escrow/escrowBannerCopy.ts
+++ b/frontend/src/components/escrow/escrowBannerCopy.ts
@@ -84,7 +84,7 @@ export function escrowBannerCopy(input: BannerCopyInput): BannerCopyResult {
       if (role === "winner") {
         return {
           headline: "Buy the parcel",
-          detail: "purchase the parcel — only if it shows L$0.",
+          detail: "purchase the parcel, only if it shows L$0.",
           tone: "action",
         };
       }

--- a/frontend/src/components/escrow/state/TransferPendingStateCard.tsx
+++ b/frontend/src/components/escrow/state/TransferPendingStateCard.tsx
@@ -191,7 +191,7 @@ function VerifyControls({
       </p>
       {escrow.manualReviewStatus === "OPEN" ? (
         <p className="text-xs font-medium text-fg-muted">
-          A manual review is open — SLParcels staff will follow up.
+          A manual review is open. SLParcels staff will follow up.
         </p>
       ) : (
         <Button
@@ -330,7 +330,7 @@ function WinnerBuyParcelCard({ escrow }: { escrow: EscrowStatusResponse }) {
       </h2>
       <p className="text-sm text-fg-muted">
         The seller has listed the parcel for sale to you. Open it in Second
-        Life and buy it now —{" "}
+        Life and buy it now,{" "}
         <span className="font-medium text-fg">
           only if the price shows L$ 0
         </span>

--- a/frontend/src/components/listing/AgentCommissionPreview.test.tsx
+++ b/frontend/src/components/listing/AgentCommissionPreview.test.tsx
@@ -142,7 +142,7 @@ describe("AgentCommissionPreview (case 3)", () => {
 
     expect(
       await screen.findByText(
-        /Listing fee paid from Sunset Realty wallet — current balance L\$500/,
+        /Listing fee paid from Sunset Realty wallet\. Current balance L\$500/,
       ),
     ).toBeInTheDocument();
     await waitFor(() => expect(onInsufficient).toHaveBeenCalledWith(false));

--- a/frontend/src/components/listing/AgentCommissionPreview.tsx
+++ b/frontend/src/components/listing/AgentCommissionPreview.tsx
@@ -132,7 +132,7 @@ export function AgentCommissionPreview({
         </p>
       ) : balance !== null ? (
         <p className="text-xs text-fg-muted">
-          Listing fee paid from {groupName} wallet — current balance L$
+          Listing fee paid from {groupName} wallet. Current balance L$
           {balance.toLocaleString()}.
         </p>
       ) : null}

--- a/frontend/src/components/listing/BrokerCancelModal.test.tsx
+++ b/frontend/src/components/listing/BrokerCancelModal.test.tsx
@@ -87,7 +87,7 @@ describe("BrokerCancelModal", () => {
     );
     expect(screen.getByText("Sunset Plot")).toBeInTheDocument();
     expect(screen.getByTestId("broker-cancel-bids")).toHaveTextContent(
-      /3 bids — current highest L\$1,500/,
+      /3 bids\. Current highest L\$1,500/,
     );
     expect(
       screen.getByText(/refund will be credited to the group wallet/i),

--- a/frontend/src/components/listing/BrokerCancelModal.tsx
+++ b/frontend/src/components/listing/BrokerCancelModal.tsx
@@ -128,7 +128,7 @@ export function BrokerCancelModal({
       </p>
       <p className="text-xs text-fg-muted" data-testid="broker-cancel-bids">
         {bidCount > 0 && highestBid != null
-          ? `${bidCount} bid${bidCount === 1 ? "" : "s"} — current highest L$${highestBid.toLocaleString()}.`
+          ? `${bidCount} bid${bidCount === 1 ? "" : "s"}. Current highest L$${highestBid.toLocaleString()}.`
           : "No bids on this listing yet."}
       </p>
       <p className="text-xs text-fg-muted">

--- a/frontend/src/components/realty/BulkMemberCommissionEditDrawer.tsx
+++ b/frontend/src/components/realty/BulkMemberCommissionEditDrawer.tsx
@@ -290,7 +290,7 @@ function BulkRow({ agent, value, onChange, error, disabled }: BulkRowProps) {
   const currentRateLabel =
     agent.agentCommissionRate != null
       ? `${rateToPercentDisplay(agent.agentCommissionRate)}%`
-      : "—";
+      : "(none)";
   return (
     <li
       className="flex flex-col gap-1 rounded-lg border border-border bg-surface-raised px-3 py-2.5"

--- a/frontend/src/components/realty/browse/PublicGroupProfile.tsx
+++ b/frontend/src/components/realty/browse/PublicGroupProfile.tsx
@@ -157,7 +157,7 @@ export function PublicGroupProfile({ group }: PublicGroupProfileProps) {
             value={
               reviewCount > 0 && averageRating !== null
                 ? averageRating.toFixed(2)
-                : "—"
+                : "(none)"
             }
             hint={`${reviewCount} reviews`}
           />

--- a/frontend/src/components/realty/slgroup/SlGroupListRow.tsx
+++ b/frontend/src/components/realty/slgroup/SlGroupListRow.tsx
@@ -164,7 +164,7 @@ export function SlGroupListRow({ groupPublicId, row }: SlGroupListRowProps) {
               {verifiedViaLabel(row.verifiedVia)}
             </span>
           ) : (
-            <span className="text-fg-muted">—</span>
+            <span className="text-fg-muted">(none)</span>
           )}
         </td>
 

--- a/frontend/src/components/realty/wallet/GroupWalletLedgerTable.tsx
+++ b/frontend/src/components/realty/wallet/GroupWalletLedgerTable.tsx
@@ -193,7 +193,7 @@ function LedgerRow({ entry }: LedgerRowProps) {
             Auction
           </a>
         ) : (
-          <span className="text-fg-muted text-xs">—</span>
+          <span className="text-fg-muted text-xs">(none)</span>
         )}
       </td>
 
@@ -202,7 +202,7 @@ function LedgerRow({ entry }: LedgerRowProps) {
         {entry.actor ? (
           <span className="text-xs">{entry.actor.displayName}</span>
         ) : (
-          <span className="text-xs">—</span>
+          <span className="text-xs">(none)</span>
         )}
       </td>
     </tr>

--- a/frontend/src/components/realty/wallet/GroupWalletPage.tsx
+++ b/frontend/src/components/realty/wallet/GroupWalletPage.tsx
@@ -137,7 +137,7 @@ export function GroupWalletPage({ publicId, groupName }: GroupWalletPageProps) {
                 role="alert"
                 className="text-sm text-fg-muted py-8 text-center"
               >
-                Couldn&apos;t display transactions — try again.
+                Couldn&apos;t display transactions. Try again.
               </div>
             }
           >

--- a/frontend/src/components/realty/wallet/GroupWithdrawModal.tsx
+++ b/frontend/src/components/realty/wallet/GroupWithdrawModal.tsx
@@ -229,7 +229,7 @@ export function GroupWithdrawModal({
                 data-testid="withdraw-recipient-sl-group"
                 title={
                   slGroupDisabled
-                    ? "Group registration suspended — choose Leader's avatar instead"
+                    ? "Group registration suspended. Choose Leader's avatar instead."
                     : undefined
                 }
               />
@@ -241,7 +241,7 @@ export function GroupWithdrawModal({
               className="text-xs text-fg-muted"
               data-testid="withdraw-recipient-sl-group-suspended-hint"
             >
-              Group registration suspended — choose Leader&apos;s avatar
+              Group registration suspended. Choose Leader&apos;s avatar
               instead.
             </p>
           ) : null}

--- a/frontend/src/components/wallet/WalletPanel.tsx
+++ b/frontend/src/components/wallet/WalletPanel.tsx
@@ -307,7 +307,7 @@ export function WalletPanel() {
               role="alert"
               className="text-sm text-fg-muted py-8 text-center"
             >
-              Couldn&apos;t display transactions — try again.
+              Couldn&apos;t display transactions. Try again.
             </div>
           }
         >

--- a/frontend/src/hooks/admin/useAdminListings.ts
+++ b/frontend/src/hooks/admin/useAdminListings.ts
@@ -23,7 +23,7 @@ export function adminListingErrorMessage(err: unknown, fallback: string): string
   const code = (err.problem as { code?: string }).code;
   switch (code) {
     case "INVALID_STATUS_FOR_ACTION":
-      return "This listing's status changed — refresh and try again.";
+      return "This listing's status changed. Refresh and try again.";
     case "ALREADY_SUSPENDED":
       return "This listing is already suspended.";
     case "NOT_SUSPENDED":

--- a/frontend/src/hooks/admin/useAdminWallet.ts
+++ b/frontend/src/hooks/admin/useAdminWallet.ts
@@ -45,7 +45,7 @@ function adminWalletErrorMessage(err: unknown, fallback: string): string {
     case "ALREADY_FROZEN": return "Wallet is already frozen.";
     case "NOT_FROZEN": return "Wallet is not frozen.";
     case "NOT_IN_DORMANCY": return "Wallet is not in dormancy state.";
-    case "BOT_PROCESSING": return "Bot is mid-payout — wait for the callback to finish or for the lease to expire.";
+    case "BOT_PROCESSING": return "Bot is mid-payout. Wait for the callback to finish or for the lease to expire.";
     case "WITHDRAWAL_NOT_PENDING": return "Withdrawal already finalized.";
     case "COMMAND_NOT_FOUND": return "Withdrawal not found.";
     case "COMMAND_USER_MISMATCH": return "Withdrawal does not belong to this user.";


### PR DESCRIPTION
Removes em-dashes and connector en-dashes from all user/admin-facing copy across the codebase (AI-tell policy). Frontend (30 files: connectors rewritten as proper sentences, missing-value glyphs to "(none)", numeric ranges preserved) + backend (the ESCROW_SELL_TO_SET notification body) + a review follow-up (drift row "0 failures" not "(none)" for the healthy state). LSL had none in scope. Comments/logs/docs/identifiers untouched.

Combined spec+quality review approved. Local gate green: frontend lint 0 / 2011 vitest / tsc clean / verify 4/4; backend PhotoUrlGuardTest 2/2 + targeted suites + compile. One broad-parallel-run backend failure (SlImCleanupJobTest, logger-string assertion tied to shared-dev-Postgres row counts) proven environmental (fails identically on base commit in isolation, untouched by this change). Triggers deploy-backend + Amplify; no bot/LSL deploy.
