### PR TITLE
fix(escrow,bot): complete VERIFY_BUY_OWNER classification by passing seller/group UUID to bot

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/bot/dto/BotTaskResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/bot/dto/BotTaskResponse.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import com.slparcelauctions.backend.bot.BotTask;
 import com.slparcelauctions.backend.bot.BotTaskStatus;
 import com.slparcelauctions.backend.bot.BotTaskType;
+import com.slparcelauctions.backend.escrow.EscrowManualActionService;
 
 /**
  * Bot queue projection returned by the claim endpoint. After the
@@ -14,6 +15,13 @@ import com.slparcelauctions.backend.bot.BotTaskType;
  * expected_sale_price_lindens fields are gone; the remaining
  * historical-shape fields stay for forensic compatibility with the bot
  * worker's wire contract.
+ *
+ * <p><b>expectedPreTransferUuid / expectedOwnerType</b> ride out alongside
+ * the historical fields for the bot's VERIFY_BUY_OWNER classification.
+ * Pre-transfer UUID re-uses the historical {@code expected_seller_uuid}
+ * column (case-1 = seller's avatar UUID, case-3 = registered SL group UUID);
+ * ownerType comes from the {@code resultData} JSON payload key
+ * {@link EscrowManualActionService#EXPECTED_OWNER_TYPE_KEY}.
  */
 public record BotTaskResponse(
         Long id,
@@ -30,6 +38,8 @@ public record BotTaskResponse(
         UUID expectedOwnerUuid,
         UUID expectedWinnerUuid,
         UUID expectedSellerUuid,
+        UUID expectedPreTransferUuid,
+        String expectedOwnerType,
         Long expectedMaxSalePriceLindens,
         UUID assignedBotUuid,
         String failureReason,
@@ -54,6 +64,8 @@ public record BotTaskResponse(
                 t.getExpectedOwnerUuid(),
                 t.getExpectedWinnerUuid(),
                 t.getExpectedSellerUuid(),
+                t.getExpectedSellerUuid(),
+                extractExpectedOwnerType(t),
                 t.getExpectedMaxSalePriceLindens(),
                 t.getAssignedBotUuid(),
                 t.getFailureReason(),
@@ -61,5 +73,13 @@ public record BotTaskResponse(
                 t.getRecurrenceIntervalSeconds(),
                 t.getCreatedAt(),
                 t.getCompletedAt());
+    }
+
+    private static String extractExpectedOwnerType(BotTask t) {
+        if (t.getResultData() == null) {
+            return null;
+        }
+        Object v = t.getResultData().get(EscrowManualActionService.EXPECTED_OWNER_TYPE_KEY);
+        return v == null ? null : v.toString();
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowManualActionService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowManualActionService.java
@@ -27,6 +27,8 @@ import com.slparcelauctions.backend.escrow.review.ManualReviewRole;
 import com.slparcelauctions.backend.escrow.review.ManualReviewStatus;
 import com.slparcelauctions.backend.escrow.review.ManualReviewStep;
 import com.slparcelauctions.backend.escrow.terminal.EscrowConfigProperties;
+import com.slparcelauctions.backend.realty.slgroup.RealtyGroupSlGroup;
+import com.slparcelauctions.backend.realty.slgroup.RealtyGroupSlGroupRepository;
 import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.user.UserRepository;
 
@@ -56,11 +58,20 @@ public class EscrowManualActionService {
     public static final String REQUESTING_ROLE_SELLER = "SELLER";
     public static final String REQUESTING_ROLE_BUYER = "BUYER";
 
+    /** Payload key carrying the expected pre-transfer owner type
+     *  ("agent" for case-1 / "group" for case-3) so the bot can match both
+     *  UUID and ownerType when classifying live ownership. The pre-transfer
+     *  UUID itself is stamped onto {@link BotTask#getExpectedSellerUuid()}. */
+    public static final String EXPECTED_OWNER_TYPE_KEY = "expectedOwnerType";
+    public static final String EXPECTED_OWNER_TYPE_AGENT = "agent";
+    public static final String EXPECTED_OWNER_TYPE_GROUP = "group";
+
     private final EscrowRepository escrowRepo;
     private final EscrowService escrowService;
     private final BotTaskRepository botTaskRepo;
     private final EscrowManualReviewRepository manualReviewRepo;
     private final UserRepository userRepo;
+    private final RealtyGroupSlGroupRepository slGroupRepo;
     private final EscrowConfigProperties props;
     private final Clock clock;
 
@@ -154,27 +165,54 @@ public class EscrowManualActionService {
         OffsetDateTime now = OffsetDateTime.now(clock);
         String requestingRole = isSeller ? REQUESTING_ROLE_SELLER : REQUESTING_ROLE_BUYER;
 
+        // Resolve the expected pre-transfer owner. Case-3 (group listing):
+        // the parcel is held by the realty group's registered SL group until
+        // the buy completes — expected owner is the SL group UUID with type
+        // "group". Case-1 (individual): expected owner is the seller's
+        // avatar UUID with type "agent".
+        java.util.UUID expectedPreTransferUuid;
+        String expectedOwnerType;
+        if (auction.getRealtyGroupSlGroupId() != null) {
+            RealtyGroupSlGroup slGroup = slGroupRepo
+                    .findById(auction.getRealtyGroupSlGroupId())
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Auction " + auction.getId() + " references missing "
+                                    + "RealtyGroupSlGroup " + auction.getRealtyGroupSlGroupId()));
+            expectedPreTransferUuid = slGroup.getSlGroupUuid();
+            expectedOwnerType = EXPECTED_OWNER_TYPE_GROUP;
+        } else {
+            expectedPreTransferUuid = auction.getSeller() == null
+                    ? null : auction.getSeller().getSlAvatarUuid();
+            expectedOwnerType = EXPECTED_OWNER_TYPE_AGENT;
+        }
+
         // Expedite any open VERIFY_BUY_OWNER task for this escrow; otherwise
         // create one. The "one open task per escrow per type" invariant
         // matches the VERIFY_SELL_TO path (BotTaskRepository.findOpenByEscrowAndType
-        // returns at most one row). The requesting role is stamped onto the
-        // task's resultData payload so the bot callback consumes the correct
-        // role counter on a definitive negative.
+        // returns at most one row). The requesting role + expected
+        // pre-transfer owner type are stamped onto the task's resultData
+        // payload so the bot callback consumes the correct role counter on a
+        // definitive negative and the bot can distinguish PRE_TRANSFER from
+        // STRANGER outcomes. The pre-transfer UUID itself rides on the
+        // dedicated expectedSellerUuid column.
         List<BotTask> open = botTaskRepo.findOpenByEscrowAndType(
                 escrow.getId(), BotTaskType.VERIFY_BUY_OWNER);
         BotTask task;
         if (!open.isEmpty()) {
             task = open.get(0);
             task.setNextRunAt(now);
+            task.setExpectedSellerUuid(expectedPreTransferUuid);
             Map<String, Object> payload = task.getResultData() == null
                     ? new HashMap<>() : new HashMap<>(task.getResultData());
             payload.put(REQUESTING_ROLE_KEY, requestingRole);
+            payload.put(EXPECTED_OWNER_TYPE_KEY, expectedOwnerType);
             task.setResultData(payload);
         } else {
             AuctionParcelSnapshot snap = auction.getParcelSnapshot();
             User winner = userRepo.findById(auction.getWinnerUserId()).orElseThrow();
             Map<String, Object> payload = new HashMap<>();
             payload.put(REQUESTING_ROLE_KEY, requestingRole);
+            payload.put(EXPECTED_OWNER_TYPE_KEY, expectedOwnerType);
             task = BotTask.builder()
                     .taskType(BotTaskType.VERIFY_BUY_OWNER)
                     .status(BotTaskStatus.PENDING)
@@ -187,6 +225,7 @@ public class EscrowManualActionService {
                     .positionY(snap != null ? snap.getPositionY() : null)
                     .positionZ(snap != null ? snap.getPositionZ() : null)
                     .expectedWinnerUuid(winner.getSlAvatarUuid())
+                    .expectedSellerUuid(expectedPreTransferUuid)
                     .nextRunAt(now)
                     .sentinelPrice(0L)
                     .resultData(payload)

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowManualActionServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowManualActionServiceTest.java
@@ -47,6 +47,8 @@ import com.slparcelauctions.backend.escrow.review.ManualReviewRole;
 import com.slparcelauctions.backend.escrow.review.ManualReviewStatus;
 import com.slparcelauctions.backend.escrow.review.ManualReviewStep;
 import com.slparcelauctions.backend.escrow.terminal.EscrowConfigProperties;
+import com.slparcelauctions.backend.realty.slgroup.RealtyGroupSlGroup;
+import com.slparcelauctions.backend.realty.slgroup.RealtyGroupSlGroupRepository;
 import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.user.UserRepository;
 
@@ -67,6 +69,8 @@ class EscrowManualActionServiceTest {
     private static final UUID PARCEL_UUID = UUID.fromString("33333333-3333-3333-3333-333333333333");
     private static final UUID SELLER_AVATAR = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     private static final UUID WINNER_AVATAR = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID SL_GROUP_UUID = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final Long SL_GROUP_ROW_ID = 770L;
     private static final int CAP = 3;
 
     @Mock EscrowRepository escrowRepo;
@@ -74,6 +78,7 @@ class EscrowManualActionServiceTest {
     @Mock BotTaskRepository botTaskRepo;
     @Mock EscrowManualReviewRepository manualReviewRepo;
     @Mock UserRepository userRepo;
+    @Mock RealtyGroupSlGroupRepository slGroupRepo;
     @Mock EscrowConfigProperties props;
 
     EscrowManualActionService service;
@@ -84,7 +89,7 @@ class EscrowManualActionServiceTest {
         fixed = Clock.fixed(Instant.parse("2026-05-17T12:00:00Z"), ZoneOffset.UTC);
         service = new EscrowManualActionService(
                 escrowRepo, escrowService, botTaskRepo, manualReviewRepo,
-                userRepo, props, fixed);
+                userRepo, slGroupRepo, props, fixed);
         lenient().when(props.manualVerifyAttempts()).thenReturn(CAP);
         lenient().when(escrowService.getStatus(eq(AUCTION_ID), any()))
                 .thenReturn(stubStatus());
@@ -172,8 +177,12 @@ class EscrowManualActionServiceTest {
         assertThat(saved.getNextRunAt()).isEqualTo(OffsetDateTime.now(fixed));
         assertThat(saved.getResultData())
                 .containsEntry(EscrowManualActionService.REQUESTING_ROLE_KEY,
-                        EscrowManualActionService.REQUESTING_ROLE_BUYER);
+                        EscrowManualActionService.REQUESTING_ROLE_BUYER)
+                .containsEntry(EscrowManualActionService.EXPECTED_OWNER_TYPE_KEY,
+                        EscrowManualActionService.EXPECTED_OWNER_TYPE_AGENT);
         assertThat(saved.getExpectedWinnerUuid()).isEqualTo(WINNER_AVATAR);
+        // Case-1 (individual listing): pre-transfer owner is the seller's avatar.
+        assertThat(saved.getExpectedSellerUuid()).isEqualTo(SELLER_AVATAR);
 
         assertThat(escrow.getManualVerifyPending()).isTrue();
         assertThat(escrow.getBuyVerifyBuyerAttempts()).isZero();
@@ -181,6 +190,34 @@ class EscrowManualActionServiceTest {
         verify(escrowService, never()).confirmTransfer(any(), any());
         verify(escrowService, never()).stampChecked(any(), any());
         verify(escrowService, never()).freezeForFraud(any(), any(), any(), any());
+    }
+
+    @Test
+    void verifyTransfer_case3GroupListing_stampsGroupUuid_andGroupOwnerType() {
+        Escrow escrow = buildBuyParcel();
+        // Case-3 discriminator: auction references a registered SL group row.
+        escrow.getAuction().setRealtyGroupSlGroupId(SL_GROUP_ROW_ID);
+        when(escrowRepo.findByAuctionId(AUCTION_ID)).thenReturn(Optional.of(escrow));
+        when(escrowRepo.findByIdForUpdate(ESCROW_ID)).thenReturn(Optional.of(escrow));
+        stubWinner();
+        RealtyGroupSlGroup slGroup = RealtyGroupSlGroup.builder()
+                .id(SL_GROUP_ROW_ID)
+                .slGroupUuid(SL_GROUP_UUID)
+                .build();
+        when(slGroupRepo.findById(SL_GROUP_ROW_ID)).thenReturn(Optional.of(slGroup));
+        when(botTaskRepo.findOpenByEscrowAndType(ESCROW_ID, BotTaskType.VERIFY_BUY_OWNER))
+                .thenReturn(List.of());
+
+        service.verifyTransfer(AUCTION_ID, WINNER_ID);
+
+        ArgumentCaptor<BotTask> taskCap = ArgumentCaptor.forClass(BotTask.class);
+        verify(botTaskRepo).save(taskCap.capture());
+        BotTask saved = taskCap.getValue();
+        assertThat(saved.getExpectedSellerUuid()).isEqualTo(SL_GROUP_UUID);
+        assertThat(saved.getExpectedWinnerUuid()).isEqualTo(WINNER_AVATAR);
+        assertThat(saved.getResultData())
+                .containsEntry(EscrowManualActionService.EXPECTED_OWNER_TYPE_KEY,
+                        EscrowManualActionService.EXPECTED_OWNER_TYPE_GROUP);
     }
 
     @Test
@@ -226,7 +263,12 @@ class EscrowManualActionServiceTest {
         assertThat(existing.getNextRunAt()).isEqualTo(OffsetDateTime.now(fixed));
         assertThat(existing.getResultData())
                 .containsEntry(EscrowManualActionService.REQUESTING_ROLE_KEY,
-                        EscrowManualActionService.REQUESTING_ROLE_BUYER);
+                        EscrowManualActionService.REQUESTING_ROLE_BUYER)
+                .containsEntry(EscrowManualActionService.EXPECTED_OWNER_TYPE_KEY,
+                        EscrowManualActionService.EXPECTED_OWNER_TYPE_AGENT);
+        // Pre-transfer UUID is re-stamped on the expedited task in case the
+        // case-1 / case-3 discriminator was unset on a legacy row.
+        assertThat(existing.getExpectedSellerUuid()).isEqualTo(SELLER_AVATAR);
         verify(botTaskRepo).save(existing);
         assertThat(escrow.getManualVerifyPending()).isTrue();
     }

--- a/bot/src/Slpa.Bot/Backend/Models/BotTaskResponse.cs
+++ b/bot/src/Slpa.Bot/Backend/Models/BotTaskResponse.cs
@@ -20,4 +20,13 @@ public sealed record BotTaskResponse(
     DateTimeOffset? CompletedAt,
     Guid? RecipientUuid = null,
     long? AmountL = null,
-    Guid? ExpectedWinnerUuid = null);
+    Guid? ExpectedWinnerUuid = null,
+    // VERIFY_BUY_OWNER classification context (2026-05-19):
+    //  - ExpectedPreTransferUuid: seller's avatar UUID (case-1) or registered
+    //    SL group UUID (case-3). Owner observation matching this UUID +
+    //    ExpectedOwnerType => OWNER_STILL_PRE_TRANSFER.
+    //  - ExpectedOwnerType: "agent" for case-1 / "group" for case-3. The bot
+    //    requires both UUID and ownerType to match before reporting
+    //    PRE_TRANSFER; otherwise the residual case is OWNER_IS_STRANGER.
+    Guid? ExpectedPreTransferUuid = null,
+    string? ExpectedOwnerType = null);

--- a/bot/src/Slpa.Bot/Tasks/VerifyBuyOwnerHandler.cs
+++ b/bot/src/Slpa.Bot/Tasks/VerifyBuyOwnerHandler.cs
@@ -7,24 +7,31 @@ namespace Slpa.Bot.Tasks;
 
 /// <summary>
 /// Handles <see cref="BotTaskType.VERIFY_BUY_OWNER"/> tasks (bot-dispatch
-/// verify-purchase, 2026-05-18). Teleports onto the parcel, reads
-/// <see cref="ParcelSnapshot"/>, classifies the live owner against the
-/// expected winner UUID stamped on the task, and POSTs a
-/// <see cref="BuyOwnerOutcome"/> back to the backend via
-/// <see cref="IBackendClient.ReportBuyOwnerResultAsync"/>.
+/// verify-purchase, 2026-05-18; full classification 2026-05-19). Teleports
+/// onto the parcel, reads <see cref="ParcelSnapshot"/>, classifies the live
+/// owner against the expected winner UUID + expected pre-transfer owner
+/// stamped on the task, and POSTs a <see cref="BuyOwnerOutcome"/> back to
+/// the backend via <see cref="IBackendClient.ReportBuyOwnerResultAsync"/>.
 ///
-/// <para><b>Classification (with the data the task currently carries).</b> The
-/// dispatching backend stamps only <c>expectedWinnerUuid</c> on the
-/// <c>VERIFY_BUY_OWNER</c> task — not the seller / registered-group UUID. The
-/// handler can therefore only distinguish "owner == winner" from "owner !=
-/// winner", and reports the residual case as
-/// <see cref="BuyOwnerOutcome.OWNER_STILL_PRE_TRANSFER"/> (a definitive
-/// negative that consumes a manual-verify attempt). True
-/// <see cref="BuyOwnerOutcome.OWNER_IS_STRANGER"/> classification would need
-/// the seller / group UUID on the task payload — the 30-minute World API
-/// ownership monitor remains the authoritative path for fraud detection in
-/// the meantime, so the conservative PRE_TRANSFER default keeps a misidentified
-/// stranger from auto-freezing a healthy escrow.</para>
+/// <para><b>Classification matrix.</b> The backend stamps the task with both
+/// <c>expectedWinnerUuid</c> and <c>expectedPreTransferUuid</c>
+/// (seller avatar for case-1 / registered SL group UUID for case-3) plus
+/// <c>expectedOwnerType</c> ("agent" / "group"):
+/// <list type="bullet">
+///   <item><description>Owner UUID == winner AND ownerType == "agent" →
+///   <see cref="BuyOwnerOutcome.OWNER_IS_WINNER"/>.</description></item>
+///   <item><description>Owner UUID == expected pre-transfer UUID AND
+///   ownerType == expected pre-transfer ownerType →
+///   <see cref="BuyOwnerOutcome.OWNER_STILL_PRE_TRANSFER"/> (consumes one
+///   manual-verify attempt).</description></item>
+///   <item><description>Otherwise →
+///   <see cref="BuyOwnerOutcome.OWNER_IS_STRANGER"/> (backend freezes the
+///   escrow for fraud review).</description></item>
+/// </list>
+/// A defensive UUID-match-but-type-mismatch case (shouldn't happen in SL but
+/// possible if the pre-transfer entity changed group status mid-flight) also
+/// maps to <c>OWNER_IS_STRANGER</c> — the safer side, since a flipped owner
+/// type implies a real ownership change.</para>
 ///
 /// <para><b>Failure mapping.</b> Region-not-found → <see cref="BuyOwnerOutcome.PARCEL_DELETED"/>;
 /// teleport-access-denied / read-parcel null → <see cref="BuyOwnerOutcome.WORLD_API_FAILURE"/>
@@ -90,22 +97,12 @@ public sealed class VerifyBuyOwnerHandler
                 {
                     observedOwner = snap.OwnerId;
                     observedOwnerType = snap.IsGroupOwned ? "group" : "agent";
-                    if (snap.OwnerId == task.ExpectedWinnerUuid.Value)
-                    {
-                        outcome = BuyOwnerOutcome.OWNER_IS_WINNER;
-                    }
-                    else
-                    {
-                        // Conservative default: without expectedSellerUuid /
-                        // expectedGroupUuid on the task payload we cannot
-                        // reliably distinguish seller/group (PRE_TRANSFER) from
-                        // a true STRANGER. The 30-min World API ownership
-                        // monitor is the authoritative stranger-detector;
-                        // misclassifying a seller as a stranger here would
-                        // wrongly freeze a healthy escrow, so the safer
-                        // default is PRE_TRANSFER (consumes one attempt).
-                        outcome = BuyOwnerOutcome.OWNER_STILL_PRE_TRANSFER;
-                    }
+                    outcome = Classify(
+                        observedOwner: snap.OwnerId,
+                        observedOwnerType: observedOwnerType,
+                        expectedWinner: task.ExpectedWinnerUuid.Value,
+                        expectedPreTransfer: task.ExpectedPreTransferUuid,
+                        expectedPreTransferType: task.ExpectedOwnerType);
                 }
             }
         }
@@ -129,5 +126,37 @@ public sealed class VerifyBuyOwnerHandler
             new BuyOwnerResultRequest(outcome, observedOwner, observedOwnerType), ct)
             .ConfigureAwait(false);
         _log.LogInformation("VERIFY_BUY_OWNER {Id} -> {Outcome}", task.Id, outcome);
+    }
+
+    /// <summary>
+    /// Maps the observed (owner, ownerType) pair against the task's expected
+    /// winner / pre-transfer context. See the class docstring for the full
+    /// matrix. <paramref name="expectedPreTransfer"/> / <paramref name="expectedPreTransferType"/>
+    /// may be null on legacy / malformed tasks — without them we cannot
+    /// safely classify PRE_TRANSFER, so any non-winner owner is reported as
+    /// STRANGER (the backend's existing fraud-evidence path will surface the
+    /// observed UUID for the admin queue).
+    /// </summary>
+    internal static BuyOwnerOutcome Classify(
+        Guid observedOwner,
+        string observedOwnerType,
+        Guid expectedWinner,
+        Guid? expectedPreTransfer,
+        string? expectedPreTransferType)
+    {
+        if (observedOwner == expectedWinner && observedOwnerType == "agent")
+        {
+            return BuyOwnerOutcome.OWNER_IS_WINNER;
+        }
+
+        if (expectedPreTransfer is not null
+            && observedOwner == expectedPreTransfer.Value
+            && expectedPreTransferType is not null
+            && observedOwnerType == expectedPreTransferType)
+        {
+            return BuyOwnerOutcome.OWNER_STILL_PRE_TRANSFER;
+        }
+
+        return BuyOwnerOutcome.OWNER_IS_STRANGER;
     }
 }

