### PR TITLE
feat(bot): VERIFY_BUY_OWNER task handler

### DIFF
--- a/bot/src/Slpa.Bot/Backend/HttpBackendClient.cs
+++ b/bot/src/Slpa.Bot/Backend/HttpBackendClient.cs
@@ -95,6 +95,22 @@ public sealed class HttpBackendClient : IBackendClient
         resp.EnsureSuccessStatusCode();
     }
 
+    public async Task ReportBuyOwnerResultAsync(
+        long taskId, BuyOwnerResultRequest body, CancellationToken ct)
+    {
+        using var resp = await SendWithRetryAsync(() =>
+        {
+            var req = new HttpRequestMessage(
+                HttpMethod.Post,
+                "/api/v1/bot/tasks/" + taskId + "/verify-buy-owner-result")
+            {
+                Content = JsonContent.Create(body, options: JsonOpts)
+            };
+            return req;
+        }, ct).ConfigureAwait(false);
+        resp.EnsureSuccessStatusCode();
+    }
+
     private async Task<HttpResponseMessage> SendWithRetryAsync(
         Func<HttpRequestMessage> requestFactory, CancellationToken ct)
     {

--- a/bot/src/Slpa.Bot/Backend/IBackendClient.cs
+++ b/bot/src/Slpa.Bot/Backend/IBackendClient.cs
@@ -24,6 +24,14 @@ public interface IBackendClient
     /// <see cref="AuthConfigException"/> on 401.
     /// </summary>
     Task ReportTaskResultAsync(long taskId, BotTaskResultRequest body, CancellationToken ct);
+
+    /// <summary>
+    /// Posts a <c>VERIFY_BUY_OWNER</c> classification back to the backend
+    /// (<c>POST /api/v1/bot/tasks/{taskId}/verify-buy-owner-result</c>, 204 on
+    /// success). Shares the bearer auth + 5xx retry ladder. Throws
+    /// <see cref="AuthConfigException"/> on 401.
+    /// </summary>
+    Task ReportBuyOwnerResultAsync(long taskId, BuyOwnerResultRequest body, CancellationToken ct);
 }
 
 /// <summary>

--- a/bot/src/Slpa.Bot/Backend/Models/BotTaskType.cs
+++ b/bot/src/Slpa.Bot/Backend/Models/BotTaskType.cs
@@ -1,3 +1,3 @@
 namespace Slpa.Bot.Backend.Models;
 
-public enum BotTaskType { WITHDRAW_GROUP, VERIFY_SELL_TO }
+public enum BotTaskType { WITHDRAW_GROUP, VERIFY_SELL_TO, VERIFY_BUY_OWNER }

--- a/bot/src/Slpa.Bot/Backend/Models/BuyOwnerOutcome.cs
+++ b/bot/src/Slpa.Bot/Backend/Models/BuyOwnerOutcome.cs
@@ -1,0 +1,34 @@
+namespace Slpa.Bot.Backend.Models;
+
+/// <summary>
+/// Bot <c>VERIFY_BUY_OWNER</c> task classification result. Mirrors the backend
+/// <c>BuyOwnerOutcome</c> Java enum byte-for-byte — this is the <b>frozen bot
+/// wire contract</b>. Do not rename or reorder values.
+///
+/// <list type="bullet">
+///   <item><see cref="OWNER_IS_WINNER"/> — parcel owner is the auction winner.
+///     Backend confirms the transfer.</item>
+///   <item><see cref="OWNER_STILL_PRE_TRANSFER"/> — parcel owner is still the
+///     seller (or the registered SL group for case-3 listings). Definitive
+///     negative: consumes one of the requesting role's manual attempts.</item>
+///   <item><see cref="OWNER_IS_STRANGER"/> — parcel owner is some unknown third
+///     party. Triggers a fraud freeze (UNKNOWN_OWNER).</item>
+///   <item><see cref="PARCEL_DELETED"/> — the bot could not locate the parcel
+///     (returned / abandoned / region down). Triggers a fraud freeze
+///     (PARCEL_DELETED).</item>
+///   <item><see cref="WORLD_API_FAILURE"/> — transient SL-side / observation
+///     failure. No attempt consumed; the manual-verify pending flag is cleared
+///     so the user can retry.</item>
+///   <item><see cref="UNKNOWN_ERROR"/> — catch-all for unexpected bot errors.
+///     Same transient handling as <see cref="WORLD_API_FAILURE"/>.</item>
+/// </list>
+/// </summary>
+public enum BuyOwnerOutcome
+{
+    OWNER_IS_WINNER,
+    OWNER_STILL_PRE_TRANSFER,
+    OWNER_IS_STRANGER,
+    PARCEL_DELETED,
+    WORLD_API_FAILURE,
+    UNKNOWN_ERROR
+}

