### PR TITLE
Deploy: listing/auction UX (Sell Price projection, Buy now button, real seller stats)

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java
@@ -199,6 +199,7 @@ public class AuctionDtoMapper {
         return new SellerAuctionResponse(
                 a.getPublicId(),
                 a.getSeller().getPublicId(),
+                sellerSummary(a.getSeller()),
                 a.getTitle(),
                 ParcelResponse.from(a.getParcelSnapshot()),
                 a.getStatus(),

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/dto/SellerAuctionResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/dto/SellerAuctionResponse.java
@@ -26,6 +26,15 @@ import com.slparcelauctions.backend.parceltag.dto.ParcelTagResponse;
 public record SellerAuctionResponse(
         UUID publicId,
         UUID sellerPublicId,
+        /**
+         * Seller reputation summary, mirroring
+         * {@link PublicAuctionResponse.SellerSummary} on the buyer-facing view.
+         * Populated identically (same server-computed completionRate via
+         * SellerCompletionRateMapper) so the seller's own draft / activate
+         * preview shows the exact card a buyer would see instead of a
+         * placeholder. Null only when the seller association is unset.
+         */
+        PublicAuctionResponse.SellerSummary seller,
         String title,
         ParcelResponse parcel,
         AuctionStatus status,

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionControllerTest.java
@@ -100,6 +100,7 @@ class AuctionControllerTest {
         return new SellerAuctionResponse(
                 AUCTION_PUBLIC_ID,
                 UUID.fromString("00000000-0000-0000-0000-0000000000b1"),
+                /* seller */ null,
                 "Sample Listing",
                 null,
                 AuctionStatus.CANCELLED,

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionDtoMapperTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionDtoMapperTest.java
@@ -23,6 +23,7 @@ import com.slparcelauctions.backend.auction.dto.SellerAuctionResponse;
 import com.slparcelauctions.backend.escrow.EscrowRepository;
 import com.slparcelauctions.backend.realty.RealtyGroup;
 import com.slparcelauctions.backend.realty.RealtyGroupRepository;
+import com.slparcelauctions.backend.user.SellerCompletionRateMapper;
 import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.testsupport.TestRegions;
 
@@ -201,29 +202,7 @@ class AuctionDtoMapperTest {
                 .cancelledWithBids(2)
                 .createdAt(OffsetDateTime.now())
                 .build();
-        UUID parcelUuid = UUID.randomUUID();
-        Auction a = Auction.builder()
-                .title("Test listing")
-                .id(1L).seller(seller).slParcelUuid(parcelUuid)
-                .status(AuctionStatus.ACTIVE)
-                .startingBid(1000L).durationHours(168)
-                .snipeProtect(false).snipeWindowMin(null)
-                .listingFeePaid(false)
-                .currentBid(0L).bidCount(0)
-                .commissionRate(new BigDecimal("0.0500"))
-                .tags(new HashSet<>())
-                .createdAt(OffsetDateTime.now())
-                .updatedAt(OffsetDateTime.now())
-                .build();
-        a.setParcelSnapshot(AuctionParcelSnapshot.builder()
-                .slParcelUuid(parcelUuid)
-                .ownerUuid(UUID.randomUUID()).ownerType("agent")
-                .parcelName("Test Parcel")
-                .region(TestRegions.mainland())
-                .regionName("Coniston").regionMaturityRating("MODERATE")
-                .areaSqm(1024)
-                .positionX(128.0).positionY(64.0).positionZ(22.0)
-                .build());
+        Auction a = buildAuction(AuctionStatus.ACTIVE, seller);
 
         SellerAuctionResponse seller_ = mapper.toSellerResponse(a);
         PublicAuctionResponse public_ = mapper.toPublicResponse(a);
@@ -233,7 +212,8 @@ class AuctionDtoMapperTest {
         assertThat(seller_.seller().averageRating()).isEqualByComparingTo("4.75");
         assertThat(seller_.seller().reviewCount()).isEqualTo(8);
         assertThat(seller_.seller().completedSales()).isEqualTo(12);
-        assertThat(seller_.seller().completionRate()).isNotNull();
+        assertThat(seller_.seller().completionRate())
+                .isEqualByComparingTo(SellerCompletionRateMapper.compute(12, 2, 0));
     }
 
     @Test
@@ -248,7 +228,10 @@ class AuctionDtoMapperTest {
     }
 
     private Auction buildAuction(AuctionStatus status) {
-        User seller = User.builder().id(42L).email("s@example.com").username("s").build();
+        return buildAuction(status, User.builder().id(42L).email("s@example.com").username("s").build());
+    }
+
+    private Auction buildAuction(AuctionStatus status, User seller) {
         UUID parcelUuid = UUID.randomUUID();
         Auction a = Auction.builder()
                 .title("Test listing")

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionDtoMapperTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/AuctionDtoMapperTest.java
@@ -191,6 +191,52 @@ class AuctionDtoMapperTest {
     }
 
     @Test
+    void toSellerResponse_carriesSameSellerSummaryAsPublicResponse() {
+        User seller = User.builder()
+                .id(42L).email("s@example.com").username("s")
+                .displayName("Sally Seller")
+                .avgSellerRating(new BigDecimal("4.75"))
+                .totalSellerReviews(8)
+                .completedSales(12)
+                .cancelledWithBids(2)
+                .createdAt(OffsetDateTime.now())
+                .build();
+        UUID parcelUuid = UUID.randomUUID();
+        Auction a = Auction.builder()
+                .title("Test listing")
+                .id(1L).seller(seller).slParcelUuid(parcelUuid)
+                .status(AuctionStatus.ACTIVE)
+                .startingBid(1000L).durationHours(168)
+                .snipeProtect(false).snipeWindowMin(null)
+                .listingFeePaid(false)
+                .currentBid(0L).bidCount(0)
+                .commissionRate(new BigDecimal("0.0500"))
+                .tags(new HashSet<>())
+                .createdAt(OffsetDateTime.now())
+                .updatedAt(OffsetDateTime.now())
+                .build();
+        a.setParcelSnapshot(AuctionParcelSnapshot.builder()
+                .slParcelUuid(parcelUuid)
+                .ownerUuid(UUID.randomUUID()).ownerType("agent")
+                .parcelName("Test Parcel")
+                .region(TestRegions.mainland())
+                .regionName("Coniston").regionMaturityRating("MODERATE")
+                .areaSqm(1024)
+                .positionX(128.0).positionY(64.0).positionZ(22.0)
+                .build());
+
+        SellerAuctionResponse seller_ = mapper.toSellerResponse(a);
+        PublicAuctionResponse public_ = mapper.toPublicResponse(a);
+
+        assertThat(seller_.seller()).isNotNull();
+        assertThat(seller_.seller()).isEqualTo(public_.seller());
+        assertThat(seller_.seller().averageRating()).isEqualByComparingTo("4.75");
+        assertThat(seller_.seller().reviewCount()).isEqualTo(8);
+        assertThat(seller_.seller().completedSales()).isEqualTo(12);
+        assertThat(seller_.seller().completionRate()).isNotNull();
+    }
+
+    @Test
     void toPublicResponse_individualListing_nullGroupAndAgent() {
         Auction a = buildAuction(AuctionStatus.ACTIVE);
         // realtyGroupId and listingAgent are null by default in buildAuction

--- a/docs/implementation/FOOTGUNS.md
+++ b/docs/implementation/FOOTGUNS.md
@@ -838,6 +838,42 @@ leak the refresh token because the field doesn't exist on the type.
 - If a future contributor proposes a PR that merges the records, the PR review should reference
   this entry and decline.
 
+### B.11 An append-only `*_ledger` table's `amount > 0` CHECK and its `entry_type` CHECK are two separate constraints; a signed admin-adjustment type needs BOTH widened
+
+**Why:** Every `*_ledger` table is created with an inline `amount BIGINT NOT NULL CHECK (amount > 0)`,
+which Postgres auto-names `<table>_amount_check`. Admin wallet adjustments store the request
+amount *signed* (positive credit, negative debit) under a single adjustment entry type. When a
+later migration widens the `<table>_entry_type_check` to admit that adjustment type, it is easy
+to believe the table now accepts adjustments. It does not: the amount-sign CHECK is a wholly
+separate constraint and was never touched, so the first negative-amount adjustment fails the
+insert with `DataIntegrityViolationException` and the endpoint 500s. Credits pass (positive),
+debits fail (negative), so the bug hides until someone debits in production. This has bitten
+twice: `realty_group_ledger` (V26 created `amount > 0`; V29 widened `entry_type` for
+`ADMIN_ADJUSTMENT` but missed the sign; V30 fixed it) and `user_ledger` (V3 created
+`amount > 0`; `AdminWalletService.adjust` wrote signed `ADJUSTMENT`; bug shipped to prod;
+V38 fixed it).
+
+**How to apply:**
+- When introducing or repurposing a `*_ledger` entry type whose `amount` is signed (any admin
+  adjustment), the **same migration** that adds the entry type must also relax the amount CHECK:
+  ```sql
+  ALTER TABLE <table> DROP CONSTRAINT IF EXISTS <table>_amount_check;
+  ALTER TABLE <table> ADD CONSTRAINT <table>_amount_check CHECK (
+      amount <> 0 AND (entry_type = '<SIGNED_TYPE>' OR amount > 0)
+  );
+  ```
+  (See V30 and V38 for the canonical shape.)
+- Never edit the original migration that created the `amount > 0` check to "fix it in place" —
+  Flyway checksum-validates applied migrations and a content change fails startup. Add a new
+  forward migration, exactly as V30 did not touch V26 and V38 did not touch V3.
+- The regression test must actually persist a negative row against real Postgres (a
+  `@SpringBootTest` service/integration test, like `AdminWalletServiceTest` /
+  `AdminRealtyGroupWalletServiceTest`). A mocked-repository unit test cannot catch a DB-level
+  CHECK and gives false confidence.
+- The amount sign is intentional for adjustments; do not "fix" it by storing `abs(amount)` and
+  deriving direction elsewhere. The signed value equals the true balance delta and matches the
+  request DTO contract and the frontend ledger rendering.
+
 This is non-negotiable. Without the meta-discipline of "every catch becomes a ledger entry," the ledger doesn't compound and we re-burn the same lessons.
 
 ---

--- a/docs/superpowers/plans/2026-05-18-listing-auction-ux.md
+++ b/docs/superpowers/plans/2026-05-18-listing-auction-ux.md
@@ -1,0 +1,493 @@
+# Listing + auction UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship three listing/auction UX changes: an editable "Sell Price" what-if projection, a dedicated "Buy now" button under Place bid, and real seller stats in the create-listing preview.
+
+**Architecture:** Areas 1 and 2 are frontend-only. Area 3 enriches the seller-facing auction response DTO with the seller summary the public response already computes (no schema/Flyway, no new endpoint). One feature branch `feature/listing-auction-ux` off `dev`, one PR.
+
+**Tech Stack:** Next.js 16 / React 19 / TS 5 / Vitest + Testing Library (frontend); Spring Boot 4 / Java 24 / JUnit (backend).
+
+**Spec:** `docs/superpowers/specs/2026-05-18-listing-auction-ux-design.md`
+
+**Global rules (apply to every task):** No emoji. No em-dashes or connector en-dashes in any user-facing copy, comments, commits, or PRs. Feature branch off `dev`. Backend changes need a paired migration only when an entity changes (none here). Run the relevant test command after each step.
+
+---
+
+### Task 1: Backend - populate seller summary on SellerAuctionResponse
+
+**Files:**
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/dto/SellerAuctionResponse.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java:197-238` (the `toSellerResponse(Auction, Escrow, MapperBatchContext)` body)
+- Modify: `backend/src/test/java/com/slparcelauctions/backend/auction/AuctionControllerTest.java` (the `new SellerAuctionResponse(...)` construction site - arity change)
+- Test: `backend/src/test/java/com/slparcelauctions/backend/auction/AuctionDtoMapperTest.java` (create if absent; otherwise add a method)
+
+**Context:** `AuctionDtoMapper.sellerSummary(User s)` (line 335) already builds a
+`PublicAuctionResponse.SellerSummary` including the server-computed
+`completionRate` (`SellerCompletionRateMapper.compute(...)`).
+`toPublicResponse` passes `sellerSummary(a.getSeller())`; `toSellerResponse`
+does not, so the seller-facing draft/activate preview has no seller block and
+the frontend falls back to a `"You" / 0 sales` placeholder.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `AuctionDtoMapperTest` (mirror the existing public-response seller-summary test if one exists; otherwise construct an `Auction` with a seller `User` that has `avgSellerRating`, `totalSellerReviews`, `completedSales`, `cancelledWithBids`, `createdAt` set):
+
+```java
+@Test
+void toSellerResponse_populatesSellerSummary_withSameComputationAsPublic() {
+    Auction a = /* existing test-builder for an auction with a seeded seller */;
+    SellerAuctionResponse seller = mapper.toSellerResponse(a);
+    PublicAuctionResponse pub = mapper.toPublicResponse(a);
+
+    assertThat(seller.seller()).isNotNull();
+    assertThat(seller.seller()).isEqualTo(pub.seller());
+}
+```
+
+- [ ] **Step 2: Run it, expect compile failure / red**
+
+Run: `backend/mvnw -q -f backend/pom.xml test -Dtest=AuctionDtoMapperTest`
+Expected: fails to compile (`SellerAuctionResponse` has no `seller()` accessor) or fails red.
+
+- [ ] **Step 3: Add the record component**
+
+In `SellerAuctionResponse.java`, add a component immediately after
+`UUID sellerPublicId,` (line 28):
+
+```java
+        UUID sellerPublicId,
+        /**
+         * Seller reputation summary. Mirrors {@link PublicAuctionResponse.SellerSummary}
+         * and is populated identically to the public view so the seller's own
+         * draft/activate preview matches the buyer-facing card exactly
+         * (including the server-computed completionRate).
+         */
+        PublicAuctionResponse.SellerSummary seller,
+```
+
+Add the import if not already present:
+`import com.slparcelauctions.backend.auction.dto.PublicAuctionResponse;`
+(same package, so reference as `PublicAuctionResponse.SellerSummary` directly;
+no import needed since it is the same `dto` package).
+
+- [ ] **Step 4: Pass the summary in the mapper**
+
+In `AuctionDtoMapper.toSellerResponse(...)` (the 3-arg overload, the
+`new SellerAuctionResponse(` call starting line 199), insert
+`sellerSummary(a.getSeller()),` as the second constructor argument,
+immediately after `a.getSeller().getPublicId(),`:
+
+```java
+        return new SellerAuctionResponse(
+                a.getPublicId(),
+                a.getSeller().getPublicId(),
+                sellerSummary(a.getSeller()),
+                a.getTitle(),
+                /* ...rest unchanged... */
+```
+
+- [ ] **Step 5: Fix the other construction site**
+
+`AuctionControllerTest.java` constructs `new SellerAuctionResponse(...)`
+directly. Add the matching `seller` argument in the same position (after
+`sellerPublicId`). Use a representative `PublicAuctionResponse.SellerSummary`
+(or `null` if the test does not assert seller fields).
+
+- [ ] **Step 6: Run the test, expect green**
+
+Run: `backend/mvnw -q -f backend/pom.xml test -Dtest=AuctionDtoMapperTest`
+Expected: PASS.
+
+- [ ] **Step 7: Run the broader auction backend slice**
+
+Run: `backend/mvnw -q -f backend/pom.xml test -Dtest='com.slparcelauctions.backend.auction.*'`
+Expected: PASS (catches any other `SellerAuctionResponse` assertion that now sees the new field).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/auction/dto/SellerAuctionResponse.java backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java backend/src/test/java/com/slparcelauctions/backend/auction/AuctionControllerTest.java backend/src/test/java/com/slparcelauctions/backend/auction/AuctionDtoMapperTest.java
+git commit -m "feat(auction): populate seller summary on SellerAuctionResponse"
+```
+
+---
+
+### Task 2: Frontend - draft preview renders real seller stats
+
+**Files:**
+- Verify only (no logic change expected): `frontend/src/app/listings/(verified)/[publicId]/activate/DraftEditorClient.tsx:160-175`
+- Verify only: `frontend/src/types/auction.ts` (`SellerAuctionResponse.seller?` already exists; confirm field names match the backend `SellerSummary` JSON)
+- Modify: `frontend/src/test/fixtures/auction.ts` (add a `seller` block to the seller-auction fixture)
+- Test: `frontend/src/app/listings/(verified)/[publicId]/activate/ActivateClient.test.tsx`
+
+**Context:** `DraftEditorClient` already maps `sellerCardData` from
+`auction.seller` when present; with Task 1 it is now present. The placeholder
+becomes defensive-only and must remain.
+
+- [ ] **Step 1: Update the fixture**
+
+In `frontend/src/test/fixtures/auction.ts`, add a `seller` block to the
+seller-auction fixture object matching `AuctionSellerSummaryDto`:
+
+```ts
+seller: {
+  publicId: "11111111-1111-1111-1111-111111111111",
+  displayName: "Test Seller",
+  avatarUrl: null,
+  averageRating: 4.5,
+  reviewCount: 12,
+  completedSales: 7,
+  completionRate: 0.92,
+  memberSince: "2025-11-03",
+},
+```
+
+- [ ] **Step 2: Write the failing test**
+
+In `ActivateClient.test.tsx` (or the draft-editor test that renders
+`DraftEditorClient`), add a case asserting the real seller card shows the
+fixture stats, not the placeholder:
+
+```ts
+it("renders the seller's real reputation in the draft preview", async () => {
+  // render with the seller-auction fixture (now carrying `seller`)
+  expect(await screen.findByTestId("seller-profile-card")).toBeInTheDocument();
+  expect(screen.getByText("Test Seller")).toBeInTheDocument();
+  expect(screen.getByText(/7 completed sale/)).toBeInTheDocument();
+  expect(screen.getByText(/Completion rate: 92%/)).toBeInTheDocument();
+  expect(screen.queryByText(/^You$/)).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 3: Run it**
+
+Run: `cd frontend && npm test -- ActivateClient`
+Expected: PASS without any `DraftEditorClient` code change (Task 1 + fixture
+drive it). If it fails because the test harness mocks `getAuction` without the
+`seller` block, update that mock to use the fixture. Do NOT modify the
+`DraftEditorClient` placeholder branch (keep it defensive).
+
+- [ ] **Step 4: Confirm types**
+
+Open `frontend/src/types/auction.ts`; confirm `AuctionSellerSummaryDto` field
+names (`averageRating`, `reviewCount`, `completedSales`, `completionRate`,
+`memberSince`, `publicId`, `displayName`, `avatarUrl`) match the backend
+`SellerSummary` JSON (the public auction already deserializes this shape, so
+no change is expected). If a mismatch exists, fix the fixture, not the type.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/test/fixtures/auction.ts "frontend/src/app/listings/(verified)/[publicId]/activate/ActivateClient.test.tsx"
+git commit -m "test(listing): draft preview asserts real seller stats"
+```
+
+---
+
+### Task 3: Sell Price editable projection
+
+**Files:**
+- Modify: `frontend/src/components/listing/AgentCommissionPreview.tsx`
+- Modify: `frontend/src/components/listing/ListingWizardForm.tsx` (the `<AgentCommissionPreview ... />` render site, ~line 367)
+- Test: `frontend/src/components/listing/AgentCommissionPreview.test.tsx`
+- Test: `frontend/src/components/listing/ListingWizardForm.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `AgentCommissionPreview.test.tsx`, replace the "List price" string
+expectations with "Sell Price" and add:
+
+```ts
+it('labels the row "Sell Price" and the derived rows "at sell price"', () => {
+  render(<AgentCommissionPreview startingBid={1000} reservePrice={2000} buyNowPrice={5000} groupName="Sunset Realty" groupPublicId="g1" agentCommissionRate={0.1} />);
+  expect(screen.getByText("Sell Price")).toBeInTheDocument();
+  expect(screen.getByText("Platform commission at sell price")).toBeInTheDocument();
+  expect(screen.getByText("Your earnings at sell price")).toBeInTheDocument();
+  expect(screen.getByText("Sunset Realty earnings at sell price")).toBeInTheDocument();
+});
+
+it("defaults the Sell Price input to buyNow ?? reserve ?? starting", () => {
+  const { rerender } = render(<AgentCommissionPreview startingBid={1000} reservePrice={2000} buyNowPrice={5000} groupName="G" groupPublicId="g1" agentCommissionRate={0.1} />);
+  expect((screen.getByTestId("sell-price-input") as HTMLInputElement).value).toBe("5000");
+  rerender(<AgentCommissionPreview startingBid={1000} reservePrice={2000} buyNowPrice={null} groupName="G" groupPublicId="g1" agentCommissionRate={0.1} />);
+  expect((screen.getByTestId("sell-price-input") as HTMLInputElement).value).toBe("2000");
+  rerender(<AgentCommissionPreview startingBid={1000} reservePrice={null} buyNowPrice={null} groupName="G" groupPublicId="g1" agentCommissionRate={0.1} />);
+  expect((screen.getByTestId("sell-price-input") as HTMLInputElement).value).toBe("1000");
+});
+
+it("recomputes the projected rows when the Sell Price input changes", async () => {
+  render(<AgentCommissionPreview startingBid={1000} reservePrice={null} buyNowPrice={null} groupName="G" groupPublicId="g1" agentCommissionRate={0.1} />);
+  const input = screen.getByTestId("sell-price-input");
+  fireEvent.change(input, { target: { value: "10000" } });
+  // platformCommission = floor(10000*0.05)=500; earnings=9500; agentSlice=floor(9500*0.1)=950; group=8550
+  expect(screen.getByText("L$500", { exact: false })).toBeInTheDocument();
+  expect(screen.getByText("L$950", { exact: false })).toBeInTheDocument();
+  expect(screen.getByText("L$8,550", { exact: false })).toBeInTheDocument();
+});
+
+it("keeps the listing-fee gating keyed off starting bid, not the Sell Price input", async () => {
+  const onInsufficient = vi.fn();
+  // wallet balance mock so balance < floor(startingBid*0.05) toggles insufficient.
+  render(<AgentCommissionPreview startingBid={1000} reservePrice={null} buyNowPrice={null} groupName="G" groupPublicId="g1" agentCommissionRate={0.1} onInsufficient={onInsufficient} />);
+  const firstCallCount = onInsufficient.mock.calls.length;
+  fireEvent.change(screen.getByTestId("sell-price-input"), { target: { value: "999999" } });
+  // Editing the projection must not change the insufficiency decision.
+  expect(onInsufficient.mock.calls.length).toBe(firstCallCount);
+});
+```
+
+(Reuse the file's existing wallet-query mock setup for the gating test.)
+
+- [ ] **Step 2: Run, expect red**
+
+Run: `cd frontend && npm test -- AgentCommissionPreview`
+Expected: FAIL (props `reservePrice`/`buyNowPrice` unknown, no `sell-price-input`, old labels).
+
+- [ ] **Step 3: Implement**
+
+In `AgentCommissionPreview.tsx`:
+
+- Extend `AgentCommissionPreviewProps`: add `reservePrice: number | null;`
+  and `buyNowPrice: number | null;`.
+- Add state + default logic near the top of the component body:
+
+```tsx
+const defaultSell = buyNowPrice ?? reservePrice ?? startingBid;
+const [raw, setRaw] = useState<string>(String(defaultSell));
+const [touched, setTouched] = useState(false);
+useEffect(() => {
+  if (!touched) {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setRaw(String(defaultSell));
+  }
+}, [defaultSell, touched]);
+const parsedSell = raw.trim() === "" ? defaultSell : Math.floor(Number(raw));
+const sellPrice =
+  Number.isFinite(parsedSell) && parsedSell > 0 ? parsedSell : defaultSell;
+```
+
+- Compute the displayed projection from `sellPrice` (not `startingBid`):
+
+```tsx
+const platformCommission = floorLindens(sellPrice, PLATFORM_COMMISSION_RATE);
+const earnings = sellPrice - platformCommission;
+const agentSlice = floorLindens(earnings, agentCommissionRate);
+const groupSlice = earnings - agentSlice;
+```
+
+- Keep the fee/gating decoupled and based on `startingBid`:
+
+```tsx
+const listingFee = floorLindens(startingBid, PLATFORM_COMMISSION_RATE);
+const insufficient = balance !== null && balance < listingFee;
+const shortfall = insufficient && balance !== null ? listingFee - balance : 0;
+```
+
+(`onInsufficient` effect unchanged - it depends on `insufficient`, which is
+now starting-bid-derived only.)
+
+- Keep `if (startingBid <= 0) return null;`.
+- Replace the "List price" `<dt>/<dd>` row: `<dt>` text becomes
+  `Sell Price`; the `<dd>` becomes a controlled numeric input:
+
+```tsx
+<div className="flex justify-between gap-4 py-1">
+  <dt className="text-fg-muted">Sell Price</dt>
+  <dd>
+    <input
+      type="number"
+      inputMode="numeric"
+      min={1}
+      step={1}
+      aria-label="Sell price (L$)"
+      data-testid="sell-price-input"
+      value={raw}
+      onChange={(e) => {
+        setTouched(true);
+        setRaw(e.target.value);
+      }}
+      className="w-28 rounded-md bg-surface-raised px-2 py-1 text-right tabular-nums font-medium text-fg ring-1 ring-transparent focus:outline-none focus:ring-2 focus:ring-brand"
+    />
+  </dd>
+</div>
+```
+
+- Rename the three derived `<dt>` strings to "Platform commission at sell
+  price", "Your earnings at sell price", "{groupName} earnings at sell
+  price". Keep the `(5%)`, `({ratePct}% of remaining)`, `(remaining)`
+  annotations and all existing classNames.
+- Add `useEffect` to the React import if not already imported.
+
+- [ ] **Step 4: Wire the wizard**
+
+In `ListingWizardForm.tsx`, at the `<AgentCommissionPreview>` render site,
+add `reservePrice={...}` and `buyNowPrice={...}` from the same
+auction-settings state object that supplies `startingBid` (the
+`AuctionSettingsValue` carries `reservePrice` and `buyNowPrice` as
+`number | null`). Update `ListingWizardForm.test.tsx` assertions that
+reference "List price" to "Sell Price" and pass the new props in any direct
+`AgentCommissionPreview` render.
+
+- [ ] **Step 5: Run, expect green**
+
+Run: `cd frontend && npm test -- AgentCommissionPreview ListingWizardForm`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/listing/AgentCommissionPreview.tsx frontend/src/components/listing/AgentCommissionPreview.test.tsx frontend/src/components/listing/ListingWizardForm.tsx frontend/src/components/listing/ListingWizardForm.test.tsx
+git commit -m "feat(listing): editable Sell Price what-if projection"
+```
+
+---
+
+### Task 4: Buy now button under Place bid
+
+**Files:**
+- Modify: `frontend/src/components/auction/PlaceBidForm.tsx`
+- Test: `frontend/src/components/auction/PlaceBidForm.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `PlaceBidForm.test.tsx`:
+
+```ts
+it("shows a Buy now button when the auction has a buy-now price", () => {
+  renderForm({ buyNowPrice: 25000 });
+  expect(screen.getByTestId("place-bid-buy-now")).toHaveTextContent("Buy now · L$25,000");
+});
+
+it("does not show the Buy now button when there is no buy-now price", () => {
+  renderForm({ buyNowPrice: null });
+  expect(screen.queryByTestId("place-bid-buy-now")).not.toBeInTheDocument();
+});
+
+it("Buy now opens the buy-now confirm and places a bid at exactly the buy-now price", async () => {
+  const placeBidSpy = /* spy on placeBid */;
+  renderForm({ buyNowPrice: 25000 });
+  fireEvent.click(screen.getByTestId("place-bid-buy-now"));
+  // ConfirmBidDialog buy-now branch is open
+  fireEvent.click(screen.getByRole("button", { name: /Buy now · L\$25,000/ }));
+  await waitFor(() => expect(placeBidSpy).toHaveBeenCalledWith(expect.any(String), 25000));
+});
+
+it("disables Buy now when disconnected", () => {
+  renderForm({ buyNowPrice: 25000, connectionState: { status: "reconnecting" } });
+  expect(screen.getByTestId("place-bid-buy-now")).toBeDisabled();
+});
+```
+
+(Use the file's existing render helper / mock conventions; `renderForm` is
+illustrative for whatever the file already uses.)
+
+- [ ] **Step 2: Run, expect red**
+
+Run: `cd frontend && npm test -- PlaceBidForm`
+Expected: FAIL (no `place-bid-buy-now`).
+
+- [ ] **Step 3: Implement**
+
+In `PlaceBidForm.tsx`, immediately after the existing submit `<Button>`
+(the one rendering `{buttonLabel}`, ~line 206-215) and before the
+`{!isConnected ? ...}` helper, add:
+
+```tsx
+{buyNow != null ? (
+  <Button
+    type="button"
+    variant="secondary"
+    fullWidth
+    disabled={!isConnected || mutation.isPending}
+    data-testid="place-bid-buy-now"
+    onClick={() => setConfirm({ kind: "buy-now", amount: buyNow })}
+  >
+    {`Buy now · L$${buyNow.toLocaleString()}`}
+  </Button>
+) : null}
+```
+
+No other change: the existing `confirm.kind === "buy-now"` dialog block
+(lines 225-237) already renders for `buyNow != null` and calls
+`submitBid(confirm.amount)`; `amount === buyNow` so the dialog copy is
+accurate. The group-COI early return already prevents the button from
+rendering for group members; `BidPanel` variant gating prevents
+non-bidder viewers from mounting the form.
+
+- [ ] **Step 4: Run, expect green**
+
+Run: `cd frontend && npm test -- PlaceBidForm`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/auction/PlaceBidForm.tsx frontend/src/components/auction/PlaceBidForm.test.tsx
+git commit -m "feat(auction): dedicated Buy now button under Place bid"
+```
+
+---
+
+### Task 5: Postman, README sweep, full verification
+
+**Files:**
+- Modify: Postman SLPA collection (seller `GET /api/v1/auctions/{id}` saved example)
+- Modify: `README.md` (sweep for staleness; add a one-line note only if a slice description is now inaccurate)
+
+- [ ] **Step 1: Postman**
+
+Update the SLPA Postman collection's seller `GET /api/v1/auctions/{id}`
+saved response/example so it includes the new `seller` block (mirror the
+public auction's seller summary shape). Use the Postman MCP tools; do not
+change any request scripts.
+
+- [ ] **Step 2: README sweep**
+
+Grep `README.md` for any slice text describing the seller-facing auction
+response or the create-listing preview placeholder. If a sentence is now
+inaccurate, correct it in one line. If nothing is stale, make no change
+(the sweep itself satisfies the project convention).
+
+- [ ] **Step 3: Full frontend verification**
+
+Run: `cd frontend && npm run lint && npm test && npm run build && npm run verify`
+Expected: all pass (CI is main-only; this is the gate).
+
+- [ ] **Step 4: Full backend verification**
+
+Run: `backend/mvnw -q -f backend/pom.xml test`
+Expected: BUILD SUCCESS. A single failure in
+`com.slparcelauctions.backend.auction.concurrency.BidCancelRaceTest` is the
+known pre-existing flake (FOOTGUNS F.117) - re-run it in isolation to
+confirm green before treating the suite as passing; it is unrelated to
+this work.
+
+- [ ] **Step 5: Commit any sweep/Postman-export changes**
+
+```bash
+git add README.md
+git commit -m "docs: README sweep for listing/auction UX changes"
+```
+
+(Only if the sweep changed something. Never `git add -A` - the repo has
+untracked unrelated files.)
+
+---
+
+## Self-review
+
+- Spec coverage: Area 1 (Task 3), Area 2 (Task 4), Area 3 backend (Task 1) +
+  frontend (Task 2), Postman/README/verification (Task 5). All spec sections
+  mapped.
+- Type consistency: `SellerAuctionResponse.seller` (backend record) ↔
+  `AuctionSellerSummaryDto` (frontend, already present) ↔ the existing
+  `sellerSummary()` computation reused verbatim, so JSON shape is identical
+  to the already-working public response. `sellPrice` projection is local to
+  `AgentCommissionPreview`; `listingFee`/`onInsufficient` remain
+  `startingBid`-derived (decoupling pinned by a test in Task 3).
+- No placeholders: every code/label string and test assertion is concrete;
+  `renderForm`/test-builder references defer to each file's existing helper
+  by design.
+- Ordering: Task 1 (backend) precedes Task 2 (frontend Area 3) so the
+  frontend test runs against the real enriched shape.

--- a/docs/superpowers/specs/2026-05-18-listing-auction-ux-design.md
+++ b/docs/superpowers/specs/2026-05-18-listing-auction-ux-design.md
@@ -1,0 +1,354 @@
+# Listing + auction UX: Sell Price projection, Buy Now button, real seller stats in preview
+
+Date: 2026-05-18
+Status: Approved (brainstorming)
+
+## Problem
+
+Three independent listing/auction UX gaps, bundled into one spec + one PR:
+
+1. The create-listing fee/earnings preview shows a static, read-only
+   "List price" row equal to the starting bid. Sellers cannot see what
+   they would net if the parcel sells for a different amount.
+2. Buy-it-now is only reachable implicitly: a bidder must type an amount
+   greater than or equal to the buy-now price into the bid field. There
+   is no discoverable "Buy Now" action.
+3. When a seller previews their own draft listing, the seller profile
+   card shows a hardcoded placeholder (`"You"`, 0 completed sales, no
+   rating, no completion rate) instead of their real reputation, so the
+   preview does not reflect what buyers will actually see.
+
+## Decisions
+
+1. **Sell Price is a pure what-if projection.** Relabel and make the
+   value editable; recompute only the displayed projection. Never change
+   what is actually charged, stored, or gated. No backend change for
+   this area.
+2. **Default Sell Price priority: Buy It Now, then Reserve, then
+   Starting Bid** (`buyNowPrice ?? reservePrice ?? startingBid`).
+3. **The Buy Now button reuses the existing buy-now flow verbatim.** It
+   sets the existing `confirm` state to the buy-now branch at exactly the
+   buy-now price; no new mutation, dialog, or backend.
+4. **Real seller stats come from the existing server computation, not a
+   second fetch.** The public auction response already builds a full
+   seller summary (including the server-computed `completionRate`). The
+   fix is to populate the same summary on the seller-facing auction
+   response, which the draft/activate preview already knows how to
+   render. This guarantees the preview is byte-identical to the
+   buyer-facing card with zero fidelity gap. It is a DTO enrichment with
+   no schema/Flyway change and no new endpoint.
+5. **Packaging:** one spec, one implementation plan, one PR
+   `feature/listing-auction-ux` into `dev`, then `dev` to `main`.
+   Areas 1 and 2 are frontend-only; Area 3 touches the backend response
+   DTO + mapper + their tests + Postman. The `dev` to `main` promotion
+   triggers the backend deploy pipeline and an Amplify rebuild.
+
+## Area 1: Sell Price editable projection
+
+### Files
+
+- Modify: `frontend/src/components/listing/AgentCommissionPreview.tsx`
+- Modify: `frontend/src/components/listing/ListingWizardForm.tsx`
+  (the `<AgentCommissionPreview ... />` render site, ~line 367, passes
+  two new props)
+- Test: `frontend/src/components/listing/AgentCommissionPreview.test.tsx`
+- Test: `frontend/src/components/listing/ListingWizardForm.test.tsx`
+
+### Behaviour
+
+`AgentCommissionPreview` is the single fee/earnings preview rendered
+unconditionally by the wizard post Realty-Groups-G (case-1 `AgentFeePreview`
+was removed). Today every row is computed from the `startingBid` prop and
+labelled "...at list price".
+
+Props change (`AgentCommissionPreviewProps`): add
+`reservePrice: number | null` and `buyNowPrice: number | null`.
+`startingBid: number` stays. `groupName`, `groupPublicId`,
+`agentCommissionRate`, `onInsufficient` stay.
+
+State: an editable integer L$ input whose default is
+`buyNowPrice ?? reservePrice ?? startingBid`. The input is controlled
+text (mirrors `PlaceBidForm`'s `useState<string>` numeric-input pattern).
+A `touched` flag tracks whether the seller has edited it:
+
+- While `!touched`, the input value tracks the computed default. If the
+  seller changes starting bid / reserve / buy-now upstream, the still
+  untouched input re-seeds to the new default (a `useEffect` on the
+  computed default, guarded by `!touched`). This is the project's
+  established intentional post-mount `setState` in effect; if ESLint
+  flags `react-hooks/set-state-in-effect`, add the bare
+  `// eslint-disable-next-line react-hooks/set-state-in-effect` comment
+  exactly as `WalletPanel.tsx` / `WalletTermsBanner.tsx` do. Do not
+  restructure to avoid the lint; the re-seed is the desired behaviour.
+- On the first `onChange`, set `touched = true`; from then on the input
+  is fully seller-controlled and is never re-seeded.
+
+Projection number used for the displayed rows:
+
+```
+const defaultSell = buyNowPrice ?? reservePrice ?? startingBid;
+const parsed = raw.trim() === "" ? defaultSell : Math.floor(Number(raw));
+const sellPrice = Number.isFinite(parsed) && parsed > 0 ? parsed : defaultSell;
+```
+
+Empty or non-numeric input falls back to `defaultSell` for the
+projection math (the text box still shows whatever the seller typed; only
+the computed rows fall back). The existing `if (startingBid <= 0) return
+null;` guard is unchanged, so the component is hidden until a starting
+bid exists and `defaultSell` is always well-defined when shown.
+
+Displayed rows recompute from `sellPrice` (not `startingBid`):
+
+```
+platformCommission = floor(sellPrice * 0.05)
+earnings           = sellPrice - platformCommission
+agentSlice         = floor(earnings * agentCommissionRate)
+groupSlice         = earnings - agentSlice
+```
+
+Labels:
+
+- "List price" becomes "Sell Price" and its value cell becomes the
+  editable input.
+- "Platform commission at list price" becomes "Platform commission at
+  sell price" (keep the `(5%)` annotation).
+- "Your earnings at list price" becomes "Your earnings at sell price"
+  (keep the `({ratePct}% of remaining)` annotation).
+- "{groupName} earnings at list price" becomes "{groupName} earnings at
+  sell price" (keep the `(remaining)` annotation).
+
+Decoupled and unchanged (must NOT use `sellPrice`):
+
+- `listingFee` stays `floorLindens(startingBid, PLATFORM_COMMISSION_RATE)`.
+- `insufficient`, `shortfall`, and the `onInsufficient(insufficient)`
+  callback stay computed from the `startingBid`-derived `listingFee`.
+- The "Listing fee paid from {groupName} wallet. Current balance L$..."
+  line and the "Group wallet has L$...; deposit L$... to publish."
+  danger line are unchanged. Editing Sell Price never enables/disables
+  the publish button and never changes the projected platform commission
+  used for the fee.
+
+Accessibility / styling / rules:
+
+- The value cell becomes a native numeric input (`type="number"`,
+  `inputMode="numeric"`, `step={1}`, `min={1}`) with an accessible name
+  (`aria-label="Sell price (L$)"` or a visually-hidden label) since the
+  surrounding `<dl>`/`<dt>` is not a `<label>`. Keep the existing
+  `tabular-nums` numeric styling and the `bg-bg-subtle` block.
+- `data-testid="agent-commission-preview"` stays; add
+  `data-testid="sell-price-input"` on the input.
+- No emoji, no em-dashes or connector en-dashes (project rules).
+
+`ListingWizardForm.tsx`: the existing `<AgentCommissionPreview>` render
+site passes `startingBid` from the wizard's auction-settings state; add
+`reservePrice={settings.reservePrice}` and
+`buyNowPrice={settings.buyNowPrice}` from the same state object
+(`AuctionSettingsValue` already carries both as `number | null`).
+
+## Area 2: Buy Now button under Place bid
+
+### Files
+
+- Modify: `frontend/src/components/auction/PlaceBidForm.tsx`
+- Test: `frontend/src/components/auction/PlaceBidForm.test.tsx`
+
+### Behaviour
+
+Buy-now is `placeBid(auction.publicId, amount)` where `amount` is greater
+than or equal to `buyNowPrice`; the backend interprets it as a buy-now.
+`PlaceBidForm` already owns the `placeBid` mutation, the `confirm` state
+machine, and the `confirm.kind === "buy-now"` `ConfirmBidDialog` branch
+(which uses `submitBid(confirm.amount)`).
+
+Add a secondary button immediately after the existing "Place bid"
+submit `<Button>` and before the connection helper / dialog blocks:
+
+- Rendered only when `buyNow != null` (i.e. `auction.buyNowPrice` set).
+- `type="button"` (must not submit the form).
+- Label: `Buy now · L$${buyNow.toLocaleString()}` (middle dot
+  separator, exactly matching the existing typed-amount buy-now
+  submit-button label casing in `PlaceBidForm` line ~154). No em-dash.
+- `variant="secondary"` (or the project's closest non-primary full-width
+  button variant), `fullWidth`.
+- `onClick`: `setConfirm({ kind: "buy-now", amount: buyNow })`. This
+  reuses the existing buy-now `ConfirmBidDialog` branch unchanged; its
+  message ("This will trigger buy-now at L$X...") is accurate because
+  `amount === buyNow`.
+- `disabled` when `!isConnected || mutation.isPending` (mirrors the
+  submit button). It deliberately does NOT depend on `hasValidAmount`
+  or the typed amount; it always uses `buyNow` exactly.
+- `data-testid="place-bid-buy-now"`.
+
+Visibility/gating already handled upstream: the group-COI early return
+(lines 160-171) short-circuits before the main form return, so members
+of the auction's realty group never see the button; the `BidPanel`
+variant dispatcher already prevents unauth/unverified/seller/ended
+viewers from rendering `PlaceBidForm` at all.
+
+The passive "Buy now for L$X" callout in `BidPanel.tsx` (`BidderPanel`
+and `BidPanelAuthLoading`) is kept as-is. Removing it is explicitly out
+of scope (noted in Out of scope) to keep this change minimal.
+
+## Area 3: real seller stats in the create-listing preview
+
+### Files
+
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/dto/SellerAuctionResponse.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java`
+  (`toSellerResponse(Auction, Escrow, MapperBatchContext)` constructor call)
+- Modify: every other construction site of `new SellerAuctionResponse(...)`
+  (record arity change) including backend test fixtures/builders
+- Test: backend `AuctionDtoMapper` seller-response test (assert the
+  seller summary block is populated; mirror the existing public-response
+  seller-summary assertion)
+- Modify: Postman SLPA collection, the seller `GET /api/v1/auctions/{id}`
+  saved example/response (now includes the `seller` block)
+- Verify (likely no code change): `frontend/src/types/auction.ts`
+  (`SellerAuctionResponse.seller?` already exists),
+  `frontend/src/app/listings/(verified)/[publicId]/activate/DraftEditorClient.tsx`
+  (already branches on `auction.seller`)
+- Test: `frontend/src/app/listings/(verified)/[publicId]/activate/ActivateClient.test.tsx`
+  and any draft-editor test/fixture asserting the placeholder; update
+  `frontend/src/test/fixtures/auction.ts` seller-auction fixture to
+  include a `seller` block
+
+### Behaviour
+
+Backend:
+
+- `PublicAuctionResponse` already has a nested `SellerSummary` record;
+  `AuctionDtoMapper` already has the private `sellerSummary(User s)`
+  helper that builds it including the server-computed `completionRate`
+  via `SellerCompletionRateMapper.compute(...)`. `toPublicResponse`
+  passes `sellerSummary(a.getSeller())`. `toSellerResponse` currently
+  passes nothing for it.
+- Add a `PublicAuctionResponse.SellerSummary seller` component to the
+  `SellerAuctionResponse` record. Position: immediately after
+  `sellerPublicId` (keeps seller-identity fields together and reads
+  naturally; the exact ordinal is an implementation choice as long as
+  every call site updates consistently). Document on the component that
+  it mirrors `PublicAuctionResponse.SellerSummary` and is populated for
+  the auction owner's own seller-facing view.
+- In `toSellerResponse(Auction a, Escrow escrow, MapperBatchContext ctx)`,
+  pass `sellerSummary(a.getSeller())` for the new component, reusing the
+  identical computation `toPublicResponse` uses. No new query: the
+  `User` is already loaded via `a.getSeller()`.
+- Update all other `new SellerAuctionResponse(...)` call sites for the
+  arity change (production + tests/fixtures). Grep
+  `new SellerAuctionResponse(` across `backend/src`.
+
+Frontend:
+
+- `frontend/src/types/auction.ts` already declares
+  `SellerAuctionResponse.seller?: AuctionSellerSummaryDto | null`
+  (it `Mirrors PublicAuctionResponse.SellerSummary`), so no type change
+  is expected; confirm the shape matches and tighten only if needed.
+- `DraftEditorClient.tsx` already maps `sellerCardData` from
+  `auction.seller` when present and falls back to the
+  `{ displayName: "You", completedSales: 0 }` placeholder otherwise.
+  With the backend now populating `seller`, the real branch is taken and
+  `completionRate` flows through unchanged. The placeholder becomes a
+  defensive-only path (seller association theoretically null). No code
+  change required beyond confirming this; do not delete the defensive
+  fallback.
+- Update frontend tests/fixtures that previously relied on the
+  placeholder so they assert the real seller summary instead.
+
+New sellers still render correctly: `SellerProfileCard` /
+`NewSellerBadge` already handle null rating, zero sales, and null
+`completionRate` ("Too new to calculate" + New Seller badge). The
+preview will now match the buyer-facing card exactly, including those
+zero states.
+
+## Behaviour rules
+
+- Area 1 Sell Price is display-only. It must never feed `listingFee`,
+  `onInsufficient`, publish-gating, or any persisted/charged value.
+- Area 1 default re-seeds only while untouched; sticky after the first
+  edit; empty/NaN falls back to the default for the projection only.
+- Area 2 Buy Now always uses exactly `buyNowPrice`, reuses the existing
+  confirm dialog and `submitBid`, and respects connection + pending
+  state. It is excluded for group-COI members and non-bidder variants by
+  existing gating.
+- Area 3 the seller-facing auction response now carries the same seller
+  summary (incl. `completionRate`) the public response carries; the
+  draft/activate preview is byte-identical to the buyer-facing card.
+
+## Testing
+
+Frontend (Vitest + Testing Library):
+
+- `AgentCommissionPreview.test.tsx`: relabelled strings ("Sell Price",
+  "Platform commission at sell price", "Your earnings at sell price",
+  "{group} earnings at sell price"); default value priority
+  (buyNow > reserve > starting, and each fallback); editing the input
+  recomputes the three projected rows; empty/non-numeric input falls
+  back to the default for the projection; the `onInsufficient` callback
+  and the listing-fee line are unaffected by input changes (gating still
+  keyed off starting bid); untouched re-seed when starting bid changes;
+  sticky after edit.
+- `ListingWizardForm.test.tsx`: update the AgentCommissionPreview render
+  assertions for the new props and relabelled text.
+- `PlaceBidForm.test.tsx`: Buy Now button renders only when
+  `buyNowPrice` is set; click opens the buy-now `ConfirmBidDialog`;
+  confirm calls `placeBid` with exactly `buyNowPrice`; disabled when
+  disconnected or a bid is pending; not rendered for a group-COI member
+  (covered by the early return).
+- Draft-editor / `ActivateClient.test.tsx` + `test/fixtures/auction.ts`:
+  seller-auction fixture includes a `seller` block; preview renders the
+  real seller summary (rating, reviews, completed sales, completion
+  rate, member since) instead of the "You / 0 sales" placeholder.
+
+Backend (`./mvnw test`):
+
+- `AuctionDtoMapper` seller-response test: assert the `seller` block is
+  populated and equals the public-response computation (rating, reviews,
+  completed sales, `completionRate`, member since, avatar URL).
+- All `new SellerAuctionResponse(...)` construction sites compile and
+  pass after the arity change.
+- Run the full backend suite locally (no backend CI; CI is main-only).
+
+Postman: update the seller `GET /api/v1/auctions/{id}` saved example to
+include the `seller` block.
+
+Pre-push (CI is main-only): `npm run lint`, `npm test`,
+`npm run build`, `npm run verify`, and `./mvnw test` all locally.
+
+## Out of scope
+
+- Removing the passive "Buy now for L$X" callout in `BidPanel.tsx`
+  (kept; removal is an optional future cleanup).
+- Any change to actual listing-fee / commission economics or to what is
+  charged, stored, or gated.
+- Any new endpoint, schema change, or Flyway migration.
+- The create-wizard grid `ListingPreviewCard` (a different component);
+  the seller-profile placeholder bug is specifically the draft-editor
+  `SellerProfileCard` in `DraftEditorClient.tsx`.
+- A Sell Price basis selector / segmented control / custom-named bases
+  (explicitly rejected during brainstorming; it is a single editable
+  integer input with a computed default).
+
+## Files
+
+New:
+
+- `docs/superpowers/specs/2026-05-18-listing-auction-ux-design.md` (this
+  spec)
+
+Modified:
+
+- `frontend/src/components/listing/AgentCommissionPreview.tsx`
+- `frontend/src/components/listing/AgentCommissionPreview.test.tsx`
+- `frontend/src/components/listing/ListingWizardForm.tsx`
+- `frontend/src/components/listing/ListingWizardForm.test.tsx`
+- `frontend/src/components/auction/PlaceBidForm.tsx`
+- `frontend/src/components/auction/PlaceBidForm.test.tsx`
+- `backend/src/main/java/com/slparcelauctions/backend/auction/dto/SellerAuctionResponse.java`
+- `backend/src/main/java/com/slparcelauctions/backend/auction/AuctionDtoMapper.java`
+- Other backend `new SellerAuctionResponse(...)` call sites + tests/fixtures
+- `frontend/src/app/listings/(verified)/[publicId]/activate/DraftEditorClient.tsx`
+  (confirm only; defensive fallback retained)
+- `frontend/src/app/listings/(verified)/[publicId]/activate/ActivateClient.test.tsx`
+- `frontend/src/test/fixtures/auction.ts`
+- Postman SLPA collection (seller `GET /api/v1/auctions/{id}` example)
+- Root `README.md` sweep at task end (project convention)

--- a/frontend/src/app/listings/(verified)/[publicId]/activate/ActivateClient.test.tsx
+++ b/frontend/src/app/listings/(verified)/[publicId]/activate/ActivateClient.test.tsx
@@ -7,6 +7,7 @@ import {
   waitFor,
 } from "@/test/render";
 import { server } from "@/test/msw/server";
+import { fakeSellerAuction } from "@/test/fixtures/auction";
 import type { SellerAuctionResponse } from "@/types/auction";
 import { ActivateClient } from "./ActivateClient";
 
@@ -25,66 +26,13 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams(),
 }));
 
+// Seller-facing auction fixture. Delegates to the shared
+// `fakeSellerAuction` builder so the enriched `seller` block (Epic 07
+// sub-spec 1 Task 2) is present for every consumer in this file.
 function auctionBase(
   overrides: Partial<SellerAuctionResponse> = {},
 ): SellerAuctionResponse {
-  return {
-    publicId: "00000000-0000-0000-0000-00000000002a",
-    sellerPublicId: "00000000-0000-0000-0000-000000000001",
-    title: "Featured Parcel Listing",
-    parcel: {
-      slParcelUuid: "00000000-0000-0000-0000-000000000001",
-      ownerUuid: "aaaa1111-0000-0000-0000-000000000000",
-      ownerType: "agent",
-      regionName: "Heterocera",
-      gridX: 0,
-      gridY: 0,
-      positionX: 128,
-      positionY: 128,
-      positionZ: 0,
-      ownerName: null,
-      parcelName: null,
-      continentName: null,
-      areaSqm: 1024,
-      description: "Beachfront parcel",
-      snapshotUrl: null,
-      slurl: "secondlife://Heterocera/128/128/25",
-      maturityRating: "GENERAL",
-      verified: false,
-      verifiedAt: null,
-      lastChecked: null,
-      createdAt: "2026-04-17T00:00:00Z",
-    },
-    status: "DRAFT_PAID",
-    verificationTier: null,
-    verificationNotes: null,
-    startingBid: 500,
-    reservePrice: null,
-    buyNowPrice: null,
-    currentBid: null,
-    bidCount: 0,
-    currentHighBid: null,
-    bidderCount: 0,
-    winnerPublicId: null,
-    durationHours: 72,
-    snipeProtect: true,
-    snipeWindowMin: 10,
-    startsAt: null,
-    endsAt: null,
-    originalEndsAt: null,
-    sellerDesc: null,
-    tags: [],
-    photos: [],
-    listingFeePaid: true,
-    listingFeeAmt: 100,
-    listingFeeTxn: null,
-    listingFeePaidAt: null,
-    commissionRate: 0.05,
-    commissionAmt: null,
-    createdAt: "2026-04-17T00:00:00Z",
-    updatedAt: "2026-04-17T00:00:00Z",
-    ...overrides,
-  };
+  return fakeSellerAuction(overrides);
 }
 
 describe("ActivateClient", () => {
@@ -128,6 +76,39 @@ describe("ActivateClient", () => {
       await screen.findByTestId("draft-action-bar-list"),
     ).toBeInTheDocument();
     expect(screen.getByTestId("draft-action-bar-delete")).toBeInTheDocument();
+  });
+
+  it("DRAFT preview renders the real seller card stats, not the You placeholder", async () => {
+    server.use(
+      http.get("*/api/v1/auctions/00000000-0000-0000-0000-00000000002a", () =>
+        HttpResponse.json(auctionBase({ status: "DRAFT" })),
+      ),
+      http.get("*/api/v1/me/wallet", () =>
+        HttpResponse.json({
+          balance: 500,
+          reserved: 0,
+          available: 500,
+          penaltyOwed: 0,
+          queuedForWithdrawal: 0,
+          termsAccepted: true,
+          termsVersion: "v1.0",
+          termsAcceptedAt: "2026-04-17T00:00:00Z",
+          recentLedger: [],
+        }),
+      ),
+    );
+    renderWithProviders(
+      <ActivateClient auctionPublicId="00000000-0000-0000-0000-00000000002a" />,
+      { auth: "authenticated" },
+    );
+
+    const card = await screen.findByTestId("seller-profile-card");
+    expect(card).toHaveTextContent("Test Seller");
+    expect(card).toHaveTextContent("7 completed sale");
+    expect(card).toHaveTextContent("Completion rate: 92%");
+    // The defensive "You" placeholder branch must not be the one rendered
+    // once the backend supplies the enriched seller block.
+    expect(card).not.toHaveTextContent(/\bYou\b/);
   });
 
   it("DRAFT_PAID renders the Verify-ownership button and a click flips the status to ACTIVE", async () => {

--- a/frontend/src/components/auction/PlaceBidForm.test.tsx
+++ b/frontend/src/components/auction/PlaceBidForm.test.tsx
@@ -232,6 +232,86 @@ describe("PlaceBidForm", () => {
     );
   });
 
+  it("shows a Buy now button when the auction has a buy-now price", () => {
+    const auction = auctionFixture({ buyNowPrice: 25_000, currentHighBid: 0 });
+    renderWithProviders(
+      <PlaceBidForm auction={auction} connectionState={connected} />,
+      { auth: "authenticated" },
+    );
+    expect(screen.getByTestId("place-bid-buy-now")).toHaveTextContent(
+      "Buy now · L$25,000",
+    );
+  });
+
+  it("does not show the Buy now button when there is no buy-now price", () => {
+    renderWithProviders(
+      <PlaceBidForm
+        auction={auctionFixture({ buyNowPrice: null })}
+        connectionState={connected}
+      />,
+      { auth: "authenticated" },
+    );
+    expect(
+      screen.queryByTestId("place-bid-buy-now"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("Buy now opens the buy-now confirm and places a bid at exactly the buy-now price", async () => {
+    let received: { amount: number } | null = null;
+    server.use(
+      http.post("*/api/v1/auctions/00000000-0000-0000-0000-000000000007/bids", async ({ request }) => {
+        received = (await request.json()) as { amount: number };
+        return HttpResponse.json({
+          bidId: 100,
+          auctionId: 7,
+          amount: received.amount,
+          bidType: "BUY_NOW",
+          bidCount: 1,
+          endsAt: "2026-04-22T00:00:00Z",
+          originalEndsAt: "2026-04-22T00:00:00Z",
+          snipeExtensionMinutes: null,
+          newEndsAt: null,
+          buyNowTriggered: true,
+        });
+      }),
+    );
+    const auction = auctionFixture({ buyNowPrice: 25_000, currentHighBid: 0 });
+    renderWithProviders(
+      <PlaceBidForm auction={auction} connectionState={connected} />,
+      { auth: "authenticated" },
+    );
+    // Type an unrelated bid amount; Buy now must ignore it.
+    const input = screen.getByTestId(
+      "place-bid-amount-input",
+    ) as HTMLInputElement;
+    await userEvent.type(input, "600");
+    await userEvent.click(screen.getByTestId("place-bid-buy-now"));
+    // ConfirmBidDialog buy-now branch is open — its confirm button reads
+    // "Buy now · L$25,000"; scope to the dialog testid since the dedicated
+    // trigger button carries the same accessible name.
+    const dialog = await screen.findByTestId("confirm-bid-dialog");
+    expect(dialog).toHaveTextContent("buy-now at L$25,000");
+    await userEvent.click(
+      screen.getByTestId("confirm-bid-dialog-confirm"),
+    );
+    await waitFor(() => {
+      expect(received).not.toBeNull();
+    });
+    expect(received!.amount).toBe(25_000);
+  });
+
+  it("disables Buy now when disconnected", () => {
+    const auction = auctionFixture({ buyNowPrice: 25_000, currentHighBid: 0 });
+    renderWithProviders(
+      <PlaceBidForm
+        auction={auction}
+        connectionState={{ status: "reconnecting" }}
+      />,
+      { auth: "authenticated" },
+    );
+    expect(screen.getByTestId("place-bid-buy-now")).toBeDisabled();
+  });
+
   it("fires the large-bid confirm dialog when amount > 10,000", async () => {
     // currentHighBid=0 → min = startingBid = 500, so 15000 is valid.
     const auction = auctionFixture({

--- a/frontend/src/components/auction/PlaceBidForm.tsx
+++ b/frontend/src/components/auction/PlaceBidForm.tsx
@@ -213,6 +213,18 @@ export function PlaceBidForm({ auction, connectionState }: PlaceBidFormProps) {
       >
         {buttonLabel}
       </Button>
+      {buyNow != null ? (
+        <Button
+          type="button"
+          variant="secondary"
+          fullWidth
+          disabled={!isConnected || mutation.isPending}
+          data-testid="place-bid-buy-now"
+          onClick={() => setConfirm({ kind: "buy-now", amount: buyNow })}
+        >
+          {`Buy now · L$${buyNow.toLocaleString()}`}
+        </Button>
+      ) : null}
       {!isConnected ? (
         <p
           className="text-xs text-fg-muted"

--- a/frontend/src/components/listing/AgentCommissionPreview.test.tsx
+++ b/frontend/src/components/listing/AgentCommissionPreview.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { http, HttpResponse } from "msw";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
 import { renderWithProviders } from "@/test/render";
 import { server } from "@/test/msw/server";
 import { AgentCommissionPreview } from "./AgentCommissionPreview";
@@ -31,6 +31,8 @@ describe("AgentCommissionPreview (case 3)", () => {
     renderWithProviders(
       <AgentCommissionPreview
         startingBid={1000}
+        reservePrice={null}
+        buyNowPrice={null}
         groupName="Sunset Realty"
         groupPublicId={GROUP_ID}
         agentCommissionRate={0.1}
@@ -42,17 +44,20 @@ describe("AgentCommissionPreview (case 3)", () => {
       // dt/dd siblings have no inline whitespace between them, so the
       // visible "<label> <value>" is "labelvalue" in textContent. Assert
       // on each row's components separately to stay robust against
-      // future layout tweaks.
+      // future layout tweaks. With no reserve/buy-now the Sell Price
+      // input defaults to the starting bid (1000).
       const text = preview.textContent ?? "";
-      expect(text).toContain("List price");
-      expect(text).toContain("L$1,000");
-      expect(text).toContain("Platform commission at list price");
+      expect(text).toContain("Sell Price");
+      expect(
+        (screen.getByTestId("sell-price-input") as HTMLInputElement).value,
+      ).toBe("1000");
+      expect(text).toContain("Platform commission at sell price");
       expect(text).toContain("L$50");
       expect(text).toContain("(5%)");
-      expect(text).toContain("Your earnings at list price");
+      expect(text).toContain("Your earnings at sell price");
       expect(text).toContain("L$95");
       expect(text).toContain("(10% of remaining)");
-      expect(text).toContain("Sunset Realty earnings at list price");
+      expect(text).toContain("Sunset Realty earnings at sell price");
       expect(text).toContain("L$855");
       expect(text).toContain("(remaining)");
     });
@@ -66,6 +71,8 @@ describe("AgentCommissionPreview (case 3)", () => {
     renderWithProviders(
       <AgentCommissionPreview
         startingBid={1000}
+        reservePrice={null}
+        buyNowPrice={null}
         groupName="Sunset Realty"
         groupPublicId={GROUP_ID}
         agentCommissionRate={0}
@@ -75,12 +82,12 @@ describe("AgentCommissionPreview (case 3)", () => {
     const preview = await screen.findByTestId("agent-commission-preview");
     await waitFor(() => {
       const text = preview.textContent ?? "";
-      // Rate 0 falls under the < 0.01 branch → "0.00%".
-      expect(text).toContain("Your earnings at list price");
+      // Rate 0 falls under the < 0.01 branch -> "0.00%".
+      expect(text).toContain("Your earnings at sell price");
       expect(text).toContain("L$0");
       expect(text).toContain("(0.00% of remaining)");
       // L$1000 - 50 platform = 950 group slice when agent rate = 0.
-      expect(text).toContain("Sunset Realty earnings at list price");
+      expect(text).toContain("Sunset Realty earnings at sell price");
       expect(text).toContain("L$950");
     });
   });
@@ -91,6 +98,8 @@ describe("AgentCommissionPreview (case 3)", () => {
     renderWithProviders(
       <AgentCommissionPreview
         startingBid={0}
+        reservePrice={null}
+        buyNowPrice={null}
         groupName="Sunset Realty"
         groupPublicId={GROUP_ID}
         agentCommissionRate={0.1}
@@ -110,6 +119,8 @@ describe("AgentCommissionPreview (case 3)", () => {
     renderWithProviders(
       <AgentCommissionPreview
         startingBid={1000}
+        reservePrice={null}
+        buyNowPrice={null}
         groupName="Sunset Realty"
         groupPublicId={GROUP_ID}
         agentCommissionRate={0.1}
@@ -133,6 +144,8 @@ describe("AgentCommissionPreview (case 3)", () => {
     renderWithProviders(
       <AgentCommissionPreview
         startingBid={1000}
+        reservePrice={null}
+        buyNowPrice={null}
         groupName="Sunset Realty"
         groupPublicId={GROUP_ID}
         agentCommissionRate={0.1}
@@ -146,5 +159,137 @@ describe("AgentCommissionPreview (case 3)", () => {
       ),
     ).toBeInTheDocument();
     await waitFor(() => expect(onInsufficient).toHaveBeenCalledWith(false));
+  });
+
+  it('labels the row "Sell Price" and the derived rows "at sell price"', async () => {
+    installWallet(10000);
+
+    renderWithProviders(
+      <AgentCommissionPreview
+        startingBid={1000}
+        reservePrice={2000}
+        buyNowPrice={5000}
+        groupName="Sunset Realty"
+        groupPublicId={GROUP_ID}
+        agentCommissionRate={0.1}
+      />,
+    );
+
+    await screen.findByTestId("agent-commission-preview");
+    expect(screen.getByText("Sell Price")).toBeInTheDocument();
+    expect(
+      screen.getByText("Platform commission at sell price"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Your earnings at sell price"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Sunset Realty earnings at sell price"),
+    ).toBeInTheDocument();
+  });
+
+  it("defaults the Sell Price input to buyNow ?? reserve ?? starting", async () => {
+    installWallet(10000);
+
+    const { rerender } = renderWithProviders(
+      <AgentCommissionPreview
+        startingBid={1000}
+        reservePrice={2000}
+        buyNowPrice={5000}
+        groupName="G"
+        groupPublicId={GROUP_ID}
+        agentCommissionRate={0.1}
+      />,
+    );
+    await screen.findByTestId("agent-commission-preview");
+    expect(
+      (screen.getByTestId("sell-price-input") as HTMLInputElement).value,
+    ).toBe("5000");
+
+    rerender(
+      <AgentCommissionPreview
+        startingBid={1000}
+        reservePrice={2000}
+        buyNowPrice={null}
+        groupName="G"
+        groupPublicId={GROUP_ID}
+        agentCommissionRate={0.1}
+      />,
+    );
+    expect(
+      (screen.getByTestId("sell-price-input") as HTMLInputElement).value,
+    ).toBe("2000");
+
+    rerender(
+      <AgentCommissionPreview
+        startingBid={1000}
+        reservePrice={null}
+        buyNowPrice={null}
+        groupName="G"
+        groupPublicId={GROUP_ID}
+        agentCommissionRate={0.1}
+      />,
+    );
+    expect(
+      (screen.getByTestId("sell-price-input") as HTMLInputElement).value,
+    ).toBe("1000");
+  });
+
+  it("recomputes the projected rows when the Sell Price input changes", async () => {
+    installWallet(10000);
+
+    renderWithProviders(
+      <AgentCommissionPreview
+        startingBid={1000}
+        reservePrice={null}
+        buyNowPrice={null}
+        groupName="G"
+        groupPublicId={GROUP_ID}
+        agentCommissionRate={0.1}
+      />,
+    );
+    const preview = await screen.findByTestId("agent-commission-preview");
+    const input = screen.getByTestId("sell-price-input");
+    fireEvent.change(input, { target: { value: "10000" } });
+
+    // platformCommission = floor(10000*0.05)=500; earnings=9500;
+    // agentSlice = floor(9500*0.1)=950; group = 9500-950 = 8550.
+    const text = preview.textContent ?? "";
+    expect(text).toContain("L$500");
+    expect(text).toContain("L$950");
+    expect(text).toContain("L$8,550");
+  });
+
+  it("keeps the listing-fee gating keyed off starting bid, not the Sell Price input", async () => {
+    // Wallet balance >= floor(startingBid*0.05)=50 so gating starts
+    // sufficient. Editing the Sell Price up must not flip it insufficient.
+    installWallet(100);
+
+    const onInsufficient = vi.fn();
+
+    renderWithProviders(
+      <AgentCommissionPreview
+        startingBid={1000}
+        reservePrice={null}
+        buyNowPrice={null}
+        groupName="G"
+        groupPublicId={GROUP_ID}
+        agentCommissionRate={0.1}
+        onInsufficient={onInsufficient}
+      />,
+    );
+    await screen.findByTestId("agent-commission-preview");
+    await waitFor(() =>
+      expect(onInsufficient).toHaveBeenCalledWith(false),
+    );
+    const firstCallCount = onInsufficient.mock.calls.length;
+
+    fireEvent.change(screen.getByTestId("sell-price-input"), {
+      target: { value: "999999" },
+    });
+
+    // Editing the projection must not change the insufficiency decision.
+    expect(onInsufficient.mock.calls.length).toBe(firstCallCount);
+    expect(onInsufficient).not.toHaveBeenCalledWith(true);
   });
 });

--- a/frontend/src/components/listing/AgentCommissionPreview.tsx
+++ b/frontend/src/components/listing/AgentCommissionPreview.tsx
@@ -48,10 +48,15 @@ export interface AgentCommissionPreviewProps {
  * Case-3 ("Realty Groups: E") fee preview for the listing wizard.
  *
  * Case 3 is an agent listing a group-owned parcel under the realty group:
- * the platform takes a 5% commission off the starting bid, then the
- * remaining earnings are split between the agent and the group per the
- * agent's per-member {@code agentCommissionRate}. The group wallet pays the
- * listing fee (which equals the platform commission in Phase 1).
+ * the platform takes a 5% commission, then the remaining earnings are split
+ * between the agent and the group per the agent's per-member
+ * {@code agentCommissionRate}. The visible projection rows (platform
+ * commission, your earnings, group earnings) recompute from the editable
+ * Sell Price input (default {@code buyNowPrice ?? reservePrice ??
+ * startingBid}). The group wallet pays the listing fee, which stays
+ * decoupled from the Sell Price input: it remains {@code floor(startingBid *
+ * 0.05)} (== the platform commission on the starting bid in Phase 1) and is
+ * also what drives the insufficient-balance publish gating.
  *
  * The agent's commission rate arrives as a prop from the wizard, which
  * reads it off the eligible-list row the user picked in

--- a/frontend/src/components/listing/AgentCommissionPreview.tsx
+++ b/frontend/src/components/listing/AgentCommissionPreview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { getGroupWallet } from "@/lib/api/realtyGroupWallet";
 
@@ -16,6 +16,16 @@ function floorLindens(amount: number, rate: number): number {
 
 export interface AgentCommissionPreviewProps {
   startingBid: number;
+  /**
+   * Reserve price for the auction settings, or null when none is set.
+   * Only feeds the Sell Price what-if default; never the listing fee.
+   */
+  reservePrice: number | null;
+  /**
+   * Buy-it-now price for the auction settings, or null when none is set.
+   * Only feeds the Sell Price what-if default; never the listing fee.
+   */
+  buyNowPrice: number | null;
   groupName: string;
   /** publicId of the realty group the listing is being created under. */
   groupPublicId: string;
@@ -51,6 +61,8 @@ export interface AgentCommissionPreviewProps {
  */
 export function AgentCommissionPreview({
   startingBid,
+  reservePrice,
+  buyNowPrice,
   groupName,
   groupPublicId,
   agentCommissionRate,
@@ -64,18 +76,38 @@ export function AgentCommissionPreview({
   });
   const balance = walletQuery.data?.available ?? null;
 
-  // Case-3 math (spec §6.3):
-  //   platformCommission = floor(startingBid * 0.05)
-  //   earnings           = startingBid - platformCommission
+  // Sell Price is a pure what-if projection (spec Area 1). It defaults to
+  // Buy It Now, then Reserve, then Starting Bid, and re-seeds while the
+  // seller has not touched it; once edited it is fully seller-controlled.
+  const defaultSell = buyNowPrice ?? reservePrice ?? startingBid;
+  const [raw, setRaw] = useState<string>(String(defaultSell));
+  const [touched, setTouched] = useState(false);
+  useEffect(() => {
+    if (!touched) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setRaw(String(defaultSell));
+    }
+  }, [defaultSell, touched]);
+  const parsedSell = raw.trim() === "" ? defaultSell : Math.floor(Number(raw));
+  const sellPrice =
+    Number.isFinite(parsedSell) && parsedSell > 0 ? parsedSell : defaultSell;
+
+  // Displayed projection recomputes from the what-if Sell Price (spec §6.3
+  // math, sellPrice substituted for the old static list price):
+  //   platformCommission = floor(sellPrice * 0.05)
+  //   earnings           = sellPrice - platformCommission
   //   agentSlice         = floor(earnings * agentCommissionRate)
   //   groupSlice         = earnings - agentSlice
-  const platformCommission = floorLindens(startingBid, PLATFORM_COMMISSION_RATE);
-  const earnings = startingBid - platformCommission;
+  const platformCommission = floorLindens(sellPrice, PLATFORM_COMMISSION_RATE);
+  const earnings = sellPrice - platformCommission;
   const agentSlice = floorLindens(earnings, agentCommissionRate);
   const groupSlice = earnings - agentSlice;
-  // Listing fee equals the platform commission in Phase 1 — the group
-  // wallet pays it up-front (refundable per cancellation rules).
-  const listingFee = platformCommission;
+  // Listing fee / publish gating stays DECOUPLED from the Sell Price
+  // what-if: it is always floor(startingBid * 0.05) (== the platform
+  // commission on the starting bid in Phase 1). The group wallet pays it
+  // up-front (refundable per cancellation rules). Editing Sell Price must
+  // never change what is charged or gated.
+  const listingFee = floorLindens(startingBid, PLATFORM_COMMISSION_RATE);
   const insufficient = balance !== null && balance < listingFee;
   const shortfall = insufficient && balance !== null ? listingFee - balance : 0;
 
@@ -96,20 +128,33 @@ export function AgentCommissionPreview({
     <div className="flex flex-col gap-2 mt-2" data-testid="agent-commission-preview">
       <dl className="flex flex-col rounded-lg bg-bg-subtle px-4 py-3 text-sm">
         <div className="flex justify-between gap-4 py-1">
-          <dt className="text-fg-muted">List price</dt>
-          <dd className="tabular-nums font-medium text-fg">
-            L${startingBid.toLocaleString()}
+          <dt className="text-fg-muted">Sell Price</dt>
+          <dd>
+            <input
+              type="number"
+              inputMode="numeric"
+              min={1}
+              step={1}
+              aria-label="Sell price (L$)"
+              data-testid="sell-price-input"
+              value={raw}
+              onChange={(e) => {
+                setTouched(true);
+                setRaw(e.target.value);
+              }}
+              className="w-28 rounded-md bg-surface-raised px-2 py-1 text-right tabular-nums font-medium text-fg ring-1 ring-transparent focus:outline-none focus:ring-2 focus:ring-brand"
+            />
           </dd>
         </div>
         <div className="flex justify-between gap-4 py-1">
-          <dt className="text-fg-muted">Platform commission at list price</dt>
+          <dt className="text-fg-muted">Platform commission at sell price</dt>
           <dd className="tabular-nums font-medium text-fg">
             L${platformCommission.toLocaleString()}{" "}
             <span className="text-fg-muted font-normal">(5%)</span>
           </dd>
         </div>
         <div className="flex justify-between gap-4 py-1">
-          <dt className="text-fg-muted">Your earnings at list price</dt>
+          <dt className="text-fg-muted">Your earnings at sell price</dt>
           <dd className="tabular-nums font-medium text-fg">
             L${agentSlice.toLocaleString()}{" "}
             <span className="text-fg-muted font-normal">
@@ -118,7 +163,7 @@ export function AgentCommissionPreview({
           </dd>
         </div>
         <div className="flex justify-between gap-4 py-1">
-          <dt className="text-fg-muted">{groupName} earnings at list price</dt>
+          <dt className="text-fg-muted">{groupName} earnings at sell price</dt>
           <dd className="tabular-nums font-medium text-fg">
             L${groupSlice.toLocaleString()}{" "}
             <span className="text-fg-muted font-normal">(remaining)</span>

--- a/frontend/src/components/listing/ListingWizardForm.tsx
+++ b/frontend/src/components/listing/ListingWizardForm.tsx
@@ -366,6 +366,8 @@ export function ListingWizardForm({ mode, id }: ListingWizardFormProps) {
                       // group per the caller's per-member commission rate.
                       <AgentCommissionPreview
                         startingBid={draft.state.startingBid}
+                        reservePrice={settings.reservePrice}
+                        buyNowPrice={settings.buyNowPrice}
                         groupName={selectedGroup.name}
                         groupPublicId={selectedGroup.publicId}
                         agentCommissionRate={selectedGroup.agentCommissionRate}

--- a/frontend/src/test/fixtures/auction.ts
+++ b/frontend/src/test/fixtures/auction.ts
@@ -10,7 +10,98 @@
 // returns response.json()), so a partial object would technically work — but
 // every consumer builds against the type, so keeping the fixture complete
 // avoids spread-override footguns when tests need to tweak one field.
-import type { PublicAuctionResponse } from "@/types/auction";
+import type {
+  PublicAuctionResponse,
+  SellerAuctionResponse,
+} from "@/types/auction";
+
+/**
+ * Canonical enriched seller block. Mirrors the backend
+ * {@code PublicAuctionResponse.SellerSummary} JSON shape (Epic 07 sub-spec 1
+ * Task 2) that both the public and seller-facing auction responses now
+ * carry. Kept here so every fixture consumer (activate / draft-editor
+ * tests, auction detail tests) asserts against one canonical shape.
+ */
+export const fakeAuctionSeller = {
+  publicId: "11111111-1111-1111-1111-111111111111",
+  displayName: "Test Seller",
+  avatarUrl: null,
+  averageRating: 4.5,
+  reviewCount: 12,
+  completedSales: 7,
+  completionRate: 0.92,
+  memberSince: "2025-11-03",
+} as const;
+
+/**
+ * Shared seller-facing auction fixture. Mirrors the backend
+ * {@code SellerAuctionResponse} returned by the seller-scoped
+ * {@code GET /api/v1/auctions/{publicId}} (the activate / draft-editor
+ * flow). Carries the enriched {@code seller} block so the draft preview
+ * renders the real seller card instead of the "You" placeholder.
+ */
+export function fakeSellerAuction(
+  overrides: Partial<SellerAuctionResponse> = {},
+): SellerAuctionResponse {
+  return {
+    publicId: "00000000-0000-0000-0000-00000000002a",
+    sellerPublicId: "00000000-0000-0000-0000-000000000001",
+    title: "Featured Parcel Listing",
+    parcel: {
+      slParcelUuid: "00000000-0000-0000-0000-000000000001",
+      ownerUuid: "aaaa1111-0000-0000-0000-000000000000",
+      ownerType: "agent",
+      regionName: "Heterocera",
+      gridX: 0,
+      gridY: 0,
+      positionX: 128,
+      positionY: 128,
+      positionZ: 0,
+      ownerName: null,
+      parcelName: null,
+      continentName: null,
+      areaSqm: 1024,
+      description: "Beachfront parcel",
+      snapshotUrl: null,
+      slurl: "secondlife://Heterocera/128/128/25",
+      maturityRating: "GENERAL",
+      verified: false,
+      verifiedAt: null,
+      lastChecked: null,
+      createdAt: "2026-04-17T00:00:00Z",
+    },
+    status: "DRAFT_PAID",
+    verificationTier: null,
+    verificationNotes: null,
+    startingBid: 500,
+    reservePrice: null,
+    buyNowPrice: null,
+    currentBid: null,
+    bidCount: 0,
+    currentHighBid: null,
+    bidderCount: 0,
+    winnerPublicId: null,
+    durationHours: 72,
+    snipeProtect: true,
+    snipeWindowMin: 10,
+    startsAt: null,
+    endsAt: null,
+    originalEndsAt: null,
+    sellerDesc: null,
+    tags: [],
+    photos: [],
+    seller: { ...fakeAuctionSeller },
+    listingFeePaid: true,
+    listingFeeAmt: 100,
+    listingFeeTxn: null,
+    listingFeePaidAt: null,
+    commissionRate: 0.05,
+    commissionAmt: null,
+    createdAt: "2026-04-17T00:00:00Z",
+    updatedAt: "2026-04-17T00:00:00Z",
+    ...overrides,
+  };
+}
 
 export function fakePublicAuction(
   overrides: Partial<PublicAuctionResponse> = {},


### PR DESCRIPTION
Promotes the listing/auction UX changes to production.

- Editable "Sell Price" what-if projection on the create-listing fee preview (frontend-only, display-only, decoupled from fee/gating).
- Dedicated "Buy now" button under Place bid (frontend-only, reuses existing buy-now flow).
- Real seller reputation in the create-listing draft preview via SellerAuctionResponse seller-summary enrichment (backend DTO change, no schema/Flyway, no new endpoint).

PR to dev: #360. Verified: frontend lint/2065 tests/build/verify all green; backend 2444 tests 0 failures 0 errors; per-task + whole-branch review passed. Backend changed -> deploy-backend pipeline triggers; frontend changed -> Amplify rebuild.