--- a/bot/tests/Slpa.Bot.Tests/VerifyBuyOwnerHandlerTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/VerifyBuyOwnerHandlerTests.cs
@@ -14,12 +14,11 @@ namespace Slpa.Bot.Tests;
 /// report path via the in-test <see cref="FakeBotSession"/> + a mocked
 /// <see cref="IBackendClient"/>; never touches GridClient.
 ///
-/// <para>Backend dispatch (EscrowManualActionService.verifyTransfer) currently
-/// only stamps <c>expectedWinnerUuid</c> on the task, so the handler can only
-/// classify "owner == winner" vs "owner != winner". The residual case is
-/// reported as <see cref="BuyOwnerOutcome.OWNER_STILL_PRE_TRANSFER"/>; reliable
-/// stranger detection is left to the 30-min background ownership monitor that
-/// has the full seller / registered-group context.</para>
+/// <para>Backend dispatch stamps <c>expectedWinnerUuid</c>,
+/// <c>expectedPreTransferUuid</c> (seller avatar for case-1 / registered SL
+/// group UUID for case-3) and <c>expectedOwnerType</c> ("agent"/"group") on
+/// the task; the handler classifies the observed (owner, ownerType) pair
+/// against that triple per the matrix in <see cref="VerifyBuyOwnerHandler"/>.</para>
 /// </summary>
 public sealed class VerifyBuyOwnerHandlerTests
 {
@@ -48,8 +47,9 @@ public sealed class VerifyBuyOwnerHandlerTests
     public async Task OwnerEqualsWinner_ReportsOwnerIsWinner()
     {
         var winner = Guid.NewGuid();
+        var seller = Guid.NewGuid();
         _session.ReadPolicy = (_, _) => Snapshot(owner: winner, isGroupOwned: false);
-        var task = BuildTask(winner);
+        var task = BuildCase1Task(winner, seller);
 
         await NewHandler().HandleAsync(task, CancellationToken.None);
 
@@ -59,12 +59,12 @@ public sealed class VerifyBuyOwnerHandlerTests
     }
 
     [Fact]
-    public async Task OwnerEqualsSellerAvatar_ReportsStillPreTransfer()
+    public async Task Case1_OwnerEqualsSellerAvatar_ReportsStillPreTransfer()
     {
         var winner = Guid.NewGuid();
         var seller = Guid.NewGuid();
         _session.ReadPolicy = (_, _) => Snapshot(owner: seller, isGroupOwned: false);
-        var task = BuildTask(winner);
+        var task = BuildCase1Task(winner, seller);
 
         await NewHandler().HandleAsync(task, CancellationToken.None);
 
@@ -74,12 +74,15 @@ public sealed class VerifyBuyOwnerHandlerTests
     }
 
     [Fact]
-    public async Task OwnerEqualsCase3Group_ReportsStillPreTransfer()
+    public async Task Case3_OwnerEqualsRegisteredGroup_ReportsStillPreTransfer()
     {
+        // Case-3 group listing: pre-transfer owner is the registered SL group
+        // UUID with ownerType "group". Bot sees the same group still holding
+        // the parcel -> PRE_TRANSFER (consumes one attempt, no freeze).
         var winner = Guid.NewGuid();
         var group = Guid.NewGuid();
         _session.ReadPolicy = (_, _) => Snapshot(owner: group, isGroupOwned: true);
-        var task = BuildTask(winner);
+        var task = BuildCase3Task(winner, group);
 
         await NewHandler().HandleAsync(task, CancellationToken.None);
 
@@ -89,22 +92,58 @@ public sealed class VerifyBuyOwnerHandlerTests
     }
 
     [Fact]
-    public async Task OwnerIsUnknownAvatar_ReportsStillPreTransfer_ObservedUuidPropagated()
+    public async Task Case1_OwnerIsStrangerAvatar_ReportsOwnerIsStranger()
     {
-        // Conservative default: without expectedSellerUuid on the task, the
-        // bot cannot reliably distinguish stranger from seller — it reports
-        // PRE_TRANSFER and lets the World API ownership monitor handle real
-        // strangers. The observed UUID + type still flow to the backend so
-        // admin tooling can see what the bot saw.
+        // Now that the backend stamps expectedPreTransferUuid, a non-winner
+        // non-seller owner is a real stranger -> STRANGER (backend freezes).
         var winner = Guid.NewGuid();
+        var seller = Guid.NewGuid();
         var stranger = Guid.NewGuid();
         _session.ReadPolicy = (_, _) => Snapshot(owner: stranger, isGroupOwned: false);
-        var task = BuildTask(winner);
+        var task = BuildCase1Task(winner, seller);
 
         await NewHandler().HandleAsync(task, CancellationToken.None);
 
-        Reported().Should().Be(BuyOwnerOutcome.OWNER_STILL_PRE_TRANSFER);
+        Reported().Should().Be(BuyOwnerOutcome.OWNER_IS_STRANGER);
         _captured!.ObservedOwnerUuid.Should().Be(stranger);
+        _captured.ObservedOwnerType.Should().Be("agent");
+    }
+
+    [Fact]
+    public async Task Case3_OwnerIsStrangerGroup_ReportsOwnerIsStranger()
+    {
+        // Case-3 stranger: parcel is now held by some other group, not the
+        // registered SL group -> STRANGER.
+        var winner = Guid.NewGuid();
+        var registeredGroup = Guid.NewGuid();
+        var strangerGroup = Guid.NewGuid();
+        _session.ReadPolicy = (_, _) => Snapshot(owner: strangerGroup, isGroupOwned: true);
+        var task = BuildCase3Task(winner, registeredGroup);
+
+        await NewHandler().HandleAsync(task, CancellationToken.None);
+
+        Reported().Should().Be(BuyOwnerOutcome.OWNER_IS_STRANGER);
+        _captured!.ObservedOwnerUuid.Should().Be(strangerGroup);
+        _captured.ObservedOwnerType.Should().Be("group");
+    }
+
+    [Fact]
+    public async Task Case3_UuidMatchesButTypeFlipped_ReportsOwnerIsStranger()
+    {
+        // Defensive: expected type="group" but observed type="agent" with the
+        // same UUID (shouldn't happen in SL — group UUIDs and avatar UUIDs are
+        // disjoint — but if it ever did, a flipped owner type means a real
+        // ownership change). Safer to surface as STRANGER than treat as
+        // PRE_TRANSFER.
+        var winner = Guid.NewGuid();
+        var registeredGroup = Guid.NewGuid();
+        _session.ReadPolicy = (_, _) => Snapshot(owner: registeredGroup, isGroupOwned: false);
+        var task = BuildCase3Task(winner, registeredGroup);
+
+        await NewHandler().HandleAsync(task, CancellationToken.None);
+
+        Reported().Should().Be(BuyOwnerOutcome.OWNER_IS_STRANGER);
+        _captured!.ObservedOwnerType.Should().Be("agent");
     }
 
     [Fact]
@@ -213,9 +252,22 @@ public sealed class VerifyBuyOwnerHandlerTests
         SnapshotId: Guid.NewGuid(),
         Flags: 0u);
 