--- a/bot/src/Slpa.Bot/Backend/Models/BuyOwnerResultRequest.cs
+++ b/bot/src/Slpa.Bot/Backend/Models/BuyOwnerResultRequest.cs
@@ -1,0 +1,20 @@
+namespace Slpa.Bot.Backend.Models;
+
+/// <summary>
+/// Bot <c>VERIFY_BUY_OWNER</c> result callback body. Posted to
+/// <c>POST /api/v1/bot/tasks/{taskId}/verify-buy-owner-result</c>. This is the
+/// <b>frozen bot wire contract</b> — field names mirror the backend
+/// <c>BuyOwnerResultRequest</c> record. Do not rename fields.
+/// </summary>
+/// <param name="Outcome">Classification of the live owner observation.</param>
+/// <param name="ObservedOwnerUuid">The parcel owner the bot observed
+/// (best-effort — null for <see cref="BuyOwnerOutcome.PARCEL_DELETED"/> /
+/// transient failures). Logged into the fraud-flag evidence for freeze
+/// outcomes.</param>
+/// <param name="ObservedOwnerType">"agent" or "group" (best-effort, null on
+/// failure). Lets admins distinguish stranger from third-party group at a
+/// glance in the fraud queue.</param>
+public sealed record BuyOwnerResultRequest(
+    BuyOwnerOutcome Outcome,
+    Guid? ObservedOwnerUuid,
+    string? ObservedOwnerType);

--- a/bot/src/Slpa.Bot/Program.cs
+++ b/bot/src/Slpa.Bot/Program.cs
@@ -31,6 +31,7 @@ builder.Services.AddHttpClient<IBackendClient, HttpBackendClient>((sp, client) =
 });
 builder.Services.AddSingleton<WithdrawGroupHandler>();
 builder.Services.AddSingleton<VerifySellToHandler>();
+builder.Services.AddSingleton<VerifyBuyOwnerHandler>();
 builder.Services.AddHostedService<BotSessionBootstrapper>();
 builder.Services.AddHostedService<TaskLoop>();
 builder.Services.AddHostedService<HeartbeatLoop>();

--- a/bot/src/Slpa.Bot/Tasks/TaskLoop.cs
+++ b/bot/src/Slpa.Bot/Tasks/TaskLoop.cs
@@ -20,6 +20,7 @@ public sealed class TaskLoop : BackgroundService
     private readonly IBotSession _session;
     private readonly Func<WithdrawGroupHandler> _withdrawGroup;
     private readonly Func<VerifySellToHandler> _verifySellTo;
+    private readonly Func<VerifyBuyOwnerHandler> _verifyBuyOwner;
     private readonly IBackendClient _backend;
     private readonly IIdleParker _idleParker;
     private readonly BotActivityState _activity;
@@ -35,9 +36,10 @@ public sealed class TaskLoop : BackgroundService
         BotActivityState activity,
         WithdrawGroupHandler withdrawGroup,
         VerifySellToHandler verifySellTo,
+        VerifyBuyOwnerHandler verifyBuyOwner,
         ILogger<TaskLoop> log)
         : this(session, backend, idleParker, activity,
-            () => withdrawGroup, () => verifySellTo, log)
+            () => withdrawGroup, () => verifySellTo, () => verifyBuyOwner, log)
     {
     }
 
@@ -52,6 +54,7 @@ public sealed class TaskLoop : BackgroundService
         BotActivityState activity,
         Func<WithdrawGroupHandler> withdrawGroup,
         Func<VerifySellToHandler> verifySellTo,
+        Func<VerifyBuyOwnerHandler> verifyBuyOwner,
         ILogger<TaskLoop> log)
     {
         _session = session;
@@ -60,6 +63,7 @@ public sealed class TaskLoop : BackgroundService
         _activity = activity;
         _withdrawGroup = withdrawGroup;
         _verifySellTo = verifySellTo;
+        _verifyBuyOwner = verifyBuyOwner;
         _log = log;
     }
 
