### PR TITLE
fix(wallet): terms banner appears post-verify without a reload

### DIFF
--- a/docs/implementation/DEFERRED_WORK.md
+++ b/docs/implementation/DEFERRED_WORK.md
@@ -341,6 +341,13 @@ Spec: `docs/superpowers/specs/2026-05-12-realty-groups-final-cleanup-design.md` 
 - **When:** Done (2026-05-18) — closed as no-op.
 - **Notes:** Append-only resolution row, per the ledger's immutability rule. Cross-ref: autonomy decisions log `docs/superpowers/decisions/2026-05-17-escrow-split-autonomy-notes.md`.
 
+### Systemic: `useAuth().user.verified` is stale after in-SPA verification
+
+- **From:** Wallet-terms-banner bug (2026-05-18). `WalletTermsBanner` didn't appear for a newly-verified user until a full page reload. Root cause: it gated on `useAuth()`, whose session cache (`["auth","session"]`, `staleTime: Infinity`, `refetchOnWindowFocus: false`) is populated once by `bootstrapSession` and never refreshed in-SPA. Avatar verification flips `verified` server-side but the frontend only learns it via `useCurrentUser()` (polled `/me`); nothing refreshes the auth-session cache. The component-level fix shipped (switch the banner to `useCurrentUser`, branch `fix/wallet-terms-banner-verified-source`), mirroring `WalletPill`.
+- **Why deferred:** The component fix removes the symptom for this banner, but the footgun is systemic: any current/future component that gates on `useAuth().user.verified` (or any other post-login-mutable field on the session user, e.g. a future role change) will be stale until a hard reload. A proper fix is broader than this bug and touches deliberately-frozen session semantics (`useAuth` is `staleTime: Infinity` to avoid the refresh-stampede captured in FOOTGUNS §F.2/§F.4), so it warrants its own scoped change rather than being bundled into a one-component hotfix.
+- **When:** Indefinite — next auth/session touch, or sooner if another `useAuth().*.verified`-gated surface regresses.
+- **Notes:** Likely shape: when the verify/onboarding flow observes `/me` flip to `verified: true` (it already polls via `useCurrentUser`), reconcile the auth-session cache from that same fresh user (`queryClient.setQueryData(["auth","session"], freshUser)`) rather than triggering a new `bootstrapSession`/refresh round-trip — keeps the no-stampede guarantee intact. Add a guard test (or lint) that flags `useAuth()`-derived `verified` gating in components so the next consumer is steered to `useCurrentUser`. Touchpoints: `lib/auth/hooks.ts` (`useAuth`, `SESSION_QUERY_KEY`), `lib/user/hooks.ts` (`useCurrentUser`, `CURRENT_USER_KEY`), `components/user/UnverifiedVerifyFlow.tsx` (the existing polling site that would do the reconcile).
+
 ---
 
 ## Removal Criteria

--- a/frontend/src/components/wallet/WalletTermsBanner.integration.test.tsx
+++ b/frontend/src/components/wallet/WalletTermsBanner.integration.test.tsx
@@ -7,6 +7,7 @@ import {
   userEvent,
 } from "@/test/render";
 import { server } from "@/test/msw/server";
+import { userHandlers } from "@/test/msw/handlers";
 import type { AuthUser } from "@/lib/auth/session";
 import type { WalletView } from "@/types/wallet";
 import { WalletTermsBanner } from "./WalletTermsBanner";