-    private static BotTaskResponse BuildTask(Guid winner) => BuildTask((Guid?)winner);
+    /// <summary>Case-1 (individual listing): pre-transfer owner is the seller's avatar UUID.</summary>
+    private static BotTaskResponse BuildCase1Task(Guid winner, Guid seller) =>
+        BuildTask(winner, expectedPreTransfer: seller, expectedOwnerType: "agent");
 
-    private static BotTaskResponse BuildTask(Guid? expectedWinner) => new(
+    /// <summary>Case-3 (group listing): pre-transfer owner is the registered SL group UUID.</summary>
+    private static BotTaskResponse BuildCase3Task(Guid winner, Guid registeredGroup) =>
+        BuildTask(winner, expectedPreTransfer: registeredGroup, expectedOwnerType: "group");
+
+    /// <summary>Legacy / malformed tasks: only expectedWinnerUuid present.</summary>
+    private static BotTaskResponse BuildTask(Guid winner) =>
+        BuildTask((Guid?)winner, expectedPreTransfer: null, expectedOwnerType: null);
+
+    private static BotTaskResponse BuildTask(
+        Guid? expectedWinner,
+        Guid? expectedPreTransfer = null,
+        string? expectedOwnerType = null) => new(
         Id: 77,
         TaskType: BotTaskType.VERIFY_BUY_OWNER,
         Status: BotTaskStatus.IN_PROGRESS,
@@ -235,5 +287,7 @@ public sealed class VerifyBuyOwnerHandlerTests
         CompletedAt: null,
         RecipientUuid: null,
         AmountL: null,
-        ExpectedWinnerUuid: expectedWinner);
+        ExpectedWinnerUuid: expectedWinner,
+        ExpectedPreTransferUuid: expectedPreTransfer,
+        ExpectedOwnerType: expectedOwnerType);
 }


