### PR TITLE
feat(auction): gallery thumbnail strip + keyboard / touch navigation

### DIFF
--- a/docs/superpowers/specs/2026-05-19-auction-gallery-thumb-strip-design.md
+++ b/docs/superpowers/specs/2026-05-19-auction-gallery-thumb-strip-design.md
@@ -1,0 +1,135 @@
+# Auction Gallery Thumbnail Strip
+
+**Date:** 2026-05-19
+**Status:** Awaiting user review.
+
+## 1. Goal
+
+Replace the asymmetric 3-cell hero grid in `frontend/src/components/auction/AuctionHero.tsx` with a single hero image + horizontal thumbnail strip directly beneath it. Click a thumb to swap the hero, click the hero to open the existing Lightbox at the currently-selected index, use `← / →` to navigate. Gallery stays inside the existing `lg:col-span-8` column — no layout change beyond the gallery component itself.
+
+The Lightbox component is unchanged; only how it's invoked + seeded changes.
+
+## 2. Interaction model
+
+| Trigger | Effect |
+|---|---|
+| Click a thumb | Hero swaps to that photo. No Lightbox. |
+| Click the hero | Lightbox opens at the currently-selected index. |
+| `←` (page-level, gallery not in Lightbox) | Previous image; wraps from first to last. |
+| `→` (page-level, gallery not in Lightbox) | Next image; wraps from last to first. |
+| Swipe hero left (touch) | Next image (same as `→`). |
+| Swipe hero right (touch) | Previous image (same as `←`). |
+| Tap hero (touch, no swipe) | Lightbox opens at currently-selected index. |
+| Lightbox open + arrow keys | Lightbox's existing handlers — no change. |
+| Close Lightbox | Page restores at whatever index the Lightbox left off on. |
+
+**Arrow-key activation rules:**
+- Listener attached at `window` level on mount of `AuctionHero`, detached on unmount.
+- Ignored if `event.target` is `<input>`, `<textarea>`, `<select>`, or `contentEditable`.
+- Ignored if `event.metaKey || event.ctrlKey || event.altKey` (don't steal browser hotkeys).
+- Ignored if the Lightbox is open. `AuctionHero` infers this from its own state: `lightboxIndex !== null`. Lightbox's own arrow-key handler is what runs in that case.
+
+**Touch-swipe detection:**
+- `pointerdown` records start `(x, y, t)`.
+- `pointerup` checks horizontal delta > 30px AND vertical delta < 30px AND elapsed < 500ms.
+- A pointerup that fails the swipe test counts as a tap → opens Lightbox.
+
+## 3. Layout
+
+### Desktop (`md:`+)
+
+- Hero: full column width, height `380px` (down from the current `500px` asymmetric grid).
+- Thumb row: `flex gap-2 overflow-x-auto` below the hero. Squares `64px`. Single row.
+- Active thumb: `outline-2 outline-brand outline-offset-2`. Inactive thumbs: no opacity change (full opacity, no border).
+- Edge fades: two `pointer-events-none` gradients on the left + right edges of the scroll container, conditionally visible based on `scrollLeft` and (`scrollWidth - clientWidth - scrollLeft`). Both can be active simultaneously when the user is in the middle of the strip.
+- Counter overlay: dark pill `bottom-right` of the hero. Copy `"{selectedIndex + 1} / {total}"` — 1-indexed so the first photo reads `1 / N`.
+
+### Mobile (<`md:`)
+
+- Hero: full width, height `240px`.
+- Thumb row: same `overflow-x-auto` strip, thumbs `56px`.
+- Counter overlay: same.
+- Touch swipe enabled on the hero (see §2).
+
+### Removed
+
+- Asymmetric 3-cell grid (1 large hero + 2 small secondaries).
+- `+N more` overlay on the last secondary cell.
+
+## 4. State model
+
+`AuctionHero` owns two pieces of local state (inside the multi-photo branch):
+
+- `selectedIndex: number` — source of truth for the hero render and the active-thumb outline. Default `0`.
+- `lightboxIndex: number | null` — existing field. Reused. Seeded from `selectedIndex` on hero click; updated alongside `selectedIndex` on Lightbox `onIndexChange` callbacks so closing restores the page-level state.
+
+**Defensive clamp:** mirrors the existing `effectiveLightboxIndex` pattern. Derive `effectiveSelectedIndex = selectedIndex < sorted.length ? selectedIndex : 0` at render time so a stale index from a soft navigation / photo-array change collapses to a safe default without a state-mutating effect.
+
+**Auto-scroll-into-view:** whenever `selectedIndex` changes from a non-click source (arrow key, swipe), call `thumbButtonRefs[selectedIndex].scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' })` so the active thumb is always visible. `block: 'nearest'` avoids stealing vertical page scroll.
+
+## 5. Component structure
+
+Single file: `frontend/src/components/auction/AuctionHero.tsx`. The existing no-photo / single-photo branches stay untouched. Rewrite the multi-photo branch in place. Pull two small internal subcomponents out for clarity — same file, not exported:
+
+```ts
+function HeroImage({ photo, index, total, onClick, onSwipeLeft, onSwipeRight }) { … }
+function ThumbStrip({ photos, selectedIndex, onSelect }) { … }
+```
+
+The window-level keydown listener lives in `AuctionHero` itself via a single `useEffect`. The touch-swipe handlers live in `<HeroImage>` via inline `onPointerDown` / `onPointerUp`. Edge-fade visibility lives in `<ThumbStrip>` via a `useEffect` that listens for the container's `scroll` event and updates two boolean state slots (`hasLeftOverflow`, `hasRightOverflow`).
+
+## 6. Accessibility
+
+- Each thumb is a real `<button>`:
+  - `aria-label="Show photo N"`
+  - `aria-current="true"` when `i === selectedIndex`; absent otherwise.
+- Hero `<button>` keeps `aria-label="Open photo"` (already present).
+- Tab order: hero → thumb 1 → thumb 2 → … (natural DOM order).
+- Arrow keys are visual-keyboard shortcuts; not announced. Screen-reader users navigate via tab + Enter.
+- `scrollIntoView` uses `block: 'nearest'` so screen-reader scroll position isn't disturbed.
+- `outline` (not `border`) for the active state to avoid layout shift on selection change.
+
+## 7. Testing
+
+Extend `frontend/src/components/auction/AuctionHero.test.tsx`. Don't remove existing single-photo / placeholder / snapshot cases — they're outside this rewrite's scope.
+
+New cases for the multi-photo branch:
+
+1. **Initial render** — hero shows photo 0; thumb 0 has `aria-current="true"`.
+2. **Click thumb** — clicking thumb 2 swaps the hero `src` and moves `aria-current` to thumb 2.
+3. **Click hero opens Lightbox at selected index** — select thumb 2, click hero, assert Lightbox renders with photo 2 as the initial image.
+4. **ArrowRight advances** — `selectedIndex` increments; hero `src` updates.
+5. **ArrowLeft retreats**.
+6. **Wrap from last to first** — `ArrowRight` on last photo lands on photo 0.
+7. **Wrap from first to last** — `ArrowLeft` on photo 0 lands on the last photo.
+8. **Form-input guard** — render an `<input>` outside `AuctionHero`, focus it, dispatch `ArrowRight` → no-op (hero unchanged).
+9. **Modifier-key guard** — `keydown ArrowRight` with `metaKey: true` → no-op.
+10. **Lightbox-open guard** — open Lightbox, dispatch `ArrowRight` → page-level handler must not also fire (assert via spy on `setSelectedIndex` or via behavior).
+11. **Photos shrink defensive** — start with 6 photos, `selectedIndex=4`; rerender with 3 photos → no crash, hero renders photo 0.
+12. **`aria-current` exactly one** — after any navigation, exactly one thumb has `aria-current="true"`.
+13. **Touch swipe left → next** — simulate `pointerdown` at `(200, 100)`, `pointerup` at `(120, 100)` within 200ms → `selectedIndex` advances.
+14. **Touch swipe right → previous**.
+15. **Tap (no horizontal delta) → opens Lightbox** — `pointerdown` and `pointerup` at the same position → Lightbox opens.
+16. **Counter overlay** — assert the pill renders `"{selected+1} / {total}"` and updates when `selectedIndex` changes.
+
+No backend changes — the photo DTO shape (`AuctionPhotoDto[]` sorted by `sortOrder`) is unchanged.
+
+## 8. Out of scope
+
+- Pinch-to-zoom inside the Lightbox (Lightbox is unchanged).
+- Photo reordering UI for the seller.
+- Lazy-loading thumbs past the visible strip (all photos render eagerly today; no change).
+- Keyboard navigation *inside* the Lightbox (Lightbox owns that).
+- Photo upload / capacity changes.
+
+## 9. Decision log
+
+Captured during brainstorming (2026-05-19):
+
+- **Overflow** = horizontal scroll with bidirectional edge fade. Rejected wrap-to-second-row (layout shift on photo-heavy listings) and cap-with-`+N` tile (extra click on a strip we're already simplifying).
+- **Mobile** = same desktop pattern + touch swipe on the hero. Rejected snap-scroll carousel (diverges from desktop, drops the thumb strip).
+- **Active thumb** = outline-offset, no inactive fading. Rejected scale + underline (animation-heavy) and inset border (too subtle).
+- **Arrow keys** = window-level with input/modifier guards. Rejected focus-scoped (discoverability) and viewport-scoped (added complexity for marginal gain).
+- **Edge behaviour** = wrap around.
+- **Lightbox opens at** = currently-selected index.
+- **Counter** = pill overlay on the hero (stays visible regardless of strip scroll state).

--- a/frontend/src/components/auction/AuctionHero.test.tsx
+++ b/frontend/src/components/auction/AuctionHero.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { renderWithProviders, screen, userEvent } from "@/test/render";
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+  userEvent,
+} from "@/test/render";
+import { act } from "@testing-library/react";
 import type { AuctionPhotoDto } from "@/types/auction";
 import { AuctionHero } from "./AuctionHero";
 
@@ -16,6 +22,30 @@ function photo(
     uploadedAt: "2026-04-20T00:00:00Z",
     ...overrides,
   };
+}
+
+// Dispatch a window-level keydown event with a controllable target. The
+// page-level listener guards on `event.target` (skip when focus is in an
+// input / textarea / contentEditable), so tests must be able to set a
+// realistic target. fireEvent on `window` defaults to `document.body` as
+// the target, which satisfies the non-form-input branch.
+function dispatchWindowKey(
+  key: string,
+  init: KeyboardEventInit & { target?: EventTarget } = {},
+) {
+  const { target, ...rest } = init;
+  const event = new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...rest,
+  });
+  if (target) {
+    Object.defineProperty(event, "target", { value: target, writable: false });
+  }
+  act(() => {
+    window.dispatchEvent(event);
+  });
 }
 
 describe("AuctionHero", () => {
@@ -53,20 +83,7 @@ describe("AuctionHero", () => {
     expect(img.getAttribute("src")).toBe("https://cdn.example/1.jpg");
   });
 
-  it("renders the asymmetric gallery for 2 or more photos", () => {
-    renderWithProviders(
-      <AuctionHero photos={[photo(1), photo(2), photo(3)]} snapshotUrl={null} />,
-    );
-    const hero = screen.getByTestId("auction-hero");
-    expect(hero).toHaveAttribute("data-variant", "gallery");
-    expect(screen.getByTestId("auction-hero-image").getAttribute("src")).toBe(
-      "https://cdn.example/1.jpg",
-    );
-    expect(screen.getByTestId("auction-hero-secondary-0")).toBeInTheDocument();
-    expect(screen.getByTestId("auction-hero-secondary-1")).toBeInTheDocument();
-  });
-
-  it("sorts photos by sortOrder before selecting the hero cell", () => {
+  it("sorts photos by sortOrder before selecting the hero", () => {
     renderWithProviders(
       <AuctionHero
         photos={[
@@ -83,34 +100,6 @@ describe("AuctionHero", () => {
     );
   });
 
-  it("shows a '+N more' overlay when more than 3 photos are provided", () => {
-    renderWithProviders(
-      <AuctionHero
-        photos={[photo(1), photo(2), photo(3), photo(4), photo(5)]}
-        snapshotUrl={null}
-      />,
-    );
-    const overlay = screen.getByTestId("auction-hero-more-overlay");
-    expect(overlay).toHaveTextContent("+2 more");
-  });
-
-  it("omits the 'more' overlay when photos.length <= 3", () => {
-    renderWithProviders(
-      <AuctionHero photos={[photo(1), photo(2), photo(3)]} snapshotUrl={null} />,
-    );
-    expect(screen.queryByTestId("auction-hero-more-overlay")).toBeNull();
-  });
-
-  it("includes a horizontal thumbnail strip on the mobile stack", () => {
-    renderWithProviders(
-      <AuctionHero photos={[photo(1), photo(2), photo(3)]} snapshotUrl={null} />,
-    );
-    const strip = screen.getByTestId("auction-hero-mobile-strip");
-    expect(strip.className).toContain("overflow-x-auto");
-    // 2 non-hero thumbnails.
-    expect(strip.querySelectorAll("li").length).toBe(2);
-  });
-
   it("opens the Lightbox at index 0 when the hero image is clicked (single-photo variant)", async () => {
     renderWithProviders(
       <AuctionHero photos={[photo(1)]} snapshotUrl={null} />,
@@ -119,32 +108,6 @@ describe("AuctionHero", () => {
     await userEvent.click(screen.getByTestId("auction-hero"));
     expect(screen.getByTestId("lightbox")).toBeInTheDocument();
     expect(screen.getByTestId("lightbox-counter")).toHaveTextContent("1 / 1");
-  });
-
-  it("opens the Lightbox at the clicked cell's index in the gallery variant", async () => {
-    renderWithProviders(
-      <AuctionHero
-        photos={[photo(1), photo(2), photo(3)]}
-        snapshotUrl={null}
-      />,
-    );
-    // Clicking the second secondary cell (visual index 2) opens the
-    // Lightbox at index 2 — hero is 0, first secondary is 1.
-    await userEvent.click(screen.getByTestId("auction-hero-secondary-1"));
-    expect(screen.getByTestId("lightbox-counter")).toHaveTextContent("3 / 3");
-  });
-
-  it("renders the +N overlay without breaking the button click handler", async () => {
-    renderWithProviders(
-      <AuctionHero
-        photos={[photo(1), photo(2), photo(3), photo(4), photo(5)]}
-        snapshotUrl={null}
-      />,
-    );
-    // The last secondary cell carries the overlay; clicking it must still
-    // open the Lightbox (the overlay is {@code pointer-events-none}).
-    await userEvent.click(screen.getByTestId("auction-hero-secondary-1"));
-    expect(screen.getByTestId("lightbox-counter")).toHaveTextContent("3 / 5");
   });
 
   it("renders under the dark theme without crashing", () => {
@@ -158,24 +121,241 @@ describe("AuctionHero", () => {
     );
   });
 
-  it("closes the Lightbox when the photos prop changes (soft navigation / live update)", async () => {
-    // Start with three photos and open the Lightbox at the last cell.
-    // If the parent swaps the photos prop out underneath us (soft nav to a
-    // sibling auction, or a live seller update), the stored index can
-    // point past the end of the new array. The Lightbox guards itself
-    // from crashing but still renders a visibly empty dialog — we close
-    // it on the photos change to avoid that.
-    const { rerender } = renderWithProviders(
-      <AuctionHero
-        photos={[photo(1), photo(2), photo(3)]}
-        snapshotUrl={null}
-      />,
-    );
-    await userEvent.click(screen.getByTestId("auction-hero-secondary-1"));
-    expect(screen.getByTestId("lightbox")).toBeInTheDocument();
+  // ---------- multi-photo branch (gallery + thumb strip) ----------
 
-    rerender(<AuctionHero photos={[photo(10)]} snapshotUrl={null} />);
+  describe("multi-photo gallery", () => {
+    const PHOTOS = [photo(1), photo(2), photo(3), photo(4)];
 
-    expect(screen.queryByTestId("lightbox")).toBeNull();
+    it("renders hero showing photo 0 and marks thumb 0 as current", () => {
+      renderWithProviders(<AuctionHero photos={PHOTOS} snapshotUrl={null} />);
+      expect(
+        screen.getByTestId("auction-hero-image").getAttribute("src"),
+      ).toBe("https://cdn.example/1.jpg");
+      expect(screen.getByTestId("auction-hero-thumb-0")).toHaveAttribute(
+        "aria-current",
+        "true",
+      );
+      // No other thumb should claim current.
+      expect(screen.getByTestId("auction-hero-thumb-1")).not.toHaveAttribute(
+        "aria-current",
+      );
+    });
+
+    it("clicking thumb 2 swaps the hero and moves aria-current", async () => {
+      renderWithProviders(<AuctionHero photos={PHOTOS} snapshotUrl={null} />);
+      await userEvent.click(screen.getByTestId("auction-hero-thumb-2"));
+      expect(
+        screen.getByTestId("auction-hero-image").getAttribute("src"),
+      ).toBe("https://cdn.example/3.jpg");
+      expect(screen.getByTestId("auction-hero-thumb-2")).toHaveAttribute(
+        "aria-current",
+        "true",
+      );
+      expect(screen.getByTestId("auction-hero-thumb-0")).not.toHaveAttribute(
+        "aria-current",
+      );
+    });
+
+    it("clicking the hero opens the Lightbox at the selected index", async () => {
+      renderWithProviders(<AuctionHero photos={PHOTOS} snapshotUrl={null} />);
+      await userEvent.click(screen.getByTestId("auction-hero-thumb-2"));
+      await userEvent.click(screen.getByTestId("auction-hero-main"));
+      expect(screen.getByTestId("lightbox")).toBeInTheDocument();
+      expect(screen.getByTestId("lightbox-counter")).toHaveTextContent(
+        "3 / 4",
+      );
+    });
+
+    it("ArrowRight advances the hero", () => {
+      renderWithProviders(<AuctionHero photos={PHOTOS} snapshotUrl={null} />);
+      dispatchWindowKey("ArrowRight");
+      expect(
+        screen.getByTestId("auction-hero-image").getAttribute("src"),
+      ).toBe("https://cdn.example/2.jpg");
+      expect(screen.getByTestId("auction-hero-thumb-1")).toHaveAttribute(
+        "aria-current",
+        "true",
+      );
+    });
+
+    it("ArrowLeft retreats the hero", async () => {
+      renderWithProviders(<AuctionHero photos={PHOTOS} snapshotUrl={null} />);
+      // Move forward first so we have somewhere to retreat to without
+      // exercising the wrap-around path.
+      await userEvent.click(screen.getByTestId("auction-hero-thumb-2"));
+      dispatchWindowKey("ArrowLeft");
+      expect(
+        screen.getByTestId("auction-hero-image").getAttribute("src"),
+      ).toBe("https://cdn.example/2.jpg");
+    });
+
+    it("wraps from last to first on ArrowRight", async () => {
+      renderWithProviders(<AuctionHero photos={PHOTOS} snapshotUrl={null} />);
+      await userEvent.click(screen.getByTestId("auction-hero-thumb-3"));
+      dispatchWindowKey("ArrowRight");
+      expect(
+        screen.getByTestId("auction-hero-image").getAttribute("src"),
+      ).toBe("https://cdn.example/1.jpg");
+      expect(screen.getByTestId("auction-hero-thumb-0")).toHaveAttribute(
+        "aria-current",
+        "true",
+      );
+    });
+
+    it("wraps from first to last on ArrowLeft", () => {
+      renderWithProviders(<AuctionHero photos={PHOTOS} snapshotUrl={null} />);
+      dispatchWindowKey("ArrowLeft");
+      expect(
+        screen.getByTestId("auction-hero-image").getAttribute("src"),
+      ).toBe("https://cdn.example/4.jpg");
+      expect(screen.getByTestId("auction-hero-thumb-3")).toHaveAttribute(
+        "aria-current",
+        "true",
+      );
+    });
+
+    it("ignores ArrowRight when focus is inside a form input", () => {
+      renderWithProviders(
+        <div>
+          <input data-testid="probe" />
+          <AuctionHero photos={PHOTOS} snapshotUrl={null} />
+        </div>,
+      );
+      const input = screen.getByTestId("probe");
+      input.focus();
+      dispatchWindowKey("ArrowRight", { target: input });
+      expect(
+        screen.getByTestId("auction-hero-image").getAttribute("src"),
+      ).toBe("https://cdn.example/1.jpg");
+    });
+
+    it("ignores ArrowRight when a modifier key is held", () => {
+      renderWithProviders(<AuctionHero photos={PHOTOS} snapshotUrl={null} />);
+      dispatchWindowKey("ArrowRight", { metaKey: true });
+      expect(
+        screen.getByTestId("auction-hero-image").getAttribute("src"),
+      ).toBe("https://cdn.example/1.jpg");
+    });
+
+    it("page-level ArrowRight is a no-op while the Lightbox is open", async () => {
+      renderWithProviders(<AuctionHero photos={PHOTOS} snapshotUrl={null} />);
+      await userEvent.click(screen.getByTestId("auction-hero-main"));
+      expect(screen.getByTestId("lightbox")).toBeInTheDocument();
+      // The Lightbox's own handler advances its index; the page-level
+      // handler must not double-advance the hero behind it. We assert by
+      // closing the lightbox and verifying the hero is still on photo 0.
+      dispatchWindowKey("ArrowRight");
+      await userEvent.click(screen.getByTestId("lightbox-close"));
+      expect(
+        screen.getByTestId("auction-hero-image").getAttribute("src"),
+      ).toBe("https://cdn.example/1.jpg");
+    });
+
+    it("clamps selectedIndex when the photos array shrinks", async () => {
+      const { rerender } = renderWithProviders(
+        <AuctionHero
+          photos={[photo(1), photo(2), photo(3), photo(4), photo(5), photo(6)]}
+          snapshotUrl={null}
+        />,
+      );
+      await userEvent.click(screen.getByTestId("auction-hero-thumb-4"));
+      expect(
+        screen.getByTestId("auction-hero-image").getAttribute("src"),
+      ).toBe("https://cdn.example/5.jpg");
+      rerender(
+        <AuctionHero
+          photos={[photo(10), photo(11), photo(12)]}
+          snapshotUrl={null}
+        />,
+      );
+      // Index 4 no longer exists; render falls back to photo 0.
+      expect(
+        screen.getByTestId("auction-hero-image").getAttribute("src"),
+      ).toBe("https://cdn.example/10.jpg");
+      expect(screen.getByTestId("auction-hero-thumb-0")).toHaveAttribute(
+        "aria-current",
+        "true",
+      );
+    });
+
+    it("after any navigation exactly one thumb has aria-current", () => {
+      renderWithProviders(<AuctionHero photos={PHOTOS} snapshotUrl={null} />);
+      dispatchWindowKey("ArrowRight");
+      dispatchWindowKey("ArrowRight");
+      const currents = screen
+        .getAllByRole("button")
+        .filter((b) => b.getAttribute("aria-current") === "true");
+      expect(currents).toHaveLength(1);
+      expect(currents[0]).toBe(screen.getByTestId("auction-hero-thumb-2"));
+    });
+
+    it("touch swipe left advances the hero", () => {
+      renderWithProviders(<AuctionHero photos={PHOTOS} snapshotUrl={null} />);
+      const main = screen.getByTestId("auction-hero-main");
+      fireEvent.pointerDown(main, {
+        clientX: 200,
+        clientY: 100,
+        pointerType: "touch",
+      });
+      fireEvent.pointerUp(main, {
+        clientX: 120,
+        clientY: 100,
+        pointerType: "touch",
+      });
+      expect(
+        screen.getByTestId("auction-hero-image").getAttribute("src"),
+      ).toBe("https://cdn.example/2.jpg");
+      // Swipe must not open the Lightbox.
+      expect(screen.queryByTestId("lightbox")).toBeNull();
+    });
+
+    it("touch swipe right retreats the hero", async () => {
+      renderWithProviders(<AuctionHero photos={PHOTOS} snapshotUrl={null} />);
+      await userEvent.click(screen.getByTestId("auction-hero-thumb-2"));
+      const main = screen.getByTestId("auction-hero-main");
+      fireEvent.pointerDown(main, {
+        clientX: 120,
+        clientY: 100,
+        pointerType: "touch",
+      });
+      fireEvent.pointerUp(main, {
+        clientX: 200,
+        clientY: 100,
+        pointerType: "touch",
+      });
+      expect(
+        screen.getByTestId("auction-hero-image").getAttribute("src"),
+      ).toBe("https://cdn.example/2.jpg");
+      expect(screen.queryByTestId("lightbox")).toBeNull();
+    });
+
+    it("a tap (no horizontal delta) opens the Lightbox", () => {
+      renderWithProviders(<AuctionHero photos={PHOTOS} snapshotUrl={null} />);
+      const main = screen.getByTestId("auction-hero-main");
+      fireEvent.pointerDown(main, {
+        clientX: 150,
+        clientY: 100,
+        pointerType: "touch",
+      });
+      fireEvent.pointerUp(main, {
+        clientX: 150,
+        clientY: 100,
+        pointerType: "touch",
+      });
+      expect(screen.getByTestId("lightbox")).toBeInTheDocument();
+      expect(screen.getByTestId("lightbox-counter")).toHaveTextContent(
+        "1 / 4",
+      );
+    });
+
+    it("counter overlay shows '{selected+1} / {total}' and updates with navigation", () => {
+      renderWithProviders(<AuctionHero photos={PHOTOS} snapshotUrl={null} />);
+      const counter = screen.getByTestId("auction-hero-counter");
+      expect(counter).toHaveTextContent("1 / 4");
+      dispatchWindowKey("ArrowRight");
+      expect(screen.getByTestId("auction-hero-counter")).toHaveTextContent(
+        "2 / 4",
+      );
+    });
   });
 });

--- a/frontend/src/components/auction/AuctionHero.tsx
+++ b/frontend/src/components/auction/AuctionHero.tsx
@@ -3,7 +3,13 @@
  * convention where next/image's remotePatterns loader is unnecessary. */
 "use client";
 
-import { useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { Building2 } from "@/components/ui/icons";
 import { Lightbox } from "@/components/ui/Lightbox";
 import { cn } from "@/lib/cn";
@@ -13,25 +19,29 @@ import type { AuctionPhotoDto } from "@/types/auction";
 /**
  * Hero gallery for the auction detail page.
  *
- * Desktop (`md:`+) layout — asymmetric 4-cell grid, 2 rows tall:
- *   - Cell 1 (3 cols × 2 rows): primary hero photo
- *   - Cells 2 and 3 (1 col × 1 row each): secondary photos
- *   - A "view all N photos" overlay sits on cell 3 when the gallery has
- *     more than 3 photos total; clicking it opens the Lightbox at cell 3's
- *     index.
- *
- * Mobile (<`md:`) — hero image full-width, then a horizontal thumbnail
- * strip. CSS-only responsive: no {@code useMediaQuery}, no hydration flash.
+ * Layout — single full-width hero image plus a horizontal thumbnail strip
+ * directly beneath it. Stays inside the existing {@code lg:col-span-8}
+ * column. Mobile and desktop share the same structure; only the hero height
+ * and thumb sizes step up at the {@code md:} breakpoint.
  *
  * Fallback chain (matches ListingSummaryRow / MyListingsTab):
  *   - photos present     → render hero + thumbs
  *   - photos empty, snap → snapshot as solo hero
  *   - nothing at all     → gradient placeholder with region name centred
  *
- * Clicking any photo (hero, secondary, mobile thumb) opens a full-screen
- * {@link Lightbox} at that image's index. The Lightbox itself is portaled
- * to document.body via Headless UI so it sits above the sticky bid bar
- * without a z-index fight.
+ * Interaction model (multi-photo branch only):
+ *   - Click a thumb     → swap the hero; no Lightbox.
+ *   - Click the hero    → open the Lightbox at the currently-selected index.
+ *   - {@code ←} / {@code →} (page-level) → previous / next; wraps at edges.
+ *   - Touch swipe hero  → swipe-left = next, swipe-right = previous.
+ *   - Touch tap hero    → open the Lightbox.
+ *   - Arrow keys are ignored while the Lightbox is open (the Lightbox owns
+ *     its own keybindings) and while focus is in a form input or any
+ *     modifier key is held.
+ *
+ * Clicking any photo opens a full-screen {@link Lightbox} at that image's
+ * index. The Lightbox itself is portaled to document.body via Headless UI
+ * so it sits above the sticky bid bar without a z-index fight.
  */
 interface Props {
   photos: AuctionPhotoDto[];
@@ -104,17 +114,15 @@ export function AuctionHero({
     );
   }
 
-  const [hero, ...rest] = sorted;
-  const secondaries = rest.slice(0, 2);
-  const remainingCount = Math.max(0, sorted.length - 3);
+  const [hero] = sorted;
   const lightboxImages = sorted.map((p) => ({
     id: p.publicId,
     url: apiUrl(p.url) ?? p.url,
   }));
 
-  // Single-photo shortcut: skip the asymmetric grid entirely so the hero
-  // goes full-width at all breakpoints.
-  if (secondaries.length === 0) {
+  // Single-photo shortcut: skip the thumb strip entirely so the hero goes
+  // full-width at all breakpoints with no trailing empty row beneath it.
+  if (sorted.length === 1) {
     return (
       <>
         <button
@@ -146,108 +154,115 @@ export function AuctionHero({
   }
 
   return (
+    <MultiPhotoGallery
+      sorted={sorted}
+      lightboxImages={lightboxImages}
+      lightboxIndex={lightboxIndex}
+      setLightboxIndex={setLightboxIndex}
+      effectiveLightboxIndex={effectiveLightboxIndex}
+      className={className}
+    />
+  );
+}
+
+/* --------------------------------------------------------------------- */
+/* Multi-photo branch                                                    */
+/* --------------------------------------------------------------------- */
+
+interface MultiPhotoGalleryProps {
+  sorted: AuctionPhotoDto[];
+  lightboxImages: { id: string; url: string }[];
+  lightboxIndex: number | null;
+  setLightboxIndex: (i: number | null) => void;
+  effectiveLightboxIndex: number | null;
+  className?: string;
+}
+
+function MultiPhotoGallery({
+  sorted,
+  lightboxImages,
+  lightboxIndex,
+  setLightboxIndex,
+  effectiveLightboxIndex,
+  className,
+}: MultiPhotoGalleryProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  // Defensive clamp: if the photos array shrinks under us (soft nav, live
+  // seller update), a stale selectedIndex can point past the end. Derive
+  // the effective index at render time so we never reach into sorted[]
+  // with an out-of-bounds value.
+  const effectiveSelectedIndex =
+    selectedIndex < sorted.length ? selectedIndex : 0;
+
+  const goPrev = useCallback(() => {
+    setSelectedIndex(
+      (current) => (current - 1 + sorted.length) % sorted.length,
+    );
+  }, [sorted.length]);
+
+  const goNext = useCallback(() => {
+    setSelectedIndex((current) => (current + 1) % sorted.length);
+  }, [sorted.length]);
+
+  const openLightboxHere = useCallback(() => {
+    setLightboxIndex(effectiveSelectedIndex);
+  }, [effectiveSelectedIndex, setLightboxIndex]);
+
+  // Window-level keydown listener for ← / →. Guards:
+  //   - Lightbox open  → Lightbox owns the arrow keys; bail.
+  //   - Modifier held  → respect browser hotkeys (back / forward, etc.).
+  //   - Form input     → don't steal typing context.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+      if (lightboxIndex !== null) return;
+      if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+      const target = e.target as HTMLElement | null;
+      if (target) {
+        const tag = target.tagName;
+        if (
+          tag === "INPUT" ||
+          tag === "TEXTAREA" ||
+          tag === "SELECT" ||
+          target.isContentEditable
+        ) {
+          return;
+        }
+      }
+      e.preventDefault();
+      if (e.key === "ArrowLeft") {
+        goPrev();
+      } else {
+        goNext();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [goPrev, goNext, lightboxIndex]);
+
+  const heroPhoto = sorted[effectiveSelectedIndex];
+
+  return (
     <>
       <div
         className={cn("flex flex-col gap-2", className)}
         data-testid="auction-hero"
         data-variant="gallery"
       >
-        {/* Desktop asymmetric grid: hero (3 cols × 2 rows) + two secondaries. */}
-        <div className="hidden md:grid md:grid-cols-4 md:grid-rows-2 md:gap-2 md:h-[500px]">
-          <button
-            type="button"
-            onClick={() => setLightboxIndex(0)}
-            aria-label="Open photo 1"
-            className="md:col-span-3 md:row-span-2 rounded-lg overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
-          >
-            <img
-              src={apiUrl(hero.url) ?? undefined}
-              alt=""
-              className="h-full w-full object-cover"
-              data-testid="auction-hero-image"
-            />
-          </button>
-          {secondaries.map((photo, i) => {
-            // +1 because the hero is index 0.
-            const photoIndex = i + 1;
-            return (
-              <button
-                type="button"
-                key={photo.publicId}
-                onClick={() => setLightboxIndex(photoIndex)}
-                aria-label={`Open photo ${photoIndex + 1}`}
-                className="rounded-lg overflow-hidden relative focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
-                data-testid={`auction-hero-secondary-${i}`}
-              >
-                <img
-                  src={apiUrl(photo.url) ?? undefined}
-                  alt=""
-                  className="h-full w-full object-cover"
-                />
-                {/* Overlay "view all" marker on the last secondary cell when
-                 * extra photos exist. Clicks still fire the enclosing
-                 * button's handler because the overlay is {@code
-                 * pointer-events-none} by default; the outer button opens
-                 * the Lightbox at this cell's index. */}
-                {i === secondaries.length - 1 && remainingCount > 0 && (
-                  <span
-                    className="absolute inset-0 bg-scrim/60 text-white flex items-center justify-center text-sm font-medium pointer-events-none"
-                    data-testid="auction-hero-more-overlay"
-                  >
-                    +{remainingCount} more
-                  </span>
-                )}
-              </button>
-            );
-          })}
-        </div>
-
-        {/* Mobile stack: hero first, then a horizontal thumb strip. */}
-        <div className="md:hidden flex flex-col gap-2">
-          <button
-            type="button"
-            onClick={() => setLightboxIndex(0)}
-            aria-label="Open photo 1"
-            className="rounded-lg overflow-hidden h-[240px] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
-            data-testid="auction-hero-mobile-primary"
-          >
-            <img
-              src={apiUrl(hero.url) ?? undefined}
-              alt=""
-              className="h-full w-full object-cover"
-            />
-          </button>
-          {rest.length > 0 && (
-            <ul
-              className="flex gap-2 overflow-x-auto pb-1"
-              data-testid="auction-hero-mobile-strip"
-            >
-              {rest.map((photo, i) => {
-                // +1 because the hero is index 0.
-                const photoIndex = i + 1;
-                return (
-                  <li
-                    key={photo.publicId}
-                    className="shrink-0 w-24 h-24 rounded-lg overflow-hidden"
-                  >
-                    <button
-                      type="button"
-                      onClick={() => setLightboxIndex(photoIndex)}
-                      aria-label={`Open photo ${photoIndex + 1}`}
-                      className="h-full w-full focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
-                    >
-                      <img
-                        src={apiUrl(photo.url) ?? undefined}
-                        alt=""
-                        className="h-full w-full object-cover"
-                      />
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </div>
+        <HeroImage
+          photo={heroPhoto}
+          index={effectiveSelectedIndex}
+          total={sorted.length}
+          onTap={openLightboxHere}
+          onSwipeLeft={goNext}
+          onSwipeRight={goPrev}
+        />
+        <ThumbStrip
+          photos={sorted}
+          selectedIndex={effectiveSelectedIndex}
+          onSelect={setSelectedIndex}
+        />
       </div>
       <Lightbox
         images={lightboxImages}
@@ -256,5 +271,205 @@ export function AuctionHero({
         onIndexChange={setLightboxIndex}
       />
     </>
+  );
+}
+
+/* --------------------------------------------------------------------- */
+/* Subcomponents                                                         */
+/* --------------------------------------------------------------------- */
+
+interface HeroImageProps {
+  photo: AuctionPhotoDto;
+  index: number;
+  total: number;
+  onTap: () => void;
+  onSwipeLeft: () => void;
+  onSwipeRight: () => void;
+}
+
+// Touch-swipe heuristic thresholds. Numbers chosen for the spec's
+// {@code 30px horizontal / 30px vertical / 500ms} rule — keeps a deliberate
+// horizontal flick distinct from a vertical page scroll or a slow drag.
+const SWIPE_MIN_HORIZONTAL_PX = 30;
+const SWIPE_MAX_VERTICAL_PX = 30;
+const SWIPE_MAX_DURATION_MS = 500;
+
+function HeroImage({
+  photo,
+  index,
+  total,
+  onTap,
+  onSwipeLeft,
+  onSwipeRight,
+}: HeroImageProps) {
+  // Pointer-down state — captured at the start of every press; cleared on
+  // pointerup. A null value during pointerup means we never saw the
+  // corresponding pointerdown (e.g. focus came in from outside the
+  // element) so we treat that as a no-op rather than a tap.
+  const pointerStart = useRef<{ x: number; y: number; t: number } | null>(
+    null,
+  );
+
+  const handlePointerDown = (e: ReactPointerEvent<HTMLButtonElement>) => {
+    pointerStart.current = {
+      x: e.clientX,
+      y: e.clientY,
+      t: Date.now(),
+    };
+  };
+
+  const handlePointerUp = (e: ReactPointerEvent<HTMLButtonElement>) => {
+    const start = pointerStart.current;
+    pointerStart.current = null;
+    if (!start) {
+      // Defensive: no recorded press — open the Lightbox via the standard
+      // click path (the synthetic click will follow this pointerup).
+      return;
+    }
+    const dx = e.clientX - start.x;
+    const dy = e.clientY - start.y;
+    const elapsed = Date.now() - start.t;
+    const isSwipe =
+      Math.abs(dx) > SWIPE_MIN_HORIZONTAL_PX &&
+      Math.abs(dy) < SWIPE_MAX_VERTICAL_PX &&
+      elapsed < SWIPE_MAX_DURATION_MS;
+    if (isSwipe) {
+      // Prevent the synthetic click that follows a pointerup so the
+      // Lightbox does not also open on a deliberate swipe.
+      e.preventDefault();
+      if (dx < 0) {
+        onSwipeLeft();
+      } else {
+        onSwipeRight();
+      }
+      return;
+    }
+    // Not a swipe — fall through to onTap. We invoke onTap directly rather
+    // than relying on the button's onClick because preventDefault on
+    // pointerup can suppress the click event on some browsers.
+    onTap();
+  };
+
+  return (
+    <button
+      type="button"
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      aria-label="Open photo"
+      className="relative block w-full rounded-lg overflow-hidden h-[240px] md:h-[380px] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+      data-testid="auction-hero-main"
+    >
+      <img
+        src={apiUrl(photo.url) ?? undefined}
+        alt=""
+        className="h-full w-full object-cover"
+        data-testid="auction-hero-image"
+      />
+      <span
+        className="absolute bottom-2 right-2 rounded-full bg-scrim/70 px-2.5 py-1 text-xs font-medium text-white"
+        data-testid="auction-hero-counter"
+      >
+        {index + 1} / {total}
+      </span>
+    </button>
+  );
+}
+
+interface ThumbStripProps {
+  photos: AuctionPhotoDto[];
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+}
+
+function ThumbStrip({ photos, selectedIndex, onSelect }: ThumbStripProps) {
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const thumbRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [hasLeftOverflow, setHasLeftOverflow] = useState(false);
+  const [hasRightOverflow, setHasRightOverflow] = useState(false);
+
+  const recomputeOverflow = useCallback(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    setHasLeftOverflow(el.scrollLeft > 0);
+    setHasRightOverflow(
+      el.scrollWidth - el.clientWidth - el.scrollLeft > 0,
+    );
+  }, []);
+
+  // Hook the scroll event + recompute on mount and whenever the photo set
+  // or active thumb changes (the latter because auto-scroll-into-view can
+  // shift scrollLeft).
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    recomputeOverflow();
+    el.addEventListener("scroll", recomputeOverflow, { passive: true });
+    return () => el.removeEventListener("scroll", recomputeOverflow);
+  }, [recomputeOverflow, photos.length, selectedIndex]);
+
+  // Auto-scroll the active thumb into view whenever selectedIndex changes.
+  // Click handlers also trigger this — the active thumb is already visible
+  // in that case, so scrollIntoView is a no-op and the cost is negligible.
+  // jsdom lacks scrollIntoView, so guard before calling.
+  useEffect(() => {
+    const el = thumbRefs.current[selectedIndex];
+    if (el && typeof el.scrollIntoView === "function") {
+      el.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+        inline: "center",
+      });
+    }
+  }, [selectedIndex]);
+
+  return (
+    <div className="relative">
+      <div
+        ref={scrollContainerRef}
+        className="flex gap-2 overflow-x-auto pb-1"
+        data-testid="auction-hero-thumb-strip"
+      >
+        {photos.map((photo, i) => {
+          const active = i === selectedIndex;
+          return (
+            <button
+              key={photo.publicId}
+              ref={(node) => {
+                thumbRefs.current[i] = node;
+              }}
+              type="button"
+              onClick={() => onSelect(i)}
+              aria-label={`Show photo ${i + 1}`}
+              aria-current={active ? "true" : undefined}
+              data-testid={`auction-hero-thumb-${i}`}
+              className={cn(
+                "shrink-0 w-14 h-14 md:w-16 md:h-16 rounded-lg overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+                active && "outline-2 outline-brand outline-offset-2",
+              )}
+            >
+              <img
+                src={apiUrl(photo.url) ?? undefined}
+                alt=""
+                className="h-full w-full object-cover"
+              />
+            </button>
+          );
+        })}
+      </div>
+      {hasLeftOverflow && (
+        <div
+          aria-hidden="true"
+          data-testid="auction-hero-thumb-fade-left"
+          className="pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-bg to-transparent"
+        />
+      )}
+      {hasRightOverflow && (
+        <div
+          aria-hidden="true"
+          data-testid="auction-hero-thumb-fade-right"
+          className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-bg to-transparent"
+        />
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
Promotes the gallery rewrite from #378 plus any already-on-dev work to main.

## Summary

Replaces the asymmetric 3-cell hero grid in AuctionHero with a single full-width hero + horizontal scrolling thumbnail strip. Click a thumb to swap the hero; click / tap the hero to open the existing Lightbox at the selected index; ArrowLeft / ArrowRight (page-level) navigate with wrap-around; touch swipe on the hero advances / retreats.

Spec: docs/superpowers/specs/2026-05-19-auction-gallery-thumb-strip-design.md

## Test plan

- [x] 22 AuctionHero tests pass (16 new gallery cases + 6 existing fallback / single-photo cases).
- [x] Full auction-component vitest suite green: 242 / 242.
- [x] Lint clean; tsc clean modulo the documented pre-existing useBulkCommissionEdit.test.tsx error.