@@ -19,6 +20,11 @@ const verifiedAuthUser: AuthUser = {
   slAvatarUuid: "11111111-1111-1111-1111-111111111111",
   verified: true,
   role: "USER",
+};
+
+const staleUnverifiedAuthUser: AuthUser = {
+  ...verifiedAuthUser,
+  verified: false,
 };
 
 function walletView(overrides: Partial<WalletView> = {}): WalletView {
@@ -41,12 +47,33 @@ describe("WalletTermsBanner integration", () => {
     window.localStorage.clear();
   });
 
+  it("appears when /me reports verified even though the bootstrap session is stale-unverified (regression)", async () => {
+    // Seed the auth session as unverified (stale) but have /me return verified.
+    // The banner must still appear because it should read from useCurrentUser,
+    // not the stale auth-session bootstrap cache.
+    server.use(
+      userHandlers.meVerified(),
+      http.get("*/api/v1/me/wallet", () =>
+        HttpResponse.json(walletView({ termsAccepted: false })),
+      ),
+    );
+
+    renderWithProviders(<WalletTermsBanner />, {
+      auth: "authenticated",
+      authUser: staleUnverifiedAuthUser,
+    });
+
+    // findByText waits for both /me and /wallet fetches to resolve.
+    await screen.findByText(/Accept the SLParcels Wallet Terms of Use/i);
+  });
+
   it("banner disappears after user accepts terms via the modal", async () => {
     // First GET returns termsAccepted:false; subsequent GETs (triggered by
     // invalidateQueries after the modal posts accept-terms) return
     // termsAccepted:true so the banner gates out and unmounts.
     let callCount = 0;
     server.use(
+      userHandlers.meVerified(),
       http.get("*/api/v1/me/wallet", () => {
         callCount += 1;
         return HttpResponse.json(

--- a/frontend/src/components/wallet/WalletTermsBanner.test.tsx
+++ b/frontend/src/components/wallet/WalletTermsBanner.test.tsx
@@ -6,12 +6,11 @@ import {
   waitFor,
 } from "@/test/render";
 import type { WalletView } from "@/types/wallet";
-import { mockUser } from "@/test/msw/fixtures";
 import { WALLET_TERMS_VERSION } from "@/components/wallet/WalletTermsModal";
 import { termsBannerDismissalKey } from "@/lib/wallet/terms-banner-dismissed";
 
-vi.mock("@/lib/auth", () => ({
-  useAuth: vi.fn(),
+vi.mock("@/lib/user", () => ({
+  useCurrentUser: vi.fn(),
 }));
 
 vi.mock("@/lib/wallet/use-wallet", async () => {
@@ -21,7 +20,7 @@ vi.mock("@/lib/wallet/use-wallet", async () => {
   return { ...actual, useWallet: vi.fn() };
 });
 
-import { useAuth } from "@/lib/auth";
+import { useCurrentUser } from "@/lib/user";
 import { useWallet } from "@/lib/wallet/use-wallet";
 import { WalletTermsBanner } from "./WalletTermsBanner";
 
@@ -40,14 +39,13 @@ function walletView(overrides: Partial<WalletView> = {}): WalletView {
   };
 }
 
-function setAuth(opts: { authenticated: boolean; verified?: boolean }) {
-  vi.mocked(useAuth).mockReturnValue(
-    opts.authenticated
-      ? {
-          status: "authenticated",
-          user: { ...mockUser, verified: opts.verified ?? true },
-        }
-      : { status: "unauthenticated", user: null },
+function setUser(opts: { verified: boolean } | null) {
+  vi.mocked(useCurrentUser).mockReturnValue(
+    opts === null
+      ? ({ data: undefined } as unknown as ReturnType<typeof useCurrentUser>)
+      : ({
+          data: { verified: opts.verified },
+        } as unknown as ReturnType<typeof useCurrentUser>),
   );
 }
 
@@ -66,7 +64,7 @@ describe("WalletTermsBanner", () => {
   });
 
   it("shows for a verified user who has not accepted terms", () => {
-    setAuth({ authenticated: true, verified: true });
+    setUser({ verified: true });
     setWallet(walletView({ termsAccepted: false }));
     renderWithProviders(<WalletTermsBanner />);
     expect(screen.getByText(BANNER)).toBeInTheDocument();
@@ -79,28 +77,28 @@ describe("WalletTermsBanner", () => {
   });
 
   it("is hidden for guests / unauthenticated", () => {
-    setAuth({ authenticated: false });
+    setUser(null);
     setWallet(undefined);
     renderWithProviders(<WalletTermsBanner />);
     expect(screen.queryByText(BANNER)).not.toBeInTheDocument();
   });
 
   it("is hidden for an authenticated but unverified user", () => {
-    setAuth({ authenticated: true, verified: false });
+    setUser({ verified: false });
     setWallet(undefined);
     renderWithProviders(<WalletTermsBanner />);
     expect(screen.queryByText(BANNER)).not.toBeInTheDocument();
   });
 
   it("renders nothing while the wallet query is loading", () => {
-    setAuth({ authenticated: true, verified: true });
+    setUser({ verified: true });
     setWallet(undefined);
     renderWithProviders(<WalletTermsBanner />);
     expect(screen.queryByText(BANNER)).not.toBeInTheDocument();
   });
 
   it("is hidden once terms are accepted", () => {
-    setAuth({ authenticated: true, verified: true });
+    setUser({ verified: true });
     setWallet(walletView({ termsAccepted: true }));
     renderWithProviders(<WalletTermsBanner />);
     expect(screen.queryByText(BANNER)).not.toBeInTheDocument();
@@ -111,7 +109,7 @@ describe("WalletTermsBanner", () => {
       termsBannerDismissalKey(WALLET_TERMS_VERSION),
       "1",
     );
-    setAuth({ authenticated: true, verified: true });
+    setUser({ verified: true });
     setWallet(walletView({ termsAccepted: false }));
     renderWithProviders(<WalletTermsBanner />);
     await waitFor(() =>
@@ -120,7 +118,7 @@ describe("WalletTermsBanner", () => {
   });
 
   it("opens the WalletTermsModal on Accept Wallet Terms", async () => {
-    setAuth({ authenticated: true, verified: true });
+    setUser({ verified: true });
     setWallet(walletView({ termsAccepted: false }));
     renderWithProviders(<WalletTermsBanner />);
     await userEvent.click(
@@ -132,7 +130,7 @@ describe("WalletTermsBanner", () => {
   });
 
   it("Don't show again writes localStorage and hides the banner", async () => {
-    setAuth({ authenticated: true, verified: true });
+    setUser({ verified: true });
     setWallet(walletView({ termsAccepted: false }));
     renderWithProviders(<WalletTermsBanner />);
     await userEvent.click(

--- a/frontend/src/components/wallet/WalletTermsBanner.tsx
+++ b/frontend/src/components/wallet/WalletTermsBanner.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { Wallet } from "@/components/ui/icons";
-import { useAuth } from "@/lib/auth";
+import { useCurrentUser } from "@/lib/user";
 import { useWallet } from "@/lib/wallet/use-wallet";
 import {
   WalletTermsModal,
@@ -28,8 +28,8 @@ import {
  * Spec: docs/superpowers/specs/2026-05-18-wallet-terms-modal-everywhere-design.md
  */
 export function WalletTermsBanner() {
-  const { status, user } = useAuth();
-  const verified = status === "authenticated" && user?.verified === true;
+  const { data: user } = useCurrentUser();
+  const verified = user?.verified === true;
   const { data: wallet } = useWallet(verified);
 
   const [dismissed, setDismissed] = useState(false);


### PR DESCRIPTION
Fixes the just-deployed wallet-terms banner not appearing for a newly-verified user until a manual page refresh.

Root cause: WalletTermsBanner gated `verified` on useAuth() (the [auth,session] bootstrap cache: staleTime:Infinity, refetchOnWindowFocus:false, never refreshed in-SPA). Avatar verification flips verified server-side but the frontend only learns it via useCurrentUser() (polled /me); nothing refreshes the session cache, so the banner stayed hidden until a full reload.

Fix: derive verified from useCurrentUser() (mirrors the proven WalletPill pattern). Adds an integration regression test that reproduces the stale-session scenario (fails against pre-fix code). Unit tests reworked to mock useCurrentUser.

Also: appended a DEFERRED_WORK.md follow-up tracking the systemic useAuth().verified staleness footgun (option B).

Verification: npm run lint (0 errors), npm test (2056 passing, +1 regression), npm run verify (guards pass), npm run build (succeeds).