### PR DESCRIPTION
## Summary

Completes the manual Verify Purchase loop shipped in #362/#363/#364/#365. The bot task now carries enough context for the worker to fully classify live ownership instead of conservatively reporting every non-winner as PRE_TRANSFER.

Backend (`EscrowManualActionService.verifyTransfer`):
- Stamps the expected pre-transfer owner UUID on the task. Case-1 = seller's avatar UUID; case-3 = the registered SL group UUID (looked up via `RealtyGroupSlGroupRepository`).
- Stamps the expected ownerType ("agent" / "group") onto the `resultData` JSON payload alongside `requestingRole`.
- Pre-transfer UUID rides on the existing `expectedSellerUuid` column; ownerType rides on `resultData`.

Bot DTO + worker (`VerifyBuyOwnerHandler`):
- `BotTaskResponse` gains `ExpectedPreTransferUuid` + `ExpectedOwnerType`.
- Handler classifies (owner UUID, ownerType) against the (winner, expectedPreTransfer, expectedOwnerType) triple:
  - winner + "agent" -> OWNER_IS_WINNER
  - expected pre-transfer + matching type -> OWNER_STILL_PRE_TRANSFER
  - otherwise -> OWNER_IS_STRANGER (backend freezes for fraud review)
- Removes the inline "conservative fallback" doc comment that's no longer accurate.

Backend `BotTaskResultService.applyVerifyBuyOwnerResult` was already trust-the-bot, so no changes there — it acts on whatever outcome the bot reports.

## Test plan

- [x] `./mvnw -Dtest='EscrowManualActionServiceTest,BotTaskResultServiceTest' test` -> 38 passed
- [x] `dotnet test` -> 88 passed (added case-3 group test + case-3 type-flip defensive test + case-1 stranger test; "stranger -> PRE_TRANSFER" turned into "stranger -> STRANGER")
- [x] Full `./mvnw test` -> only 3 pre-existing failures in `AdminRealtyGroupSuspensionControllerSliceTest` (verified on branch base, unrelated)