### PR TITLE
fix(escrow): seller COMPLETED card shows sale price + fee + net breakdown

### DIFF
--- a/frontend/src/components/escrow/state/CompletedStateCard.test.tsx
+++ b/frontend/src/components/escrow/state/CompletedStateCard.test.tsx
@@ -4,12 +4,13 @@ import { CompletedStateCard } from "./CompletedStateCard";
 import { fakeEscrow } from "@/test/fixtures/escrow";
 
 describe("CompletedStateCard", () => {
-  describe("seller view", () => {
-    it("renders payout + commission amounts", () => {
+  describe("seller view (individual sale)", () => {
+    it("renders the payout headline + sale-price / fee / net breakdown", () => {
       renderWithProviders(
         <CompletedStateCard
           escrow={fakeEscrow({
             state: "COMPLETED",
+            finalBidAmount: 5000,
             payoutAmt: 4750,
             commissionAmt: 250,
             completedAt: "2026-05-02T10:00:05Z",
@@ -17,8 +18,48 @@ describe("CompletedStateCard", () => {
           role="seller"
         />,
       );
+
+      // Headline keeps the net "Payout of L$X sent" so the eye lands on
+      // the amount that actually moved to the seller's avatar.
       expect(screen.getByText(/payout of l\$\s*4,?750/i)).toBeInTheDocument();
-      expect(screen.getByText(/commission l\$\s*250/i)).toBeInTheDocument();
+
+      // Breakdown body: sale price anchor + SLParcels fee row + net.
+      // Use queryAllByText for "L$ 4,750" since it shows up in both the
+      // headline and the net row.
+      expect(screen.getByText(/^sale price$/i)).toBeInTheDocument();
+      expect(screen.getByText(/^l\$\s*5,?000$/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/slparcels fee \(5%, l\$50 min\)/i),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/^.{1,2}l\$\s*250$/i)).toBeInTheDocument();
+      expect(screen.getByText(/^your payout$/i)).toBeInTheDocument();
+
+      // Old "Commission L$N" copy is gone — the term is reserved for the
+      // agent-commission slice on group listings now.
+      expect(screen.queryByText(/^commission l\$/i)).not.toBeInTheDocument();
+    });
+
+    it("shows the L$50-floor case correctly for small sales", () => {
+      // L$100 sale → 5% would be L$5 but the floor lands the fee at L$50,
+      // so the seller nets half. This is the scenario that prompted the
+      // breakdown — make sure the math is legible.
+      renderWithProviders(
+        <CompletedStateCard
+          escrow={fakeEscrow({
+            state: "COMPLETED",
+            finalBidAmount: 100,
+            payoutAmt: 50,
+            commissionAmt: 50,
+            completedAt: "2026-05-19T14:40:00Z",
+          })}
+          role="seller"
+        />,
+      );
+      expect(screen.getByText(/payout of l\$\s*50/i)).toBeInTheDocument();
+      expect(screen.getByText(/^l\$\s*100$/i)).toBeInTheDocument(); // sale price row
+      expect(
+        screen.getByText(/slparcels fee \(5%, l\$50 min\)/i),
+      ).toBeInTheDocument();
     });
 
     it("does not render winner-only copy", () => {
@@ -30,6 +71,32 @@ describe("CompletedStateCard", () => {
       );
       expect(
         screen.queryByText(/parcel transferred/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("seller view (group listing, payoutAmt = 0)", () => {
+    it("shows 'Sale completed' acknowledgement without the Payout-of-L$0 headline", () => {
+      renderWithProviders(
+        <CompletedStateCard
+          escrow={fakeEscrow({
+            state: "COMPLETED",
+            finalBidAmount: 5000,
+            payoutAmt: 0,
+            commissionAmt: 250,
+            completedAt: "2026-05-02T10:00:05Z",
+          })}
+          role="seller"
+        />,
+      );
+      expect(screen.getByText(/sale completed/i)).toBeInTheDocument();
+      expect(screen.getByText(/sale price: l\$\s*5,?000/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/payout was split to the listing agent and the group wallet/i),
+      ).toBeInTheDocument();
+      // The misleading "Payout of L$0 sent" headline must NOT appear here.
+      expect(
+        screen.queryByText(/payout of l\$\s*0/i),
       ).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/components/escrow/state/CompletedStateCard.tsx
+++ b/frontend/src/components/escrow/state/CompletedStateCard.tsx
@@ -18,17 +18,7 @@ export function CompletedStateCard({ escrow, role }: StateCardProps) {
         {role === "seller" ? "Seller" : "Winner"}
       </span>
       {role === "seller" ? (
-        <>
-          <h2 className="text-sm font-semibold tracking-tight text-fg">
-            Payout of L$ {escrow.payoutAmt.toLocaleString()} sent
-          </h2>
-          <p className="text-sm text-fg-muted">
-            Commission L$ {escrow.commissionAmt.toLocaleString()}.
-            {escrow.completedAt
-              ? ` Completed ${formatTimestamp(escrow.completedAt)}.`
-              : ""}
-          </p>
-        </>
+        <SellerPayoutBreakdown escrow={escrow} />
       ) : (
         <>
           <h2 className="text-sm font-semibold tracking-tight text-fg">Parcel transferred</h2>
@@ -41,6 +31,80 @@ export function CompletedStateCard({ escrow, role }: StateCardProps) {
         </>
       )}
     </section>
+  );
+}
+
+/**
+ * Seller-facing payout breakdown. Replaces the prior single-line "Commission
+ * L$N" copy that left sellers asking why a L$100 sale only netted them L$50.
+ *
+ * For individual sales (case-1, `payoutAmt > 0`) the breakdown lays out:
+ *   - Sale price (anchor — the seller knows what the parcel sold for)
+ *   - SLParcels fee (with the 5% / L$50-minimum rule inline so the floor on
+ *     small sales doesn't look arbitrary)
+ *   - Net payout
+ *
+ * "Fee" intentionally — "commission" is reserved for the agent-commission
+ * slice on group listings (case-3) per the realty-group spec; mislabelling
+ * the platform's per-sale cut as "commission" confused sellers post-launch.
+ *
+ * For group listings (case-3, `payoutAmt === 0`) the L$ split goes to the
+ * listing agent + group wallet, not to the seller's avatar. The escrow DTO
+ * doesn't surface the agent / group-wallet split here today, so we show a
+ * minimal acknowledgement instead of forcing a "Payout of L$0" headline that
+ * would only confuse the lister. Full case-3 breakdown is a follow-up that
+ * needs the agent-commission + group-slice fields surfaced on the DTO.
+ */
+function SellerPayoutBreakdown({
+  escrow,
+}: {
+  escrow: StateCardProps["escrow"];
+}) {
+  const completedSuffix = escrow.completedAt
+    ? ` Completed ${formatTimestamp(escrow.completedAt)}.`
+    : "";
+
+  if (escrow.payoutAmt === 0) {
+    return (
+      <>
+        <h2 className="text-sm font-semibold tracking-tight text-fg">
+          Sale completed
+        </h2>
+        <p className="text-sm text-fg-muted">
+          Sale price: L$ {escrow.finalBidAmount.toLocaleString()}. Payout was
+          split to the listing agent and the group wallet.{completedSuffix}
+        </p>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h2 className="text-sm font-semibold tracking-tight text-fg">
+        Payout of L$ {escrow.payoutAmt.toLocaleString()} sent
+      </h2>
+      <dl className="grid grid-cols-[1fr_auto] gap-y-1 text-sm text-fg-muted">
+        <dt>Sale price</dt>
+        <dd className="text-right tabular-nums text-fg">
+          L$ {escrow.finalBidAmount.toLocaleString()}
+        </dd>
+        <dt>SLParcels fee (5%, L$50 min)</dt>
+        <dd className="text-right tabular-nums text-fg">
+          &minus; L$ {escrow.commissionAmt.toLocaleString()}
+        </dd>
+        <dt className="border-t border-border-subtle pt-1 font-medium text-fg">
+          Your payout
+        </dt>
+        <dd className="border-t border-border-subtle pt-1 text-right tabular-nums font-medium text-fg">
+          L$ {escrow.payoutAmt.toLocaleString()}
+        </dd>
+      </dl>
+      {completedSuffix ? (
+        <p className="text-xs text-fg-muted">
+          {completedSuffix.trim()}
+        </p>
+      ) : null}
+    </>
   );
 }
 


### PR DESCRIPTION
Promotes PR #370 from dev. Frontend-only — replaces the bare 'Commission L$N' line with a sale-price → fee → net breakdown on the seller's COMPLETED card. No backend changes (Amplify auto-deploys; backend deploy correctly skips).