### PR TITLE
feat(escrow): individual-sale payouts credit SLParcels wallet (no more avatar transfer at sale conclusion)

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/EscrowService.java
@@ -459,17 +459,16 @@ public class EscrowService {
     /**
      * Delegates to {@link TerminalCommandService#queuePayout} once the
      * ownership monitor confirms the seller has transferred the parcel to
-     * the winner. For non-zero payouts (individual / non-group), the state
-     * flip from {@code TRANSFER_PENDING} to {@code COMPLETED} is owned by the
-     * callback path in {@code TerminalCommandService.applyCallback}, not this
-     * hook — queuing the command merely schedules the terminal POST.
-     *
-     * <p>Sub-project G §8.1: for group sales (SL-group-owned, payoutAmt = 0),
-     * {@code queuePayout} short-circuits and runs the success path inline,
-     * returning {@link java.util.Optional#empty()}. The state flip to
-     * {@code COMPLETED} has already happened by the time this method returns.
-     * We discard the return value either way — the contract is
-     * fire-and-forget; the caller doesn't care which branch ran.
+     * the winner. Post wallet-first cutover both sale shapes complete inline:
+     * {@code queuePayout} credits the seller's wallet (individual) or invokes
+     * the agent-commission distributor (group), flips escrow to
+     * {@code COMPLETED}, writes the ledger rows, and returns
+     * {@link java.util.Optional#empty()} -- no {@link
+     * com.slparcelauctions.backend.escrow.command.TerminalCommand} is enqueued.
+     * Historical in-flight {@code PAYOUT} terminal commands at deploy time
+     * continue to complete via {@code TerminalCommandService.applyCallback}.
+     * We discard the return value -- the contract is fire-and-forget; the
+     * caller doesn't care which branch ran.
      */
     void queuePayoutOnConfirm(Escrow escrow) {
         terminalCommandService.queuePayout(escrow);
@@ -767,11 +766,14 @@ public class EscrowService {
         escrow.setConsecutiveWorldApiFailures(0);
         escrow = escrowRepo.save(escrow);
         // No auction-status flip here. confirmTransfer only stamps
-        // transferConfirmedAt — the escrow stays in TRANSFER_PENDING, and so
-        // does the auction. The COMPLETED flip happens later in
-        // TerminalCommandService.handleEscrowPayoutSuccess /
-        // runZeroPayoutSuccessInline, where the escrow itself actually
-        // transitions to COMPLETED.
+        // transferConfirmedAt; the COMPLETED flip is owned by the inline
+        // payout success path in TerminalCommandService.queuePayout (which
+        // queuePayoutOnConfirm delegates to), which runs immediately below.
+        // Post wallet-first cutover both sale shapes complete inline -- the
+        // managed escrow entity is mutated to COMPLETED before the envelope
+        // snapshot below is taken. Historical PAYOUT TerminalCommand
+        // callbacks (in-flight at deploy) still drive the older
+        // handleEscrowPayoutSuccess path.
 
         queuePayoutOnConfirm(escrow);
 

--- a/backend/src/main/java/com/slparcelauctions/backend/escrow/command/TerminalCommandService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/escrow/command/TerminalCommandService.java
@@ -77,42 +77,65 @@ public class TerminalCommandService {
     private final com.slparcelauctions.backend.wallet.WalletWithdrawalCallbackHandler walletWithdrawalCallbackHandler;
     private final com.slparcelauctions.backend.auction.agentfee.AgentCommissionDistributor agentCommissionDistributor;
     private final com.slparcelauctions.backend.realty.wallet.GroupWalletWithdrawalCallbackHandler groupWalletWithdrawalCallbackHandler;
+    private final com.slparcelauctions.backend.wallet.WalletService walletService;
     private final AuctionStatusFlipper statusFlipper;
 
     /**
-     * Queues an escrow payout to the seller's SL terminal. Sub-project G §8.1
-     * short-circuit: when {@code escrow.getPayoutAmt() == 0L} (group sales --
-     * SL-group-owned auctions; the agent commission and group slice both flow
-     * through {@link com.slparcelauctions.backend.auction.agentfee.AgentCommissionDistributor}
-     * inside the success path), the terminal round-trip is skipped and the
-     * post-payout work runs inline via {@link #runZeroPayoutSuccessInline}.
-     * Returns {@link Optional#empty()} in that case so the caller knows no
-     * {@link TerminalCommand} was enqueued.
+     * Runs the escrow-payout success path inline. No terminal round-trip
+     * happens for either sale shape any more:
      *
-     * @return the enqueued command, or {@link Optional#empty()} when the
-     *         payout amount is zero and the success path ran inline.
+     * <ul>
+     *   <li>Individual sale ({@code payoutAmt > 0}, no
+     *       {@code realtyGroupSlGroupId}): credits the seller's SLParcels
+     *       wallet via {@link com.slparcelauctions.backend.wallet.WalletService#creditAuctionPayout}
+     *       and then runs the shared bookkeeping. Replaces the prior
+     *       {@code TerminalCommand{action=PAYOUT}} dispatch to the seller's
+     *       avatar -- per the wallet-first policy, L$ stays inside SLParcels
+     *       at sale conclusion and the seller withdraws separately if they
+     *       choose.</li>
+     *   <li>Group sale ({@code payoutAmt == 0},
+     *       {@code realtyGroupSlGroupId != null}): no wallet credit (the
+     *       distributor splits the earnings into agent + group slices);
+     *       runs the same shared bookkeeping; then invokes
+     *       {@link com.slparcelauctions.backend.auction.agentfee.AgentCommissionDistributor#distribute}.</li>
+     * </ul>
+     *
+     * <p>Always returns {@link Optional#empty()}: no {@link TerminalCommand}
+     * is enqueued from this path post wallet-first cutover. The method name
+     * is kept for the EscrowService call-site shape; rename is out of scope.
+     *
+     * <p>Historical in-flight {@link TerminalCommandAction#PAYOUT} rows queued
+     * before this cutover continue to flow through
+     * {@link #handleEscrowPayoutSuccess} via the callback path.
+     *
+     * @return always {@link Optional#empty()}.
      */
     @Transactional(propagation = Propagation.MANDATORY)
     public Optional<TerminalCommand> queuePayout(Escrow escrow) {
-        if (escrow.getPayoutAmt() != null && escrow.getPayoutAmt() == 0L) {
-            if (escrow.getState() == EscrowState.COMPLETED) {
-                // Idempotent replay: a previous call already ran the inline
-                // success path. No-op so we don't double-write the ledger row,
-                // double-notify the seller, or double-credit commissions.
-                log.info("queuePayout: escrow {} already COMPLETED, no-op", escrow.getId());
-                return Optional.empty();
-            }
-            log.info("queuePayout: escrow {} payoutAmt=0 (group sale), running success path inline",
-                    escrow.getId());
-            runZeroPayoutSuccessInline(escrow, OffsetDateTime.now(clock));
+        if (escrow.getState() == EscrowState.COMPLETED) {
+            // Idempotent replay: a previous call already ran the inline
+            // success path. No-op so we don't double-write the ledger row,
+            // double-credit the wallet, double-notify the seller, or
+            // double-credit commissions.
+            log.info("queuePayout: escrow {} already COMPLETED, no-op", escrow.getId());
             return Optional.empty();
         }
-        String recipientUuid = escrow.getAuction().getSeller().getSlAvatarUuid().toString();
-        TerminalCommand cmd = queue(escrow.getId(), null,
-                TerminalCommandAction.PAYOUT, TerminalCommandPurpose.AUCTION_ESCROW,
-                recipientUuid, escrow.getPayoutAmt(),
-                idempotencyKey("ESC", escrow.getId(), TerminalCommandAction.PAYOUT, 1));
-        return Optional.of(cmd);
+        long payoutAmt = escrow.getPayoutAmt() == null ? 0L : escrow.getPayoutAmt();
+        if (payoutAmt > 0L) {
+            log.info("queuePayout: escrow {} payoutAmt={} (individual sale), crediting seller wallet inline",
+                    escrow.getId(), payoutAmt);
+            User seller = escrow.getAuction().getSeller();
+            walletService.creditAuctionPayout(
+                    seller.getId(),
+                    escrow.getAuction().getId(),
+                    escrow.getId(),
+                    payoutAmt);
+        } else {
+            log.info("queuePayout: escrow {} payoutAmt=0 (group sale), running success path inline",
+                    escrow.getId());
+        }
+        runPayoutSuccessInline(escrow, OffsetDateTime.now(clock), payoutAmt);
+        return Optional.empty();
     }
 
     /**
@@ -278,6 +301,15 @@ public class TerminalCommandService {
         }
     }
 
+    /**
+     * Historical callback handler for in-flight {@link TerminalCommandAction#PAYOUT}
+     * commands. New payouts (both individual and group sales) no longer queue
+     * a terminal command -- {@link #queuePayout} runs the success path inline
+     * via {@link #runPayoutSuccessInline}. This handler is preserved so that
+     * PAYOUT rows in {@code QUEUED} / {@code IN_FLIGHT} state at the wallet-
+     * first cutover can still complete via their callback when the terminal
+     * eventually responds.
+     */
     private void handleEscrowPayoutSuccess(TerminalCommand cmd, String slTxn, OffsetDateTime now) {
         Escrow escrow = escrowRepo.findByIdForUpdate(cmd.getEscrowId()).orElseThrow();
         EscrowService.enforceTransitionAllowed(
@@ -363,29 +395,49 @@ public class TerminalCommandService {
     }
 
     /**
-     * Sub-project G §8.1 -- post-payout success path for the group-sale
-     * zero-payout branch. Mirrors {@link #handleEscrowPayoutSuccess}'s body but is driven
-     * directly from {@link #queuePayout} (no terminal callback because no
-     * terminal round-trip happened). Writes the {@code AUCTION_ESCROW_PAYOUT}
-     * ledger row with amount=0, transitions the escrow to COMPLETED, bumps the
-     * seller's completedSales counter, broadcasts the
-     * {@link EscrowCompletedEnvelope} after commit, notifies the seller, and
-     * invokes
+     * Shared post-payout success bookkeeping for both sale shapes. Mirrors
+     * the body of {@link #handleEscrowPayoutSuccess} (which still runs for
+     * in-flight historical {@link TerminalCommandAction#PAYOUT} callbacks)
+     * but is driven directly from {@link #queuePayout}, no terminal
+     * round-trip.
+     *
+     * <p>Writes the {@code AUCTION_ESCROW_PAYOUT} + {@code AUCTION_ESCROW_COMMISSION}
+     * escrow_transactions rows, flips escrow -> COMPLETED, lockstep flips
+     * the auction to COMPLETED, bumps the seller's completed-sales counter,
+     * broadcasts the {@link EscrowCompletedEnvelope} after commit, and
+     * notifies the seller. For group sales (auctions with
+     * {@code realtyGroupSlGroupId}) the caller has already passed
+     * {@code sellerCreditAmt == 0} (no wallet credit happened in the parent);
+     * this method then invokes
      * {@link com.slparcelauctions.backend.auction.agentfee.AgentCommissionDistributor#distribute}
-     * so the agent slice and group slice land in their respective wallets.
+     * to split earnings into agent + group slices. Individual sales pass
+     * {@code sellerCreditAmt > 0}; the caller has already credited the
+     * seller's wallet via
+     * {@link com.slparcelauctions.backend.wallet.WalletService#creditAuctionPayout}
+     * and no distributor call is made here.
      *
      * <p>Idempotency is enforced by the caller -- {@link #queuePayout} short-
      * circuits when the escrow is already COMPLETED.
+     *
+     * @param escrow            the escrow being completed (state must be a
+     *                          legal predecessor of {@code COMPLETED}).
+     * @param now               the completion timestamp.
+     * @param sellerCreditAmt   L$ paid to the seller this transition.
+     *                          {@code > 0} for individual sales (wallet
+     *                          credit already issued), {@code 0} for group
+     *                          sales (split flows through the distributor).
+     *                          Surfaces as the {@code AUCTION_ESCROW_PAYOUT}
+     *                          ledger-row {@code amount} so reconciliation by
+     *                          type continues to balance.
      */
-    private void runZeroPayoutSuccessInline(Escrow escrow, OffsetDateTime now) {
+    private void runPayoutSuccessInline(Escrow escrow, OffsetDateTime now, long sellerCreditAmt) {
         EscrowService.enforceTransitionAllowed(
                 escrow.getId(), escrow.getState(), EscrowState.COMPLETED);
         escrow.setState(EscrowState.COMPLETED);
         escrow.setCompletedAt(now);
         escrow = escrowRepo.save(escrow);
-        // Lockstep auction-status flip: group-sale zero-payout still transitions
-        // the escrow to COMPLETED inline (no terminal round-trip), so the
-        // auction lands at COMPLETED here too.
+        // Lockstep auction-status flip: the inline path still transitions
+        // the escrow to COMPLETED, so the auction lands at COMPLETED here too.
         statusFlipper.flip(escrow, AuctionStatus.COMPLETED);
 
         User seller = escrow.getAuction().getSeller();
@@ -393,14 +445,15 @@ public class TerminalCommandService {
         seller.setCompletedSales(prior + 1);
         userRepo.save(seller);
 
-        // Same shape as the terminal-callback path; amount = 0, no slTxn, no
-        // terminalId. Reconciliation by type (AUCTION_ESCROW_PAYOUT) still works.
+        // Same row shape as the historical terminal-callback path; no slTxn /
+        // terminalId because no terminal round-trip happened. Reconciliation
+        // by type (AUCTION_ESCROW_PAYOUT) still works.
         ledgerRepo.save(EscrowTransaction.builder()
                 .escrow(escrow)
                 .auction(escrow.getAuction())
                 .type(EscrowTransactionType.AUCTION_ESCROW_PAYOUT)
                 .status(EscrowTransactionStatus.COMPLETED)
-                .amount(0L)
+                .amount(sellerCreditAmt)
                 .payee(escrow.getAuction().getSeller())
                 .completedAt(now)
                 .build());
@@ -417,21 +470,20 @@ public class TerminalCommandService {
         final EscrowCompletedEnvelope env = EscrowCompletedEnvelope.of(finalEscrow, now);
         registerAfterCommit(() -> broadcastPublisher.publishCompleted(env));
 
-        // Seller payout notification; Task 24 tweaks the body copy so group
-        // sales don't say "L$0 payout received". Amount is still 0 here -- the
-        // builder decides the body string based on realtyGroupId.
+        // Seller payout notification. The body copy diverges on groupName --
+        // individual sales now say "credited to your SLParcels wallet" instead
+        // of "payout received" since L$ no longer flows to the avatar.
         notificationPublisher.escrowPayout(
                 finalEscrow.getAuction().getSeller().getId(),
                 finalEscrow.getAuction().getId(),
                 finalEscrow.getId(),
                 finalEscrow.getAuction().getTitle(),
-                0L);
+                sellerCreditAmt);
 
         // Group-sale distributor: credits agent_slice to the listing agent's
-        // wallet, group_slice to the group wallet. Both flow through here
-        // because payoutAmt = 0 meant no L$ left SLPA via the terminal. By
-        // construction (Sub-project E spec §9.6 post-G), group sales are the
-        // only branch that reaches this method.
+        // wallet, group_slice to the group wallet. Only group sales reach this
+        // branch (realtyGroupSlGroupId != null); individual sales were already
+        // credited to the seller's wallet by the queuePayout call site.
         if (finalEscrow.getAuction().getRealtyGroupSlGroupId() != null) {
             agentCommissionDistributor.distribute(
                 finalEscrow.getAuction(),

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisher.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisher.java
@@ -59,8 +59,10 @@ public interface NotificationPublisher {
      * <p>Sub-project G section 8.3: copy differs by sale type. For group sales
      * (SL-group-owned; {@code groupName != null}) the body surfaces the
      * commission slice and group slice instead of "L$0 payout received". For
-     * individual sales the body is the legacy "payout received" copy. Subject
-     * ("Auction payout processed") is identical for both sale types.
+     * individual sales the body says the L$ was credited to the seller's
+     * SLParcels wallet (post wallet-first cutover, sale conclusion no longer
+     * dispatches L$ to the seller's avatar; the seller withdraws separately).
+     * Subject ("Auction payout processed") is identical for both sale types.
      *
      * @param payoutL           L$ paid to the seller (0 for group sales)
      * @param groupName         realty group display name, or {@code null} for
@@ -78,9 +80,7 @@ public interface NotificationPublisher {
     /**
      * Backwards-compatible overload for individual-sale callers. Delegates to
      * the group-sale-aware variant with {@code groupName=null} so the body
-     * composes the legacy "payout received" copy. Task 22 will migrate the
-     * {@code TerminalCommandService} call sites to the full signature; until
-     * then this overload keeps the project compiling.
+     * composes the individual-sale "credited to your SLParcels wallet" copy.
      */
     default void escrowPayout(long sellerUserId, long auctionId, long escrowId,
                               String parcelName, long payoutL) {

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java
@@ -300,8 +300,11 @@ public class NotificationPublisherImpl implements NotificationPublisher {
                 + "L$%d credited to %s group wallet.",
                 commissionAmt, groupSliceAmt, groupName);
         } else {
-            // Individual sale.
-            body = String.format("L$%d payout received for %s.", payoutL, parcelName);
+            // Individual sale. Post wallet-first cutover the L$ now lands in
+            // the seller's SLParcels wallet, not on their avatar -- the copy
+            // changed from "payout received" to make the in-wallet location
+            // unambiguous so the seller knows they need to withdraw separately.
+            body = String.format("L$%d credited to your SLParcels wallet.", payoutL);
         }
         notificationService.publish(new NotificationEvent(
             sellerUserId, NotificationCategory.ESCROW_PAYOUT, title, body,

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerEntryType.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/UserLedgerEntryType.java
@@ -121,5 +121,17 @@ public enum UserLedgerEntryType {
      * row on {@code realty_group_ledger} that shares the same {@code idempotencyKey}.
      * {@code description} carries the group display name (and optional user-supplied memo).
      */
-    GROUP_WALLET_DEPOSIT_DEBIT
+    GROUP_WALLET_DEPOSIT_DEBIT,
+
+    /**
+     * Individual-sale payout credited to the seller's SLParcels wallet at escrow
+     * COMPLETED. Replaces the prior {@code TerminalCommand{action=PAYOUT}} flow
+     * that paid L$ directly to the seller's avatar; per the wallet-first policy
+     * the sale conclusion keeps L$ inside SLParcels and the seller withdraws
+     * separately when they choose. Idempotency key {@code AUCPAYOUT-{escrowId}}.
+     * Group sales (auctions with {@code realty_group_sl_group_id}) continue to
+     * split via {@link #AGENT_COMMISSION_CREDIT} + realty-group ledger; this
+     * entry type is individual-sale only.
+     */
+    AUCTION_PAYOUT_CREDIT
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/wallet/WalletService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/wallet/WalletService.java
@@ -450,6 +450,50 @@ public class WalletService {
             userId, auctionId, amount, newBalance);
     }
 
+    /**
+     * Credit the seller's user wallet with the individual-sale payout slice.
+     * Called from the escrow-payout-success path for individual sales
+     * (auctions with no {@code realty_group_sl_group_id}). Replaces the prior
+     * path that dispatched a {@code TerminalCommandAction.PAYOUT} to send L$
+     * to the seller's SL avatar in-world -- per the wallet-first policy, sale
+     * conclusion keeps L$ inside SLParcels; the seller withdraws to their
+     * avatar separately if/when they choose.
+     *
+     * <p>Idempotency key {@code AUCPAYOUT-{escrowId}} prevents a duplicate
+     * credit if the payout-success path is replayed.
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void creditAuctionPayout(Long userId, Long auctionId, Long escrowId, long amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount must be positive: " + amount);
+        }
+        String idempotencyKey = "AUCPAYOUT-" + escrowId;
+        Optional<UserLedgerEntry> existing = ledgerRepository.findByIdempotencyKey(idempotencyKey);
+        if (existing.isPresent()) {
+            log.debug("auction payout credit replay for escrowId={} (existing entry id={})",
+                escrowId, existing.get().getId());
+            return;
+        }
+        User user = userRepository.findByIdForUpdate(userId).orElseThrow();
+        long newBalance = user.getBalanceLindens() + amount;
+        user.setBalanceLindens(newBalance);
+        userRepository.save(user);
+        UserLedgerEntry entry = ledgerRepository.save(UserLedgerEntry.builder()
+            .userId(user.getId())
+            .entryType(UserLedgerEntryType.AUCTION_PAYOUT_CREDIT)
+            .amount(amount)
+            .balanceAfter(newBalance)
+            .reservedAfter(user.getReservedLindens())
+            .refType("ESCROW")
+            .refId(escrowId)
+            .idempotencyKey(idempotencyKey)
+            .build());
+        walletBroadcastPublisher.publish(user,
+            UserLedgerEntryType.AUCTION_PAYOUT_CREDIT.name(), entry.getPublicId());
+        log.info("auction payout credit: userId={}, auctionId={}, escrowId={}, amount={}, balanceAfter={}",
+            userId, auctionId, escrowId, amount, newBalance);
+    }
+
     @Transactional(propagation = Propagation.MANDATORY)
     public void creditListingFeeRefund(User user, long amount, Long listingFeeRefundId) {
         UserLedgerEntry entry = creditCommon(user, amount,

--- a/backend/src/main/resources/db/migration/V39__add_auction_payout_credit_ledger_type.sql
+++ b/backend/src/main/resources/db/migration/V39__add_auction_payout_credit_ledger_type.sql
@@ -1,0 +1,26 @@
+-- V39: add AUCTION_PAYOUT_CREDIT to user_ledger.entry_type CHECK constraint.
+--
+-- Individual-sale payouts now credit the seller's SLParcels wallet inline
+-- with escrow -> COMPLETED instead of dispatching a TerminalCommand{action=PAYOUT}
+-- to the seller's avatar. Per the wallet-first policy the sale conclusion
+-- keeps L$ inside SLParcels; the seller withdraws separately if they choose.
+-- Idempotency key on the ledger row is "AUCPAYOUT-{escrowId}".
+--
+-- user_ledger_entry_type_check was last touched in V33.
+
+ALTER TABLE user_ledger DROP CONSTRAINT user_ledger_entry_type_check;
+ALTER TABLE user_ledger ADD CONSTRAINT user_ledger_entry_type_check CHECK (
+    entry_type IN (
+        'DEPOSIT',
+        'WITHDRAW_QUEUED', 'WITHDRAW_COMPLETED', 'WITHDRAW_REVERSED',
+        'BID_RESERVED', 'BID_RELEASED',
+        'ESCROW_DEBIT', 'ESCROW_REFUND',
+        'LISTING_FEE_DEBIT', 'LISTING_FEE_REFUND',
+        'PENALTY_DEBIT',
+        'AGENT_FEE_CREDIT',
+        'AGENT_COMMISSION_CREDIT',
+        'ADJUSTMENT',
+        'GROUP_WALLET_DEPOSIT_DEBIT',
+        'AUCTION_PAYOUT_CREDIT'
+    )
+);

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowEndToEndIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowEndToEndIntegrationTest.java
@@ -1,8 +1,6 @@
 package com.slparcelauctions.backend.escrow;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
@@ -40,14 +38,9 @@ import com.slparcelauctions.backend.escrow.broadcast.EscrowBroadcastPublisher;
 import com.slparcelauctions.backend.escrow.broadcast.EscrowCompletedEnvelope;
 import com.slparcelauctions.backend.escrow.command.TerminalCommand;
 import com.slparcelauctions.backend.escrow.command.TerminalCommandAction;
-import com.slparcelauctions.backend.escrow.command.TerminalCommandPurpose;
 import com.slparcelauctions.backend.escrow.command.TerminalCommandRepository;
-import com.slparcelauctions.backend.escrow.command.TerminalCommandService;
-import com.slparcelauctions.backend.escrow.command.TerminalCommandStatus;
 import com.slparcelauctions.backend.escrow.command.TerminalHttpClient;
-import com.slparcelauctions.backend.escrow.command.dto.PayoutResultRequest;
 import com.slparcelauctions.backend.escrow.scheduler.EscrowOwnershipMonitorJob;
-import com.slparcelauctions.backend.escrow.scheduler.TerminalCommandDispatcherJob;
 import com.slparcelauctions.backend.escrow.terminal.Terminal;
 import com.slparcelauctions.backend.escrow.terminal.TerminalRepository;
 import com.slparcelauctions.backend.auction.AuctionParcelSnapshot;
@@ -60,16 +53,26 @@ import com.slparcelauctions.backend.notification.NotificationRepository;
 import com.slparcelauctions.backend.user.UserRepository;
 import com.slparcelauctions.backend.verification.VerificationCodeRepository;
 import com.slparcelauctions.backend.verification.VerificationCodeType;
+import com.slparcelauctions.backend.wallet.UserLedgerEntry;
+import com.slparcelauctions.backend.wallet.UserLedgerEntryType;
+import com.slparcelauctions.backend.wallet.UserLedgerRepository;
 
 import reactor.core.publisher.Mono;
 
 /**
- * End-to-end coverage from TRANSFER_PENDING onwards: ownership monitor
- * confirm â†’ payout queued â†’ dispatcher POSTs â†’ callback success â†’ state
- * COMPLETED + ledger (PAYOUT + COMMISSION) + envelope. The earlier stages
- * (auction-end Escrow creation + payment receipt) have their own
- * integration tests (EscrowCreateOnAuctionEndIntegrationTest,
- * EscrowPaymentIntegrationTest) to avoid re-seeding overhead.
+ * End-to-end coverage from TRANSFER_PENDING onwards. Post wallet-first
+ * cutover the happy path runs entirely inline: ownership monitor confirms
+ * the parcel transfer -> queuePayout credits the seller's SLParcels wallet
+ * via WalletService.creditAuctionPayout and flips escrow + auction to
+ * COMPLETED inside the same transaction. No TerminalCommand is enqueued
+ * and no terminal-callback round-trip happens.
+ *
+ * <p>The earlier stages (auction-end Escrow creation + payment receipt)
+ * have their own integration tests (EscrowCreateOnAuctionEndIntegrationTest,
+ * EscrowPaymentIntegrationTest) to avoid re-seeding overhead. The historical
+ * PAYOUT TerminalCommand callback machinery still has coverage in
+ * TerminalCommandDispatcherTaskTest / TerminalCommandRetryIntegrationTest
+ * for any in-flight rows that survive deploy.
  */
 @SpringBootTest
 @ActiveProfiles("dev")
@@ -94,7 +97,6 @@ class EscrowEndToEndIntegrationTest {
     private static final String TERMINAL_ID = "terminal-e2e-" + UUID.randomUUID();
     private static final String HTTP_IN_URL = "https://sim-e2e.agni.lindenlab.com:12043/cap/abc";
     private static final String REGION_NAME = "E2ERegion";
-    private static final String SHARED_SECRET = "dev-escrow-secret-do-not-use-in-prod";
 
     @TestConfiguration
     static class CapturingConfig {
@@ -109,8 +111,6 @@ class EscrowEndToEndIntegrationTest {
     @MockitoBean TerminalHttpClient terminalHttp;
 
     @Autowired EscrowOwnershipMonitorJob ownershipMonitorJob;
-    @Autowired TerminalCommandDispatcherJob dispatcherJob;
-    @Autowired TerminalCommandService terminalCommandService;
     @Autowired TerminalCommandRepository cmdRepo;
     @Autowired TerminalRepository terminalRepo;
     @Autowired EscrowRepository escrowRepo;
@@ -123,6 +123,7 @@ class EscrowEndToEndIntegrationTest {
     @Autowired RefreshTokenRepository refreshTokenRepo;
     @Autowired VerificationCodeRepository verificationCodeRepo;
     @Autowired NotificationRepository notificationRepo;
+    @Autowired UserLedgerRepository userLedgerRepo;
     @Autowired PlatformTransactionManager txManager;
     @Autowired CapturingEscrowBroadcastPublisher capturingEscrowPublisher;
 
@@ -155,6 +156,15 @@ class EscrowEndToEndIntegrationTest {
                     .forEach(cmdRepo::delete);
             escrowTxRepo.findByEscrowIdOrderByCreatedAtAsc(seededEscrowId)
                     .forEach(escrowTxRepo::delete);
+            // creditAuctionPayout writes user_ledger rows keyed by refType=ESCROW,
+            // refId=escrowId. Drop those before deleting the parent escrow / users.
+            final Long escrowForCleanup = seededEscrowId;
+            if (escrowForCleanup != null) {
+                userLedgerRepo.findAll().stream()
+                        .filter(e -> "ESCROW".equals(e.getRefType())
+                                && escrowForCleanup.equals(e.getRefId()))
+                        .forEach(userLedgerRepo::delete);
+            }
             escrowRepo.findByAuctionId(seededAuctionId).ifPresent(escrowRepo::delete);
             bidRepo.deleteAllByAuctionId(seededAuctionId);
             proxyBidRepo.deleteAllByAuctionId(seededAuctionId);
@@ -181,60 +191,58 @@ class EscrowEndToEndIntegrationTest {
     }
 
     @Test
-    void fullHappyPath_transferConfirmDispatchCompleteCallback_rowsAndEnvelopesLineUp() {
+    void fullHappyPath_transferConfirmCompletesInlineAndCreditsSellerWallet() {
         seedTransferPendingWithFundedEscrowAndTerminal();
 
-        // World API reports the winner owns the parcel â†’ monitor stamps
-        // transferConfirmedAt and queues the PAYOUT command.
+        long sellerBalanceBefore = userRepo.findById(seededSellerId).orElseThrow()
+                .getBalanceLindens();
+
+        // World API reports the winner owns the parcel -> monitor stamps
+        // transferConfirmedAt and triggers queuePayout, which now runs the
+        // success path inline (credits the seller's wallet, flips escrow ->
+        // COMPLETED, writes the ledger rows, notifies the seller). The
+        // terminalHttp client must not be invoked along the happy path post
+        // wallet-first cutover -- we don't stub it.
         when(worldApi.fetchParcelPage(seededParcelUuid))
                 .thenReturn(
                 Mono.just(new ParcelPageData(meta(seededWinnerAvatar, "agent"), java.util.UUID.randomUUID())));
-        // Dispatcher's HTTP POST ACKs â†’ command flips to IN_FLIGHT.
-        when(terminalHttp.post(anyString(), any()))
-                .thenReturn(TerminalHttpClient.TerminalHttpResult.ok());
 
         ownershipMonitorJob.sweep();
 
-        // After the monitor sweep: escrow transferConfirmedAt stamped, one
-        // PAYOUT command queued for this escrow.
+        // No TerminalCommand of action=PAYOUT was queued for the new sale --
+        // queuePayout runs inline now.
+        List<TerminalCommand> payoutCmds = findCommandsForEscrow(seededEscrowId).stream()
+                .filter(c -> c.getAction() == TerminalCommandAction.PAYOUT)
+                .toList();
+        assertThat(payoutCmds).isEmpty();
+
+        // Escrow flipped straight to COMPLETED with completedAt stamped.
         Escrow afterMonitor = escrowRepo.findById(seededEscrowId).orElseThrow();
-        assertThat(afterMonitor.getState()).isEqualTo(EscrowState.TRANSFER_PENDING);
+        assertThat(afterMonitor.getState()).isEqualTo(EscrowState.COMPLETED);
         assertThat(afterMonitor.getTransferConfirmedAt()).isNotNull();
+        assertThat(afterMonitor.getCompletedAt()).isNotNull();
         assertThat(capturingEscrowPublisher.transferConfirmed).hasSize(1);
 
-        List<TerminalCommand> queued = findCommandsForEscrow(seededEscrowId);
-        assertThat(queued).hasSize(1);
-        TerminalCommand cmd = queued.get(0);
-        assertThat(cmd.getAction()).isEqualTo(TerminalCommandAction.PAYOUT);
-        assertThat(cmd.getPurpose()).isEqualTo(TerminalCommandPurpose.AUCTION_ESCROW);
-        assertThat(cmd.getStatus()).isEqualTo(TerminalCommandStatus.QUEUED);
-        assertThat(cmd.getAmount()).isEqualTo(seededPayout);
+        // Seller's SLParcels wallet balance increased by the payout amount.
+        long sellerBalanceAfter = userRepo.findById(seededSellerId).orElseThrow()
+                .getBalanceLindens();
+        assertThat(sellerBalanceAfter).isEqualTo(sellerBalanceBefore + seededPayout);
 
-        // Dispatcher sweep: QUEUED â†’ IN_FLIGHT.
-        dispatcherJob.dispatch();
-        TerminalCommand afterDispatch = cmdRepo.findById(cmd.getId()).orElseThrow();
-        assertThat(afterDispatch.getStatus()).isEqualTo(TerminalCommandStatus.IN_FLIGHT);
-        assertThat(afterDispatch.getAttemptCount()).isEqualTo(1);
-        assertThat(afterDispatch.getTerminalId()).isEqualTo(TERMINAL_ID);
-        assertThat(afterDispatch.getDispatchedAt()).isNotNull();
+        // user_ledger has a single AUCTION_PAYOUT_CREDIT row keyed by the escrow
+        // with the AUCPAYOUT-{escrowId} idempotency key.
+        List<UserLedgerEntry> creditRows = userLedgerRepo.findAll().stream()
+                .filter(e -> seededSellerId.equals(e.getUserId()))
+                .filter(e -> e.getEntryType() == UserLedgerEntryType.AUCTION_PAYOUT_CREDIT)
+                .toList();
+        assertThat(creditRows).hasSize(1);
+        UserLedgerEntry credit = creditRows.get(0);
+        assertThat(credit.getAmount()).isEqualTo(seededPayout);
+        assertThat(credit.getRefType()).isEqualTo("ESCROW");
+        assertThat(credit.getRefId()).isEqualTo(seededEscrowId);
+        assertThat(credit.getIdempotencyKey()).isEqualTo("AUCPAYOUT-" + seededEscrowId);
 
-        // Simulate the terminal's payout-result callback: success.
-        String slTxn = "sl-txn-" + UUID.randomUUID();
-        terminalCommandService.applyCallback(new PayoutResultRequest(
-                afterDispatch.getIdempotencyKey(), true, slTxn, null,
-                TERMINAL_ID, SHARED_SECRET));
-
-        // Command COMPLETED.
-        TerminalCommand afterCallback = cmdRepo.findById(cmd.getId()).orElseThrow();
-        assertThat(afterCallback.getStatus()).isEqualTo(TerminalCommandStatus.COMPLETED);
-        assertThat(afterCallback.getCompletedAt()).isNotNull();
-
-        // Escrow COMPLETED with completedAt stamped.
-        Escrow afterEscrowCallback = escrowRepo.findById(seededEscrowId).orElseThrow();
-        assertThat(afterEscrowCallback.getState()).isEqualTo(EscrowState.COMPLETED);
-        assertThat(afterEscrowCallback.getCompletedAt()).isNotNull();
-
-        // Ledger has two new rows (PAYOUT + COMMISSION), both COMPLETED.
+        // escrow_transactions has PAYOUT + COMMISSION rows, both COMPLETED, no slTxn
+        // (no terminal round-trip happened).
         List<EscrowTransaction> ledger =
                 escrowTxRepo.findByEscrowIdOrderByCreatedAtAsc(seededEscrowId);
         Optional<EscrowTransaction> payoutRow = ledger.stream()
@@ -243,7 +251,7 @@ class EscrowEndToEndIntegrationTest {
         assertThat(payoutRow).isPresent();
         assertThat(payoutRow.get().getStatus()).isEqualTo(EscrowTransactionStatus.COMPLETED);
         assertThat(payoutRow.get().getAmount()).isEqualTo(seededPayout);
-        assertThat(payoutRow.get().getSlTransactionId()).isEqualTo(slTxn);
+        assertThat(payoutRow.get().getSlTransactionId()).isNull();
         assertThat(payoutRow.get().getPayee()).isNotNull();
         assertThat(payoutRow.get().getPayee().getId()).isEqualTo(seededSellerId);
 
@@ -262,11 +270,10 @@ class EscrowEndToEndIntegrationTest {
         assertThat(env.escrowPublicId()).isEqualTo(seededEscrowPublicId);
         assertThat(env.state()).isEqualTo(EscrowState.COMPLETED);
 
-        // Epic 08 sub-spec 1 Â§3.4 / Â§6.1: the seller's completedSales
-        // counter must bump in the same transaction that flipped the escrow
-        // to COMPLETED. Prior to sub-spec 1 this counter was declared but
-        // never written; the reputation & completion-rate pipeline hangs
-        // off this increment landing inside the payout-success handler.
+        // Epic 08 sub-spec 1 §3.4 / §6.1: the seller's completedSales counter
+        // must bump in the same transaction that flipped the escrow to
+        // COMPLETED. The reputation + completion-rate pipeline hangs off this
+        // increment landing inside the payout-success path.
         User seller = userRepo.findById(seededSellerId).orElseThrow();
         assertThat(seller.getCompletedSales()).isEqualTo(1);
     }

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowOwnershipMonitorIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/EscrowOwnershipMonitorIntegrationTest.java
@@ -184,7 +184,7 @@ class EscrowOwnershipMonitorIntegrationTest {
     }
 
     @Test
-    void winnerOwnsParcel_stampsTransferConfirmed_broadcastsConfirmation() {
+    void winnerOwnsParcel_stampsTransferConfirmed_completesInlineAndCreditsSeller() {
         seedTransferPendingEscrow();
         when(worldApi.fetchParcelPage(seededParcelUuid))
                 .thenReturn(
@@ -194,10 +194,18 @@ class EscrowOwnershipMonitorIntegrationTest {
         job.sweep();
         OffsetDateTime after = OffsetDateTime.now();
 
+        // Post wallet-first cutover, the monitor's confirm step also runs the
+        // inline payout success path: escrow flips straight to COMPLETED in
+        // the same transaction, with the seller's wallet credited via
+        // WalletService.creditAuctionPayout. The TRANSFER_CONFIRMED envelope
+        // still fires (the envelope snapshot is taken before the COMPLETED
+        // transition in the EscrowService confirm path); a COMPLETED
+        // envelope fires alongside.
         Escrow refreshed = escrowRepo.findById(seededEscrowId).orElseThrow();
-        assertThat(refreshed.getState()).isEqualTo(EscrowState.TRANSFER_PENDING);
+        assertThat(refreshed.getState()).isEqualTo(EscrowState.COMPLETED);
         assertThat(refreshed.getTransferConfirmedAt()).isNotNull();
         assertThat(refreshed.getTransferConfirmedAt()).isBetween(before, after);
+        assertThat(refreshed.getCompletedAt()).isNotNull();
         assertThat(refreshed.getConsecutiveWorldApiFailures()).isZero();
         assertThat(refreshed.getLastCheckedAt()).isNotNull();
 
@@ -206,7 +214,8 @@ class EscrowOwnershipMonitorIntegrationTest {
         assertThat(env.type()).isEqualTo("ESCROW_TRANSFER_CONFIRMED");
         assertThat(env.auctionPublicId()).isEqualTo(seededAuctionPublicId);
         assertThat(env.escrowPublicId()).isEqualTo(seededEscrowPublicId);
-        assertThat(env.state()).isEqualTo(EscrowState.TRANSFER_PENDING);
+
+        assertThat(capturingEscrowPublisher.completed).hasSize(1);
 
         assertThat(capturingEscrowPublisher.frozen).isEmpty();
         assertThat(fraudFlagRepo.findByAuctionId(seededAuctionId)).isEmpty();

--- a/backend/src/test/java/com/slparcelauctions/backend/escrow/command/TerminalCommandServiceZeroPayoutTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/escrow/command/TerminalCommandServiceZeroPayoutTest.java
@@ -50,20 +50,29 @@ import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.user.UserRepository;
 import com.slparcelauctions.backend.verification.VerificationCodeRepository;
 import com.slparcelauctions.backend.verification.VerificationCodeType;
+import com.slparcelauctions.backend.wallet.UserLedgerEntry;
+import com.slparcelauctions.backend.wallet.UserLedgerEntryType;
 import com.slparcelauctions.backend.wallet.UserLedgerRepository;
 
 /**
- * Verifies the Sub-project G §8.1 short-circuit:
+ * Verifies the inline payout-success path. Post wallet-first cutover both sale
+ * shapes run inline -- no {@link TerminalCommand} is ever enqueued from
+ * {@link TerminalCommandService#queuePayout}.
+ *
  * <ul>
- *   <li>{@code queuePayout} returns {@link Optional#empty()} for payoutAmt == 0.</li>
- *   <li>No {@link TerminalCommand} row is persisted for the escrow.</li>
- *   <li>An {@code AUCTION_ESCROW_PAYOUT} ledger row with amount=0 is written.</li>
- *   <li>The escrow transitions to {@link EscrowState#COMPLETED}.</li>
- *   <li>The seller notification fires.</li>
- *   <li>Re-invocation is idempotent: a second call is a no-op (no extra ledger row,
- *       no second seller notification).</li>
- *   <li>For a positive payoutAmt the legacy path still queues a
- *       {@link TerminalCommand}.</li>
+ *   <li>{@code queuePayout} returns {@link Optional#empty()} for both shapes.</li>
+ *   <li>Group sale (payoutAmt == 0): no wallet credit; an
+ *       {@code AUCTION_ESCROW_PAYOUT} ledger row with amount=0 is written;
+ *       escrow transitions to {@link EscrowState#COMPLETED}; seller notified.</li>
+ *   <li>Individual sale (payoutAmt > 0): seller's wallet is credited via
+ *       {@code creditAuctionPayout}; an {@code AUCTION_ESCROW_PAYOUT} ledger
+ *       row with amount=payoutAmt is written; a {@code user_ledger} row of
+ *       type {@code AUCTION_PAYOUT_CREDIT} is written; escrow transitions
+ *       to {@link EscrowState#COMPLETED}; auction status flips to
+ *       {@code COMPLETED}; seller notified; <em>no</em> {@link TerminalCommand}
+ *       of action {@link TerminalCommandAction#PAYOUT} is enqueued.</li>
+ *   <li>Re-invocation is idempotent for both shapes (no extra ledger row,
+ *       no double wallet credit, no second seller notification).</li>
  * </ul>
  */
 @SpringBootTest
@@ -131,11 +140,17 @@ class TerminalCommandServiceZeroPayoutTest {
             }
             // AgentCommissionDistributor writes user_ledger + realty_group_ledger
             // rows keyed by refType=AUCTION, refId=auctionId. Drop those before
-            // we delete the parent group / users.
+            // we delete the parent group / users. WalletService.creditAuctionPayout
+            // (new individual-sale inline path) writes user_ledger rows keyed by
+            // refType=ESCROW, refId=escrowId; drop those too.
             final Long auctionForCleanup = seededAuctionId;
+            final Long escrowForCleanup = seededEscrowId;
             userLedgerRepo.findAll().stream()
-                    .filter(e -> "AUCTION".equals(e.getRefType())
-                            && auctionForCleanup.equals(e.getRefId()))
+                    .filter(e -> ("AUCTION".equals(e.getRefType())
+                                    && auctionForCleanup.equals(e.getRefId()))
+                            || (escrowForCleanup != null
+                                    && "ESCROW".equals(e.getRefType())
+                                    && escrowForCleanup.equals(e.getRefId())))
                     .forEach(userLedgerRepo::delete);
             realtyGroupLedgerRepo.findAll().stream()
                     .filter(e -> "AUCTION".equals(e.getRefType())
@@ -249,19 +264,123 @@ class TerminalCommandServiceZeroPayoutTest {
     }
 
     @Test
-    void queuePayout_enqueues_a_command_when_payout_amt_is_positive() {
-        Escrow escrow = fixtureIndividualEscrow(1000L);
-        TransactionTemplate tx = new TransactionTemplate(txManager);
+    void queuePayout_credits_seller_wallet_inline_for_individual_sale() {
+        long payoutAmt = 1000L;
+        Escrow escrow = fixtureIndividualEscrow(payoutAmt);
 
+        long sellerBalanceBefore = userRepo.findById(seededSellerId).orElseThrow()
+                .getBalanceLindens();
+
+        TransactionTemplate tx = new TransactionTemplate(txManager);
         Optional<TerminalCommand> result = tx.execute(status -> {
             Escrow managed = escrowRepo.findById(escrow.getId()).orElseThrow();
             return svc.queuePayout(managed);
         });
 
-        assertThat(result).isPresent();
-        assertThat(result.get().getAmount()).isEqualTo(1000L);
-        assertThat(result.get().getAction()).isEqualTo(TerminalCommandAction.PAYOUT);
-        assertThat(result.get().getPurpose()).isEqualTo(TerminalCommandPurpose.AUCTION_ESCROW);
+        // queuePayout never enqueues a TerminalCommand any more.
+        assertThat(result).isEmpty();
+
+        // No TerminalCommand of action=PAYOUT for the new sale.
+        long payoutCmdRows = cmdRepo.findAll().stream()
+                .filter(c -> escrow.getId().equals(c.getEscrowId()))
+                .filter(c -> c.getAction() == TerminalCommandAction.PAYOUT)
+                .count();
+        assertThat(payoutCmdRows).isZero();
+
+        // Seller wallet credited by exactly payoutAmt.
+        User sellerAfter = userRepo.findById(seededSellerId).orElseThrow();
+        assertThat(sellerAfter.getBalanceLindens())
+                .isEqualTo(sellerBalanceBefore + payoutAmt);
+
+        // user_ledger has an AUCTION_PAYOUT_CREDIT row pointing at the escrow.
+        List<UserLedgerEntry> sellerLedger = userLedgerRepo.findAll().stream()
+                .filter(e -> seededSellerId.equals(e.getUserId()))
+                .filter(e -> e.getEntryType() == UserLedgerEntryType.AUCTION_PAYOUT_CREDIT)
+                .toList();
+        assertThat(sellerLedger).hasSize(1);
+        UserLedgerEntry credit = sellerLedger.get(0);
+        assertThat(credit.getAmount()).isEqualTo(payoutAmt);
+        assertThat(credit.getRefType()).isEqualTo("ESCROW");
+        assertThat(credit.getRefId()).isEqualTo(escrow.getId());
+        assertThat(credit.getIdempotencyKey()).isEqualTo("AUCPAYOUT-" + escrow.getId());
+
+        // Escrow flipped to COMPLETED.
+        Escrow reloaded = escrowRepo.findById(escrow.getId()).orElseThrow();
+        assertThat(reloaded.getState()).isEqualTo(EscrowState.COMPLETED);
+        assertThat(reloaded.getCompletedAt()).isNotNull();
+
+        // Auction flipped to COMPLETED via statusFlipper.
+        com.slparcelauctions.backend.auction.Auction auctionReloaded =
+                auctionRepo.findById(seededAuctionId).orElseThrow();
+        assertThat(auctionReloaded.getStatus())
+                .isEqualTo(com.slparcelauctions.backend.auction.AuctionStatus.COMPLETED);
+
+        // AUCTION_ESCROW_PAYOUT escrow_transactions row written with amount=payoutAmt.
+        List<EscrowTransaction> ledger =
+                ledgerRepo.findByEscrowIdOrderByCreatedAtAsc(escrow.getId());
+        EscrowTransaction payoutRow = ledger.stream()
+                .filter(r -> r.getType() == EscrowTransactionType.AUCTION_ESCROW_PAYOUT)
+                .findFirst()
+                .orElseThrow();
+        assertThat(payoutRow.getStatus())
+                .isEqualTo(com.slparcelauctions.backend.escrow.EscrowTransactionStatus.COMPLETED);
+        assertThat(payoutRow.getAmount()).isEqualTo(payoutAmt);
+        assertThat(payoutRow.getPayee()).isNotNull();
+        assertThat(payoutRow.getPayee().getId()).isEqualTo(seededSellerId);
+
+        // Seller payout notification fired.
+        List<Notification> sellerNotifs = notificationRepo.findAllByUserId(seededSellerId);
+        long payoutNotifs = sellerNotifs.stream()
+                .filter(n -> n.getCategory() == NotificationCategory.ESCROW_PAYOUT)
+                .count();
+        assertThat(payoutNotifs).isEqualTo(1L);
+    }
+
+    @Test
+    void queuePayout_individual_sale_is_idempotent_on_replay() {
+        long payoutAmt = 1500L;
+        Escrow escrow = fixtureIndividualEscrow(payoutAmt);
+
+        long sellerBalanceBefore = userRepo.findById(seededSellerId).orElseThrow()
+                .getBalanceLindens();
+
+        TransactionTemplate tx = new TransactionTemplate(txManager);
+
+        // First call -- credits wallet, completes escrow.
+        tx.executeWithoutResult(status -> {
+            Escrow managed = escrowRepo.findById(escrow.getId()).orElseThrow();
+            svc.queuePayout(managed);
+        });
+
+        long sellerBalanceAfterFirst = userRepo.findById(seededSellerId).orElseThrow()
+                .getBalanceLindens();
+        long ledgerCountAfterFirst =
+                ledgerRepo.findByEscrowIdOrderByCreatedAtAsc(escrow.getId()).size();
+
+        // Second call -- escrow already COMPLETED, must be a no-op.
+        Optional<TerminalCommand> second = tx.execute(status -> {
+            Escrow managed = escrowRepo.findById(escrow.getId()).orElseThrow();
+            return svc.queuePayout(managed);
+        });
+
+        assertThat(second).isEmpty();
+
+        // Wallet balance unchanged after second call.
+        long sellerBalanceAfterSecond = userRepo.findById(seededSellerId).orElseThrow()
+                .getBalanceLindens();
+        assertThat(sellerBalanceAfterSecond).isEqualTo(sellerBalanceAfterFirst);
+        assertThat(sellerBalanceAfterFirst).isEqualTo(sellerBalanceBefore + payoutAmt);
+
+        // Exactly one AUCTION_PAYOUT_CREDIT row.
+        long creditRows = userLedgerRepo.findAll().stream()
+                .filter(e -> seededSellerId.equals(e.getUserId()))
+                .filter(e -> e.getEntryType() == UserLedgerEntryType.AUCTION_PAYOUT_CREDIT)
+                .count();
+        assertThat(creditRows).isEqualTo(1L);
+
+        // Escrow ledger row count unchanged.
+        assertThat(ledgerRepo.findByEscrowIdOrderByCreatedAtAsc(escrow.getId()).size())
+                .isEqualTo(ledgerCountAfterFirst);
     }
 
     // -------------------------------------------------------------------------

--- a/backend/src/test/java/com/slparcelauctions/backend/notification/NotificationPublisherImplTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/notification/NotificationPublisherImplTest.java
@@ -498,9 +498,10 @@ class NotificationPublisherImplTest {
         assertThat(n.getCategory()).isEqualTo(NotificationCategory.ESCROW_PAYOUT);
         assertThat(n.getData()).containsKey("payoutL");
         assertThat(((Number) n.getData().get("payoutL")).longValue()).isEqualTo(18500L);
-        // Non-case-3 body — legacy "payout received" copy, parcel name embedded.
+        // Individual-sale body says the L$ landed in the SLParcels wallet,
+        // not on the seller's avatar (post wallet-first cutover).
         assertThat(n.getTitle()).isEqualTo("Auction payout processed");
-        assertThat(n.getBody()).isEqualTo("L$18500 payout received for Parcel C.");
+        assertThat(n.getBody()).isEqualTo("L$18500 credited to your SLParcels wallet.");
 
         verify(broadcasterPort).broadcastUpsert(eq(seller.getId()), any(), any());
     }
@@ -540,12 +541,11 @@ class NotificationPublisherImplTest {
     }
 
     @Test
-    void escrowPayout_nonCase3_legacyOverloadDelegatesToFullSignature() {
+    void escrowPayout_individualSale_legacyOverloadDelegatesToFullSignature() {
         User seller = testUser("payout-seller-overload");
 
-        // The 5-arg overload (used today by TerminalCommandService line 312
-        // until Task 22 lands) must delegate to the 8-arg path with
-        // groupName=null so the legacy body composes correctly.
+        // The 5-arg overload delegates to the 8-arg path with groupName=null
+        // so the individual-sale body composes correctly.
         transactionTemplate.execute(status -> {
             publisher.escrowPayout(seller.getId(), 33L, 303L, "Parcel D", 12000L);
             return null;
@@ -555,7 +555,7 @@ class NotificationPublisherImplTest {
         assertThat(rows).hasSize(1);
         Notification n = rows.get(0);
         assertThat(n.getTitle()).isEqualTo("Auction payout processed");
-        assertThat(n.getBody()).isEqualTo("L$12000 payout received for Parcel D.");
+        assertThat(n.getBody()).isEqualTo("L$12000 credited to your SLParcels wallet.");
         assertThat(n.getBody()).doesNotContain("group wallet");
 
         verify(broadcasterPort).broadcastUpsert(eq(seller.getId()), any(), any());

--- a/frontend/src/components/escrow/state/CompletedStateCard.test.tsx
+++ b/frontend/src/components/escrow/state/CompletedStateCard.test.tsx
@@ -5,7 +5,7 @@ import { fakeEscrow } from "@/test/fixtures/escrow";
 
 describe("CompletedStateCard", () => {
   describe("seller view (individual sale)", () => {
-    it("renders the payout headline + sale-price / fee / net breakdown", () => {
+    it("renders the wallet-credit headline + sale-price / fee / net breakdown", () => {
       renderWithProviders(
         <CompletedStateCard
           escrow={fakeEscrow({
@@ -19,9 +19,15 @@ describe("CompletedStateCard", () => {
         />,
       );
 
-      // Headline keeps the net "Payout of L$X sent" so the eye lands on
-      // the amount that actually moved to the seller's avatar.
-      expect(screen.getByText(/payout of l\$\s*4,?750/i)).toBeInTheDocument();
+      // Headline says the L$ landed in the SLParcels wallet, not on the
+      // seller's avatar. The seller withdraws to their avatar separately
+      // via the wallet flow.
+      expect(
+        screen.getByText(/l\$\s*4,?750 added to your slparcels wallet/i),
+      ).toBeInTheDocument();
+      // Old "Payout of L$X sent" copy is gone -- it implied an avatar
+      // transfer that no longer happens at sale conclusion.
+      expect(screen.queryByText(/payout of l\$/i)).not.toBeInTheDocument();
 
       // Breakdown body: sale price anchor + SLParcels fee row + net.
       // Use queryAllByText for "L$ 4,750" since it shows up in both the
@@ -55,7 +61,9 @@ describe("CompletedStateCard", () => {
           role="seller"
         />,
       );
-      expect(screen.getByText(/payout of l\$\s*50/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/l\$\s*50 added to your slparcels wallet/i),
+      ).toBeInTheDocument();
       expect(screen.getByText(/^l\$\s*100$/i)).toBeInTheDocument(); // sale price row
       expect(
         screen.getByText(/slparcels fee \(5%, l\$50 min\)/i),

--- a/frontend/src/components/escrow/state/CompletedStateCard.tsx
+++ b/frontend/src/components/escrow/state/CompletedStateCard.tsx
@@ -42,7 +42,11 @@ export function CompletedStateCard({ escrow, role }: StateCardProps) {
  *   - Sale price (anchor — the seller knows what the parcel sold for)
  *   - SLParcels fee (with the 5% / L$50-minimum rule inline so the floor on
  *     small sales doesn't look arbitrary)
- *   - Net payout
+ *   - Net payout (now credited to the SLParcels wallet, not the avatar)
+ *
+ * Headline copy says "L$X added to your SLParcels wallet" to make the
+ * in-wallet location unambiguous post wallet-first cutover. The seller
+ * withdraws to their avatar separately via the wallet flow.
  *
  * "Fee" intentionally — "commission" is reserved for the agent-commission
  * slice on group listings per the realty-group spec; mislabelling the
@@ -120,7 +124,7 @@ function SellerPayoutBreakdown({
   return (
     <>
       <h2 className="text-sm font-semibold tracking-tight text-fg">
-        Payout of L$ {escrow.payoutAmt.toLocaleString()} sent
+        L$ {escrow.payoutAmt.toLocaleString()} added to your SLParcels wallet
       </h2>
       <dl className="grid grid-cols-[1fr_auto] gap-y-1 text-sm text-fg-muted">
         <dt>Sale price</dt>


### PR DESCRIPTION
## Summary

Promotes dev to main. Individual-sale payouts now credit the seller's SLParcels wallet atomically with escrow -> COMPLETED, instead of dispatching a TerminalCommand{action=PAYOUT} to the seller's avatar. Group sale + refund + listing-fee-refund + withdraw flows unchanged.

## Changed surfaces

- New `AUCTION_PAYOUT_CREDIT` user_ledger entry type + Flyway V39 to extend the CHECK constraint.
- `WalletService.creditAuctionPayout` mirrors `creditAgentCommission` (refType=ESCROW, idempotency key AUCPAYOUT-{escrowId}).
- `TerminalCommandService.queuePayout` routes both sale shapes through a shared `runPayoutSuccessInline` bookkeeping. Individual sale: wallet credit before the shared body. Group sale: distributor invoke after.
- Individual-sale ESCROW_PAYOUT notification body switched to \"L\$X credited to your SLParcels wallet.\"
- Frontend COMPLETED card headline switched to \"L\$X added to your SLParcels wallet\".

## In-flight PAYOUT terminal commands

Verified via prod RDS query: 0 in-flight PAYOUT commands. `handleEscrowPayoutSuccess` callback path is preserved with a javadoc note for any in-flight rows.

## Test plan

- [x] Backend: 2457 tests pass.
- [x] Frontend: vitest escrow suite 104/104, tsc clean (modulo pre-existing useBulkCommissionEdit error).