### PR TITLE
release: FOOTGUNS F.117 + inert FE photo-URL fixture alignment

### DIFF
--- a/docs/implementation/FOOTGUNS.md
+++ b/docs/implementation/FOOTGUNS.md
@@ -1877,6 +1877,14 @@ pattern.
 
 **How to apply:** If you lengthen any escrow IM copy, budget for the appended `Parcel:` line and verify total bytes stay under 1024. If escrow IM copy grows materially, move the SLURL out of the ellipsizable body into the reserved (non-truncating) IM component so the in-world clickable link can't be silently dropped.
 
+### F.117 - Broad parallel `./mvnw test` against the shared dev Postgres produces sporadic integration-test pollution; a failure there is not a regression until reproduced in isolation
+
+**Why:** A wide parallel surefire run (`./mvnw test`, or a large `-Dtest='*Glob*'` set, especially when fanned out across subagents) executes many `@SpringBootTest` integration tests concurrently against the long-lived dev Postgres. That shared, persistent database produces sporadic, non-deterministic failures from three distinct causes: (1) orphaned rows left behind by a prior aborted run; (2) FK-ordered `@AfterEach` teardown racing between tests that touch overlapping tables; and (3) assertions bound to time-window row counts over shared data (e.g. `SlImCleanupJobTest` asserts a logger line carrying `expired=N` / `top_users=[...]` derived from a cleanup query that scans rows other concurrent tests are writing). Pure source-scan / unit tests (`PhotoUrlGuardTest`, `UserAvatarUrlGuardTest`, and similar) never touch the DB and are reliable; the DB-touching integration tests are the flaky population.
+
+This session it caused 3 false alarms: a misattributed `PhotoUrlGuardTest` "failure" inside a ~2400-test glob (passes 2/2 standalone), an `SlImCleanupJobTest` failure that reproduces identically on the base commit when run in isolation (so it is pre-existing environmental noise, not a regression introduced here), and an earlier `BotTaskControllerAuthIntegrationTest` / `EscrowOwnershipMonitorIntegrationTest` pair failing on orphaned-row pollution.
+
+**How to apply:** Treat any failure observed only under a broad parallel run as ENVIRONMENTAL until you reproduce it by running that single test class in ISOLATION (`./mvnw test -Dtest=ThatClass`). Do not file or "fix" a regression on the strength of a glob-run failure alone. Mitigation: run targeted suites rather than the full surefire fan-out; verify every suspected regression standalone before acting on it; and when accumulated pollution is suspected, the documented dev DB-wipe / schema-reset clears it.
+
 ## §G Realty groups
 
 ### G.1 `runZeroPayoutSuccessInline` is the entire post-payout work for case-3 escrows

--- a/frontend/src/components/listing/ListingPreviewCard.test.tsx
+++ b/frontend/src/components/listing/ListingPreviewCard.test.tsx
@@ -96,7 +96,7 @@ describe("ListingPreviewCard", () => {
           photos: [
             {
               publicId: "00000000-0000-0000-0000-000000000001",
-              url: "/api/v1/auctions/1/photos/1/bytes",
+              url: "/api/v1/photos/00000000-0000-0000-0000-000000000001",
               contentType: "image/png",
               sizeBytes: 100,
               sortOrder: 0,
@@ -111,6 +111,8 @@ describe("ListingPreviewCard", () => {
     // find it — fall back to a DOM query for the src match.
     const cover = container.querySelector("img");
     // apiUrl prefixes relative paths; assert on the invariant path tail.
-    expect(cover?.getAttribute("src")).toMatch(/photos\/1\/bytes/);
+    expect(cover?.getAttribute("src")).toMatch(
+      /photos\/00000000-0000-0000-0000-000000000001/,
+    );
   });
 });

--- a/frontend/src/lib/api/reviews.test.ts
+++ b/frontend/src/lib/api/reviews.test.ts
@@ -24,7 +24,7 @@ function reviewDto(overrides: Partial<ReviewDto> = {}): ReviewDto {
     publicId: "00000000-0000-0000-0000-000000000001",
     auctionPublicId: "00000000-0000-0000-0000-00000000000a",
     auctionTitle: "Aurora Parcel",
-    auctionPrimaryPhotoUrl: "/api/v1/auctions/10/photos/1/bytes",
+    auctionPrimaryPhotoUrl: "/api/v1/photos/00000000-0000-0000-0000-000000000001",
     reviewerPublicId: "00000000-0000-0000-0000-00000000002a",
     reviewerDisplayName: "Alice",
     reviewerAvatarUrl: "/api/v1/users/42/avatar/256",


### PR DESCRIPTION
Non-blocking cleanups: FOOTGUNS F.117 documenting the shared-dev-Postgres broad-parallel-test pollution flake (append-only; the entry itself is em/en-dash free per the enforced policy), and alignment of two inert FE test fixtures from the dead /api/v1/auctions/{id}/photos/{id}/bytes string to the canonical /api/v1/photos/{publicId} shape. No production code; docs + test fixtures only. Combined review approved; gates green (13 vitest, tsc clean, eslint 0). No backend/bot deploy; frontend CI + Amplify rebuild on the main push only.
