### PR TITLE
feat(escrow): group-sale payout breakdown on COMPLETED card + drop case-1/case-3 terminology

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/Auction.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/Auction.java
@@ -83,16 +83,17 @@ public class Auction extends BaseMutableEntity {
     private Long realtyGroupId;
 
     /**
-     * Sub-project E case-3 discriminator. NULL for individual listings and for legacy case-1
-     * rows. Set at create-time to the verified {@link com.slparcelauctions.backend.realty
-     * .slgroup.RealtyGroupSlGroup} row whose SL group UUID matches the parcel's SL owner.
+     * Group-sale discriminator. NULL for individual listings and for legacy non-SL-group
+     * realty-group rows. Set at create-time to the verified {@link com.slparcelauctions
+     * .backend.realty.slgroup.RealtyGroupSlGroup} row whose SL group UUID matches the
+     * parcel's SL owner.
      */
     @Column(name = "realty_group_sl_group_id")
     private Long realtyGroupSlGroupId;
 
     /**
      * Per-listing commission rate snapshotted from {@code realty_group_members.agent_commission_rate}
-     * at listing-create. NULL for non-case-3 auctions. Consumed by {@code AgentCommissionDistributor}
+     * at listing-create. NULL for individual sales. Consumed by {@code AgentCommissionDistributor}
      * at SOLD close.
      */
     @Column(name = "agent_commission_rate", precision = 5, scale = 4)

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionController.java
@@ -141,7 +141,7 @@ public class AuctionController {
     /**
      * Triggers the synchronous World API ownership check. No body is
      * required -- the expected owner UUID is derived from the auction
-     * (seller's avatar, or registered SL group UUID for case-3 listings).
+     * (seller's avatar, or registered SL group UUID for group sales).
      * On match the auction transitions DRAFT_PAID -> ACTIVE; on any
      * miss it transitions to VERIFICATION_FAILED with a retryable note.
      */
@@ -175,12 +175,12 @@ public class AuctionController {
     }
 
     /**
-     * Broker-initiated cancellation of a case-3 (SL-group-owned) listing —
+     * Broker-initiated cancellation of a group-sale (SL-group-owned) listing —
      * Realty Groups E spec §5.2. The caller is a broker on the owning realty
      * group, not the listing's seller, so the auction is loaded via the
      * non-seller-scoped {@code loadAnyByPublicId}. Authorization (the broker
      * must hold {@link com.slparcelauctions.backend.realty.permission.RealtyGroupPermission#MANAGE_ALL_LISTINGS}
-     * on the owning group) and the case-3 precondition are enforced inside
+     * on the owning group) and the group-sale precondition are enforced inside
      * {@code CancellationService.brokerCancel} under the row lock.
      */
     @PostMapping("/auctions/{publicId}/broker-cancel")

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionRepository.java
@@ -220,13 +220,14 @@ public interface AuctionRepository extends JpaRepository<Auction, Long>, JpaSpec
     boolean existsActiveListingsByGroupId(@Param("groupId") Long groupId);
 
     /**
-     * Sub-project E §10.2 — case-3 reassignment. Updates {@code seller_id} to the
-     * leader for the departing member's pre-terminal listings (DRAFT, DRAFT_PAID,
-     * VERIFICATION_PENDING, VERIFICATION_FAILED, ACTIVE) under the given group.
-     * {@code listing_agent_id} stays stable so commission attribution is
-     * preserved; the management/notification surface flips to the leader.
+     * Sub-project E §10.2 — group-sale seller reassignment. Updates
+     * {@code seller_id} to the leader for the departing member's pre-terminal
+     * listings (DRAFT, DRAFT_PAID, VERIFICATION_PENDING, VERIFICATION_FAILED,
+     * ACTIVE) under the given group. {@code listing_agent_id} stays stable so
+     * commission attribution is preserved; the management/notification surface
+     * flips to the leader.
      *
-     * <p>Scoped to case-3 only via {@code realty_group_sl_group_id IS NOT NULL}.
+     * <p>Scoped to group sales only via {@code realty_group_sl_group_id IS NOT NULL}.
      * Called from {@code RealtyGroupMembershipService.leave} and
      * {@code RealtyGroupMembershipService.removeMember}.
      */
@@ -283,8 +284,8 @@ public interface AuctionRepository extends JpaRepository<Auction, Long>, JpaSpec
 
     /**
      * Active listings attributed to the given realty group, covering both
-     * case-1 (direct {@code realty_group_id} attribution) and case-3 (the
-     * auction's {@code realty_group_sl_group_id} resolves to a
+     * legacy direct {@code realty_group_id} attribution and group sales
+     * (the auction's {@code realty_group_sl_group_id} resolves to a
      * {@link com.slparcelauctions.backend.realty.slgroup.RealtyGroupSlGroup}
      * whose {@code realty_group_id} matches). Consumed by the bulk-suspend
      * path so an admin acting against a realty group can sweep every live
@@ -307,8 +308,8 @@ public interface AuctionRepository extends JpaRepository<Auction, Long>, JpaSpec
 
     /**
      * Sub-project F §13.5 — admin force-unregister cascade. Returns every
-     * {@link AuctionStatus#ACTIVE} case-3 auction attached to the given SL
-     * group registration. Used by
+     * {@link AuctionStatus#ACTIVE} group-sale auction attached to the given
+     * SL group registration. Used by
      * {@link com.slparcelauctions.backend.realty.slgroup.SlGroupForceUnregisterService}
      * to decide whether the bulk-suspend cascade needs to run when an admin
      * force-unregisters the SL group claim. Pre-ACTIVE statuses (DRAFT,
@@ -325,7 +326,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long>, JpaSpec
     List<Auction> findActiveCase3ListingsForSlGroup(@Param("slGroupId") Long slGroupId);
 
     /**
-     * Returns {@code true} when any non-terminal case-3 auction references the
+     * Returns {@code true} when any non-terminal group-sale auction references the
      * given {@code realty_group_sl_group_id}. Used by
      * {@link com.slparcelauctions.backend.realty.slgroup.RealtyGroupSlGroupService#unregister}
      * to block removal of an SL group registration while live listings still

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionVerificationService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/AuctionVerificationService.java
@@ -31,10 +31,10 @@ import lombok.extern.slf4j.Slf4j;
  * no seller-chosen "method". The expected owner is derived from the
  * auction:
  * <ul>
- *   <li><b>Case 1 (individual seller)</b> -- parcel must be owned by the
- *       seller's avatar (ownerType == "agent").</li>
- *   <li><b>Case 3 (SL group)</b> -- parcel must be owned by the registered
- *       SL group UUID (ownerType == "group"), looked up via
+ *   <li><b>Individual sale</b> -- parcel must be owned by the seller's
+ *       avatar (ownerType == "agent").</li>
+ *   <li><b>Group sale (SL group)</b> -- parcel must be owned by the
+ *       registered SL group UUID (ownerType == "group"), looked up via
  *       {@link RealtyGroupSlGroupRepository}.</li>
  * </ul>
  *

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationOffenseKind.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationOffenseKind.java
@@ -27,7 +27,7 @@ public enum CancellationOffenseKind {
     PENALTY_AND_30D,
     PERMANENT_BAN,
     /**
-     * Sub-project E §11.4 -- broker-initiated cancellation on a case-3
+     * Sub-project E §11.4 -- broker-initiated cancellation on a group-sale
      * (SL-group-owned) listing. Excluded from
      * {@code countPriorOffensesWithBids} so it never advances the seller's
      * penalty ladder. Like {@code NONE} and {@code WARNING} it carries no

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/CancellationService.java
@@ -394,7 +394,7 @@ public class CancellationService {
     }
 
     /**
-     * Sub-project E §11.4 -- broker-initiated cancellation of a case-3
+     * Sub-project E §11.4 -- broker-initiated cancellation of a group-sale
      * (SL-group-owned) listing. The acting broker must hold
      * {@link RealtyGroupPermission#MANAGE_ALL_LISTINGS} on the owning realty
      * group. Skips the seller penalty ladder entirely: a broker acting on
@@ -403,19 +403,19 @@ public class CancellationService {
      * {@link CancellationOffenseKind#BROKER_CANCEL} rows belt-and-braces
      * (alongside the {@code cancelledByAdminId} predicate).
      *
-     * <p>Only case-3 listings are eligible. Case-1 (individual) listings and
-     * legacy auctions with no realty group attached raise
-     * {@link BrokerCancelNotApplicableException} so case-3 stays the only
+     * <p>Only group sales are eligible. Individual listings and legacy
+     * auctions with no realty group attached raise
+     * {@link BrokerCancelNotApplicableException} so group sales stay the only
      * surface where broker authority overrides seller agency.
      *
      * <p>Listing-fee refund is created in every state when {@code listingFeePaid}
      * is true -- including {@code ACTIVE}. This differs from the seller path
-     * (which refunds only on pre-active cancels) because case-3 listing fees
-     * are paid out of the group wallet at create-time; the group must be made
-     * whole even on an active-state cancel. Existing
+     * (which refunds only on pre-active cancels) because group-sale listing
+     * fees are paid out of the group wallet at create-time; the group must
+     * be made whole even on an active-state cancel. Existing
      * {@code ListingFeeRefundProcessorJob} routes the refund back to the
-     * originating wallet via the ledger row, so case-3 refunds land in the
-     * group wallet without a routing flag here.
+     * originating wallet via the ledger row, so group-sale refunds land in
+     * the group wallet without a routing flag here.
      */
     @Transactional
     public Auction brokerCancel(Long brokerUserId, Long auctionId, String reason, String ipAddress) {
@@ -431,16 +431,16 @@ public class CancellationService {
         }
         if (a.getRealtyGroupSlGroupId() == null) {
             throw new BrokerCancelNotApplicableException(a.getPublicId(),
-                    "Broker-cancel only applies to case-3 (SL-group-owned) listings.");
+                    "Broker-cancel only applies to group sales (SL-group-owned listings).");
         }
         Long groupId = a.getRealtyGroupId();
         if (groupId == null) {
-            // Defensive: case-3 auctions must always carry both realty_group_id
+            // Defensive: group-sale auctions must always carry both realty_group_id
             // and realty_group_sl_group_id. If the latter is set but the former
             // is null the row is malformed; fail fast rather than silently
             // skipping the authorization check.
             throw new BrokerCancelNotApplicableException(a.getPublicId(),
-                    "Case-3 auction missing realty_group_id; cannot authorize broker.");
+                    "Group-sale auction missing realty_group_id; cannot authorize broker.");
         }
 
         realtyGroupAuthorizer.assertCan(brokerUserId, groupId,
@@ -474,16 +474,16 @@ public class CancellationService {
         Auction saved = auctionRepo.save(a);
 
         // Listing-fee refund: D's existing ListingFeeRefundProcessorJob routes
-        // by originating ledger row, so case-3 refunds credit back to the group
-        // wallet without explicit routing here. Issued regardless of from-status
-        // because the group paid the fee -- they must be made whole.
+        // by originating ledger row, so group-sale refunds credit back to the
+        // group wallet without explicit routing here. Issued regardless of
+        // from-status because the group paid the fee -- they must be made whole.
         if (Boolean.TRUE.equals(a.getListingFeePaid())) {
             refundRepo.save(ListingFeeRefund.builder()
                     .auction(saved)
                     .amount(a.getListingFeeAmt() == null ? 0L : a.getListingFeeAmt())
                     .status(RefundStatus.PENDING)
                     .build());
-            log.info("Listing fee refund (PENDING) created for case-3 auction {} broker-cancel", a.getId());
+            log.info("Listing fee refund (PENDING) created for group-sale auction {} broker-cancel", a.getId());
         }
 
         // Notify the original listing agent -- the commission recipient, which
@@ -493,7 +493,7 @@ public class CancellationService {
         notificationPublisher.brokerCancelled(
                 listingAgent.getId(), saved.getId(), saved.getTitle(), brokerUserId, reason);
 
-        // Bidder fan-out: case-3 listings can have live bids same as any other
+        // Bidder fan-out: group sales can have live bids same as any other
         // ACTIVE auction. Mirror the seller-cancel fan-out so bidders see the
         // cancellation in their feed.
         if (hadBids) {

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/agentfee/AgentCommissionDistributor.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/agentfee/AgentCommissionDistributor.java
@@ -15,13 +15,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Sub-project E spec §9 -- case-3 payout splitter. Credits the listing agent's wallet with
- * the agent slice and the realty group's wallet with the residual group slice. Runs in the
- * MANDATORY transaction of {@code handleEscrowPayoutSuccess}; never opens its own transaction.
+ * Group-sale payout splitter. Credits the listing agent's wallet with the agent slice and
+ * the realty group's wallet with the residual group slice. Runs in the MANDATORY
+ * transaction of {@code handleEscrowPayoutSuccess}; never opens its own transaction.
  *
- * <p>The pre-G case-1 sibling distributor was deleted by sub-project G. All realty-group
- * listings post-G are case-3 (i.e. carry {@code realty_group_sl_group_id}); the
- * group-listed-not-SL-group-owned branch no longer exists.
+ * <p>The pre-G sibling distributor for the "agent listing own land under a group" variant
+ * was deleted by sub-project G. All realty-group listings post-G are group sales
+ * (i.e. carry {@code realty_group_sl_group_id}); the group-listed-not-SL-group-owned
+ * branch no longer exists.
  *
  * <p>Computation (spec §9.3):
  * <pre>
@@ -44,7 +45,7 @@ public class AgentCommissionDistributor {
     public void distribute(Auction auction, long finalBid, long platformCommission) {
         if (auction.getRealtyGroupSlGroupId() == null) {
             throw new IllegalArgumentException(
-                "AgentCommissionDistributor called on non-case-3 auction " + auction.getId());
+                "AgentCommissionDistributor called on non-group-sale auction " + auction.getId());
         }
         BigDecimal rate = auction.getAgentCommissionRate();
         if (rate == null) {

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/dto/AuctionCreateRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/dto/AuctionCreateRequest.java
@@ -37,7 +37,7 @@ public record AuctionCreateRequest(
         @Size(max = 5000) String sellerDesc,
         @Size(max = 10) Set<String> tags,          // parcel_tag codes
         /**
-         * When non-null, the auction is created under this realty group (case 1: the agent
+         * When non-null, the auction is created under this realty group (the agent
          * is also the seller). The controller routes to
          * {@link com.slparcelauctions.backend.realty.listing.RealtyGroupListingService} which
          * asserts {@code CREATE_LISTING} and snapshots {@code agent_fee_rate} +

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/dto/BrokerCancelRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/dto/BrokerCancelRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Size;
 
 /**
  * Request body for {@code POST /api/v1/auctions/{publicId}/broker-cancel} — a
- * broker-initiated cancellation of a case-3 (SL-group-owned) listing. The
+ * broker-initiated cancellation of a group-sale (SL-group-owned) listing. The
  * {@code reason} is snapshotted onto the {@code CancellationLog} row and fed
  * to the listing-agent notification body. See Realty Groups E spec §5.2.
  */

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/dto/ListingAgentDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/dto/ListingAgentDto.java
@@ -4,8 +4,8 @@ import java.util.UUID;
 
 /**
  * Compact listing-agent attribution embedded into auction DTOs when the auction is
- * group-listed. In sub-project C case 1 this is the same user as the seller; sub-project E
- * is where the two diverge.
+ * group-listed. In sub-project C this was the same user as the seller; sub-project E
+ * (group sales) is where the two diverge.
  */
 public record ListingAgentDto(
         UUID publicId,

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/BulkListingSuspendService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/BulkListingSuspendService.java
@@ -34,9 +34,10 @@ import lombok.extern.slf4j.Slf4j;
  * group suspension with the bulk-listing flag set, and directly by the admin
  * bulk-listings controller (Task 14).
  *
- * <p>{@link #suspendAll} sweeps both case-1 (direct {@code realty_group_id}) and
- * case-3 ({@code realty_group_sl_group_id} → {@link RealtyGroupSuspension}'s
- * group) listings via {@link AuctionRepository#findActiveListingsForGroup}, flips
+ * <p>{@link #suspendAll} sweeps both legacy direct {@code realty_group_id}
+ * attribution and group-sale ({@code realty_group_sl_group_id} →
+ * {@link RealtyGroupSuspension}'s group) listings via
+ * {@link AuctionRepository#findActiveListingsForGroup}, flips
  * each ACTIVE row to SUSPENDED, writes one {@link ListingSuspension} per row
  * tagged {@link ListingSuspensionCause#ADMIN_GROUP_BULK} with a shared bulk-action
  * UUID, fires the bot-monitor close hook and a per-seller suspended notification,

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/ListingSuspensionRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/ListingSuspensionRepository.java
@@ -38,8 +38,9 @@ public interface ListingSuspensionRepository extends JpaRepository<ListingSuspen
 
     /**
      * Active group-bulk listing suspensions for the given realty group, joining through
-     * both case-1 ({@code a.realtyGroupId}) and case-3 ({@code rsg.realtyGroupId} via
-     * {@code RealtyGroupSlGroup}) discriminators. Consumed by the bulk reinstate path.
+     * both legacy direct ({@code a.realtyGroupId}) and group-sale
+     * ({@code rsg.realtyGroupId} via {@code RealtyGroupSlGroup}) linkages.
+     * Consumed by the bulk reinstate path.
      */
     @Query("""
         SELECT ls FROM ListingSuspension ls

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/OwnershipCheckTask.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/monitoring/OwnershipCheckTask.java
@@ -157,12 +157,12 @@ public class OwnershipCheckTask {
         OffsetDateTime now = OffsetDateTime.now(clock);
         UUID expected;
         if (auction.getRealtyGroupSlGroupId() != null) {
-            // Case 3: parcel must remain owned by the registered SL group.
+            // Group sale: parcel must remain owned by the registered SL group.
             RealtyGroupSlGroup reg =
                     slGroupRepo.findById(auction.getRealtyGroupSlGroupId()).orElse(null);
             expected = (reg == null) ? null : reg.getSlGroupUuid();
         } else {
-            // Cases 1, individual: seller's avatar.
+            // Individual sale: seller's avatar.
             expected = auction.getSeller() == null ? null : auction.getSeller().getSlAvatarUuid();
         }
 
@@ -192,8 +192,8 @@ public class OwnershipCheckTask {
                 handleTimeout(auction, "empty World API response");
             } else {
                 observed = result.ownerUuid();
-                // Case 3 expects the parcel to be group-owned by the registered SL group;
-                // cases 1/individual expect agent-owned by the seller's avatar.
+                // Group sales expect the parcel to be group-owned by the registered SL group;
+                // individual sales expect agent-owned by the seller's avatar.
                 String expectedOwnerType = auction.getRealtyGroupSlGroupId() != null ? "group" : "agent";
                 ownerMatch = expected.equals(observed)
                         && expectedOwnerType.equalsIgnoreCase(result.ownerType());

--- a/backend/src/main/java/com/slparcelauctions/backend/bot/dto/BotTaskResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/bot/dto/BotTaskResponse.java
@@ -19,7 +19,7 @@ import com.slparcelauctions.backend.escrow.EscrowManualActionService;
  * <p><b>expectedPreTransferUuid / expectedOwnerType</b> ride out alongside
  * the historical fields for the bot's VERIFY_BUY_OWNER classification.
  * Pre-transfer UUID re-uses the historical {@code expected_seller_uuid}
- * column (case-1 = seller's avatar UUID, case-3 = registered SL group UUID);
+ * column (individual sale = seller's avatar UUID, group sale = registered SL group UUID);
  * ownerType comes from the {@code resultData} JSON payload key
  * {@link EscrowManualActionService#EXPECTED_OWNER_TYPE_KEY}.
  */

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowManualActionService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowManualActionService.java
@@ -59,7 +59,7 @@ public class EscrowManualActionService {
     public static final String REQUESTING_ROLE_BUYER = "BUYER";
 
     /** Payload key carrying the expected pre-transfer owner type
-     *  ("agent" for case-1 / "group" for case-3) so the bot can match both
+     *  ("agent" for individual sales / "group" for group sales) so the bot can match both
      *  UUID and ownerType when classifying live ownership. The pre-transfer
      *  UUID itself is stamped onto {@link BotTask#getExpectedSellerUuid()}. */
     public static final String EXPECTED_OWNER_TYPE_KEY = "expectedOwnerType";

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
@@ -1,5 +1,7 @@
 package com.slparcelauctions.backend.escrow;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -40,6 +42,8 @@ import com.slparcelauctions.backend.escrow.review.ManualReviewStatus;
 import com.slparcelauctions.backend.escrow.scheduler.SellToBotTaskFactory;
 import com.slparcelauctions.backend.escrow.terminal.EscrowConfigProperties;
 import com.slparcelauctions.backend.notification.NotificationPublisher;
+import com.slparcelauctions.backend.realty.RealtyGroup;
+import com.slparcelauctions.backend.realty.RealtyGroupRepository;
 import com.slparcelauctions.backend.sl.SlurlBuilder;
 import com.slparcelauctions.backend.escrow.command.TerminalCommandService;
 import com.slparcelauctions.backend.escrow.dispute.exception.EscrowNotDisputedException;
@@ -111,6 +115,7 @@ public class EscrowService {
     private final EscrowConfigProperties escrowConfig;
     private final EscrowManualReviewRepository manualReviewRepo;
     private final SellToBotTaskFactory sellToBotTaskFactory;
+    private final RealtyGroupRepository realtyGroupRepo;
 
     public static boolean isAllowed(EscrowState from, EscrowState to) {
         return ALLOWED_TRANSITIONS.getOrDefault(from, Set.of()).contains(to);
@@ -514,6 +519,33 @@ public class EscrowService {
                     snap.getRegionName(), snap.getPositionX(), snap.getPositionY(), snap.getPositionZ());
         }
 
+        // Group-sale payout split — populated only when the auction is
+        // group-listed (realty_group_sl_group_id != null). Same arithmetic as
+        // AgentCommissionDistributor.distribute so the seller's COMPLETED
+        // card matches the actual L$ that landed in each wallet.
+        Long agentCommissionAmt = null;
+        Long groupSliceAmt = null;
+        String groupName = null;
+        Auction auction = escrow.getAuction();
+        if (auction.getRealtyGroupSlGroupId() != null) {
+            BigDecimal rate = auction.getAgentCommissionRate();
+            if (rate == null) {
+                rate = BigDecimal.ZERO;
+            }
+            long earnings = escrow.getFinalBidAmount() - escrow.getCommissionAmt();
+            long agentSlice = BigDecimal.valueOf(earnings)
+                    .multiply(rate)
+                    .setScale(0, RoundingMode.FLOOR)
+                    .longValueExact();
+            agentCommissionAmt = agentSlice;
+            groupSliceAmt = earnings - agentSlice;
+            if (auction.getRealtyGroupId() != null) {
+                groupName = realtyGroupRepo.findById(auction.getRealtyGroupId())
+                        .map(RealtyGroup::getName)
+                        .orElse(null);
+            }
+        }
+
         return new EscrowStatusResponse(
                 escrow.getPublicId(), escrow.getAuction().getPublicId(),
                 winnerSlAvatarName, escrow.getState(),
@@ -532,7 +564,10 @@ public class EscrowService {
                 reviewStep,
                 parcelMapUrl,
                 parcelViewerUrl,
-                Boolean.TRUE.equals(escrow.getManualVerifyPending()));
+                Boolean.TRUE.equals(escrow.getManualVerifyPending()),
+                agentCommissionAmt,
+                groupSliceAmt,
+                groupName);
     }
 
     private List<EscrowTimelineEntry> buildTimeline(Escrow e) {

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
@@ -464,7 +464,7 @@ public class EscrowService {
      * callback path in {@code TerminalCommandService.applyCallback}, not this
      * hook — queuing the command merely schedules the terminal POST.
      *
-     * <p>Sub-project G §8.1: for case-3 (SL-group-owned, payoutAmt = 0),
+     * <p>Sub-project G §8.1: for group sales (SL-group-owned, payoutAmt = 0),
      * {@code queuePayout} short-circuits and runs the success path inline,
      * returning {@link java.util.Optional#empty()}. The state flip to
      * {@code COMPLETED} has already happened by the time this method returns.
@@ -1027,26 +1027,26 @@ public class EscrowService {
      * exclusive at the column level:
      *
      * <ul>
-     *   <li><b>Case 3 (E -- SL-group-owned)</b>: {@code realty_group_sl_group_id IS NOT NULL}.
+     *   <li><b>Group sale (SL-group-owned)</b>: {@code realty_group_sl_group_id IS NOT NULL}.
      *       {@code payoutAmt = 0}. The earnings (finalBid - commission) are credited
      *       entirely via internal wallet routing at payout-success:
      *       {@code AgentCommissionDistributor} credits the listing agent's wallet with
      *       {@code agent_slice} and the realty group's wallet with {@code group_slice}.
      *       No L$ leaves SLPA to an SL avatar from the escrow row, so the terminal
      *       PAYOUT command carries amount=0 and is a SL-side no-op. Spec §8.5, §9.6.</li>
-     *   <li><b>Individual</b>: both group columns null.
+     *   <li><b>Individual sale</b>: both group columns null.
      *       {@code payoutAmt = commission.payout(finalBid)}.</li>
      * </ul>
      *
      * <p>The escrow's {@code payoutTargetUuid} is still the seller's SL avatar for
-     * case-3 — the column is set elsewhere from {@code auction.seller.slAvatarUuid}
-     * and remains correct. For case-3 it simply receives 0 L$ from the terminal,
+     * group sales — the column is set elsewhere from {@code auction.seller.slAvatarUuid}
+     * and remains correct. For group sales it simply receives 0 L$ from the terminal,
      * because all routing is internal.
      */
     private long computePayoutAmt(Auction auction, long finalBid) {
         if (auction.getRealtyGroupSlGroupId() != null) {
-            // Case 3: earnings stay in SLPA; AgentCommissionDistributor credits agent
-            // and group wallets internally at payout-success.
+            // Group sale: earnings stay in SLPA; AgentCommissionDistributor credits
+            // agent and group wallets internally at payout-success.
             return 0L;
         }
         return commission.payout(finalBid);

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/command/TerminalCommandService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/command/TerminalCommandService.java
@@ -81,7 +81,7 @@ public class TerminalCommandService {
 
     /**
      * Queues an escrow payout to the seller's SL terminal. Sub-project G §8.1
-     * short-circuit: when {@code escrow.getPayoutAmt() == 0L} (case-3
+     * short-circuit: when {@code escrow.getPayoutAmt() == 0L} (group sales --
      * SL-group-owned auctions; the agent commission and group slice both flow
      * through {@link com.slparcelauctions.backend.auction.agentfee.AgentCommissionDistributor}
      * inside the success path), the terminal round-trip is skipped and the
@@ -102,7 +102,7 @@ public class TerminalCommandService {
                 log.info("queuePayout: escrow {} already COMPLETED, no-op", escrow.getId());
                 return Optional.empty();
             }
-            log.info("queuePayout: escrow {} payoutAmt=0 (case-3), running success path inline",
+            log.info("queuePayout: escrow {} payoutAmt=0 (group sale), running success path inline",
                     escrow.getId());
             runZeroPayoutSuccessInline(escrow, OffsetDateTime.now(clock));
             return Optional.empty();
@@ -342,17 +342,18 @@ public class TerminalCommandService {
 
         // Realty-group payout splitting.
         //
-        //   case 3 (E -- SL-group-owned): realty_group_sl_group_id IS NOT NULL.
+        //   group sale (SL-group-owned): realty_group_sl_group_id IS NOT NULL.
         //       The escrow's payoutAmt is 0 (set by EscrowService.createForEndedAuction);
         //       no L$ leaves SLPA via the terminal. AgentCommissionDistributor credits
         //       the full earnings (finalBid - commission) to the listing agent's wallet
         //       (agent_slice) and the group wallet (group_slice) using
         //       agent_commission_rate. Spec §8.5, §9.6.
         //
-        //   individual: realty_group_sl_group_id IS NULL -- nothing to split.
+        //   individual sale: realty_group_sl_group_id IS NULL -- nothing to split.
         //
-        //   (The pre-G case-1 path -- realty_group_id set but realty_group_sl_group_id
-        //   null -- was removed when sub-project G deleted the case-1 distributor.)
+        //   (The pre-G "agent listing own land under a group" path -- realty_group_id
+        //   set but realty_group_sl_group_id null -- was removed when sub-project G
+        //   deleted the legacy distributor.)
         if (finalEscrow.getAuction().getRealtyGroupSlGroupId() != null) {
             agentCommissionDistributor.distribute(
                 finalEscrow.getAuction(),
@@ -362,8 +363,8 @@ public class TerminalCommandService {
     }
 
     /**
-     * Sub-project G §8.1 -- post-payout success path for the case-3 zero-payout
-     * branch. Mirrors {@link #handleEscrowPayoutSuccess}'s body but is driven
+     * Sub-project G §8.1 -- post-payout success path for the group-sale
+     * zero-payout branch. Mirrors {@link #handleEscrowPayoutSuccess}'s body but is driven
      * directly from {@link #queuePayout} (no terminal callback because no
      * terminal round-trip happened). Writes the {@code AUCTION_ESCROW_PAYOUT}
      * ledger row with amount=0, transitions the escrow to COMPLETED, bumps the
@@ -382,7 +383,7 @@ public class TerminalCommandService {
         escrow.setState(EscrowState.COMPLETED);
         escrow.setCompletedAt(now);
         escrow = escrowRepo.save(escrow);
-        // Lockstep auction-status flip: case-3 zero-payout still transitions
+        // Lockstep auction-status flip: group-sale zero-payout still transitions
         // the escrow to COMPLETED inline (no terminal round-trip), so the
         // auction lands at COMPLETED here too.
         statusFlipper.flip(escrow, AuctionStatus.COMPLETED);
@@ -416,8 +417,8 @@ public class TerminalCommandService {
         final EscrowCompletedEnvelope env = EscrowCompletedEnvelope.of(finalEscrow, now);
         registerAfterCommit(() -> broadcastPublisher.publishCompleted(env));
 
-        // Seller payout notification; Task 24 tweaks the body copy so case-3
-        // doesn't say "L$0 payout received". Amount is still 0 here -- the
+        // Seller payout notification; Task 24 tweaks the body copy so group
+        // sales don't say "L$0 payout received". Amount is still 0 here -- the
         // builder decides the body string based on realtyGroupId.
         notificationPublisher.escrowPayout(
                 finalEscrow.getAuction().getSeller().getId(),
@@ -426,11 +427,11 @@ public class TerminalCommandService {
                 finalEscrow.getAuction().getTitle(),
                 0L);
 
-        // Case-3 distributor: credits agent_slice to the listing agent's wallet,
-        // group_slice to the group wallet. Both flow through here because
-        // payoutAmt = 0 meant no L$ left SLPA via the terminal. By construction
-        // (Sub-project E spec §9.6 post-G), case-3 is the only branch that
-        // reaches this method.
+        // Group-sale distributor: credits agent_slice to the listing agent's
+        // wallet, group_slice to the group wallet. Both flow through here
+        // because payoutAmt = 0 meant no L$ left SLPA via the terminal. By
+        // construction (Sub-project E spec §9.6 post-G), group sales are the
+        // only branch that reaches this method.
         if (finalEscrow.getAuction().getRealtyGroupSlGroupId() != null) {
             agentCommissionDistributor.distribute(
                 finalEscrow.getAuction(),

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/dto/EscrowStatusResponse.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/dto/EscrowStatusResponse.java
@@ -80,4 +80,28 @@ public record EscrowStatusResponse(
          * page so the button stays disabled until the async result arrives —
          * the POST roundtrip returning is not enough on its own.
          */
-        boolean manualVerifyPending) { }
+        boolean manualVerifyPending,
+        /**
+         * Group-sale agent slice in L$ — the portion of {@code earnings}
+         * ({@code finalBid - commissionAmt}) credited to the listing agent's
+         * SLParcels wallet via {@link
+         * com.slparcelauctions.backend.auction.agentfee.AgentCommissionDistributor}.
+         * Null for individual sales ({@code realty_group_sl_group_id IS NULL}).
+         * Drives the seller-facing COMPLETED card breakdown for group sales.
+         */
+        Long agentCommissionAmt,
+        /**
+         * Group-sale group-wallet slice in L$ —
+         * {@code earnings - agentCommissionAmt}, credited to the realty
+         * group's wallet. Null for individual sales. Together with
+         * {@code agentCommissionAmt} these always sum to
+         * {@code finalBidAmount - commissionAmt} (no rounding loss).
+         */
+        Long groupSliceAmt,
+        /**
+         * Display name of the realty group that received {@code groupSliceAmt}.
+         * Null for individual sales. The frontend renders this inline in the
+         * COMPLETED card row ("{groupName} group wallet"); a null fallback
+         * label is used defensively when the group lookup fails.
+         */
+        String groupName) { }

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/scheduler/EscrowOwnershipCheckTask.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/scheduler/EscrowOwnershipCheckTask.java
@@ -112,8 +112,8 @@ public class EscrowOwnershipCheckTask {
             User winner = userRepo.findById(escrow.getAuction().getWinnerUserId()).orElseThrow();
             UUID winnerUuid = winner.getSlAvatarUuid();
             // Pre-transfer expected owner is the seller side: the seller's
-            // avatar for individual listings, or the registered SL group for
-            // case-3 group listings (mirrors OwnershipCheckTask.doCheck).
+            // avatar for individual sales, or the registered SL group for
+            // group sales (mirrors OwnershipCheckTask.doCheck).
             // Without the group branch, a group-owned parcel reports the
             // group UUID and gets misclassified as UNKNOWN_OWNER on the
             // first sweep, freezing a perfectly healthy escrow.

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/scheduler/ListingFeeRefundProcessorTask.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/scheduler/ListingFeeRefundProcessorTask.java
@@ -26,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
  * the refund row under {@code PESSIMISTIC_WRITE}, re-validates the state
  * + not-yet-queued invariants, then issues an instant SLParcels-side
  * wallet credit to whichever wallet originally paid the listing fee
- * (group wallet for case-3 listings, user wallet for case-1/2).
+ * (group wallet for group sales, user wallet for individual sales).
  *
  * <p>Per-refund work runs in a fresh transaction ({@code REQUIRES_NEW}) so
  * the sweep's loop-level exception handling can isolate failures — a
@@ -68,9 +68,9 @@ public class ListingFeeRefundProcessorTask {
             return;
         }
         // Route to group wallet when the original listing-fee debit came
-        // from a realty_group_ledger row (case-3, D-era group listing).
-        // Otherwise credit the seller's user wallet (case-1/2 individual
-        // listing, or C-era group listing).
+        // from a realty_group_ledger row (group sale, D-era group listing).
+        // Otherwise credit the seller's user wallet (individual sale or
+        // C-era group listing).
         Long auctionId = refund.getAuction().getId();
         Optional<RealtyGroupLedgerEntry> groupDebit =
             realtyGroupLedgerRepository.findListingFeeDebitForAuction(auctionId);

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisher.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisher.java
@@ -56,28 +56,29 @@ public interface NotificationPublisher {
     /**
      * Seller-facing payout-completed notification.
      *
-     * <p>Sub-project G section 8.3: copy differs by case. For case-3 (SL-group-owned;
-     * {@code groupName != null}) the body surfaces the commission slice and
-     * group slice instead of "L$0 payout received". For case-1 / individual
-     * the body is the legacy "payout received" copy. Subject ("Auction payout
-     * processed") is identical for both cases.
+     * <p>Sub-project G section 8.3: copy differs by sale type. For group sales
+     * (SL-group-owned; {@code groupName != null}) the body surfaces the
+     * commission slice and group slice instead of "L$0 payout received". For
+     * individual sales the body is the legacy "payout received" copy. Subject
+     * ("Auction payout processed") is identical for both sale types.
      *
-     * @param payoutL           L$ paid to the seller (0 for case-3)
+     * @param payoutL           L$ paid to the seller (0 for group sales)
      * @param groupName         realty group display name, or {@code null} for
-     *                          non-case-3
-     * @param commissionAmt     L$ credited to the listing agent's wallet (case-3 only;
-     *                          ignored when {@code groupName == null})
-     * @param groupSliceAmt     L$ credited to the group wallet (case-3 only;
-     *                          ignored when {@code groupName == null})
+     *                          individual sales
+     * @param commissionAmt     L$ credited to the listing agent's wallet
+     *                          (group sales only; ignored when
+     *                          {@code groupName == null})
+     * @param groupSliceAmt     L$ credited to the group wallet (group sales
+     *                          only; ignored when {@code groupName == null})
      */
     void escrowPayout(long sellerUserId, long auctionId, long escrowId,
                       String parcelName, long payoutL,
                       String groupName, long commissionAmt, long groupSliceAmt);
 
     /**
-     * Backwards-compatible overload for non-case-3 callers. Delegates to the
-     * case-3-aware variant with {@code groupName=null} so the body composes the
-     * legacy "payout received" copy. Task 22 will migrate the
+     * Backwards-compatible overload for individual-sale callers. Delegates to
+     * the group-sale-aware variant with {@code groupName=null} so the body
+     * composes the legacy "payout received" copy. Task 22 will migrate the
      * {@code TerminalCommandService} call sites to the full signature; until
      * then this overload keeps the project compiling.
      */

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java
@@ -286,21 +286,21 @@ public class NotificationPublisherImpl implements NotificationPublisher {
     public void escrowPayout(long sellerUserId, long auctionId, long escrowId,
                               String parcelName, long payoutL,
                               String groupName, long commissionAmt, long groupSliceAmt) {
-        // Subject is identical for both cases (spec §8.3). Body diverges so the
-        // case-3 "L$0 payout received" misread is replaced with the commission
-        // + group-slice breakdown.
+        // Subject is identical for both sale types (spec §8.3). Body diverges
+        // so the group-sale "L$0 payout received" misread is replaced with the
+        // commission + group-slice breakdown.
         String title = "Auction payout processed";
         String body;
         if (groupName != null) {
-            // Sub-project G §8.3 -- case-3 (SL-group-owned). payoutL is 0 by
-            // construction; surface the slices instead so the seller sees the
-            // actual L$ movement.
+            // Sub-project G §8.3 -- group sale (SL-group-owned). payoutL is 0
+            // by construction; surface the slices instead so the seller sees
+            // the actual L$ movement.
             body = String.format(
                 "Your auction payout is complete. L$%d agent commission paid; "
                 + "L$%d credited to %s group wallet.",
                 commissionAmt, groupSliceAmt, groupName);
         } else {
-            // Legacy / case-1 / individual.
+            // Individual sale.
             body = String.format("L$%d payout received for %s.", payoutL, parcelName);
         }
         notificationService.publish(new NotificationEvent(

--- a/backend/src/main/java/com/slparcelauctions/backend/realty/RealtyGroupMember.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/RealtyGroupMember.java
@@ -69,10 +69,10 @@ public class RealtyGroupMember extends BaseMutableEntity {
     private OffsetDateTime joinedAt;
 
     /**
-     * Per-listing agent commission rate snapshotted onto auctions at create-time (case 3).
+     * Per-listing agent commission rate snapshotted onto auctions at create-time (group sales).
      * Stored as a fraction ({@code 0.10} = 10%). Leader-edited via the invitation +
      * edit-permissions surface; non-leader members see their own rate read-only. Has no
-     * effect on case-1 legacy auctions, which still use the snapshot from the group-level
+     * effect on legacy auctions, which still use the snapshot from the group-level
      * rate/split fields until G removes them.
      */
     @Builder.Default

--- a/backend/src/main/java/com/slparcelauctions/backend/realty/analytics/GroupCommissionAnalyticsService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/analytics/GroupCommissionAnalyticsService.java
@@ -24,7 +24,7 @@ import lombok.RequiredArgsConstructor;
  *
  * <p>Single native query (Postgres-specific {@code FILTER (WHERE ...)}, {@code INTERVAL},
  * and a correlated {@code EXISTS} stitching {@code AGCOMM-{auctionId}} idempotency keys
- * to either the case-1 {@code auctions.realty_group_id} or the case-3
+ * to either the legacy direct {@code auctions.realty_group_id} or the group-sale
  * {@code realty_group_sl_groups.realty_group_id} linkage). H2 does not implement
  * {@code FILTER}; tests must run against a real Postgres (the codebase's
  * {@code @SpringBootTest @ActiveProfiles("dev")} convention).

--- a/backend/src/main/java/com/slparcelauctions/backend/realty/analytics/dto/MemberCommissionRowDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/analytics/dto/MemberCommissionRowDto.java
@@ -11,9 +11,9 @@ import java.util.UUID;
  *
  * <p>Both totals reflect {@code AGENT_COMMISSION_CREDIT} {@code user_ledger} entries whose
  * {@code idempotency_key} ({@code AGCOMM-{auctionId}}) resolves to an auction whose
- * {@code realty_group_id} matches the group (case-1 legacy) or whose
+ * {@code realty_group_id} matches the group (legacy direct attribution) or whose
  * {@code realty_group_sl_group_id} resolves to a SL-group registration belonging to the
- * group (case-3). Case-2 was removed by E; auctions with neither linkage are excluded.
+ * group (group sale). Auctions with neither linkage are excluded.
  *
  * @param memberPublicId   {@link com.slparcelauctions.backend.user.User#publicId} of the
  *                         member; rendered into the frontend table as a stable identifier.

--- a/backend/src/main/java/com/slparcelauctions/backend/realty/listing/RealtyGroupListingService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/listing/RealtyGroupListingService.java
@@ -33,7 +33,7 @@ import lombok.RequiredArgsConstructor;
 /**
  * Entry point for listing an auction under a realty group. Wraps
  * {@link AuctionService#create} with the {@code CREATE_LISTING} permission gate, then
- * applies sub-project E case-3 validation + snapshot:
+ * applies sub-project E group-sale validation + snapshot:
  * <ul>
  *   <li>The parcel must be group-owned ({@code ownerType == "group"}); personal land
  *       cannot list under a realty group.</li>
@@ -41,7 +41,7 @@ import lombok.RequiredArgsConstructor;
  *       ({@link RealtyGroupSlGroup}) for the realty group the caller is listing under.</li>
  *   <li>The caller's per-member commission rate (from {@link RealtyGroupMember}) is
  *       snapshotted onto {@link Auction#getAgentCommissionRate()}.</li>
- *   <li>{@code listingAgent} is set to the seller (case 3: agent == seller).</li>
+ *   <li>{@code listingAgent} is set to the seller (group sale: agent == seller).</li>
  * </ul>
  */
 @Service

--- a/backend/src/main/java/com/slparcelauctions/backend/realty/permission/RealtyGroupPermission.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/permission/RealtyGroupPermission.java
@@ -17,7 +17,7 @@ public enum RealtyGroupPermission {
     /** Create an auction listing under this group. */
     CREATE_LISTING,
 
-    /** Broker-level: cancel any case-3 listing of this group regardless of who created it. */
+    /** Broker-level: cancel any group-sale listing of this group regardless of who created it. */
     MANAGE_ALL_LISTINGS,
 
     /** Initiate a withdrawal from the group wallet. */

--- a/backend/src/main/java/com/slparcelauctions/backend/realty/rating/GroupRatingCacheInvalidator.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/rating/GroupRatingCacheInvalidator.java
@@ -43,14 +43,14 @@ public class GroupRatingCacheInvalidator {
     public void on(ReviewCreatedEvent event) {
         auctionRepo.findById(event.auctionId()).ifPresent(a -> {
             if (a.getRealtyGroupId() != null) {
-                log.debug("Review {} on auction {} -> invalidating realty group {} (case-1)",
+                log.debug("Review {} on auction {} -> invalidating realty group {} (direct attribution)",
                         event.reviewId(), event.auctionId(), a.getRealtyGroupId());
                 ratingService.invalidate(a.getRealtyGroupId());
                 return;
             }
             if (a.getRealtyGroupSlGroupId() != null) {
                 slGroupRepo.findById(a.getRealtyGroupSlGroupId()).ifPresent(rsg -> {
-                    log.debug("Review {} on auction {} -> invalidating realty group {} (case-3 via sl group {})",
+                    log.debug("Review {} on auction {} -> invalidating realty group {} (group sale via sl group {})",
                             event.reviewId(), event.auctionId(), rsg.getRealtyGroupId(), rsg.getId());
                     ratingService.invalidate(rsg.getRealtyGroupId());
                 });

--- a/backend/src/main/java/com/slparcelauctions/backend/realty/rating/GroupRatingService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/rating/GroupRatingService.java
@@ -23,8 +23,8 @@ import lombok.extern.slf4j.Slf4j;
  * Aggregated star-rating computation for a realty group, with a Redis
  * read-through cache keyed by the group's internal id. Reads pull from
  * {@code reviews} via the auction-&gt;group linkage described in spec
- * §16.1 (both case-1 direct {@code auctions.realty_group_id} and case-3
- * indirect {@code realty_group_sl_groups} coverage).
+ * §16.1 (both direct {@code auctions.realty_group_id} and indirect
+ * group-sale {@code realty_group_sl_groups} coverage).
  *
  * <p>The cached value is a tiny {@code "{avg}|{count}"} string — small
  * enough that a dedicated JSON serializer would add more risk (cache
@@ -78,8 +78,9 @@ public class GroupRatingService {
             log.warn("Unparseable cached rating for group {}: {}", groupId, cached);
         }
 
-        // Case-1 (auction.realty_group_id) UNION case-3 (auction.realty_group_sl_group_id ->
-        // realty_group_sl_groups.realty_group_id). Column name is `rating` on this codebase's
+        // Direct (auction.realty_group_id) UNION group-sale
+        // (auction.realty_group_sl_group_id -> realty_group_sl_groups.realty_group_id).
+        // Column name is `rating` on this codebase's
         // `reviews` table (not `star_rating` as some spec snippets use). Cast AVG to double
         // precision so Hibernate returns Double, not BigDecimal — keeps the DTO shape simple.
         Tuple result = (Tuple) em.createNativeQuery("""
@@ -112,8 +113,8 @@ public class GroupRatingService {
     /**
      * Sub-project G §13.1 — paginated list of every visible review on
      * auctions attributed to the realty group. Attribution mirrors
-     * {@link #computeRating(Long)}: case-1 direct via
-     * {@code auctions.realty_group_id} OR case-3 indirect via
+     * {@link #computeRating(Long)}: direct via
+     * {@code auctions.realty_group_id} OR group-sale indirect via
      * {@code realty_group_sl_groups.realty_group_id}. Anonymous-accessible;
      * returns an empty page when no reviews exist.
      *

--- a/backend/src/main/java/com/slparcelauctions/backend/realty/rating/ReviewCreatedEvent.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/rating/ReviewCreatedEvent.java
@@ -9,8 +9,8 @@ package com.slparcelauctions.backend.realty.rating;
  *
  * <p>Consumed by {@link GroupRatingCacheInvalidator} to evict the Redis
  * entry at {@code realty_groups_rating:{groupId}} for whichever realty
- * group the underlying auction belongs to (case-1 via
- * {@code Auction.realtyGroupId}, case-3 via the
+ * group the underlying auction belongs to (direct via
+ * {@code Auction.realtyGroupId}, group sale via the
  * {@code RealtyGroupSlGroup} indirection).
  *
  * <p>Carries internal numeric ids only — the listener resolves the

--- a/backend/src/main/java/com/slparcelauctions/backend/realty/rating/dto/GroupRatingDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/rating/dto/GroupRatingDto.java
@@ -2,9 +2,9 @@ package com.slparcelauctions.backend.realty.rating.dto;
 
 /**
  * Aggregated star rating for a realty group, derived from {@code reviews}
- * rows that join to auctions linked to the group either directly (case-1
- * via {@code auctions.realty_group_id}) or through the SL-group registry
- * (case-3 via {@code auctions.realty_group_sl_group_id} -&gt;
+ * rows that join to auctions linked to the group either directly (legacy
+ * attribution via {@code auctions.realty_group_id}) or through the SL-group
+ * registry (group sale via {@code auctions.realty_group_sl_group_id} -&gt;
  * {@code realty_group_sl_groups.realty_group_id}).
  *
  * <p>{@code averageRating} is {@code null} when no reviews exist — the

--- a/backend/src/main/java/com/slparcelauctions/backend/realty/service/RealtyGroupMembershipService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/service/RealtyGroupMembershipService.java
@@ -71,8 +71,9 @@ public class RealtyGroupMembershipService {
             .orElseThrow(() -> new RealtyGroupNotFoundException(groupPublicId));
 
         members.deleteByGroupIdAndUserId(group.getId(), callerUserId);
-        // E §10: case-3 reassigns seller_id on pre-terminal listings; commission
-        // attribution (listing_agent_id) is preserved by leaving the original agent.
+        // E §10: group sales reassign seller_id on pre-terminal listings;
+        // commission attribution (listing_agent_id) is preserved by leaving
+        // the original agent.
         auctions.reassignSellerToLeaderForCase3(callerUserId, group.getId(), group.getLeaderId());
         // Resolve the User entity for the notification payload. Skip the fire if the row
         // somehow vanished mid-tx (defensive — same defensive posture as the dissolve path).
@@ -109,8 +110,9 @@ public class RealtyGroupMembershipService {
         }
 
         members.deleteByGroupIdAndUserId(group.getId(), row.getUserId());
-        // E §10: case-3 reassigns seller_id on pre-terminal listings; commission
-        // attribution (listing_agent_id) is preserved by leaving the original agent.
+        // E §10: group sales reassign seller_id on pre-terminal listings;
+        // commission attribution (listing_agent_id) is preserved by leaving
+        // the original agent.
         auctions.reassignSellerToLeaderForCase3(row.getUserId(), group.getId(), group.getLeaderId());
         Optional<User> removedUser = users.findById(row.getUserId());
         removedUser.ifPresent(u -> notifications.realtyGroupMemberRemoved(group, u));

--- a/backend/src/main/java/com/slparcelauctions/backend/realty/slgroup/RealtyGroupSlGroupService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/slgroup/RealtyGroupSlGroupService.java
@@ -106,7 +106,7 @@ public class RealtyGroupSlGroupService {
 
     /**
      * Removes an SL group registration. Caller must hold REGISTER_SL_GROUP.
-     * Blocked when any non-terminal case-3 auction still references this row
+     * Blocked when any non-terminal group-sale auction still references this row
      * (spec §12.2). Rows belonging to a different realty group surface as
      * not-found so existence isn't leaked across tenants.
      */

--- a/backend/src/main/java/com/slparcelauctions/backend/realty/slgroup/SlGroupForceUnregisterService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/slgroup/SlGroupForceUnregisterService.java
@@ -26,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Admin compliance-action service: force-unregister an SL group registration even
  * though the standard non-force gate ({@link RealtyGroupSlGroupService#unregister})
- * would block on in-flight case-3 listings.
+ * would block on in-flight group-sale listings.
  *
  * <p>Spec §13.5: when the admin opts into the force path, this service
  * <ol>
@@ -35,7 +35,7 @@ import lombok.extern.slf4j.Slf4j;
  *       {@code unregister_reason} so the registration is no longer load-bearing for
  *       any future listing-create attempt,</li>
  *   <li>sweeps every {@link com.slparcelauctions.backend.auction.AuctionStatus#ACTIVE}
- *       case-3 listing attached to the registration into the bulk-suspend cascade via
+ *       group-sale listing attached to the registration into the bulk-suspend cascade via
  *       {@link BulkListingSuspendService#suspendAll}; the 48 h auto-cancel timer then
  *       gives the admin a deliberate window to decide per-listing cancel-or-resolve, and</li>
  *   <li>writes a single batched {@link AdminActionType#REALTY_GROUP_SL_GROUP_FORCE_UNREGISTER}
@@ -66,7 +66,7 @@ public class SlGroupForceUnregisterService {
 
     /**
      * Force-unregister the SL group registration identified by
-     * {@code slGroupPublicId} and cascade-suspend its in-flight case-3 listings.
+     * {@code slGroupPublicId} and cascade-suspend its in-flight group-sale listings.
      *
      * @param realtyGroupPublicId  the parent realty group's public id. Carried for
      *                             API symmetry / future cross-tenant checks; the
@@ -96,7 +96,7 @@ public class SlGroupForceUnregisterService {
         row.setUnregisteredByAdmin(admin);
         row.setUnregisterReason(reason);
 
-        // Cascade: bulk-suspend any in-flight case-3 listings on this SL group.
+        // Cascade: bulk-suspend any in-flight group-sale listings on this SL group.
         // suspendAll itself short-circuits cleanly on an empty list, but skipping the
         // call entirely when there are zero targets avoids a redundant audit row that
         // would only repeat what REALTY_GROUP_SL_GROUP_FORCE_UNREGISTER already records.

--- a/backend/src/main/java/com/slparcelauctions/backend/realty/slgroup/admin/AdminSlGroupController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/slgroup/admin/AdminSlGroupController.java
@@ -52,8 +52,8 @@ import lombok.RequiredArgsConstructor;
  *         <li>{@code force=true} — delegates to
  *             {@link com.slparcelauctions.backend.realty.slgroup.SlGroupForceUnregisterService#forceUnregister
  *             SlGroupForceUnregisterService.forceUnregister}, which bypasses the
- *             gate and cascades any in-flight case-3 listings into the bulk-
- *             suspend pipeline.</li>
+ *             gate and cascades any in-flight group-sale listings into the
+ *             bulk-suspend pipeline.</li>
  *       </ul>
  *       Returns 204 on success. The request body's {@code reason} is required on
  *       both paths and is recorded on the row + audit details for the force

--- a/backend/src/main/java/com/slparcelauctions/backend/realty/slgroup/admin/AdminSlGroupService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/slgroup/admin/AdminSlGroupService.java
@@ -180,7 +180,7 @@ public class AdminSlGroupService {
      * {@link RealtyGroupSlGroupService#unregister}, which respects the
      * active-listings gate and surfaces
      * {@link com.slparcelauctions.backend.realty.slgroup.exception.RegisteredSlGroupHasListingsException}
-     * when in-flight case-3 listings are still attached.
+     * when in-flight group-sale listings are still attached.
      *
      * <p>Note: the underlying service uses
      * {@link com.slparcelauctions.backend.realty.auth.RealtyGroupAuthorizer} which
@@ -203,7 +203,7 @@ public class AdminSlGroupService {
     /**
      * Force-unregister path: delegates to
      * {@link SlGroupForceUnregisterService#forceUnregister}, which bypasses the
-     * active-listings gate and cascades any in-flight case-3 listings through
+     * active-listings gate and cascades any in-flight group-sale listings through
      * the bulk-suspend path. The service writes its own
      * {@code REALTY_GROUP_SL_GROUP_FORCE_UNREGISTER} audit row.
      */

--- a/backend/src/main/java/com/slparcelauctions/backend/realty/wallet/RealtyGroupLedgerEntryType.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/wallet/RealtyGroupLedgerEntryType.java
@@ -9,7 +9,7 @@ public enum RealtyGroupLedgerEntryType {
     LISTING_FEE_REFUND,
     AGENT_FEE_CREDIT,
     /**
-     * Sub-project E -- case-3 group slice of earnings at escrow completion.
+     * Sub-project E -- group-sale group slice of earnings at escrow completion.
      * Credited to the realty group's wallet after the group-wallet PAYOUT
      * terminal command succeeds. {@code amount = earnings - agent_slice}.
      * See spec §9.6.

--- a/backend/src/main/java/com/slparcelauctions/backend/realty/wallet/RealtyGroupWalletService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/realty/wallet/RealtyGroupWalletService.java
@@ -74,15 +74,16 @@ public class RealtyGroupWalletService {
     private long groupDepositMaxL;
 
     /* ============================================================ */
-    /* AGENT FEE CREDIT (legacy pre-G case-1 path)                   */
+    /* AGENT FEE CREDIT (legacy pre-G non-group-owned listing path)  */
     /* ============================================================ */
 
     /**
      * Credit the group wallet with its share of agent_fee_amt. Spec §7.2.
      *
-     * <p>The pre-G case-1 distributor that drove this method was deleted by
-     * sub-project G. The method and the {@code AGENT_FEE_CREDIT} ledger entry
-     * type remain for backwards compatibility with historical ledger rows.
+     * <p>The pre-G distributor that drove this method (for non-SL-group-owned
+     * group listings) was deleted by sub-project G. The method and the
+     * {@code AGENT_FEE_CREDIT} ledger entry type remain for backwards
+     * compatibility with historical ledger rows.
      */
     @Transactional(propagation = Propagation.MANDATORY)
     public void creditAgentFee(Long groupId, Long auctionId, long amount) {
@@ -114,14 +115,14 @@ public class RealtyGroupWalletService {
     }
 
     /* ============================================================ */
-    /* CASE-3 LISTING PAYOUT (called from AgentCommissionDistributor) */
+    /* GROUP-SALE LISTING PAYOUT (called from AgentCommissionDistributor) */
     /* ============================================================ */
 
     /**
-     * Credit the group wallet with its case-3 share of earnings (after platform
-     * commission and the listing agent's commission slice). Called from
-     * {@code AgentCommissionDistributor} inside the escrow-payout-success
-     * transaction for case-3 (SL-group-owned) auctions. Spec §9.6.
+     * Credit the group wallet with its group-sale share of earnings (after
+     * platform commission and the listing agent's commission slice). Called
+     * from {@code AgentCommissionDistributor} inside the escrow-payout-success
+     * transaction for group sales (SL-group-owned auctions). Spec §9.6.
      *
      * <p>Idempotency key {@code LP-{auctionId}} prevents a duplicate credit if
      * the payout callback ever fires twice for the same auction.

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerEntryType.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerEntryType.java
@@ -108,8 +108,8 @@ public enum UserLedgerEntryType {
     AGENT_FEE_CREDIT,
 
     /**
-     * Sub-project E -- listing agent's case-3 commission slice at escrow completion.
-     * Credited to the listing agent's user wallet after the case-3 group-wallet PAYOUT
+     * Sub-project E -- listing agent's group-sale commission slice at escrow completion.
+     * Credited to the listing agent's user wallet after the group-sale group-wallet PAYOUT
      * succeeds. {@code amount = floor((final_bid - platform_commission) * agent_commission_rate)}.
      * See spec §9.6.
      */

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/WalletService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/WalletService.java
@@ -393,9 +393,10 @@ public class WalletService {
      * Credit the listing agent's user wallet with their share of agent_fee_amt.
      * Spec §7.2.
      *
-     * <p>The pre-G case-1 distributor that drove this method was deleted by
-     * sub-project G. The method and the {@code AGENT_FEE_CREDIT} ledger entry
-     * type remain for backwards compatibility with historical ledger rows.
+     * <p>The pre-G distributor that drove this method (for non-SL-group-owned
+     * group listings) was deleted by sub-project G. The method and the
+     * {@code AGENT_FEE_CREDIT} ledger entry type remain for backwards
+     * compatibility with historical ledger rows.
      */
     @Transactional(propagation = Propagation.MANDATORY)
     public void creditAgentFee(Long userId, Long auctionId, long amount) {
@@ -410,9 +411,9 @@ public class WalletService {
     }
 
     /**
-     * Credit the listing agent's user wallet with their case-3 commission slice.
+     * Credit the listing agent's user wallet with their group-sale commission slice.
      * Called from {@code AgentCommissionDistributor} inside the escrow-payout-success
-     * transaction for case-3 (SL-group-owned) auctions. Spec §9.6.
+     * transaction for group sales (SL-group-owned auctions). Spec §9.6.
      *
      * <p>Idempotency key {@code AGCOMM-{auctionId}} prevents a duplicate credit if
      * the payout callback ever fires twice for the same auction.

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowConfirmSellToTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowConfirmSellToTest.java
@@ -79,6 +79,7 @@ class EscrowConfirmSellToTest {
     @Mock EscrowConfigProperties props;
     @Mock EscrowManualReviewRepository manualReviewRepo;
     @Mock SellToBotTaskFactory sellToBotTaskFactory;
+    @Mock com.slparcelauctions.backend.realty.RealtyGroupRepository realtyGroupRepo;
 
     EscrowService service;
     Clock fixed;
@@ -92,7 +93,7 @@ class EscrowConfirmSellToTest {
                 broadcastPublisher, userRepo, fraudFlagRepo, terminalService,
                 terminalRepo, terminalCommandService, notificationPublisher,
                 evidenceUploadService, walletService, props, manualReviewRepo,
-                sellToBotTaskFactory);
+                sellToBotTaskFactory, realtyGroupRepo);
         txTemplate = new TransactionTemplate(new FakeTxManager());
     }
 

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowControllerSliceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowControllerSliceTest.java
@@ -109,7 +109,8 @@ class EscrowControllerSliceTest {
                 null, null, null,
                 List.of(),
                 null, null, 3, 3, 3,
-                null, null, null, null, false);
+                null, null, null, null, false,
+                null, null, null);
     }
 
     private MockMultipartFile disputePart(String reasonCategory, String description) {

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowCreateOnAuctionEndIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowCreateOnAuctionEndIntegrationTest.java
@@ -43,6 +43,7 @@ import com.slparcelauctions.backend.wallet.BidReservationRepository;
 import com.slparcelauctions.backend.escrow.broadcast.CapturingEscrowBroadcastPublisher;
 import com.slparcelauctions.backend.escrow.broadcast.EscrowBroadcastPublisher;
 import com.slparcelauctions.backend.escrow.broadcast.EscrowCreatedEnvelope;
+import com.slparcelauctions.backend.escrow.dto.EscrowStatusResponse;
 import com.slparcelauctions.backend.auction.AuctionParcelSnapshot;
 import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.notification.NotificationRepository;
@@ -100,6 +101,7 @@ class EscrowCreateOnAuctionEndIntegrationTest {
     @Autowired RefreshTokenRepository refreshTokenRepo;
     @Autowired VerificationCodeRepository verificationCodeRepo;
     @Autowired EscrowRepository escrowRepo;
+    @Autowired EscrowService escrowService;
     @Autowired com.slparcelauctions.backend.bot.BotTaskRepository botTaskRepo;
     @Autowired EscrowTransactionRepository escrowTxRepo;
     @Autowired EscrowCommissionCalculator commissionCalculator;
@@ -198,6 +200,13 @@ class EscrowCreateOnAuctionEndIntegrationTest {
         assertThat(escrow.getFundedAt()).isNotNull();
         assertThat(escrow.getTransferDeadline())
                 .isCloseTo(escrow.getFundedAt().plusHours(72), within(1, ChronoUnit.MICROS));
+
+        // Status DTO for an individual sale must NOT carry group-sale fields.
+        EscrowStatusResponse statusResp = escrowService.getStatus(
+                seededAuctionId, seededSellerId);
+        assertThat(statusResp.agentCommissionAmt()).isNull();
+        assertThat(statusResp.groupSliceAmt()).isNull();
+        assertThat(statusResp.groupName()).isNull();
 
         assertThat(capturingEscrowPublisher.created).hasSize(1);
         EscrowCreatedEnvelope env = capturingEscrowPublisher.created.get(0);

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowManualActionServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowManualActionServiceTest.java
@@ -377,7 +377,8 @@ class EscrowManualActionServiceTest {
                 UUID.randomUUID(), UUID.randomUUID(), "Winner Resident",
                 EscrowState.TRANSFER_PENDING, 5000L, 250L, 4750L,
                 null, null, null, null, null, null, null, null, null, null,
-                List.of(), null, null, 3, 3, 3, null, null, null, null, false);
+                List.of(), null, null, 3, 3, 3, null, null, null, null, false,
+                null, null, null);
     }
 
     private Escrow buildSetSellTo() {

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowManualActionServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowManualActionServiceTest.java
@@ -267,7 +267,7 @@ class EscrowManualActionServiceTest {
                 .containsEntry(EscrowManualActionService.EXPECTED_OWNER_TYPE_KEY,
                         EscrowManualActionService.EXPECTED_OWNER_TYPE_AGENT);
         // Pre-transfer UUID is re-stamped on the expedited task in case the
-        // case-1 / case-3 discriminator was unset on a legacy row.
+        // individual / group-sale discriminator was unset on a legacy row.
         assertThat(existing.getExpectedSellerUuid()).isEqualTo(SELLER_AVATAR);
         verify(botTaskRepo).save(existing);
         assertThat(escrow.getManualVerifyPending()).isTrue();

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowServiceAgentFeePayoutTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowServiceAgentFeePayoutTest.java
@@ -48,7 +48,7 @@ import com.slparcelauctions.backend.auction.BidType;
 
 /**
  * Integration test: {@link EscrowService#createForEndedAuction} sets
- * {@code payoutAmt = 0} for case-3 (SL-group-owned) auctions, where earnings
+ * {@code payoutAmt = 0} for group sales (SL-group-owned auctions), where earnings
  * stay in SLPA and are split into wallets by
  * {@code AgentCommissionDistributor} at payout-success. Spec §8.5, §9.6.
  */
@@ -150,7 +150,7 @@ class EscrowServiceAgentFeePayoutTest {
     }
 
     /**
-     * Case 3 (E -- SL-group-owned listing): when {@code realty_group_sl_group_id IS NOT NULL},
+     * Group sale (SL-group-owned listing): when {@code realty_group_sl_group_id IS NOT NULL},
      * {@code createForEndedAuction} sets {@code payoutAmt = 0}. The earnings stay in SLPA
      * and are split into the listing agent's wallet + the group wallet by
      * {@code AgentCommissionDistributor} at payout-success. Spec §8.5, §9.6.

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowServiceAgentFeePayoutTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowServiceAgentFeePayoutTest.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.escrow.dto.EscrowStatusResponse;
 import com.slparcelauctions.backend.auction.AuctionEndOutcome;
 import com.slparcelauctions.backend.auction.AuctionRepository;
 import com.slparcelauctions.backend.auction.AuctionStatus;
@@ -170,6 +171,61 @@ class EscrowServiceAgentFeePayoutTest {
         // commission is unaffected
         assertThat(escrow.getCommissionAmt()).isEqualTo(commissionCalculator.commission(finalBid));
         assertThat(escrow.getFinalBidAmount()).isEqualTo(finalBid);
+    }
+
+    /**
+     * Status DTO surfaces the agent-slice / group-slice / group-name split for
+     * group sales so the seller's COMPLETED card can render the same breakdown
+     * that {@link com.slparcelauctions.backend.auction.agentfee.AgentCommissionDistributor}
+     * applies at payout-success. Spec §8.5, §9.6.
+     */
+    @Test
+    void getStatus_groupSale_populatesAgentSliceGroupSliceAndGroupName() {
+        // L$100 sale with 50% agent rate -> commission L$50 (5% floor),
+        // earnings L$50, agentSlice L$25, groupSlice L$25.
+        long finalBid = 100L;
+        BigDecimal agentRate = new BigDecimal("0.5000");
+        Auction auction = seedCase3Auction(finalBid, agentRate);
+
+        TransactionTemplate tx = new TransactionTemplate(txManager);
+        tx.executeWithoutResult(status -> {
+            Auction managed = auctionRepo.findById(auction.getId()).orElseThrow();
+            escrowService.createForEndedAuction(managed, OffsetDateTime.now());
+        });
+
+        EscrowStatusResponse statusResp = escrowService.getStatus(
+                auction.getId(), seededBidderId);
+
+        // Winner-side caller is fine; the DTO is identical for either party.
+        assertThat(statusResp.payoutAmt()).isZero();
+        assertThat(statusResp.commissionAmt()).isEqualTo(50L);
+        assertThat(statusResp.agentCommissionAmt()).isEqualTo(25L);
+        assertThat(statusResp.groupSliceAmt()).isEqualTo(25L);
+        assertThat(statusResp.groupName()).startsWith("Case3 Group ");
+    }
+
+    /**
+     * Null {@code agentCommissionRate} defaults to 0 (matches
+     * {@code AgentCommissionDistributor.distribute}): the whole {@code earnings}
+     * amount lands in the group wallet, agent slice is L$0.
+     */
+    @Test
+    void getStatus_groupSale_nullAgentRate_defaultsToZeroSliceAllToGroup() {
+        long finalBid = 200L;
+        Auction auction = seedCase3Auction(finalBid, null);
+
+        TransactionTemplate tx = new TransactionTemplate(txManager);
+        tx.executeWithoutResult(status -> {
+            Auction managed = auctionRepo.findById(auction.getId()).orElseThrow();
+            escrowService.createForEndedAuction(managed, OffsetDateTime.now());
+        });
+
+        EscrowStatusResponse statusResp = escrowService.getStatus(
+                auction.getId(), seededBidderId);
+        // 200 - 50 (5% floor) = 150 earnings; rate 0 -> agent L$0, group L$150.
+        assertThat(statusResp.agentCommissionAmt()).isEqualTo(0L);
+        assertThat(statusResp.groupSliceAmt()).isEqualTo(150L);
+        assertThat(statusResp.groupName()).isNotNull();
     }
 
     // -------------------------------------------------------------------------

--- a/frontend/src/components/admin/realty-groups/AdminSlGroupDriftRow.tsx
+++ b/frontend/src/components/admin/realty-groups/AdminSlGroupDriftRow.tsx
@@ -56,7 +56,7 @@ function truncateUuid(uuid: string | null | undefined): string {
  *   <li>"Ack drift" → only visible when drift is detected; clears the
  *       drift fields and rolls the founder snapshot forward.</li>
  *   <li>"Force unregister" → opens a confirmation modal (reason required);
- *       cascades any in-flight case-3 listings into the bulk-suspend
+ *       cascades any in-flight group-sale listings into the bulk-suspend
  *       pipeline.</li>
  * </ul>
  */

--- a/frontend/src/components/auction/GroupAttributionLine.tsx
+++ b/frontend/src/components/auction/GroupAttributionLine.tsx
@@ -16,14 +16,13 @@ export interface GroupAttributionLineProps {
  * attribution, and dissolved groups are retired from public display per
  * spec §6.2.
  *
- * Realty Groups: E (sub-project E, spec §6.4) — case-3 listings (agent
- * lists group-owned land under a realty group) surface the group as the
- * primary seller via the "Sold by" heading. Case-1 (legacy: agent lists
- * own land under a group) is not reachable through new listings as of
- * sub-project E so this same heading also covers legacy case-1 rows
- * without further DTO branching. The backend group-attribution DTO does
- * not carry the SL group id today, so {@code group != null} is treated
- * as the case-3 marker.
+ * Realty Groups: group sales (agent lists group-owned land under a realty
+ * group) surface the group as the primary seller via the "Sold by"
+ * heading. Legacy "agent lists own land under a group" rows are not
+ * reachable through new listings since sub-project E, so this same
+ * heading also covers those legacy rows without further DTO branching.
+ * The backend group-attribution DTO does not carry the SL group id
+ * today, so {@code group != null} is treated as the group-sale marker.
  */
 export function GroupAttributionLine({ agent, group }: GroupAttributionLineProps) {
   if (!agent || !group || group.dissolved) return null;

--- a/frontend/src/components/escrow/state/CompletedStateCard.test.tsx
+++ b/frontend/src/components/escrow/state/CompletedStateCard.test.tsx
@@ -75,8 +75,68 @@ describe("CompletedStateCard", () => {
     });
   });
 
-  describe("seller view (group listing, payoutAmt = 0)", () => {
-    it("shows 'Sale completed' acknowledgement without the Payout-of-L$0 headline", () => {
+  describe("seller view (group sale, payoutAmt = 0)", () => {
+    it("renders full agent + group-wallet breakdown when group-sale fields are present", () => {
+      // L$100 sale, 5% min L$50 platform fee, 50/50 agent/group split.
+      // Matches AgentCommissionDistributor: agentSlice + groupSlice == earnings.
+      renderWithProviders(
+        <CompletedStateCard
+          escrow={fakeEscrow({
+            state: "COMPLETED",
+            finalBidAmount: 100,
+            payoutAmt: 0,
+            commissionAmt: 50,
+            agentCommissionAmt: 25,
+            groupSliceAmt: 25,
+            groupName: "HadronTest",
+            completedAt: "2026-05-02T10:00:05Z",
+          })}
+          role="seller"
+        />,
+      );
+
+      // Heading is "Sale completed" — not a "Payout of L$0" headline.
+      expect(screen.getByText(/^sale completed$/i)).toBeInTheDocument();
+      expect(
+        screen.queryByText(/payout of l\$\s*0/i),
+      ).not.toBeInTheDocument();
+
+      // Breakdown rows: sale price, SLParcels fee, agent cut, group wallet.
+      expect(screen.getByText(/^sale price$/i)).toBeInTheDocument();
+      expect(screen.getByText(/^l\$\s*100$/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/slparcels fee \(5%, l\$50 min\)/i),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/agent commission \(your cut\)/i)).toBeInTheDocument();
+      expect(screen.getByText(/HadronTest group wallet/i)).toBeInTheDocument();
+      // Both slice rows show L$ 25.
+      expect(screen.getAllByText(/^l\$\s*25$/i).length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("falls back to 'Group wallet' label when groupName is missing", () => {
+      renderWithProviders(
+        <CompletedStateCard
+          escrow={fakeEscrow({
+            state: "COMPLETED",
+            finalBidAmount: 100,
+            payoutAmt: 0,
+            commissionAmt: 50,
+            agentCommissionAmt: 25,
+            groupSliceAmt: 25,
+            groupName: null,
+            completedAt: "2026-05-02T10:00:05Z",
+          })}
+          role="seller"
+        />,
+      );
+      expect(screen.getByText(/^sale completed$/i)).toBeInTheDocument();
+      expect(screen.getByText(/^group wallet$/i)).toBeInTheDocument();
+    });
+
+    it("falls back to minimal 'Sale completed' copy when group-sale fields are absent (defensive)", () => {
+      // Pre-DTO-extension shape — payoutAmt = 0 but the agent/group fields
+      // never landed in the response. We keep the prior minimal acknowledgement
+      // so a missing-field wire regression doesn't crash the card.
       renderWithProviders(
         <CompletedStateCard
           escrow={fakeEscrow({
@@ -84,6 +144,9 @@ describe("CompletedStateCard", () => {
             finalBidAmount: 5000,
             payoutAmt: 0,
             commissionAmt: 250,
+            agentCommissionAmt: null,
+            groupSliceAmt: null,
+            groupName: null,
             completedAt: "2026-05-02T10:00:05Z",
           })}
           role="seller"
@@ -94,7 +157,6 @@ describe("CompletedStateCard", () => {
       expect(
         screen.getByText(/payout was split to the listing agent and the group wallet/i),
       ).toBeInTheDocument();
-      // The misleading "Payout of L$0 sent" headline must NOT appear here.
       expect(
         screen.queryByText(/payout of l\$\s*0/i),
       ).not.toBeInTheDocument();

--- a/frontend/src/components/escrow/state/CompletedStateCard.tsx
+++ b/frontend/src/components/escrow/state/CompletedStateCard.tsx
@@ -38,22 +38,26 @@ export function CompletedStateCard({ escrow, role }: StateCardProps) {
  * Seller-facing payout breakdown. Replaces the prior single-line "Commission
  * L$N" copy that left sellers asking why a L$100 sale only netted them L$50.
  *
- * For individual sales (case-1, `payoutAmt > 0`) the breakdown lays out:
+ * For individual sales (`payoutAmt > 0`) the breakdown lays out:
  *   - Sale price (anchor — the seller knows what the parcel sold for)
  *   - SLParcels fee (with the 5% / L$50-minimum rule inline so the floor on
  *     small sales doesn't look arbitrary)
  *   - Net payout
  *
  * "Fee" intentionally — "commission" is reserved for the agent-commission
- * slice on group listings (case-3) per the realty-group spec; mislabelling
- * the platform's per-sale cut as "commission" confused sellers post-launch.
+ * slice on group listings per the realty-group spec; mislabelling the
+ * platform's per-sale cut as "commission" confused sellers post-launch.
  *
- * For group listings (case-3, `payoutAmt === 0`) the L$ split goes to the
- * listing agent + group wallet, not to the seller's avatar. The escrow DTO
- * doesn't surface the agent / group-wallet split here today, so we show a
- * minimal acknowledgement instead of forcing a "Payout of L$0" headline that
- * would only confuse the lister. Full case-3 breakdown is a follow-up that
- * needs the agent-commission + group-slice fields surfaced on the DTO.
+ * For group sales (`payoutAmt === 0`, group-sale fields present) the L$ split
+ * goes to the listing agent + group wallet rather than the seller's avatar.
+ * The breakdown shows sale price, SLParcels fee, agent commission (seller's
+ * cut as listing agent), and the group-wallet credit so the seller can
+ * reconcile the full split.
+ *
+ * If `payoutAmt === 0` but the group-sale fields are missing (defensive
+ * fallback for a wire-shape regression), the minimal "Sale completed"
+ * acknowledgement is shown instead of forcing a misleading "Payout of L$0"
+ * headline.
  */
 function SellerPayoutBreakdown({
   escrow,
@@ -65,15 +69,50 @@ function SellerPayoutBreakdown({
     : "";
 
   if (escrow.payoutAmt === 0) {
+    if (escrow.agentCommissionAmt == null || escrow.groupSliceAmt == null) {
+      return (
+        <>
+          <h2 className="text-sm font-semibold tracking-tight text-fg">
+            Sale completed
+          </h2>
+          <p className="text-sm text-fg-muted">
+            Sale price: L$ {escrow.finalBidAmount.toLocaleString()}. Payout was
+            split to the listing agent and the group wallet.{completedSuffix}
+          </p>
+        </>
+      );
+    }
+    const groupWalletLabel = escrow.groupName
+      ? `${escrow.groupName} group wallet`
+      : "Group wallet";
     return (
       <>
         <h2 className="text-sm font-semibold tracking-tight text-fg">
           Sale completed
         </h2>
-        <p className="text-sm text-fg-muted">
-          Sale price: L$ {escrow.finalBidAmount.toLocaleString()}. Payout was
-          split to the listing agent and the group wallet.{completedSuffix}
-        </p>
+        <dl className="grid grid-cols-[1fr_auto] gap-y-1 text-sm text-fg-muted">
+          <dt>Sale price</dt>
+          <dd className="text-right tabular-nums text-fg">
+            L$ {escrow.finalBidAmount.toLocaleString()}
+          </dd>
+          <dt>SLParcels fee (5%, L$50 min)</dt>
+          <dd className="text-right tabular-nums text-fg">
+            &minus; L$ {escrow.commissionAmt.toLocaleString()}
+          </dd>
+          <dt className="border-t border-border-subtle pt-1 text-fg">
+            Agent commission (your cut)
+          </dt>
+          <dd className="border-t border-border-subtle pt-1 text-right tabular-nums text-fg">
+            L$ {escrow.agentCommissionAmt.toLocaleString()}
+          </dd>
+          <dt className="text-fg">{groupWalletLabel}</dt>
+          <dd className="text-right tabular-nums text-fg">
+            L$ {escrow.groupSliceAmt.toLocaleString()}
+          </dd>
+        </dl>
+        {completedSuffix ? (
+          <p className="text-xs text-fg-muted">{completedSuffix.trim()}</p>
+        ) : null}
       </>
     );
   }

--- a/frontend/src/components/listing/AgentCommissionPreview.test.tsx
+++ b/frontend/src/components/listing/AgentCommissionPreview.test.tsx
@@ -20,7 +20,7 @@ function installWallet(available: number) {
   );
 }
 
-describe("AgentCommissionPreview (case 3)", () => {
+describe("AgentCommissionPreview (group sale)", () => {
   it("computes the agent/group split per spec §6.3 (floor rounding)", async () => {
     // L$1000 starting → platform commission floor(1000 * 0.05) = 50.
     //   earnings = 950

--- a/frontend/src/components/listing/AgentCommissionPreview.tsx
+++ b/frontend/src/components/listing/AgentCommissionPreview.tsx
@@ -45,9 +45,9 @@ export interface AgentCommissionPreviewProps {
 }
 
 /**
- * Case-3 ("Realty Groups: E") fee preview for the listing wizard.
+ * Group-sale fee preview for the listing wizard.
  *
- * Case 3 is an agent listing a group-owned parcel under the realty group:
+ * Group sale = an agent listing a group-owned parcel under the realty group:
  * the platform takes a 5% commission, then the remaining earnings are split
  * between the agent and the group per the agent's per-member
  * {@code agentCommissionRate}. The visible projection rows (platform
@@ -123,7 +123,7 @@ export function AgentCommissionPreview({
   if (startingBid <= 0) return null;
 
   // Render the rate as a 1- or 2-decimal percentage, trimming trailing
-  // zeros so 0.10 → "10%" and 0.075 → "7.5%". Matches the case-1
+  // zeros so 0.10 → "10%" and 0.075 → "7.5%". Matches the legacy
   // AgentFeePreview formatting so the two previews feel consistent.
   const ratePct = (agentCommissionRate * 100)
     .toFixed(agentCommissionRate < 0.01 ? 2 : 1)

--- a/frontend/src/components/listing/BrokerCancelButton.tsx
+++ b/frontend/src/components/listing/BrokerCancelButton.tsx
@@ -26,7 +26,7 @@ const BROKER_CANCELLABLE = new Set([
 ]);
 
 /**
- * Renders the "Cancel listing" affordance for case-3 brokers — members of
+ * Renders the "Cancel listing" affordance for group-sale brokers — members of
  * the realty group who hold {@code MANAGE_ALL_LISTINGS} and are NOT the
  * auction's seller. The button is hidden in three cases:
  *

--- a/frontend/src/components/listing/BrokerCancelModal.tsx
+++ b/frontend/src/components/listing/BrokerCancelModal.tsx
@@ -21,7 +21,7 @@ export interface BrokerCancelModalProps {
 }
 
 /**
- * Confirmation modal for the case-3 broker-cancel path. Surfaces the
+ * Confirmation modal for the group-sale broker-cancel path. Surfaces the
  * auction title, active-bid state, and the listing-fee refund
  * destination (group wallet — never the seller's personal wallet, since
  * the wallet paid the fee). A non-empty reason is required so the

--- a/frontend/src/components/listing/ListingWizardForm.test.tsx
+++ b/frontend/src/components/listing/ListingWizardForm.test.tsx
@@ -719,7 +719,7 @@ describe("ListingWizardForm — List-as picker", () => {
     expect(screen.queryByLabelText(/Individual/i)).not.toBeInTheDocument();
   });
 
-  it("renders the case-3 AgentCommissionPreview when the parcel is SL-group-owned", async () => {
+  it("renders the group-sale AgentCommissionPreview when the parcel is SL-group-owned", async () => {
     const groupOwnedParcel: ParcelDto = {
       ...sampleParcel,
       ownerType: "group",
@@ -789,17 +789,17 @@ describe("ListingWizardForm — List-as picker", () => {
 
     // The starting bid prefilled at 500 from sellerResponse default; the
     // wizard's AuctionSettingsForm will load the same default. Verify the
-    // case-3 preview renders with the L$/commission split copy.
+    // group-sale preview renders with the L$/commission split copy.
     expect(
       await screen.findByTestId("agent-commission-preview"),
     ).toBeInTheDocument();
   });
 
-  // Realty Groups: G — case-1 ("agent listing their own land under a group")
-  // is gone. The wizard now renders AgentCommissionPreview unconditionally
-  // whenever an eligible group is selected and startingBid > 0, regardless
-  // of whether the parcel is SL-group-owned.
-  it("renders AgentCommissionPreview for a non-SL-group-owned parcel once a group is picked (post-G — case-1 removed)", async () => {
+  // Realty Groups: G — the "agent listing their own land under a group"
+  // legacy variant is gone. The wizard now renders AgentCommissionPreview
+  // unconditionally whenever an eligible group is selected and
+  // startingBid > 0, regardless of whether the parcel is SL-group-owned.
+  it("renders AgentCommissionPreview for a non-SL-group-owned parcel once a group is picked (legacy non-group-owned variant removed)", async () => {
     const user = userEvent.setup();
 
     server.use(

--- a/frontend/src/components/listing/ListingWizardForm.tsx
+++ b/frontend/src/components/listing/ListingWizardForm.tsx
@@ -359,11 +359,12 @@ export function ListingWizardForm({ mode, id }: ListingWizardFormProps) {
                       showIndividual={!parcelIsSlGroupOwned}
                     />
                     {selectedGroup && draft.state.startingBid > 0 && (
-                      // Realty Groups: G — case-1 ("agent listing own land
-                      // under a group") is gone, so every group-attributed
-                      // listing renders the same case-3 preview: platform
-                      // commission off the top, then earnings split agent ↔
-                      // group per the caller's per-member commission rate.
+                      // Realty Groups: G — the legacy "agent listing own
+                      // land under a group" variant is gone, so every
+                      // group-attributed listing renders the same group-sale
+                      // preview: platform commission off the top, then
+                      // earnings split agent ↔ group per the caller's
+                      // per-member commission rate.
                       <AgentCommissionPreview
                         startingBid={draft.state.startingBid}
                         reservePrice={settings.reservePrice}

--- a/frontend/src/hooks/realty/useSlGroupForceUnregister.ts
+++ b/frontend/src/hooks/realty/useSlGroupForceUnregister.ts
@@ -6,7 +6,7 @@ import { realtyGroupSlGroupsQueryKey } from "./useRealtyGroupSlGroups";
 
 /**
  * Force-unregister an SL group registration. Bypasses the active-listings
- * gate (when {@code force=true}) and cascades any in-flight case-3
+ * gate (when {@code force=true}) and cascades any in-flight group-sale
  * listings into the bulk-suspend pipeline. {@code reason} is required.
  *
  * <p>Returns 204 — consumers re-query the SL-groups list to see the row

--- a/frontend/src/lib/api/auctions.ts
+++ b/frontend/src/lib/api/auctions.ts
@@ -114,7 +114,7 @@ export interface BrokerCancelRequest {
 }
 
 /**
- * POST /api/v1/auctions/{publicId}/broker-cancel — case-3 broker
+ * POST /api/v1/auctions/{publicId}/broker-cancel — group-sale broker
  * cancellation. Caller must hold {@code MANAGE_ALL_LISTINGS} on the
  * auction's realty group; backend gates that. The listing fee refund
  * lands back in the group wallet, not the agent's personal wallet, since

--- a/frontend/src/lib/api/realtyGroupSlGroupAdmin.ts
+++ b/frontend/src/lib/api/realtyGroupSlGroupAdmin.ts
@@ -19,7 +19,7 @@ import type {
  *       {@link AdminRealtyGroupSlGroup} (the post-ack row).</li>
  *   <li>{@code DELETE /?force=true|false} — unregister the row. The
  *       force path bypasses the active-listings gate and cascades any
- *       in-flight case-3 listings into the bulk-suspend pipeline. Both
+ *       in-flight group-sale listings into the bulk-suspend pipeline. Both
  *       paths require a non-blank {@code reason} in the body.</li>
  * </ul>
  *

--- a/frontend/src/lib/listing/refundCalculation.ts
+++ b/frontend/src/lib/listing/refundCalculation.ts
@@ -12,7 +12,7 @@ import type { AuctionStatus } from "@/types/auction";
  *   - DRAFT: no fee paid → no refund.
  *   - DRAFT_PAID / VERIFICATION_PENDING / VERIFICATION_FAILED: fee paid
  *     but listing never went live → full refund, credited instantly to
- *     the SLParcels wallet that paid (group wallet for case-3 listings,
+ *     the SLParcels wallet that paid (group wallet for group sales,
  *     seller's user wallet otherwise).
  *   - ACTIVE: cancelling an active listing forfeits the fee.
  *   - Anything else is not cancellable from the UI.
@@ -26,8 +26,8 @@ export interface RefundInfo {
 /**
  * @param status         current auction status
  * @param listingFeeAmt  fee paid, in L$
- * @param isGroupListing true when the auction is case-3 (the fee came
- *                       from a realty group's wallet); drives whether
+ * @param isGroupListing true when the auction is a group sale (the fee
+ *                       came from a realty group's wallet); drives whether
  *                       the copy says "your wallet" or "the group's
  *                       wallet"
  */

--- a/frontend/src/test/fixtures/escrow.ts
+++ b/frontend/src/test/fixtures/escrow.ts
@@ -36,6 +36,9 @@ export function fakeEscrow(
     parcelMapUrl: null,
     parcelViewerUrl: null,
     manualVerifyPending: false,
+    agentCommissionAmt: null,
+    groupSliceAmt: null,
+    groupName: null,
   };
   return { ...base, ...overrides };
 }

--- a/frontend/src/types/escrow.ts
+++ b/frontend/src/types/escrow.ts
@@ -104,6 +104,19 @@ export interface EscrowStatusResponse {
    * not enough to re-enable the button, since the bot may still be in transit.
    */
   manualVerifyPending: boolean;
+
+  // ── Group-sale payout breakdown ────────────────────────────────────────────
+  // Populated only for group sales (auction.realtyGroupSlGroupId != null); all
+  // three are null for individual sales. Mirror of the backend split applied by
+  // AgentCommissionDistributor: agentCommissionAmt + groupSliceAmt ==
+  // finalBidAmount - commissionAmt (no rounding loss). Drives the seller-facing
+  // COMPLETED card breakdown.
+  /** Agent slice in L$ — credited to the listing agent's wallet. */
+  agentCommissionAmt: number | null;
+  /** Group-wallet slice in L$ — credited to the realty group wallet. */
+  groupSliceAmt: number | null;
+  /** Display name of the realty group that received {@code groupSliceAmt}. */
+  groupName: string | null;
 }
 
 /** Body shape for `POST /api/v1/auctions/{id}/escrow/dispute`. */

--- a/frontend/src/types/realty.ts
+++ b/frontend/src/types/realty.ts
@@ -216,7 +216,7 @@ export interface UpdatePermissionsRequest {
  * {@code agentCommissionRate} is the calling user's per-member commission rate
  * within the group, projected from {@code realty_group_members.agent_commission_rate}
  * (sub-project G section 6.2). The wizard reads it directly off the eligible-list row
- * for the case-3 fee preview, avoiding a second round-trip via {@code useRealtyGroup}.
+ * for the group-sale fee preview, avoiding a second round-trip via {@code useRealtyGroup}.
  */
 export interface ListingEligibleGroup {
   publicId: string;
@@ -696,7 +696,7 @@ export interface MemberCommissionRow {
 
 /**
  * Aggregated star rating for a realty group, derived from {@code reviews}
- * rows joined via case-1 / case-3 auction linkage. Backend record
+ * rows joined via the auction's realty-group linkage. Backend record
  * {@code GroupRatingDto}.
  *
  * <p>{@code averageRating} is null when no reviews exist — the "No reviews


### PR DESCRIPTION
## Summary

Two related changes for group-sale UX + developer-facing language.

### Part 1 — Group-sale payout breakdown on the seller's COMPLETED card

Surface the `agent_slice / group_slice / group_name` split on the escrow status DTO so the seller's COMPLETED card can render the full breakdown for group sales instead of a minimal acknowledgement. Mirror of the L$ routing `AgentCommissionDistributor` applies at payout-success.

- Backend `EscrowStatusResponse` gains `agentCommissionAmt`, `groupSliceAmt`, `groupName` (all null for individual sales).
- `EscrowService.toStatusResponse` computes the split using the same floor-rounded `BigDecimal` arithmetic as the distributor; null `agentCommissionRate` defaults to 0 to match.
- Frontend types + `fakeEscrow` fixture mirror the new fields.
- `CompletedStateCard` `SellerPayoutBreakdown` renders a 4-row breakdown for group sales (sale price / SLParcels fee / agent cut / group wallet). Prior minimal copy retained as a defensive fallback when the fields are absent.

### Part 2 — Terminology sweep: drop case-1 / case-3

Replace developer-facing "case-1" / "case-3" comments with "individual sale" / "group sale" tied to the `realtyGroupSlGroupId` discriminator. Programmatic identifiers (e.g. `reassignSellerToLeaderForCase3`, `AuctionCase3ColumnsTest`, `RealtyGroupSlGroupId`) are intentionally left alone — this is a vocabulary cleanup, not a refactor. Spec markdown in `docs/` deliberately untouched per task scope. Frontend swept entirely (13 files). Backend `src/main` swept entirely (zero remaining occurrences). Backend `src/test` got the two highest-touched suites; ~15 remaining test files carry the legacy language inside variable names / programmatic identifiers only and are out of scope.

## Test plan

- [x] `cd backend && ./mvnw -Dtest='EscrowService*,EscrowController*,EscrowStatus*,AgentCommission*,EscrowCreateOnAuctionEnd*,EscrowConfirmSellTo*' test` — 35/35 pass
- [x] `cd backend && ./mvnw compile` — clean
- [x] `cd frontend && npx tsc --noEmit` — clean (pre-existing useBulkCommissionEdit.test.tsx error unchanged)
- [x] `cd frontend && npx vitest run src/components/escrow` — 104/104 pass
- [x] `cd frontend && npx vitest run src/components/listing` — 199/199 pass