@@ -151,6 +155,7 @@ public sealed class TaskLoop : BackgroundService
         {
             BotTaskType.WITHDRAW_GROUP => _withdrawGroup().HandleAsync(task, ct),
             BotTaskType.VERIFY_SELL_TO => _verifySellTo().HandleAsync(task, ct),
+            BotTaskType.VERIFY_BUY_OWNER => _verifyBuyOwner().HandleAsync(task, ct),
             _ => Task.CompletedTask
         };
     }

--- a/bot/src/Slpa.Bot/Tasks/VerifyBuyOwnerHandler.cs
+++ b/bot/src/Slpa.Bot/Tasks/VerifyBuyOwnerHandler.cs
@@ -1,0 +1,133 @@
+using Microsoft.Extensions.Logging;
+using Slpa.Bot.Backend;
+using Slpa.Bot.Backend.Models;
+using Slpa.Bot.Sl;
+
+namespace Slpa.Bot.Tasks;
+
+/// <summary>
+/// Handles <see cref="BotTaskType.VERIFY_BUY_OWNER"/> tasks (bot-dispatch
+/// verify-purchase, 2026-05-18). Teleports onto the parcel, reads
+/// <see cref="ParcelSnapshot"/>, classifies the live owner against the
+/// expected winner UUID stamped on the task, and POSTs a
+/// <see cref="BuyOwnerOutcome"/> back to the backend via
+/// <see cref="IBackendClient.ReportBuyOwnerResultAsync"/>.
+///
+/// <para><b>Classification (with the data the task currently carries).</b> The
+/// dispatching backend stamps only <c>expectedWinnerUuid</c> on the
+/// <c>VERIFY_BUY_OWNER</c> task — not the seller / registered-group UUID. The
+/// handler can therefore only distinguish "owner == winner" from "owner !=
+/// winner", and reports the residual case as
+/// <see cref="BuyOwnerOutcome.OWNER_STILL_PRE_TRANSFER"/> (a definitive
+/// negative that consumes a manual-verify attempt). True
+/// <see cref="BuyOwnerOutcome.OWNER_IS_STRANGER"/> classification would need
+/// the seller / group UUID on the task payload — the 30-minute World API
+/// ownership monitor remains the authoritative path for fraud detection in
+/// the meantime, so the conservative PRE_TRANSFER default keeps a misidentified
+/// stranger from auto-freezing a healthy escrow.</para>
+///
+/// <para><b>Failure mapping.</b> Region-not-found → <see cref="BuyOwnerOutcome.PARCEL_DELETED"/>;
+/// teleport-access-denied / read-parcel null → <see cref="BuyOwnerOutcome.WORLD_API_FAILURE"/>
+/// (transient — the parcel itself may be fine, the bot just couldn't observe it).
+/// Unexpected exceptions → <see cref="BuyOwnerOutcome.UNKNOWN_ERROR"/>.</para>
+/// </summary>
+public sealed class VerifyBuyOwnerHandler
+{
+    private readonly IBotSession _session;
+    private readonly IBackendClient _backend;
+    private readonly ILogger<VerifyBuyOwnerHandler> _log;
+
+    public VerifyBuyOwnerHandler(IBotSession session, IBackendClient backend,
+        ILogger<VerifyBuyOwnerHandler> log)
+    {
+        _session = session;
+        _backend = backend;
+        _log = log;
+    }
+
+    public async Task HandleAsync(BotTaskResponse task, CancellationToken ct)
+    {
+        if (task.RegionName is null || task.PositionX is null || task.PositionY is null
+            || task.ExpectedWinnerUuid is null)
+        {
+            _log.LogWarning("VERIFY_BUY_OWNER {Id} missing region/pos/winner", task.Id);
+            await _backend.ReportBuyOwnerResultAsync(task.Id,
+                new BuyOwnerResultRequest(BuyOwnerOutcome.UNKNOWN_ERROR, null, null), ct)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        BuyOwnerOutcome outcome;
+        Guid? observedOwner = null;
+        string? observedOwnerType = null;
+
+        try
+        {
+            var tp = await _session.TeleportAsync(task.RegionName,
+                task.PositionX.Value, task.PositionY.Value,
+                task.PositionZ ?? 0, ct).ConfigureAwait(false);
+            if (!tp.Success)
+            {
+                outcome = tp.Failure switch
+                {
+                    TeleportFailureKind.RegionNotFound => BuyOwnerOutcome.PARCEL_DELETED,
+                    // ACCESS_DENIED and other failures are transient observation
+                    // problems on the bot's side, not evidence the parcel itself
+                    // has changed hands — let the user retry rather than burning
+                    // an attempt or auto-freezing.
+                    _ => BuyOwnerOutcome.WORLD_API_FAILURE
+                };
+            }
+            else
+            {
+                var snap = await _session.ReadParcelAsync(
+                    task.PositionX.Value, task.PositionY.Value, ct).ConfigureAwait(false);
+                if (snap is null)
+                {
+                    outcome = BuyOwnerOutcome.WORLD_API_FAILURE;
+                }
+                else
+                {
+                    observedOwner = snap.OwnerId;
+                    observedOwnerType = snap.IsGroupOwned ? "group" : "agent";
+                    if (snap.OwnerId == task.ExpectedWinnerUuid.Value)
+                    {
+                        outcome = BuyOwnerOutcome.OWNER_IS_WINNER;
+                    }
+                    else
+                    {
+                        // Conservative default: without expectedSellerUuid /
+                        // expectedGroupUuid on the task payload we cannot
+                        // reliably distinguish seller/group (PRE_TRANSFER) from
+                        // a true STRANGER. The 30-min World API ownership
+                        // monitor is the authoritative stranger-detector;
+                        // misclassifying a seller as a stranger here would
+                        // wrongly freeze a healthy escrow, so the safer
+                        // default is PRE_TRANSFER (consumes one attempt).
+                        outcome = BuyOwnerOutcome.OWNER_STILL_PRE_TRANSFER;
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (SessionLostException)
+        {
+            // Re-throw so the TaskLoop's standard session-lost handling kicks
+            // in (logs + lets the backend sweep clean the stalled row).
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _log.LogError(ex, "VERIFY_BUY_OWNER {Id} unexpected error", task.Id);
+            outcome = BuyOwnerOutcome.UNKNOWN_ERROR;
+        }
+
+        await _backend.ReportBuyOwnerResultAsync(task.Id,
+            new BuyOwnerResultRequest(outcome, observedOwner, observedOwnerType), ct)
+            .ConfigureAwait(false);
+        _log.LogInformation("VERIFY_BUY_OWNER {Id} -> {Outcome}", task.Id, outcome);
+    }
+}

--- a/bot/tests/Slpa.Bot.Tests/HttpBackendClientTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/HttpBackendClientTests.cs
@@ -188,4 +188,35 @@ public sealed class HttpBackendClientTests : IAsyncLifetime
         var act = async () => await _client.ReportTaskResultAsync(42, body, default);
         await act.Should().ThrowAsync<AuthConfigException>();
     }
+
+    [Fact]
+    public async Task ReportBuyOwnerResult_204_Succeeds()
+    {
+        _server
+            .Given(Request.Create()
+                .WithPath("/api/v1/bot/tasks/77/verify-buy-owner-result").UsingPost()
+                .WithHeader("Authorization", "Bearer test-secret-xxxxxxxx"))
+            .RespondWith(Response.Create().WithStatusCode(204));
+
+        var body = new BuyOwnerResultRequest(
+            BuyOwnerOutcome.OWNER_IS_WINNER, Guid.NewGuid(), "agent");
+
+        var act = async () => await _client.ReportBuyOwnerResultAsync(77, body, default);
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task ReportBuyOwnerResult_401_ThrowsAuthConfigException()
+    {
+        _server
+            .Given(Request.Create()
+                .WithPath("/api/v1/bot/tasks/77/verify-buy-owner-result").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(401));
+
+        var body = new BuyOwnerResultRequest(
+            BuyOwnerOutcome.UNKNOWN_ERROR, null, null);
+
+        var act = async () => await _client.ReportBuyOwnerResultAsync(77, body, default);
+        await act.Should().ThrowAsync<AuthConfigException>();
+    }
 }

--- a/bot/tests/Slpa.Bot.Tests/TaskLoopTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/TaskLoopTests.cs
@@ -23,6 +23,8 @@ public sealed class TaskLoopTests
                     NullLogger<WithdrawGroupHandler>.Instance),
             () => new VerifySellToHandler(session, backend.Object,
                     NullLogger<VerifySellToHandler>.Instance),
+            () => new VerifyBuyOwnerHandler(session, backend.Object,
+                    NullLogger<VerifyBuyOwnerHandler>.Instance),
             NullLogger<TaskLoop>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
@@ -47,6 +49,8 @@ public sealed class TaskLoopTests
                     NullLogger<WithdrawGroupHandler>.Instance),
             () => new VerifySellToHandler(session, backend.Object,
                     NullLogger<VerifySellToHandler>.Instance),
+            () => new VerifyBuyOwnerHandler(session, backend.Object,
+                    NullLogger<VerifyBuyOwnerHandler>.Instance),
             NullLogger<TaskLoop>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(400));
@@ -86,6 +90,8 @@ public sealed class TaskLoopTests
                     NullLogger<WithdrawGroupHandler>.Instance),
             () => new VerifySellToHandler(session, backend.Object,
                     NullLogger<VerifySellToHandler>.Instance),
