### PR TITLE
fix(saved): /me/saved/auctions reads status_filter (was statusFilter; param-name mismatch)

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/saved/SavedAuctionController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/saved/SavedAuctionController.java
@@ -93,7 +93,7 @@ public class SavedAuctionController {
     @GetMapping("/auctions")
     public ResponseEntity<SearchPagedResponse<AuctionSearchResultDto>> listAuctions(
             @AuthenticationPrincipal AuthPrincipal principal,
-            @RequestParam(name = "statusFilter", required = false) String statusFilter,
+            @RequestParam(name = "status_filter", required = false) String statusFilter,
             @RequestParam(required = false) String region,
             @RequestParam(name = "min_area", required = false) Integer minArea,
             @RequestParam(name = "max_area", required = false) Integer maxArea,

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/saved/SavedAuctionControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/saved/SavedAuctionControllerIntegrationTest.java
@@ -48,7 +48,7 @@ import com.slparcelauctions.backend.user.UserRepository;
  *   <li>POST without a JWT returns 401 (per {@code JwtAuthenticationEntryPoint}).</li>
  *   <li>DELETE is idempotent â€” 204 whether the row existed or not.</li>
  *   <li>GET /ids returns a JSON array (empty for fresh users; populated post-save).</li>
- *   <li>GET /auctions returns the saved-list page envelope; {@code statusFilter}
+ *   <li>GET /auctions returns the saved-list page envelope; {@code status_filter}
  *       toggles between active-only (default) and ended-only correctly.</li>
  * </ul>
  *
@@ -268,7 +268,7 @@ class SavedAuctionControllerIntegrationTest {
 
         MvcResult res = mockMvc.perform(get("/api/v1/me/saved/auctions")
                         .header("Authorization", "Bearer " + bidderAccessToken)
-                        .param("statusFilter", "ended_only"))
+                        .param("status_filter", "ended_only"))
                 .andExpect(status().isOk())
                 .andReturn();
 
@@ -288,7 +288,7 @@ class SavedAuctionControllerIntegrationTest {
 
         MvcResult res = mockMvc.perform(get("/api/v1/me/saved/auctions")
                         .header("Authorization", "Bearer " + bidderAccessToken)
-                        .param("statusFilter", "all"))
+                        .param("status_filter", "all"))
                 .andExpect(status().isOk())
                 .andReturn();
 


### PR DESCRIPTION
The controller declared @RequestParam(name="statusFilter") (camelCase) while the frontend URL codec emits status_filter (snake_case, matching every other param). Spring fell through to fromWire(null) → ACTIVE_ONLY, so the curator tray dropdown's ALL/ENDED options silently applied the active filter — sold parcels never appeared.

Renamed to status_filter to match the URL codec convention. Integration test updated alongside (it was passing because both ends used the same wrong name). 10/10 SavedAuctionControllerIntegrationTest green.