### PR TITLE
feat(escrow): verify-transfer dispatches bot; show pending UI while bot runs

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.slparcelauctions.backend.bot.dto.BotTaskClaimRequest;
 import com.slparcelauctions.backend.bot.dto.BotTaskResponse;
 import com.slparcelauctions.backend.bot.dto.BotTaskResultRequest;
+import com.slparcelauctions.backend.bot.dto.BuyOwnerResultRequest;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -60,6 +61,21 @@ public class BotTaskController {
     public ResponseEntity<Void> result(@PathVariable Long taskId,
             @Valid @RequestBody BotTaskResultRequest body) {
         botTaskResultService.apply(taskId, body);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Bot {@code VERIFY_BUY_OWNER} result callback (bot-dispatch refactor
+     * 2026-05-18). A separate endpoint from the {@code VERIFY_SELL_TO} callback
+     * because the outcome enum + payload shape differ — sharing one endpoint
+     * via a discriminated union would force every bot client to thread the
+     * task-type through, whereas split endpoints let the bot pick the right
+     * payload at the call site. Idempotent on terminal task state.
+     */
+    @PostMapping("/{taskId}/verify-buy-owner-result")
+    public ResponseEntity<Void> verifyBuyOwnerResult(@PathVariable Long taskId,
+            @Valid @RequestBody BuyOwnerResultRequest body) {
+        botTaskResultService.applyVerifyBuyOwnerResult(taskId, body);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskResultService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskResultService.java
@@ -10,7 +10,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.slparcelauctions.backend.bot.dto.BotTaskResultRequest;
+import com.slparcelauctions.backend.bot.dto.BuyOwnerResultRequest;
 import com.slparcelauctions.backend.escrow.Escrow;
+import com.slparcelauctions.backend.escrow.EscrowManualActionService;
 import com.slparcelauctions.backend.escrow.EscrowRepository;
 import com.slparcelauctions.backend.escrow.EscrowService;
 import com.slparcelauctions.backend.escrow.FreezeReason;
@@ -128,6 +130,140 @@ public class BotTaskResultService {
             case PARCEL_NOT_FOUND ->
                     infraFailure(task, escrow, outcome, now, true);
         }
+    }
+
+    /**
+     * Bot {@code VERIFY_BUY_OWNER} result callback. Applies the bot-dispatched
+     * verify-purchase outcome matrix (see {@link BuyOwnerOutcome}):
+     *
+     * <ul>
+     *   <li>{@code OWNER_IS_WINNER} → {@link EscrowService#confirmTransfer};
+     *       clear {@code manualVerifyPending}; task COMPLETED.</li>
+     *   <li>{@code OWNER_STILL_PRE_TRANSFER} → consume the
+     *       {@code buyVerifySellerAttempts} or {@code buyVerifyBuyerAttempts}
+     *       counter depending on the {@code requestingRole} payload stamped at
+     *       dispatch; {@link EscrowService#stampChecked}; clear
+     *       {@code manualVerifyPending}; task COMPLETED. Definitive negative
+     *       per attempt — the manual flow is not a recurring schedule, so the
+     *       task does not reschedule.</li>
+     *   <li>{@code OWNER_IS_STRANGER} →
+     *       {@link EscrowService#freezeForFraud}{@code (UNKNOWN_OWNER)};
+     *       clear pending; task COMPLETED.</li>
+     *   <li>{@code PARCEL_DELETED} →
+     *       {@link EscrowService#freezeForFraud}{@code (PARCEL_DELETED)};
+     *       clear pending; task COMPLETED.</li>
+     *   <li>{@code WORLD_API_FAILURE} / {@code UNKNOWN_ERROR} → transient. Clear
+     *       {@code manualVerifyPending} so the user can retry; no attempt
+     *       consumed; task FAILED. The 30-min background ownership polling
+     *       remains the system-driven safety net for these escrows.</li>
+     * </ul>
+     *
+     * <p>Idempotent on terminal task state. Tasks are not rescheduled — manual
+     * verify is a one-shot per user click, unlike the recurring Set-Sell-To
+     * task.
+     */
+    @Transactional
+    public void applyVerifyBuyOwnerResult(long taskId, BuyOwnerResultRequest body) {
+        BotTask task = botTaskRepo.findById(taskId).orElse(null);
+        if (task == null) {
+            log.debug("Buy-owner result for unknown task {} — no-op", taskId);
+            return;
+        }
+        if (task.getTaskType() != BotTaskType.VERIFY_BUY_OWNER) {
+            log.warn("Buy-owner result for task {} of wrong type {} — no-op",
+                    taskId, task.getTaskType());
+            return;
+        }
+        if (isTerminal(task.getStatus())) {
+            log.debug("Buy-owner result for terminal task {} (status {}) — idempotent no-op",
+                    taskId, task.getStatus());
+            return;
+        }
+        if (task.getEscrow() == null) {
+            log.warn("Buy-owner result for task {} with no escrow — no-op", taskId);
+            return;
+        }
+
+        Escrow escrow = escrowRepo.findByIdForUpdate(task.getEscrow().getId())
+                .orElse(null);
+        if (escrow == null) {
+            log.warn("Buy-owner result for task {}: escrow {} not found — no-op",
+                    taskId, task.getEscrow().getId());
+            return;
+        }
+
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        BuyOwnerOutcome outcome = body.outcome();
+        String requestingRole = extractRequestingRole(task);
+        log.info("Applying buy-owner result {} for task {} (escrow {}, auction {}, role {})",
+                outcome, taskId, escrow.getId(), escrow.getAuction().getId(), requestingRole);
+
+        switch (outcome) {
+            case OWNER_IS_WINNER -> {
+                escrow.setManualVerifyPending(false);
+                escrowRepo.save(escrow);
+                escrowService.confirmTransfer(escrow, now);
+                completeTask(task, now);
+            }
+            case OWNER_STILL_PRE_TRANSFER -> {
+                if (EscrowManualActionService.REQUESTING_ROLE_SELLER.equals(requestingRole)) {
+                    escrow.setBuyVerifySellerAttempts(
+                            nz(escrow.getBuyVerifySellerAttempts()) + 1);
+                } else {
+                    // Default to buyer-counter for missing / "BUYER" / unknown
+                    // — caller-side dispatch always stamps the role, but if the
+                    // payload is ever absent we prefer to charge the buyer
+                    // counter (which is the more common manual-verify caller).
+                    escrow.setBuyVerifyBuyerAttempts(
+                            nz(escrow.getBuyVerifyBuyerAttempts()) + 1);
+                }
+                escrow.setManualVerifyPending(false);
+                escrowRepo.save(escrow);
+                escrowService.stampChecked(escrow, now);
+                completeTask(task, now);
+            }
+            case OWNER_IS_STRANGER -> {
+                escrow.setManualVerifyPending(false);
+                escrowRepo.save(escrow);
+                Map<String, Object> evidence = new HashMap<>();
+                evidence.put("observedOwnerUuid",
+                        body.observedOwnerUuid() == null ? "<null>"
+                                : body.observedOwnerUuid().toString());
+                evidence.put("observedOwnerType",
+                        body.observedOwnerType() == null ? "<null>"
+                                : body.observedOwnerType());
+                evidence.put("source", "bot-verify-buy-owner");
+                escrowService.freezeForFraud(escrow, FreezeReason.UNKNOWN_OWNER, evidence, now);
+                completeTask(task, now);
+            }
+            case PARCEL_DELETED -> {
+                escrow.setManualVerifyPending(false);
+                escrowRepo.save(escrow);
+                Map<String, Object> evidence = new HashMap<>();
+                evidence.put("source", "bot-verify-buy-owner");
+                escrowService.freezeForFraud(escrow, FreezeReason.PARCEL_DELETED, evidence, now);
+                completeTask(task, now);
+            }
+            case WORLD_API_FAILURE, UNKNOWN_ERROR -> {
+                // Transient: no attempt consumed, no state change beyond
+                // clearing the pending flag so the user can retry.
+                escrow.setManualVerifyPending(false);
+                escrowRepo.save(escrow);
+                task.setStatus(BotTaskStatus.FAILED);
+                task.setFailureReason(outcome.name());
+                task.setCompletedAt(now);
+                botTaskRepo.save(task);
+            }
+        }
+    }
+
+    private static String extractRequestingRole(BotTask task) {
+        Map<String, Object> payload = task.getResultData();
+        if (payload == null) {
+            return null;
+        }
+        Object role = payload.get(EscrowManualActionService.REQUESTING_ROLE_KEY);
+        return role == null ? null : role.toString();
     }
 
     private void definitiveNegative(BotTask task, Escrow escrow,

--- a/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskType.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskType.java
@@ -21,5 +21,20 @@ public enum BotTaskType {
      * are wired in Phase 3; Phase 2 only references the type for the manual
      * "Verify Sell To" expedite path.
      */
-    VERIFY_SELL_TO
+    VERIFY_SELL_TO,
+
+    /**
+     * Escrow Buy-Parcel ownership verification. Dispatched when the seller or
+     * winner clicks "Verify purchase" on the escrow page during the Buy-Parcel
+     * sub-phase — the bot teleports to the parcel and reports the live owner
+     * UUID, so the backend can confirm-transfer, consume a role attempt
+     * (definitive negative: seller/group still owns), or freeze the escrow
+     * (stranger / parcel deleted). The 30-min background ownership polling
+     * keeps using the cheaper World API path; this task type covers only the
+     * user-initiated manual verify so the seller and winner can grey-out the
+     * button while a bot is en-route. {@code resultData} carries
+     * {@code requestingRole} ("SELLER" / "BUYER") so the callback consumes the
+     * correct attempt counter.
+     */
+    VERIFY_BUY_OWNER
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskTypeCheckConstraintInitializer.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskTypeCheckConstraintInitializer.java
@@ -13,10 +13,11 @@ import lombok.RequiredArgsConstructor;
  * Refreshes the {@code bot_tasks_task_type_check} constraint on startup so
  * future {@link BotTaskType} enum values pass the CHECK without a manual DDL
  * edit. The escrow transfer-split spec (2026-05-17) reintroduced
- * {@code VERIFY_SELL_TO}; the initializer (re)creates the constraint
- * enumerating the current enum values, and stays in place so additional
- * task types can plug in without re-deriving the constraint plumbing.
- * See {@link EnumCheckConstraintSync}.
+ * {@code VERIFY_SELL_TO}; the bot-dispatched verify-transfer spec
+ * (2026-05-18) added {@code VERIFY_BUY_OWNER}. The initializer (re)creates
+ * the constraint enumerating the current enum values, and stays in place so
+ * additional task types can plug in without re-deriving the constraint
+ * plumbing. See {@link EnumCheckConstraintSync}.
  */
 @Component
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/slparcelauctions/backend/bot/BuyOwnerOutcome.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/bot/BuyOwnerOutcome.java
@@ -1,0 +1,38 @@
+package com.slparcelauctions.backend.bot;
+
+/**
+ * Bot {@code VERIFY_BUY_OWNER} task classification result. The bot teleports
+ * to the parcel and reports the live owner so the backend can run the same
+ * confirm-transfer / consume-attempt / freeze decision matrix that the inline
+ * {@code EscrowManualActionService.verifyTransfer} used before manual verify
+ * switched to bot dispatch.
+ *
+ * <p>This is the <b>frozen bot wire contract</b> — the .NET bot mirrors these
+ * names byte-for-byte. Do not rename or reorder values.
+ *
+ * <ul>
+ *   <li>{@link #OWNER_IS_WINNER} — parcel owner is the auction winner. Confirm
+ *       the transfer.</li>
+ *   <li>{@link #OWNER_STILL_PRE_TRANSFER} — parcel owner is still the seller
+ *       (or the realty group, for group-listed parcels). Definitive negative:
+ *       consumes one of the requesting role's manual attempts.</li>
+ *   <li>{@link #OWNER_IS_STRANGER} — parcel owner is some unknown third party.
+ *       Triggers a {@code freezeForFraud(UNKNOWN_OWNER)}.</li>
+ *   <li>{@link #PARCEL_DELETED} — the bot could not locate the parcel
+ *       (returned/abandoned/region-down). Triggers
+ *       {@code freezeForFraud(PARCEL_DELETED)}.</li>
+ *   <li>{@link #WORLD_API_FAILURE} — the bot got an upstream/SL-side failure
+ *       trying to observe the parcel. Transient: no attempt consumed, the
+ *       pending flag is cleared so the user can retry.</li>
+ *   <li>{@link #UNKNOWN_ERROR} — catch-all for unexpected bot errors. Same
+ *       transient handling as {@code WORLD_API_FAILURE}.</li>
+ * </ul>
+ */
+public enum BuyOwnerOutcome {
+    OWNER_IS_WINNER,
+    OWNER_STILL_PRE_TRANSFER,
+    OWNER_IS_STRANGER,
+    PARCEL_DELETED,
+    WORLD_API_FAILURE,
+    UNKNOWN_ERROR
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/bot/dto/BuyOwnerResultRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/bot/dto/BuyOwnerResultRequest.java
@@ -1,0 +1,27 @@
+package com.slparcelauctions.backend.bot.dto;
+
+import com.slparcelauctions.backend.bot.BuyOwnerOutcome;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+/**
+ * Bot {@code VERIFY_BUY_OWNER} result callback body. Posted by the .NET worker
+ * to {@code POST /api/v1/bot/tasks/{taskId}/verify-buy-owner-result}. This is
+ * the <b>frozen bot wire contract</b> — the bot mirrors it field-for-field.
+ * Do not rename fields.
+ *
+ * @param outcome           classification of the live owner observation
+ * @param observedOwnerUuid the parcel owner the bot observed (best-effort —
+ *                          null for {@code PARCEL_DELETED} / transient
+ *                          failures). Logged into the fraud-flag evidence for
+ *                          freeze outcomes.
+ * @param observedOwnerType "agent" or "group" (best-effort, null on failure).
+ *                          Lets admins distinguish "stranger" from "third-party
+ *                          group" at a glance in the fraud queue.
+ */
+public record BuyOwnerResultRequest(
+        @NotNull BuyOwnerOutcome outcome,
+        UUID observedOwnerUuid,
+        String observedOwnerType) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowController.java
@@ -95,8 +95,8 @@ public class EscrowController {
             @PathVariable UUID auctionPublicId,
             @AuthenticationPrincipal AuthPrincipal principal) {
         Long auctionId = resolveAuctionId(auctionPublicId);
-        return ResponseEntity.ok(
-                manualActionService.verifyTransfer(auctionId, principal.userId()));
+        return ResponseEntity.accepted()
+                .body(manualActionService.verifyTransfer(auctionId, principal.userId()));
     }
 
     @PostMapping("/manual-review")

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowManualActionService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowManualActionService.java
@@ -5,14 +5,15 @@ import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionParcelSnapshot;
 import com.slparcelauctions.backend.bot.BotTask;
 import com.slparcelauctions.backend.bot.BotTaskRepository;
+import com.slparcelauctions.backend.bot.BotTaskStatus;
 import com.slparcelauctions.backend.bot.BotTaskType;
 import com.slparcelauctions.backend.escrow.dto.EscrowStatusResponse;
 import com.slparcelauctions.backend.escrow.exception.EscrowAccessDeniedException;
@@ -26,12 +27,6 @@ import com.slparcelauctions.backend.escrow.review.ManualReviewRole;
 import com.slparcelauctions.backend.escrow.review.ManualReviewStatus;
 import com.slparcelauctions.backend.escrow.review.ManualReviewStep;
 import com.slparcelauctions.backend.escrow.terminal.EscrowConfigProperties;
-import com.slparcelauctions.backend.realty.slgroup.RealtyGroupSlGroup;
-import com.slparcelauctions.backend.realty.slgroup.RealtyGroupSlGroupRepository;
-import com.slparcelauctions.backend.sl.SlWorldApiClient;
-import com.slparcelauctions.backend.sl.dto.ParcelMetadata;
-import com.slparcelauctions.backend.sl.dto.ParcelPageData;
-import com.slparcelauctions.backend.sl.exception.ParcelNotFoundInSlException;
 import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.user.UserRepository;
 
@@ -54,13 +49,18 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class EscrowManualActionService {
 
+    /** Payload key on the {@link BotTask#getResultData()} JSON map carrying
+     *  the requesting role ("SELLER" / "BUYER") so the callback consumes the
+     *  correct manual-attempt counter for verify-purchase. */
+    public static final String REQUESTING_ROLE_KEY = "requestingRole";
+    public static final String REQUESTING_ROLE_SELLER = "SELLER";
+    public static final String REQUESTING_ROLE_BUYER = "BUYER";
+
     private final EscrowRepository escrowRepo;
     private final EscrowService escrowService;
     private final BotTaskRepository botTaskRepo;
     private final EscrowManualReviewRepository manualReviewRepo;
-    private final SlWorldApiClient worldApi;
     private final UserRepository userRepo;
-    private final RealtyGroupSlGroupRepository slGroupRepo;
     private final EscrowConfigProperties props;
     private final Clock clock;
 
@@ -110,10 +110,17 @@ public class EscrowManualActionService {
     }
 
     /**
-     * Seller-or-buyer manual "Verify Purchase" (spec §6.1). Runs the
-     * World-API owner check inline (sub-second) and applies the same
-     * outcome matrix as the scheduled monitor. Definitive-negative
-     * (owner still seller/group) consumes the caller-role attempt counter.
+     * Seller-or-buyer manual "Verify Purchase" (spec §6.1, bot-dispatch refactor
+     * 2026-05-18). Expedites an open {@code VERIFY_BUY_OWNER} bot task (or
+     * creates one if none exists) and arms {@code manualVerifyPending} so the
+     * UI greys both verify buttons until the bot result lands. Definitive-
+     * negative outcomes (owner still seller/group) consume the caller-role
+     * attempt counter back in {@link com.slparcelauctions.backend.bot.BotTaskResultService};
+     * no attempt is consumed here.
+     *
+     * <p>The 30-min automated background ownership polling stays on the
+     * cheaper World-API path — this bot-dispatched flow is scoped to the
+     * user-initiated manual verify only.
      */
     @Transactional
     public EscrowStatusResponse verifyTransfer(Long auctionId, Long callerUserId) {
@@ -145,74 +152,53 @@ public class EscrowManualActionService {
         }
 
         OffsetDateTime now = OffsetDateTime.now(clock);
-        UUID parcelUuid = auction.getSlParcelUuid();
-        try {
-            ParcelMetadata result = worldApi.fetchParcelPage(parcelUuid)
-                    .map(ParcelPageData::parcel)
-                    .block();
-            if (result == null) {
-                // Degenerate empty response — treat as a retryable infra
-                // failure, do not consume an attempt.
-                throw new IllegalStateException("Empty World API response for parcel " + parcelUuid);
-            }
+        String requestingRole = isSeller ? REQUESTING_ROLE_SELLER : REQUESTING_ROLE_BUYER;
 
-            UUID ownerUuid = result.ownerUuid();
+        // Expedite any open VERIFY_BUY_OWNER task for this escrow; otherwise
+        // create one. The "one open task per escrow per type" invariant
+        // matches the VERIFY_SELL_TO path (BotTaskRepository.findOpenByEscrowAndType
+        // returns at most one row). The requesting role is stamped onto the
+        // task's resultData payload so the bot callback consumes the correct
+        // role counter on a definitive negative.
+        List<BotTask> open = botTaskRepo.findOpenByEscrowAndType(
+                escrow.getId(), BotTaskType.VERIFY_BUY_OWNER);
+        BotTask task;
+        if (!open.isEmpty()) {
+            task = open.get(0);
+            task.setNextRunAt(now);
+            Map<String, Object> payload = task.getResultData() == null
+                    ? new HashMap<>() : new HashMap<>(task.getResultData());
+            payload.put(REQUESTING_ROLE_KEY, requestingRole);
+            task.setResultData(payload);
+        } else {
+            AuctionParcelSnapshot snap = auction.getParcelSnapshot();
             User winner = userRepo.findById(auction.getWinnerUserId()).orElseThrow();
-            UUID winnerUuid = winner.getSlAvatarUuid();
-
-            UUID expectedPreTransfer;
-            String expectedPreTransferLabel;
-            if (auction.getRealtyGroupSlGroupId() != null) {
-                RealtyGroupSlGroup reg = slGroupRepo
-                        .findById(auction.getRealtyGroupSlGroupId())
-                        .orElse(null);
-                expectedPreTransfer = (reg == null) ? null : reg.getSlGroupUuid();
-                expectedPreTransferLabel = "expectedGroupUuid";
-            } else {
-                expectedPreTransfer = auction.getSeller().getSlAvatarUuid();
-                expectedPreTransferLabel = "expectedSellerUuid";
-            }
-
-            if (winnerUuid != null && winnerUuid.equals(ownerUuid)) {
-                escrowService.confirmTransfer(escrow, now);
-                return escrowService.getStatus(auctionId, callerUserId);
-            }
-            if (expectedPreTransfer != null && expectedPreTransfer.equals(ownerUuid)) {
-                // Definitive negative: parcel still pre-transfer. Consume the
-                // caller's role counter, then stamp-checked (success of the
-                // check itself resets the World-API failure streak).
-                if (isSeller) {
-                    escrow.setBuyVerifySellerAttempts(consumed + 1);
-                } else {
-                    escrow.setBuyVerifyBuyerAttempts(consumed + 1);
-                }
-                escrowRepo.save(escrow);
-                escrowService.stampChecked(escrow, now);
-                return escrowService.getStatus(auctionId, callerUserId);
-            }
-
-            Map<String, Object> evidence = new HashMap<>();
-            evidence.put("observedOwnerUuid", ownerUuid == null ? "<null>" : ownerUuid.toString());
-            evidence.put("expectedWinnerUuid", winnerUuid == null ? "<null>" : winnerUuid.toString());
-            evidence.put(expectedPreTransferLabel,
-                    expectedPreTransfer == null ? "<null>" : expectedPreTransfer.toString());
-            evidence.put("observedOwnerType", result.ownerType() == null ? "<null>" : result.ownerType());
-            evidence.put("source", "manual-verify-transfer");
-            escrowService.freezeForFraud(escrow, FreezeReason.UNKNOWN_OWNER, evidence, now);
-            return escrowService.getStatus(auctionId, callerUserId);
-
-        } catch (ParcelNotFoundInSlException e) {
-            Map<String, Object> evidence = new HashMap<>();
-            evidence.put("parcelUuid", parcelUuid.toString());
-            evidence.put("worldApiMessage", e.getMessage() == null ? "" : e.getMessage());
-            evidence.put("source", "manual-verify-transfer");
-            escrowService.freezeForFraud(escrow, FreezeReason.PARCEL_DELETED, evidence, now);
-            return escrowService.getStatus(auctionId, callerUserId);
+            Map<String, Object> payload = new HashMap<>();
+            payload.put(REQUESTING_ROLE_KEY, requestingRole);
+            task = BotTask.builder()
+                    .taskType(BotTaskType.VERIFY_BUY_OWNER)
+                    .status(BotTaskStatus.PENDING)
+                    .auction(auction)
+                    .escrow(escrow)
+                    .parcelUuid(snap != null ? snap.getSlParcelUuid()
+                            : auction.getSlParcelUuid())
+                    .regionName(snap != null ? snap.getRegionName() : null)
+                    .positionX(snap != null ? snap.getPositionX() : null)
+                    .positionY(snap != null ? snap.getPositionY() : null)
+                    .positionZ(snap != null ? snap.getPositionZ() : null)
+                    .expectedWinnerUuid(winner.getSlAvatarUuid())
+                    .nextRunAt(now)
+                    .sentinelPrice(0L)
+                    .resultData(payload)
+                    .build();
         }
-        // ExternalApiTimeoutException (and the IllegalStateException above)
-        // propagate unconsumed — a transient infra failure must not burn a
-        // manual attempt. The escrow @RestControllerAdvice / GlobalExceptionHandler
-        // surface it as a retryable error.
+        botTaskRepo.save(task);
+        escrow.setManualVerifyPending(true);
+        escrowRepo.save(escrow);
+
+        log.info("Manual verify-transfer requested for escrow {} (auction {}) by {} ({})",
+                escrow.getId(), auctionId, callerUserId, requestingRole);
+        return escrowService.getStatus(auctionId, callerUserId);
     }
 
     /**

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
@@ -531,7 +531,8 @@ public class EscrowService {
                 reviewStatus,
                 reviewStep,
                 parcelMapUrl,
-                parcelViewerUrl);
+                parcelViewerUrl,
+                Boolean.TRUE.equals(escrow.getManualVerifyPending()));
     }
 
     private List<EscrowTimelineEntry> buildTimeline(Escrow e) {

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/dto/EscrowStatusResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/dto/EscrowStatusResponse.java
@@ -71,4 +71,13 @@ public record EscrowStatusResponse(
         /** Clickable SL map URL to the parcel (https maps.secondlife.com). */
         String parcelMapUrl,
         /** In-world viewer teleport SLURL to the parcel (secondlife:///app/teleport). */
-        String parcelViewerUrl) { }
+        String parcelViewerUrl,
+        /**
+         * {@code true} while a bot-dispatched {@code VERIFY_SELL_TO} or
+         * {@code VERIFY_BUY_OWNER} check is in flight (set when the user
+         * clicks Verify Sell To / Verify Purchase, cleared when the bot result
+         * lands). Drives the "Verification process pending" UI on the escrow
+         * page so the button stays disabled until the async result arrives —
+         * the POST roundtrip returning is not enough on its own.
+         */
+        boolean manualVerifyPending) { }

--- a/backend/src/test/java/com/slparcelauctions/backend/bot/BotTaskResultServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/bot/BotTaskResultServiceTest.java
@@ -16,7 +16,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -32,7 +34,9 @@ import com.slparcelauctions.backend.auction.AuctionEndOutcome;
 import com.slparcelauctions.backend.auction.AuctionParcelSnapshot;
 import com.slparcelauctions.backend.auction.AuctionStatus;
 import com.slparcelauctions.backend.bot.dto.BotTaskResultRequest;
+import com.slparcelauctions.backend.bot.dto.BuyOwnerResultRequest;
 import com.slparcelauctions.backend.escrow.Escrow;
+import com.slparcelauctions.backend.escrow.EscrowManualActionService;
 import com.slparcelauctions.backend.escrow.EscrowRepository;
 import com.slparcelauctions.backend.escrow.EscrowService;
 import com.slparcelauctions.backend.escrow.EscrowState;
@@ -316,6 +320,175 @@ class BotTaskResultServiceTest {
 
         verifyNoInteractions(escrowService);
         verify(escrowRepo, never()).findByIdForUpdate(any());
+    }
+
+    // ---- applyVerifyBuyOwnerResult (bot-dispatch verify-purchase 2026-05-18) ----
+
+    @Test
+    void buyOwner_ownerIsWinner_confirmsTransfer_completesTask_clearsPending() {
+        BotTask task = pendingBuyOwnerTask(EscrowManualActionService.REQUESTING_ROLE_BUYER);
+        Escrow escrow = transferPending(now.plusHours(70));
+        escrow.setManualVerifyPending(true);
+        primeLoad(task, escrow);
+
+        service.applyVerifyBuyOwnerResult(TASK_ID,
+                new BuyOwnerResultRequest(BuyOwnerOutcome.OWNER_IS_WINNER, UUID.randomUUID(), "agent"));
+
+        verify(escrowService).confirmTransfer(escrow, now);
+        verify(escrowService, never()).stampChecked(any(), any());
+        verify(escrowService, never()).freezeForFraud(any(), any(), any(), any());
+        assertThat(escrow.getManualVerifyPending()).isFalse();
+        assertThat(task.getStatus()).isEqualTo(BotTaskStatus.COMPLETED);
+    }
+
+    @Test
+    void buyOwner_ownerStillPreTransfer_sellerRequest_consumesSellerCounter() {
+        BotTask task = pendingBuyOwnerTask(EscrowManualActionService.REQUESTING_ROLE_SELLER);
+        Escrow escrow = transferPending(now.plusHours(70));
+        escrow.setManualVerifyPending(true);
+        escrow.setBuyVerifySellerAttempts(0);
+        escrow.setBuyVerifyBuyerAttempts(0);
+        primeLoad(task, escrow);
+
+        service.applyVerifyBuyOwnerResult(TASK_ID,
+                new BuyOwnerResultRequest(BuyOwnerOutcome.OWNER_STILL_PRE_TRANSFER, UUID.randomUUID(), "agent"));
+
+        assertThat(escrow.getBuyVerifySellerAttempts()).isEqualTo(1);
+        assertThat(escrow.getBuyVerifyBuyerAttempts()).isZero();
+        assertThat(escrow.getManualVerifyPending()).isFalse();
+        verify(escrowService).stampChecked(escrow, now);
+        verify(escrowService, never()).confirmTransfer(any(), any());
+        assertThat(task.getStatus()).isEqualTo(BotTaskStatus.COMPLETED);
+    }
+
+    @Test
+    void buyOwner_ownerStillPreTransfer_buyerRequest_consumesBuyerCounter() {
+        BotTask task = pendingBuyOwnerTask(EscrowManualActionService.REQUESTING_ROLE_BUYER);
+        Escrow escrow = transferPending(now.plusHours(70));
+        escrow.setManualVerifyPending(true);
+        escrow.setBuyVerifySellerAttempts(0);
+        escrow.setBuyVerifyBuyerAttempts(0);
+        primeLoad(task, escrow);
+
+        service.applyVerifyBuyOwnerResult(TASK_ID,
+                new BuyOwnerResultRequest(BuyOwnerOutcome.OWNER_STILL_PRE_TRANSFER, UUID.randomUUID(), "agent"));
+
+        assertThat(escrow.getBuyVerifyBuyerAttempts()).isEqualTo(1);
+        assertThat(escrow.getBuyVerifySellerAttempts()).isZero();
+        assertThat(escrow.getManualVerifyPending()).isFalse();
+        verify(escrowService).stampChecked(escrow, now);
+    }
+
+    @Test
+    void buyOwner_ownerIsStranger_freezesUnknownOwner_clearsPending() {
+        BotTask task = pendingBuyOwnerTask(EscrowManualActionService.REQUESTING_ROLE_BUYER);
+        Escrow escrow = transferPending(now.plusHours(70));
+        escrow.setManualVerifyPending(true);
+        primeLoad(task, escrow);
+        UUID strangerUuid = UUID.randomUUID();
+
+        service.applyVerifyBuyOwnerResult(TASK_ID,
+                new BuyOwnerResultRequest(BuyOwnerOutcome.OWNER_IS_STRANGER, strangerUuid, "agent"));
+
+        verify(escrowService).freezeForFraud(
+                eq(escrow), eq(FreezeReason.UNKNOWN_OWNER), any(), eq(now));
+        assertThat(escrow.getManualVerifyPending()).isFalse();
+        assertThat(escrow.getBuyVerifyBuyerAttempts()).isZero();
+        assertThat(task.getStatus()).isEqualTo(BotTaskStatus.COMPLETED);
+    }
+
+    @Test
+    void buyOwner_parcelDeleted_freezesParcelDeleted_clearsPending() {
+        BotTask task = pendingBuyOwnerTask(EscrowManualActionService.REQUESTING_ROLE_BUYER);
+        Escrow escrow = transferPending(now.plusHours(70));
+        escrow.setManualVerifyPending(true);
+        primeLoad(task, escrow);
+
+        service.applyVerifyBuyOwnerResult(TASK_ID,
+                new BuyOwnerResultRequest(BuyOwnerOutcome.PARCEL_DELETED, null, null));
+
+        verify(escrowService).freezeForFraud(
+                eq(escrow), eq(FreezeReason.PARCEL_DELETED), any(), eq(now));
+        assertThat(escrow.getManualVerifyPending()).isFalse();
+        assertThat(task.getStatus()).isEqualTo(BotTaskStatus.COMPLETED);
+    }
+
+    @Test
+    void buyOwner_worldApiFailure_clearsPending_noAttempt_taskFailed() {
+        BotTask task = pendingBuyOwnerTask(EscrowManualActionService.REQUESTING_ROLE_BUYER);
+        Escrow escrow = transferPending(now.plusHours(70));
+        escrow.setManualVerifyPending(true);
+        escrow.setBuyVerifyBuyerAttempts(0);
+        primeLoad(task, escrow);
+
+        service.applyVerifyBuyOwnerResult(TASK_ID,
+                new BuyOwnerResultRequest(BuyOwnerOutcome.WORLD_API_FAILURE, null, null));
+
+        assertThat(escrow.getManualVerifyPending()).isFalse();
+        assertThat(escrow.getBuyVerifyBuyerAttempts()).isZero();
+        verify(escrowService, never()).confirmTransfer(any(), any());
+        verify(escrowService, never()).stampChecked(any(), any());
+        verify(escrowService, never()).freezeForFraud(any(), any(), any(), any());
+        assertThat(task.getStatus()).isEqualTo(BotTaskStatus.FAILED);
+    }
+
+    @Test
+    void buyOwner_unknownError_sameTransientHandling_asWorldApiFailure() {
+        BotTask task = pendingBuyOwnerTask(EscrowManualActionService.REQUESTING_ROLE_BUYER);
+        Escrow escrow = transferPending(now.plusHours(70));
+        escrow.setManualVerifyPending(true);
+        primeLoad(task, escrow);
+
+        service.applyVerifyBuyOwnerResult(TASK_ID,
+                new BuyOwnerResultRequest(BuyOwnerOutcome.UNKNOWN_ERROR, null, null));
+
+        assertThat(escrow.getManualVerifyPending()).isFalse();
+        verify(escrowService, never()).confirmTransfer(any(), any());
+        assertThat(task.getStatus()).isEqualTo(BotTaskStatus.FAILED);
+    }
+
+    @Test
+    void buyOwner_terminalTask_isNoOp() {
+        BotTask task = pendingBuyOwnerTask(EscrowManualActionService.REQUESTING_ROLE_BUYER);
+        task.setStatus(BotTaskStatus.COMPLETED);
+        when(botTaskRepo.findById(TASK_ID)).thenReturn(Optional.of(task));
+
+        service.applyVerifyBuyOwnerResult(TASK_ID,
+                new BuyOwnerResultRequest(BuyOwnerOutcome.OWNER_IS_WINNER, null, null));
+
+        verifyNoInteractions(escrowService);
+        verify(escrowRepo, never()).findByIdForUpdate(any());
+    }
+
+    @Test
+    void buyOwner_wrongTaskType_isNoOp() {
+        BotTask task = pendingTask(); // VERIFY_SELL_TO type
+        when(botTaskRepo.findById(TASK_ID)).thenReturn(Optional.of(task));
+
+        service.applyVerifyBuyOwnerResult(TASK_ID,
+                new BuyOwnerResultRequest(BuyOwnerOutcome.OWNER_IS_WINNER, null, null));
+
+        verifyNoInteractions(escrowService);
+        verify(escrowRepo, never()).findByIdForUpdate(any());
+    }
+
+    private BotTask pendingBuyOwnerTask(String requestingRole) {
+        Escrow escrow = transferPending(now.plusHours(70));
+        Map<String, Object> payload = new HashMap<>();
+        if (requestingRole != null) {
+            payload.put(EscrowManualActionService.REQUESTING_ROLE_KEY, requestingRole);
+        }
+        return BotTask.builder()
+                .id(TASK_ID)
+                .taskType(BotTaskType.VERIFY_BUY_OWNER)
+                .status(BotTaskStatus.PENDING)
+                .auction(escrow.getAuction())
+                .escrow(escrow)
+                .parcelUuid(UUID.randomUUID())
+                .sentinelPrice(0L)
+                .resultData(payload)
+                .nextRunAt(now.minusMinutes(1))
+                .build();
     }
 
     // ---- helpers ----

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowControllerSliceTest.java
@@ -109,7 +109,7 @@ class EscrowControllerSliceTest {
                 null, null, null,
                 List.of(),
                 null, null, 3, 3, 3,
-                null, null, null, null);
+                null, null, null, null, false);
     }
 
     private MockMultipartFile disputePart(String reasonCategory, String description) {
@@ -261,12 +261,14 @@ class EscrowControllerSliceTest {
 
     @Test
     @WithMockAuthPrincipal(userId = 200)
-    void verifyTransfer_winnerAuthenticated_returns200() throws Exception {
+    void verifyTransfer_winnerAuthenticated_returns202() throws Exception {
+        // Bot-dispatch refactor (2026-05-18): verify-transfer is now 202-async,
+        // mirroring verify-sell-to. The bot result lands later via STOMP.
         when(manualActionService.verifyTransfer(eq(AUCTION_ID), eq(WINNER_ID)))
                 .thenReturn(stubResponse(EscrowState.TRANSFER_PENDING));
 
         mockMvc.perform(post("/api/v1/auctions/" + AUCTION_PUBLIC_ID + "/escrow/verify-transfer"))
-                .andExpect(status().isOk())
+                .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$.state").value("TRANSFER_PENDING"));
 
         verify(manualActionService).verifyTransfer(AUCTION_ID, WINNER_ID);

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowManualActionServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowManualActionServiceTest.java
@@ -17,6 +17,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -46,15 +47,8 @@ import com.slparcelauctions.backend.escrow.review.ManualReviewRole;
 import com.slparcelauctions.backend.escrow.review.ManualReviewStatus;
 import com.slparcelauctions.backend.escrow.review.ManualReviewStep;
 import com.slparcelauctions.backend.escrow.terminal.EscrowConfigProperties;
-import com.slparcelauctions.backend.realty.slgroup.RealtyGroupSlGroupRepository;
-import com.slparcelauctions.backend.sl.SlWorldApiClient;
-import com.slparcelauctions.backend.sl.dto.ParcelMetadata;
-import com.slparcelauctions.backend.sl.dto.ParcelPageData;
-import com.slparcelauctions.backend.sl.exception.ExternalApiTimeoutException;
 import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.user.UserRepository;
-
-import reactor.core.publisher.Mono;
 
 /**
  * Unit coverage for {@link EscrowManualActionService}: the seller/buyer
@@ -73,16 +67,13 @@ class EscrowManualActionServiceTest {
     private static final UUID PARCEL_UUID = UUID.fromString("33333333-3333-3333-3333-333333333333");
     private static final UUID SELLER_AVATAR = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     private static final UUID WINNER_AVATAR = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
-    private static final UUID STRANGER_AVATAR = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
     private static final int CAP = 3;
 
     @Mock EscrowRepository escrowRepo;
     @Mock EscrowService escrowService;
     @Mock BotTaskRepository botTaskRepo;
     @Mock EscrowManualReviewRepository manualReviewRepo;
-    @Mock SlWorldApiClient worldApi;
     @Mock UserRepository userRepo;
-    @Mock RealtyGroupSlGroupRepository slGroupRepo;
     @Mock EscrowConfigProperties props;
 
     EscrowManualActionService service;
@@ -93,7 +84,7 @@ class EscrowManualActionServiceTest {
         fixed = Clock.fixed(Instant.parse("2026-05-17T12:00:00Z"), ZoneOffset.UTC);
         service = new EscrowManualActionService(
                 escrowRepo, escrowService, botTaskRepo, manualReviewRepo,
-                worldApi, userRepo, slGroupRepo, props, fixed);
+                userRepo, props, fixed);
         lenient().when(props.manualVerifyAttempts()).thenReturn(CAP);
         lenient().when(escrowService.getStatus(eq(AUCTION_ID), any()))
                 .thenReturn(stubStatus());
@@ -148,7 +139,7 @@ class EscrowManualActionServiceTest {
                 .isInstanceOf(EscrowAccessDeniedException.class);
     }
 
-    // ----- verifyTransfer -----
+    // ----- verifyTransfer (bot-dispatch refactor 2026-05-18) -----
 
     @Test
     void verifyTransfer_beforeSellToConfirmed_throws409() {
@@ -161,85 +152,83 @@ class EscrowManualActionServiceTest {
     }
 
     @Test
-    void verifyTransfer_ownerIsWinner_confirmsTransfer() {
+    void verifyTransfer_noOpenTask_createsBotTask_setsPendingFlag_noAttemptConsumed() {
         Escrow escrow = buildBuyParcel();
         when(escrowRepo.findByAuctionId(AUCTION_ID)).thenReturn(Optional.of(escrow));
         when(escrowRepo.findByIdForUpdate(ESCROW_ID)).thenReturn(Optional.of(escrow));
         stubWinner();
-        when(worldApi.fetchParcelPage(PARCEL_UUID)).thenReturn(
-                Mono.just(new ParcelPageData(meta(WINNER_AVATAR, "agent"), UUID.randomUUID())));
+        when(botTaskRepo.findOpenByEscrowAndType(ESCROW_ID, BotTaskType.VERIFY_BUY_OWNER))
+                .thenReturn(List.of());
 
         service.verifyTransfer(AUCTION_ID, WINNER_ID);
 
-        verify(escrowService).confirmTransfer(eq(escrow), eq(OffsetDateTime.now(fixed)));
+        ArgumentCaptor<BotTask> taskCap = ArgumentCaptor.forClass(BotTask.class);
+        verify(botTaskRepo).save(taskCap.capture());
+        BotTask saved = taskCap.getValue();
+        assertThat(saved.getTaskType()).isEqualTo(BotTaskType.VERIFY_BUY_OWNER);
+        assertThat(saved.getStatus()).isEqualTo(BotTaskStatus.PENDING);
+        assertThat(saved.getEscrow()).isEqualTo(escrow);
+        assertThat(saved.getParcelUuid()).isEqualTo(PARCEL_UUID);
+        assertThat(saved.getNextRunAt()).isEqualTo(OffsetDateTime.now(fixed));
+        assertThat(saved.getResultData())
+                .containsEntry(EscrowManualActionService.REQUESTING_ROLE_KEY,
+                        EscrowManualActionService.REQUESTING_ROLE_BUYER);
+        assertThat(saved.getExpectedWinnerUuid()).isEqualTo(WINNER_AVATAR);
+
+        assertThat(escrow.getManualVerifyPending()).isTrue();
+        assertThat(escrow.getBuyVerifyBuyerAttempts()).isZero();
+        assertThat(escrow.getBuyVerifySellerAttempts()).isZero();
+        verify(escrowService, never()).confirmTransfer(any(), any());
         verify(escrowService, never()).stampChecked(any(), any());
         verify(escrowService, never()).freezeForFraud(any(), any(), any(), any());
-        assertThat(escrow.getBuyVerifyBuyerAttempts()).isZero();
     }
 
     @Test
-    void verifyTransfer_ownerStillSeller_consumesCallerRoleCounter_stampsChecked() {
+    void verifyTransfer_sellerCaller_stampsSellerRoleOnTask() {
         Escrow escrow = buildBuyParcel();
         when(escrowRepo.findByAuctionId(AUCTION_ID)).thenReturn(Optional.of(escrow));
         when(escrowRepo.findByIdForUpdate(ESCROW_ID)).thenReturn(Optional.of(escrow));
         stubWinner();
-        when(worldApi.fetchParcelPage(PARCEL_UUID)).thenReturn(
-                Mono.just(new ParcelPageData(meta(SELLER_AVATAR, "agent"), UUID.randomUUID())));
-
-        // Buyer calls — buyer counter consumed, seller counter untouched.
-        service.verifyTransfer(AUCTION_ID, WINNER_ID);
-
-        assertThat(escrow.getBuyVerifyBuyerAttempts()).isEqualTo(1);
-        assertThat(escrow.getBuyVerifySellerAttempts()).isZero();
-        verify(escrowService).stampChecked(eq(escrow), eq(OffsetDateTime.now(fixed)));
-        verify(escrowService, never()).confirmTransfer(any(), any());
-    }
-
-    @Test
-    void verifyTransfer_sellerCaller_ownerStillSeller_consumesSellerCounter() {
-        Escrow escrow = buildBuyParcel();
-        when(escrowRepo.findByAuctionId(AUCTION_ID)).thenReturn(Optional.of(escrow));
-        when(escrowRepo.findByIdForUpdate(ESCROW_ID)).thenReturn(Optional.of(escrow));
-        stubWinner();
-        when(worldApi.fetchParcelPage(PARCEL_UUID)).thenReturn(
-                Mono.just(new ParcelPageData(meta(SELLER_AVATAR, "agent"), UUID.randomUUID())));
+        when(botTaskRepo.findOpenByEscrowAndType(ESCROW_ID, BotTaskType.VERIFY_BUY_OWNER))
+                .thenReturn(List.of());
 
         service.verifyTransfer(AUCTION_ID, SELLER_ID);
 
-        assertThat(escrow.getBuyVerifySellerAttempts()).isEqualTo(1);
-        assertThat(escrow.getBuyVerifyBuyerAttempts()).isZero();
-        verify(escrowService).stampChecked(eq(escrow), eq(OffsetDateTime.now(fixed)));
+        ArgumentCaptor<BotTask> taskCap = ArgumentCaptor.forClass(BotTask.class);
+        verify(botTaskRepo).save(taskCap.capture());
+        assertThat(taskCap.getValue().getResultData())
+                .containsEntry(EscrowManualActionService.REQUESTING_ROLE_KEY,
+                        EscrowManualActionService.REQUESTING_ROLE_SELLER);
+        assertThat(escrow.getManualVerifyPending()).isTrue();
     }
 
     @Test
-    void verifyTransfer_ownerStranger_freezesForFraud() {
+    void verifyTransfer_openTaskExists_expedites_updatesRolePayload() {
         Escrow escrow = buildBuyParcel();
         when(escrowRepo.findByAuctionId(AUCTION_ID)).thenReturn(Optional.of(escrow));
         when(escrowRepo.findByIdForUpdate(ESCROW_ID)).thenReturn(Optional.of(escrow));
-        stubWinner();
-        when(worldApi.fetchParcelPage(PARCEL_UUID)).thenReturn(
-                Mono.just(new ParcelPageData(meta(STRANGER_AVATAR, "agent"), UUID.randomUUID())));
+        Map<String, Object> existingPayload = new java.util.HashMap<>();
+        existingPayload.put(EscrowManualActionService.REQUESTING_ROLE_KEY,
+                EscrowManualActionService.REQUESTING_ROLE_SELLER);
+        BotTask existing = BotTask.builder()
+                .id(901L).taskType(BotTaskType.VERIFY_BUY_OWNER)
+                .status(BotTaskStatus.PENDING)
+                .auction(escrow.getAuction()).escrow(escrow)
+                .parcelUuid(PARCEL_UUID).sentinelPrice(0L)
+                .resultData(existingPayload)
+                .nextRunAt(OffsetDateTime.now(fixed).plusMinutes(20))
+                .build();
+        when(botTaskRepo.findOpenByEscrowAndType(ESCROW_ID, BotTaskType.VERIFY_BUY_OWNER))
+                .thenReturn(List.of(existing));
 
         service.verifyTransfer(AUCTION_ID, WINNER_ID);
 
-        verify(escrowService).freezeForFraud(
-                eq(escrow), eq(FreezeReason.UNKNOWN_OWNER), any(), eq(OffsetDateTime.now(fixed)));
-        verify(escrowService, never()).confirmTransfer(any(), any());
-    }
-
-    @Test
-    void verifyTransfer_worldApiTimeout_doesNotConsume_rethrows() {
-        Escrow escrow = buildBuyParcel();
-        when(escrowRepo.findByAuctionId(AUCTION_ID)).thenReturn(Optional.of(escrow));
-        when(escrowRepo.findByIdForUpdate(ESCROW_ID)).thenReturn(Optional.of(escrow));
-        when(worldApi.fetchParcelPage(PARCEL_UUID)).thenReturn(
-                Mono.error(new ExternalApiTimeoutException("World", "connect timeout")));
-
-        assertThatThrownBy(() -> service.verifyTransfer(AUCTION_ID, WINNER_ID))
-                .isInstanceOf(ExternalApiTimeoutException.class);
-        assertThat(escrow.getBuyVerifyBuyerAttempts()).isZero();
-        verify(escrowService, never()).confirmTransfer(any(), any());
-        verify(escrowService, never()).stampChecked(any(), any());
+        assertThat(existing.getNextRunAt()).isEqualTo(OffsetDateTime.now(fixed));
+        assertThat(existing.getResultData())
+                .containsEntry(EscrowManualActionService.REQUESTING_ROLE_KEY,
+                        EscrowManualActionService.REQUESTING_ROLE_BUYER);
+        verify(botTaskRepo).save(existing);
+        assertThat(escrow.getManualVerifyPending()).isTrue();
     }
 
     @Test
@@ -251,6 +240,7 @@ class EscrowManualActionServiceTest {
 
         assertThatThrownBy(() -> service.verifyTransfer(AUCTION_ID, WINNER_ID))
                 .isInstanceOf(EscrowManualAttemptsExhaustedException.class);
+        verify(botTaskRepo, never()).save(any());
     }
 
     @Test
@@ -345,7 +335,7 @@ class EscrowManualActionServiceTest {
                 UUID.randomUUID(), UUID.randomUUID(), "Winner Resident",
                 EscrowState.TRANSFER_PENDING, 5000L, 250L, 4750L,
                 null, null, null, null, null, null, null, null, null, null,
-                List.of(), null, null, 3, 3, 3, null, null, null, null);
+                List.of(), null, null, 3, 3, 3, null, null, null, null, false);
     }
 
     private Escrow buildSetSellTo() {
@@ -394,11 +384,4 @@ class EscrowManualActionServiceTest {
                 .build();
     }
 
-    private ParcelMetadata meta(UUID owner, String ownerType) {
-        return new ParcelMetadata(
-                PARCEL_UUID, owner, ownerType, null,
-                "Test Parcel", "EscrowRegion",
-                1024, "desc", "http://example.com/snap.jpg", "MODERATE",
-                128.0, 64.0, 22.0);
-    }
 }

--- a/frontend/src/components/escrow/state/TransferPendingStateCard.test.tsx
+++ b/frontend/src/components/escrow/state/TransferPendingStateCard.test.tsx
@@ -133,6 +133,34 @@ describe("TransferPendingStateCard", () => {
       ).toBeInTheDocument();
     });
 
+    it("disables Verify Sell To while manualVerifyPending=true and shows pending copy", () => {
+      renderSeller({
+        sellToVerifyAttemptsRemaining: 3,
+        manualVerifyPending: true,
+      });
+      expect(
+        screen.getByRole("button", { name: /verify sell to/i }),
+      ).toBeDisabled();
+      expect(screen.getByTestId("verify-bot-pending")).toHaveTextContent(
+        /verification process pending/i,
+      );
+      // The 30-min auto-poll hint should be hidden when the pending copy is up
+      expect(screen.queryByText(/every 30 min/i)).not.toBeInTheDocument();
+    });
+
+    it("re-enables Verify Sell To when manualVerifyPending=false and attempts remain", () => {
+      renderSeller({
+        sellToVerifyAttemptsRemaining: 2,
+        manualVerifyPending: false,
+      });
+      expect(
+        screen.getByRole("button", { name: /verify sell to/i }),
+      ).toBeEnabled();
+      expect(
+        screen.queryByTestId("verify-bot-pending"),
+      ).not.toBeInTheDocument();
+    });
+
     it("shows an inline error when sellToLastResult is set", () => {
       renderSeller({ sellToLastResult: "WRONG_BUYER" });
       expect(screen.getByText(/WRONG_BUYER/)).toBeInTheDocument();
@@ -249,6 +277,33 @@ describe("TransferPendingStateCard", () => {
       ).toBeInTheDocument();
     });
 
+    it("disables Verify purchase while manualVerifyPending=true and shows pending copy", () => {
+      renderWinner({
+        buyVerifyBuyerAttemptsRemaining: 3,
+        manualVerifyPending: true,
+      });
+      expect(
+        screen.getByRole("button", { name: /verify purchase/i }),
+      ).toBeDisabled();
+      expect(screen.getByTestId("verify-bot-pending")).toHaveTextContent(
+        /verification process pending/i,
+      );
+      expect(screen.queryByText(/every 30 min/i)).not.toBeInTheDocument();
+    });
+
+    it("re-enables Verify purchase when manualVerifyPending=false and attempts remain", () => {
+      renderWinner({
+        buyVerifyBuyerAttemptsRemaining: 2,
+        manualVerifyPending: false,
+      });
+      expect(
+        screen.getByRole("button", { name: /verify purchase/i }),
+      ).toBeEnabled();
+      expect(
+        screen.queryByTestId("verify-bot-pending"),
+      ).not.toBeInTheDocument();
+    });
+
     it("renders BOTH the manual-review affordance AND the File a dispute link", () => {
       renderWinner({ auctionPublicId: "auction-buy-parcel-winner" });
       expect(
@@ -306,6 +361,19 @@ describe("TransferPendingStateCard", () => {
       expect(dispute).toHaveAttribute(
         "href",
         "/auction/auction-buy-parcel-seller/escrow/dispute",
+      );
+    });
+
+    it("disables Verify purchase (seller side) while manualVerifyPending=true and shows pending copy", () => {
+      renderSellerWaiting({
+        buyVerifySellerAttemptsRemaining: 3,
+        manualVerifyPending: true,
+      });
+      expect(
+        screen.getByRole("button", { name: /verify purchase/i }),
+      ).toBeDisabled();
+      expect(screen.getByTestId("verify-bot-pending")).toHaveTextContent(
+        /verification process pending/i,
       );
     });
   });

--- a/frontend/src/components/escrow/state/TransferPendingStateCard.tsx
+++ b/frontend/src/components/escrow/state/TransferPendingStateCard.tsx
@@ -166,13 +166,18 @@ function VerifyControls({
   onRequestReview: () => void;
 }) {
   const exhausted = attemptsRemaining <= 0;
+  // Bot-dispatched verify (Verify Sell To + Verify Purchase, spec 2026-05-18):
+  // the POST returns 202 but the bot may still be teleporting to the parcel.
+  // Keep the button disabled and show "Verification process pending" until the
+  // bot result lands and the backend flips manualVerifyPending back to false.
+  const botPending = escrow.manualVerifyPending === true;
   return (
     <div className="flex flex-col gap-2">
       <div className="flex flex-wrap items-center gap-3">
         <Button
           variant="primary"
           size="md"
-          disabled={exhausted}
+          disabled={exhausted || botPending}
           loading={verifyPending}
           onClick={onVerify}
         >
@@ -185,10 +190,19 @@ function VerifyControls({
           {attemptsRemaining} of 3 manual attempts left
         </span>
       </div>
-      <p className="text-xs text-fg-muted">
-        After your manual attempts run out, SLParcels automatically re-checks
-        every 30 min.
-      </p>
+      {botPending ? (
+        <p
+          data-testid="verify-bot-pending"
+          className="text-xs font-medium text-fg-muted"
+        >
+          Verification process pending
+        </p>
+      ) : (
+        <p className="text-xs text-fg-muted">
+          After your manual attempts run out, SLParcels automatically re-checks
+          every 30 min.
+        </p>
+      )}
       {escrow.manualReviewStatus === "OPEN" ? (
         <p className="text-xs font-medium text-fg-muted">
           A manual review is open. SLParcels staff will follow up.

--- a/frontend/src/hooks/useEscrowManualActions.ts
+++ b/frontend/src/hooks/useEscrowManualActions.ts
@@ -35,7 +35,12 @@ export function useVerifySellTo(auctionPublicId: string) {
   });
 }
 
-/** Manual buy/transfer verify (200 sync). */
+/**
+ * Manual buy/transfer verify (202 async; result arrives via STOMP +
+ * cache invalidation). Mirrors `useVerifySellTo` after the bot-dispatch
+ * refactor (spec 2026-05-18). The button stays disabled and shows
+ * "Verification process pending" while `escrow.manualVerifyPending` is true.
+ */
 export function useVerifyTransfer(auctionPublicId: string) {
   const queryClient = useQueryClient();
   return useMutation<EscrowStatusResponse, unknown, void>({

--- a/frontend/src/lib/api/escrow.test.ts
+++ b/frontend/src/lib/api/escrow.test.ts
@@ -125,20 +125,27 @@ describe("escrow API client", () => {
   });
 
   describe("verifyTransfer", () => {
-    it("POSTs and returns the updated escrow status", async () => {
+    it("POSTs and returns 202 with updated escrow status (manualVerifyPending=true)", async () => {
+      // Bot-dispatch refactor (spec 2026-05-18): verify-transfer is now 202
+      // and the bot result lands later via STOMP / cache invalidation. The
+      // immediate response carries manualVerifyPending=true so the UI greys
+      // the button until the bot result arrives.
       server.use(
         http.post("*/api/v1/auctions/7/escrow/verify-transfer", () =>
           HttpResponse.json(
             fakeEscrow({
               state: "TRANSFER_PENDING",
               sellToConfirmedAt: "2026-05-17T10:00:00Z",
-              transferConfirmedAt: "2026-05-17T10:05:00Z",
+              transferConfirmedAt: null,
+              manualVerifyPending: true,
             }),
+            { status: 202 },
           ),
         ),
       );
       const result = await verifyTransfer(7);
-      expect(result.transferConfirmedAt).toBe("2026-05-17T10:05:00Z");
+      expect(result.manualVerifyPending).toBe(true);
+      expect(result.transferConfirmedAt).toBeNull();
     });
   });
 

--- a/frontend/src/lib/api/escrow.ts
+++ b/frontend/src/lib/api/escrow.ts
@@ -48,9 +48,11 @@ export function verifySellTo(
 }
 
 /**
- * Triggers a manual buy/transfer verification (spec 2026-05-17 §9). Backend
- * returns 200 with the updated escrow status (transferConfirmedAt stamped on
- * success, decremented attempt count otherwise).
+ * Triggers a manual buy/transfer verification (spec 2026-05-17 §9; bot-dispatch
+ * refactor 2026-05-18). Backend returns 202 — the actual check runs
+ * asynchronously on the bot worker; the response carries the updated escrow
+ * status with `manualVerifyPending=true`, and the eventual bot result lands on
+ * the page via an escrow-status cache invalidation.
  */
 export function verifyTransfer(
   auctionId: number | string,

--- a/frontend/src/test/fixtures/escrow.ts
+++ b/frontend/src/test/fixtures/escrow.ts
@@ -35,6 +35,7 @@ export function fakeEscrow(
     manualReviewStep: null,
     parcelMapUrl: null,
     parcelViewerUrl: null,
+    manualVerifyPending: false,
   };
   return { ...base, ...overrides };
 }

--- a/frontend/src/types/escrow.ts
+++ b/frontend/src/types/escrow.ts
@@ -96,6 +96,14 @@ export interface EscrowStatusResponse {
   parcelMapUrl: string | null;
   /** SL viewer deep-link to the parcel (secondlife:// app URL), null until enrichment resolves it. */
   parcelViewerUrl: string | null;
+  /**
+   * True while a bot-dispatched VERIFY_SELL_TO or VERIFY_BUY_OWNER check is in
+   * flight (set on Verify Sell To / Verify Purchase POST, cleared when the bot
+   * result lands). The escrow page uses this to disable the verify button and
+   * show "Verification process pending" copy — POST roundtrip success alone is
+   * not enough to re-enable the button, since the bot may still be in transit.
+   */
+  manualVerifyPending: boolean;
 }
 
 /** Body shape for `POST /api/v1/auctions/{id}/escrow/dispute`. */


### PR DESCRIPTION
## Summary

- Manual Verify Purchase (seller + winner) now dispatches a `VERIFY_BUY_OWNER` bot task instead of running an inline World-API call, mirroring Verify Sell To.
- A shared `manualVerifyPending` flag on the escrow drives the frontend: while a bot check is in flight, both Verify Sell To and Verify Purchase buttons are disabled and show "Verification process pending" in place of the 30-min auto-poll hint.
- New `BuyOwnerOutcome` enum + bot callback endpoint (`POST /api/v1/bot/tasks/{id}/verify-buy-owner-result`) apply the existing outcome matrix: winner match → confirm transfer; seller/group still owns → consume the requesting-role's attempt counter; stranger → freeze `UNKNOWN_OWNER`; deleted → freeze `PARCEL_DELETED`; transient failures clear the pending flag without burning an attempt.
- The 30-min automated background ownership polling is untouched — it keeps using the cheaper World-API path.
- `POST /verify-transfer` switches from 200 to 202 to reflect the async semantics.
- Per-role attempt counters (`buyVerifySellerAttempts` / `buyVerifyBuyerAttempts`) stay per-role; the requesting role is stamped into the bot task's `resultData` payload at dispatch and read back in the callback.

## Test plan
- [x] `./mvnw -Dtest='EscrowManualActionService*,BotTaskResultService*,EscrowController*' test` — 50 passed
- [x] `./mvnw -Dtest='*Escrow*,*Bot*' test` — 168 passed, no regressions
- [x] `npx tsc --noEmit` — clean (only the pre-existing `useBulkCommissionEdit.test.tsx` error)
- [x] `npx vitest run src/components/escrow src/lib/api src/hooks` — 312 passed
- [ ] Bot worker update (.NET) to implement the `VERIFY_BUY_OWNER` handler will follow in Phase 7; backend treats the task as PENDING until the bot is wired