+            () => new VerifyBuyOwnerHandler(session, backend.Object,
+                    NullLogger<VerifyBuyOwnerHandler>.Instance),
             NullLogger<TaskLoop>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
@@ -111,6 +117,8 @@ public sealed class TaskLoopTests
                     NullLogger<WithdrawGroupHandler>.Instance),
             () => new VerifySellToHandler(session, backend.Object,
                     NullLogger<VerifySellToHandler>.Instance),
+            () => new VerifyBuyOwnerHandler(session, backend.Object,
+                    NullLogger<VerifyBuyOwnerHandler>.Instance),
             NullLogger<TaskLoop>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(400));
@@ -138,6 +146,8 @@ public sealed class TaskLoopTests
                     NullLogger<WithdrawGroupHandler>.Instance),
             () => new VerifySellToHandler(session, backend.Object,
                     NullLogger<VerifySellToHandler>.Instance),
+            () => new VerifyBuyOwnerHandler(session, backend.Object,
+                    NullLogger<VerifyBuyOwnerHandler>.Instance),
             NullLogger<TaskLoop>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
@@ -171,6 +181,8 @@ public sealed class TaskLoopTests
                     NullLogger<WithdrawGroupHandler>.Instance),
             () => new VerifySellToHandler(session, backend.Object,
                     NullLogger<VerifySellToHandler>.Instance),
