### PR TITLE
Deploy: user-ledger signed ADJUSTMENT fix (V38)

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerEntry.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerEntry.java
@@ -19,10 +19,12 @@ import lombok.experimental.SuperBuilder;
  * are never updated — withdraw lifecycle (QUEUED → COMPLETED|REVERSED) is
  * three separate appended rows, not mutations of the original.
  *
- * <p>{@code amount} is always positive; direction is implicit in
- * {@link UserLedgerEntryType}. {@code balanceAfter} and {@code reservedAfter}
- * are snapshots written at insert time — they are the authoritative state
- * for the user's wallet at that point in the ledger.
+ * <p>{@code amount} is positive for every entry type except
+ * {@code ADJUSTMENT}, whose sign carries the direction of an admin
+ * correction (positive credit, negative debit); direction for all other
+ * types is implicit in {@link UserLedgerEntryType}. {@code balanceAfter}
+ * and {@code reservedAfter} are snapshots written at insert time; they are
+ * the authoritative state for the user's wallet at that point in the ledger.
  *
  * <p>{@code slTransactionId} (LSL {@code llGenerateKey()}) deduplicates
  * terminal-side retries on {@code /sl/wallet/deposit} and

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerEntryType.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerEntryType.java
@@ -2,7 +2,8 @@ package com.slparcelauctions.backend.wallet;
 
 /**
  * Discriminator for {@link UserLedgerEntry} rows. Direction (debit vs credit)
- * is implicit in the entry_type — the entry's {@code amount} is always positive.
+ * is implicit in the entry_type and {@code amount} is positive, except for
+ * {@link #ADJUSTMENT} whose sign carries the direction of an admin correction.
  *
  * <p>See spec docs/superpowers/specs/2026-04-30-wallet-model-design.md §3.2.
  */
@@ -90,8 +91,12 @@ public enum UserLedgerEntryType {
     /**
      * Admin-issued ledger adjustment. {@code created_by_admin_id} required
      * (constraint enforced at the application layer; see
-     * {@code WalletService.adminAdjustment}). Used for forensic corrections
+     * {@code AdminWalletService.adjust}). Used for forensic corrections
      * after manual reconciliation, refunds-of-last-resort, etc.
+     *
+     * <p>Direction is encoded in the sign of {@code amount} (positive credit,
+     * negative debit); the {@code user_ledger_amount_check} constraint admits
+     * a negative amount only for this entry type (see migration V38).
      */
     ADJUSTMENT,
 

--- a/backend/src/main/resources/db/migration/V38__user_ledger_signed_adjustment.sql
+++ b/backend/src/main/resources/db/migration/V38__user_ledger_signed_adjustment.sql
@@ -1,0 +1,23 @@
+-- V38: allow signed amounts on user_ledger ADJUSTMENT rows.
+--
+-- V3 created user_ledger with an inline `CHECK (amount > 0)` (Postgres
+-- auto-named it user_ledger_amount_check). But AdminWalletService.adjust
+-- writes the signed request amount under a single ADJUSTMENT entry type --
+-- the same shape the group wallet uses for ADMIN_ADJUSTMENT. An admin debit
+-- (negative amount) therefore violated user_ledger_amount_check and 500ed;
+-- only credits worked. The invariant is "amount != 0 always, signed only for
+-- the admin-adjustment entry type".
+--
+-- This mirrors V30 (realty_group_ledger_signed_admin_adjustment), which fixed
+-- the byte-for-byte identical bug for realty_group_ledger. user_ledger's
+-- admin-adjustment entry type is ADJUSTMENT (ADMIN_ADJUSTMENT is group-only).
+--
+-- balance_after / reserved_after remain the authoritative wallet snapshots;
+-- reconciliation sums users.balance_lindens, never user_ledger.amount, so a
+-- signed ADJUSTMENT row has no reconciliation impact.
+
+ALTER TABLE user_ledger DROP CONSTRAINT IF EXISTS user_ledger_amount_check;
+ALTER TABLE user_ledger ADD CONSTRAINT user_ledger_amount_check CHECK (
+    amount <> 0
+    AND (entry_type = 'ADJUSTMENT' OR amount > 0)
+);

--- a/backend/src/test/java/com/slparcelauctions/backend/admin/users/wallet/AdminWalletServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/admin/users/wallet/AdminWalletServiceTest.java
@@ -1,0 +1,138 @@
+package com.slparcelauctions.backend.admin.users.wallet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.admin.users.wallet.dto.AdminWalletAdjustRequest;
+import com.slparcelauctions.backend.admin.users.wallet.dto.AdminWalletSnapshotDto;
+import com.slparcelauctions.backend.admin.users.wallet.exception.AdminWalletStateException;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import com.slparcelauctions.backend.wallet.UserLedgerEntry;
+import com.slparcelauctions.backend.wallet.UserLedgerEntryType;
+import com.slparcelauctions.backend.wallet.UserLedgerRepository;
+
+/**
+ * Service-level integration tests for {@link AdminWalletService#adjust}. The
+ * debit case is a regression guard for the user-ledger signed-adjustment bug:
+ * V3 created {@code user_ledger} with a blanket {@code CHECK (amount > 0)}, but
+ * {@code adjust} writes the signed request amount under a single
+ * {@code ADJUSTMENT} type (same shape the group wallet uses for
+ * {@code ADMIN_ADJUSTMENT}). Before the V38 migration a negative adjustment
+ * hit {@code user_ledger_amount_check} and 500ed. V30 fixed the identical bug
+ * for {@code realty_group_ledger}; V38 mirrors it for {@code user_ledger}.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+    "auth.cleanup.enabled=false",
+    "slpa.auction-end.enabled=false",
+    "slpa.ownership-monitor.enabled=false",
+    "slpa.escrow.ownership-monitor-job.enabled=false",
+    "slpa.escrow.timeout-job.enabled=false",
+    "slpa.escrow.command-dispatcher-job.enabled=false",
+    "slpa.review.scheduler.enabled=false",
+    "slpa.notifications.cleanup.enabled=false",
+    "slpa.notifications.sl-im.cleanup.enabled=false",
+    "slpa.realty.invitation-expiry.enabled=false"
+})
+@Transactional
+class AdminWalletServiceTest {
+
+    @Autowired AdminWalletService service;
+    @Autowired UserRepository users;
+    @Autowired UserLedgerRepository ledger;
+
+    @Test
+    void adjust_debitsUserWallet_whenAmountIsNegativeAndBalanceAdequate() {
+        User admin = seedAdmin();
+        User u = seedUserWithBalance(10_000L);
+
+        AdminWalletSnapshotDto out = service.adjust(
+                u.getId(), new AdminWalletAdjustRequest(-100L, "Test debit", false), admin.getId());
+
+        assertThat(out.balanceLindens()).isEqualTo(9_900L);
+        assertThat(users.findById(u.getId()).orElseThrow().getBalanceLindens()).isEqualTo(9_900L);
+        UserLedgerEntry tail = ledger
+                .findByUserIdOrderByCreatedAtDesc(u.getId(), PageRequest.of(0, 1))
+                .getContent().get(0);
+        assertThat(tail.getEntryType()).isEqualTo(UserLedgerEntryType.ADJUSTMENT);
+        assertThat(tail.getAmount()).isEqualTo(-100L);
+        assertThat(tail.getBalanceAfter()).isEqualTo(9_900L);
+    }
+
+    @Test
+    void adjust_creditsUserWallet_whenAmountIsPositive() {
+        User admin = seedAdmin();
+        User u = seedUserWithBalance(500L);
+
+        AdminWalletSnapshotDto out = service.adjust(
+                u.getId(), new AdminWalletAdjustRequest(2_500L, "Comp credit", false), admin.getId());
+
+        assertThat(out.balanceLindens()).isEqualTo(3_000L);
+        UserLedgerEntry tail = ledger
+                .findByUserIdOrderByCreatedAtDesc(u.getId(), PageRequest.of(0, 1))
+                .getContent().get(0);
+        assertThat(tail.getEntryType()).isEqualTo(UserLedgerEntryType.ADJUSTMENT);
+        assertThat(tail.getAmount()).isEqualTo(2_500L);
+        assertThat(tail.getBalanceAfter()).isEqualTo(3_000L);
+    }
+
+    @Test
+    void adjust_throws_whenDebitWouldBreachReservationFloorWithoutOverride() {
+        User admin = seedAdmin();
+        User u = seedUserWithBalance(100L);
+
+        assertThatThrownBy(() -> service.adjust(
+                u.getId(), new AdminWalletAdjustRequest(-1_000L, "Too much", false), admin.getId()))
+                .isInstanceOf(AdminWalletStateException.class)
+                .hasMessageContaining("reservation floor");
+    }
+
+    @Test
+    void adjust_throws_whenAmountIsZero() {
+        User admin = seedAdmin();
+        User u = seedUserWithBalance(100L);
+
+        assertThatThrownBy(() -> service.adjust(
+                u.getId(), new AdminWalletAdjustRequest(0L, "Nope", false), admin.getId()))
+                .isInstanceOf(AdminWalletStateException.class);
+    }
+
+    // ───────────────────────────── helpers ─────────────────────────────
+
+    private User seedAdmin() {
+        return users.save(User.builder()
+            .username("adminadj-" + uniq())
+            .email("adminadj-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("x")
+            .role(Role.ADMIN)
+            .build());
+    }
+
+    private User seedUserWithBalance(long balance) {
+        return users.save(User.builder()
+            .username("walletadj-" + uniq())
+            .email("walletadj-" + UUID.randomUUID() + "@test.local")
+            .passwordHash("x")
+            .balanceLindens(balance)
+            .build());
+    }
+
+    private static String uniq() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+}


### PR DESCRIPTION
Promotes the user-wallet debit 500 fix to production.

Fixes admin per-user wallet debits 500ing (`user_ledger_amount_check` rejected the signed negative ADJUSTMENT amount). V38 mirrors V30's group-side fix; Flyway applies it on backend container startup. No Java logic change, no frontend change.

PR to dev: #357. Full backend suite green except a pre-existing flaky concurrency test (green in isolation, no causal path from this change).