+            () => new VerifyBuyOwnerHandler(session, backend.Object,
+                    NullLogger<VerifyBuyOwnerHandler>.Instance),
             NullLogger<TaskLoop>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(400));
@@ -217,6 +229,8 @@ public sealed class TaskLoopTests
                     NullLogger<WithdrawGroupHandler>.Instance),
             () => new VerifySellToHandler(session, backend.Object,
                     NullLogger<VerifySellToHandler>.Instance),
+            () => new VerifyBuyOwnerHandler(session, backend.Object,
+                    NullLogger<VerifyBuyOwnerHandler>.Instance),
             NullLogger<TaskLoop>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(400));
@@ -228,6 +242,78 @@ public sealed class TaskLoopTests
                 It.IsAny<CancellationToken>()),
             Times.AtLeastOnce);
     }
+
+    [Fact]
+    public async Task VerifyBuyOwnerTask_IsDispatchedToHandler()
+    {
+        var session = new FakeBotSession();
+        session.SimulateLoginSuccess();
+        var winner = Guid.NewGuid();
+        session.ReadPolicy = (_, _) => new ParcelSnapshot(
+            OwnerId: winner, // owner == winner -> OWNER_IS_WINNER
+            GroupId: Guid.Empty,
+            IsGroupOwned: false,
+            AuthBuyerId: Guid.Empty,
+            SalePrice: 0,
+            ForSale: false,
+            Name: "P",
+            Description: "",
+            AreaSqm: 1024,
+            MaxPrims: 234,
+            Category: 0,
+            SnapshotId: Guid.NewGuid(),
+            Flags: 0u);
+
+        var backend = new Mock<IBackendClient>();
+        var claims = 0;
+        backend.Setup(b => b.ClaimAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(() =>
+               {
+                   claims++;
+                   return claims == 1 ? MakeVerifyBuyOwnerTask(winner) : null;
+               });
+
+        var loop = new TaskLoop(session, backend.Object,
+            Mock.Of<IIdleParker>(), new BotActivityState(),
+            () => new WithdrawGroupHandler(session, backend.Object,
+                    NullLogger<WithdrawGroupHandler>.Instance),
+            () => new VerifySellToHandler(session, backend.Object,
+                    NullLogger<VerifySellToHandler>.Instance),
+            () => new VerifyBuyOwnerHandler(session, backend.Object,
+                    NullLogger<VerifyBuyOwnerHandler>.Instance),
+            NullLogger<TaskLoop>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(400));
+        await loop.RunAsync(cts.Token);
+
+        backend.Verify(b => b.ReportBuyOwnerResultAsync(
+                66,
+                It.Is<BuyOwnerResultRequest>(r => r.Outcome == BuyOwnerOutcome.OWNER_IS_WINNER),
+                It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+    }
+
+    private static BotTaskResponse MakeVerifyBuyOwnerTask(Guid winner) => new(
+        Id: 66,
+        TaskType: BotTaskType.VERIFY_BUY_OWNER,
+        Status: BotTaskStatus.IN_PROGRESS,
+        AuctionId: 7,
+        EscrowId: 11,
+        ParcelUuid: Guid.NewGuid(),
+        RegionName: "R",
+        PositionX: 128,
+        PositionY: 64,
+        PositionZ: 25,
+        SentinelPrice: 0,
+        AssignedBotUuid: Guid.NewGuid(),
+        FailureReason: null,
+        NextRunAt: null,
+        RecurrenceIntervalSeconds: null,
+        CreatedAt: DateTimeOffset.UtcNow,
+        CompletedAt: null,
+        RecipientUuid: null,
+        AmountL: null,
+        ExpectedWinnerUuid: winner);
 
     private static BotTaskResponse MakeVerifySellToTask(Guid winner) => new(
         Id: 55,

--- a/bot/tests/Slpa.Bot.Tests/VerifyBuyOwnerHandlerTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/VerifyBuyOwnerHandlerTests.cs
@@ -1,0 +1,239 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Slpa.Bot.Backend;
+using Slpa.Bot.Backend.Models;
+using Slpa.Bot.Sl;
+using Slpa.Bot.Tasks;
+using Xunit;
+
+namespace Slpa.Bot.Tests;
+
+/// <summary>
+/// VERIFY_BUY_OWNER handler. Drives the teleport -> read-parcel -> classify ->
+/// report path via the in-test <see cref="FakeBotSession"/> + a mocked
+/// <see cref="IBackendClient"/>; never touches GridClient.
+///
+/// <para>Backend dispatch (EscrowManualActionService.verifyTransfer) currently
+/// only stamps <c>expectedWinnerUuid</c> on the task, so the handler can only
+/// classify "owner == winner" vs "owner != winner". The residual case is
+/// reported as <see cref="BuyOwnerOutcome.OWNER_STILL_PRE_TRANSFER"/>; reliable
+/// stranger detection is left to the 30-min background ownership monitor that
+/// has the full seller / registered-group context.</para>
+/// </summary>
+public sealed class VerifyBuyOwnerHandlerTests
+{
+    private readonly Mock<IBackendClient> _backend = new();
+    private readonly FakeBotSession _session = new();
+    private BuyOwnerResultRequest? _captured;
+
+    public VerifyBuyOwnerHandlerTests()
+    {
+        _session.SimulateLoginSuccess();
+        _backend
+            .Setup(b => b.ReportBuyOwnerResultAsync(
+                It.IsAny<long>(), It.IsAny<BuyOwnerResultRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<long, BuyOwnerResultRequest, CancellationToken>(
+                (_, body, _) => _captured = body)
+            .Returns(Task.CompletedTask);
+    }
+
+    private VerifyBuyOwnerHandler NewHandler() =>
+        new(_session, _backend.Object, NullLogger<VerifyBuyOwnerHandler>.Instance);
+
+    private BuyOwnerOutcome? Reported() => _captured?.Outcome;
+
+    [Fact]
+    public async Task OwnerEqualsWinner_ReportsOwnerIsWinner()
+    {
+        var winner = Guid.NewGuid();
+        _session.ReadPolicy = (_, _) => Snapshot(owner: winner, isGroupOwned: false);
+        var task = BuildTask(winner);
+
+        await NewHandler().HandleAsync(task, CancellationToken.None);
+
+        Reported().Should().Be(BuyOwnerOutcome.OWNER_IS_WINNER);
+        _captured!.ObservedOwnerUuid.Should().Be(winner);
+        _captured.ObservedOwnerType.Should().Be("agent");
+    }
+
+    [Fact]
+    public async Task OwnerEqualsSellerAvatar_ReportsStillPreTransfer()
+    {
+        var winner = Guid.NewGuid();
+        var seller = Guid.NewGuid();
+        _session.ReadPolicy = (_, _) => Snapshot(owner: seller, isGroupOwned: false);
+        var task = BuildTask(winner);
+
+        await NewHandler().HandleAsync(task, CancellationToken.None);
+
+        Reported().Should().Be(BuyOwnerOutcome.OWNER_STILL_PRE_TRANSFER);
+        _captured!.ObservedOwnerUuid.Should().Be(seller);
+        _captured.ObservedOwnerType.Should().Be("agent");
+    }
+
+    [Fact]
+    public async Task OwnerEqualsCase3Group_ReportsStillPreTransfer()
+    {
+        var winner = Guid.NewGuid();
+        var group = Guid.NewGuid();
+        _session.ReadPolicy = (_, _) => Snapshot(owner: group, isGroupOwned: true);
+        var task = BuildTask(winner);
+
+        await NewHandler().HandleAsync(task, CancellationToken.None);
+
+        Reported().Should().Be(BuyOwnerOutcome.OWNER_STILL_PRE_TRANSFER);
+        _captured!.ObservedOwnerUuid.Should().Be(group);
+        _captured.ObservedOwnerType.Should().Be("group");
+    }
+
+    [Fact]
+    public async Task OwnerIsUnknownAvatar_ReportsStillPreTransfer_ObservedUuidPropagated()
+    {
+        // Conservative default: without expectedSellerUuid on the task, the
+        // bot cannot reliably distinguish stranger from seller — it reports
+        // PRE_TRANSFER and lets the World API ownership monitor handle real
+        // strangers. The observed UUID + type still flow to the backend so
+        // admin tooling can see what the bot saw.
+        var winner = Guid.NewGuid();
+        var stranger = Guid.NewGuid();
+        _session.ReadPolicy = (_, _) => Snapshot(owner: stranger, isGroupOwned: false);
+        var task = BuildTask(winner);
+
+        await NewHandler().HandleAsync(task, CancellationToken.None);
+
+        Reported().Should().Be(BuyOwnerOutcome.OWNER_STILL_PRE_TRANSFER);
+        _captured!.ObservedOwnerUuid.Should().Be(stranger);
+    }
+
+    [Fact]
+    public async Task TeleportRegionNotFound_ReportsParcelDeleted()
+    {
+        var winner = Guid.NewGuid();
+        _session.TeleportPolicy = _ => TeleportResult.Fail(TeleportFailureKind.RegionNotFound);
+        var readCalled = false;
+        _session.ReadPolicy = (_, _) => { readCalled = true; return null; };
+        var task = BuildTask(winner);
+
+        await NewHandler().HandleAsync(task, CancellationToken.None);
+
+        Reported().Should().Be(BuyOwnerOutcome.PARCEL_DELETED);
+        readCalled.Should().BeFalse();
+        _captured!.ObservedOwnerUuid.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TeleportAccessDenied_ReportsWorldApiFailure_NoReadParcel()
+    {
+        // ACCESS_DENIED at teleport is a transient bot-side observation gap,
+        // not evidence the parcel changed hands. WORLD_API_FAILURE leaves the
+        // pending flag cleared but consumes no attempt, so the user can retry.
+        var winner = Guid.NewGuid();
+        _session.TeleportPolicy = _ => TeleportResult.Fail(TeleportFailureKind.AccessDenied);
+        var readCalled = false;
+        _session.ReadPolicy = (_, _) => { readCalled = true; return null; };
+        var task = BuildTask(winner);
+
+        await NewHandler().HandleAsync(task, CancellationToken.None);
+
+        Reported().Should().Be(BuyOwnerOutcome.WORLD_API_FAILURE);
+        readCalled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ReadParcelNull_ReportsWorldApiFailure()
+    {
+        var winner = Guid.NewGuid();
+        _session.ReadPolicy = (_, _) => null;
+        var task = BuildTask(winner);
+
+        await NewHandler().HandleAsync(task, CancellationToken.None);
+
+        Reported().Should().Be(BuyOwnerOutcome.WORLD_API_FAILURE);
+    }
+
+    [Fact]
+    public async Task MissingWinner_ReportsUnknownError()
+    {
+        // Defensive guard: a malformed task (no expectedWinnerUuid) shouldn't
+        // teleport, but it must still close the loop with a transient outcome
+        // so the backend can clear the pending flag and let the user retry.
+        _session.ReadPolicy = (_, _) => Snapshot(owner: Guid.NewGuid(), isGroupOwned: false);
+        var task = BuildTask(expectedWinner: null);
+
+        await NewHandler().HandleAsync(task, CancellationToken.None);
+
+        Reported().Should().Be(BuyOwnerOutcome.UNKNOWN_ERROR);
+    }
+
+    [Fact]
+    public async Task UnexpectedSessionException_ReportsUnknownError()
+    {
+        var winner = Guid.NewGuid();
+        _session.TeleportPolicy = _ => throw new InvalidOperationException("boom");
+        var task = BuildTask(winner);
+
+        await NewHandler().HandleAsync(task, CancellationToken.None);
+
+        Reported().Should().Be(BuyOwnerOutcome.UNKNOWN_ERROR);
+    }
+
+    [Fact]
+    public async Task SessionLost_PropagatesToLoop()
+    {
+        // The handler must let SessionLostException bubble so TaskLoop's
+        // standard "session lost mid-task" handling fires — backend's
+        // IN_PROGRESS sweep then cleans up the row.
+        var winner = Guid.NewGuid();
+        _session.TeleportPolicy = _ => throw new SessionLostException("dropped");
+        var task = BuildTask(winner);
+
+        var act = async () => await NewHandler().HandleAsync(task, CancellationToken.None);
+        await act.Should().ThrowAsync<SessionLostException>();
+
+        _backend.Verify(b => b.ReportBuyOwnerResultAsync(
+                It.IsAny<long>(), It.IsAny<BuyOwnerResultRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static ParcelSnapshot Snapshot(Guid owner, bool isGroupOwned) => new(
+        OwnerId: owner,
+        GroupId: isGroupOwned ? owner : Guid.Empty,
+        IsGroupOwned: isGroupOwned,
+        AuthBuyerId: Guid.Empty,
+        SalePrice: 0,
+        ForSale: false,
+        Name: "P",
+        Description: "",
+        AreaSqm: 1024,
+        MaxPrims: 234,
+        Category: 0,
+        SnapshotId: Guid.NewGuid(),
+        Flags: 0u);
+
+    private static BotTaskResponse BuildTask(Guid winner) => BuildTask((Guid?)winner);
+
+    private static BotTaskResponse BuildTask(Guid? expectedWinner) => new(
+        Id: 77,
+        TaskType: BotTaskType.VERIFY_BUY_OWNER,
+        Status: BotTaskStatus.IN_PROGRESS,
+        AuctionId: 7,
+        EscrowId: 11,
+        ParcelUuid: Guid.NewGuid(),
+        RegionName: "R",
+        PositionX: 128,
+        PositionY: 64,
+        PositionZ: 25,
+        SentinelPrice: 0,
+        AssignedBotUuid: Guid.NewGuid(),
+        FailureReason: null,
+        NextRunAt: null,
+        RecurrenceIntervalSeconds: null,
+        CreatedAt: DateTimeOffset.UtcNow,
+        CompletedAt: null,
+        RecipientUuid: null,
+        AmountL: null,
+        ExpectedWinnerUuid: expectedWinner);
+}


### PR DESCRIPTION
## Summary

Promotes the .NET bot worker side of the VERIFY_BUY_OWNER task handler from dev to main. Backend + frontend for this feature already shipped to main earlier; this completes the manual verify-purchase loop end-to-end so the "Verify Purchase" button no longer stays greyed until the 30-min auto-poll resolves.

- New `VerifyBuyOwnerHandler` mirrors `VerifySellToHandler`: teleports, reads `ParcelSnapshot`, classifies against `expectedWinnerUuid`, POSTs `BuyOwnerResultRequest` to `/verify-buy-owner-result`.
- `BotTaskType`, `BuyOwnerOutcome`, `BuyOwnerResultRequest` mirror the backend wire contracts byte-for-byte.
- TaskLoop dispatch + Program.cs DI wiring updated.

## Classification

Dispatch only stamps `expectedWinnerUuid` today, so the bot reports `OWNER_IS_WINNER` on a winner match and falls through to `OWNER_STILL_PRE_TRANSFER` on any other owner; the 30-min World API ownership monitor remains the authoritative stranger detector. Region-not-found -> `PARCEL_DELETED`; access-denied / null snapshot -> `WORLD_API_FAILURE` (transient); unexpected -> `UNKNOWN_ERROR`.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` — 86 tests pass (10 new for the handler, 1 new for dispatch, 2 new for HttpBackendClient)
- [ ] Watch deploy-bot-1 and deploy-bot-2 workflows complete after merge