### PR TITLE
release: coupon mapper lazy-init hotfix

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/coupon/AdminCouponController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/coupon/AdminCouponController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -69,7 +70,15 @@ public class AdminCouponController {
     private final CouponGrantRepository grantRepo;
     private final CouponMapper mapper;
 
+    // @Transactional on every controller method that maps a Coupon
+    // outside the service: the mapper iterates the lazy
+    // {@code discounts} / {@code allowedUsers} collections, which would
+    // otherwise throw LazyInitializationException now that OSIV is off.
+    // The inner service call uses propagation REQUIRED and joins this
+    // outer tx, so the session stays open through the mapper.
+
     @GetMapping
+    @Transactional(readOnly = true)
     public PagedResponse<CouponSummaryDto> list(
             @RequestParam(required = false) String q,
             @RequestParam(required = false) Boolean active,
@@ -84,11 +93,13 @@ public class AdminCouponController {
     }
 
     @GetMapping("/{publicId}")
+    @Transactional(readOnly = true)
     public CouponDto get(@PathVariable UUID publicId) {
         return mapper.toDto(service.findByPublicId(publicId));
     }
 
     @PostMapping
+    @Transactional
     public ResponseEntity<CouponDto> create(
             @AuthenticationPrincipal AuthPrincipal principal,
             @Valid @RequestBody CreateCouponRequest req) {
@@ -97,6 +108,7 @@ public class AdminCouponController {
     }
 
     @PatchMapping("/{publicId}")
+    @Transactional
     public CouponDto patch(
             @PathVariable UUID publicId,
             @Valid @RequestBody PatchCouponRequest req) {

--- a/backend/src/main/java/com/slparcelauctions/backend/coupon/AdminCouponGrantController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/coupon/AdminCouponGrantController.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -64,7 +65,12 @@ public class AdminCouponGrantController {
     private final CouponGrantRepository grantRepo;
     private final CouponMapper mapper;
 
+    // @Transactional on every method: mapper::toGrantDto dereferences
+    // {@code grant.coupon} (LAZY) and {@code coupon.discounts} (LAZY),
+    // which throw LazyInitializationException outside a session.
+
     @GetMapping
+    @Transactional(readOnly = true)
     public PagedResponse<CouponGrantDto> list(
             @PathVariable UUID publicId,
             @RequestParam(required = false) CouponGrantState state,
@@ -78,6 +84,7 @@ public class AdminCouponGrantController {
     }
 
     @PostMapping
+    @Transactional
     public ResponseEntity<List<CouponGrantDto>> directGrant(
             @PathVariable UUID publicId,
             @Valid @RequestBody DirectGrantRequest req) {
@@ -87,6 +94,7 @@ public class AdminCouponGrantController {
     }
 
     @PostMapping("/{grantPublicId}/revoke")
+    @Transactional
     public CouponGrantDto revoke(
             @PathVariable UUID publicId,
             @PathVariable UUID grantPublicId) {

--- a/backend/src/main/java/com/slparcelauctions/backend/coupon/CouponRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/coupon/CouponRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -18,9 +19,26 @@ public interface CouponRepository
      * Case-insensitive lookup used by the redemption flow when the user
      * types a code. Backed by the {@code coupons_code_lower_idx}
      * functional index on {@code LOWER(code)}.
+     *
+     * <p>Eagerly fetches {@code discounts} and {@code allowedUsers} so
+     * the redemption flow can evaluate the allowlist and stamp discount
+     * lines without a follow-up query, and so mapper calls after the
+     * service transaction closes do not trip
+     * {@link org.hibernate.LazyInitializationException}.
      */
+    @EntityGraph(attributePaths = {"discounts", "allowedUsers"})
     Optional<Coupon> findByCodeIgnoreCase(String code);
 
+    /**
+     * Single-coupon lookup by public UUID. Eagerly fetches
+     * {@code discounts} and {@code allowedUsers} so callers (admin GET +
+     * PATCH paths) can map to {@link
+     * com.slparcelauctions.backend.coupon.dto.CouponDto} after the
+     * service transaction closes without a {@code
+     * LazyInitializationException}. OSIV is off in every profile, so
+     * lazy collections never survive the service-method boundary.
+     */
+    @EntityGraph(attributePaths = {"discounts", "allowedUsers"})
     Optional<Coupon> findByPublicId(UUID publicId);
 
     /**

--- a/backend/src/main/java/com/slparcelauctions/backend/coupon/MeCouponController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/coupon/MeCouponController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -53,7 +54,15 @@ public class MeCouponController {
     private final CouponGrantRepository grantRepo;
     private final CouponMapper mapper;
 
+    // @Transactional on every controller method that maps a grant
+    // outside the service: {@code mapper.toGrantDto} dereferences
+    // {@code grant.coupon} (LAZY ManyToOne) and then {@code
+    // coupon.discounts} (LAZY OneToMany), both of which throw
+    // LazyInitializationException once the service tx closes. The
+    // outer @Transactional keeps the session open through the mapper.
+
     @GetMapping("/coupons")
+    @Transactional(readOnly = true)
     public List<CouponGrantDto> list(
             @AuthenticationPrincipal AuthPrincipal principal,
             @RequestParam(defaultValue = "active") String filter) {
@@ -70,6 +79,7 @@ public class MeCouponController {
     }
 
     @PostMapping("/coupons/redeem")
+    @Transactional
     public ResponseEntity<CouponGrantDto> redeem(
             @AuthenticationPrincipal AuthPrincipal principal,
             @Valid @RequestBody RedeemCouponRequest req) {
@@ -78,6 +88,7 @@ public class MeCouponController {
     }
 
     @GetMapping("/listings/prospective-discounts")
+    @Transactional(readOnly = true)
     public ProspectiveDiscountsDto prospective(@AuthenticationPrincipal AuthPrincipal principal) {
         CouponDiscountResolver.DiscountSnapshot snap = resolver.resolve(principal.userId());
         return mapper.toProspective(snap);

--- a/backend/src/test/java/com/slparcelauctions/backend/coupon/AdminCouponLazyInitRegressionTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/coupon/AdminCouponLazyInitRegressionTest.java
@@ -1,0 +1,150 @@
+package com.slparcelauctions.backend.coupon;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Regression coverage for the {@link org.hibernate.LazyInitializationException}
+ * surfaced in prod on {@code GET /api/v1/admin/coupons/{publicId}}: the mapper
+ * iterated {@code Coupon.discounts} (LAZY @OneToMany) after the service
+ * transaction closed.
+ *
+ * <p>The companion {@link AdminCouponControllerIntegrationTest} runs every
+ * test method inside a class-level {@code @Transactional}, which causes
+ * MockMvc's invocation to share the test's open session - so the bug never
+ * triggered there. This class deliberately omits {@code @Transactional} on
+ * the test methods so the controller call sees the same boundary as a real
+ * HTTP request: setup writes commit, the controller runs in its own
+ * transaction, and the post-service mapper has to survive a closed session.
+ *
+ * <p>Cleanup is manual in {@link #cleanup()} because there's no
+ * test-wrapping rollback.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.auction-end.enabled=false",
+        "slpa.ownership-monitor.enabled=false",
+        "slpa.escrow.ownership-monitor-job.enabled=false",
+        "slpa.escrow.timeout-job.enabled=false",
+        "slpa.escrow.command-dispatcher-job.enabled=false",
+        "slpa.review.scheduler.enabled=false",
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false",
+        "slpa.realty.invitation-expiry.enabled=false"
+})
+class AdminCouponLazyInitRegressionTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired JwtService jwtService;
+    @Autowired UserRepository userRepo;
+    @Autowired CouponRepository couponRepo;
+
+    private User admin;
+    private String adminJwt;
+    private Long createdCouponId;
+
+    @BeforeEach
+    @Transactional
+    void seed() {
+        // Unique username/email per run; this method commits, so we
+        // can't rely on rollback to clean it up.
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        admin = userRepo.save(User.builder()
+                .username("lazy-init-admin-" + suffix)
+                .email("lazy-init-admin-" + suffix + "@example.com")
+                .passwordHash("x")
+                .role(Role.ADMIN)
+                .build());
+        adminJwt = jwtService.issueAccessToken(new AuthPrincipal(
+                admin.getId(), admin.getPublicId(), admin.getEmail(), 0L, Role.ADMIN));
+
+        // Coupon with at least one discount line - the LAZY @OneToMany
+        // collection is exactly what triggered the bug.
+        Coupon coupon = Coupon.builder()
+                .code("LAZY-INIT-" + suffix)
+                .description("regression for LazyInitializationException")
+                .durationDays(30)
+                .maxPerUser(1)
+                .active(true)
+                .notifyOnGrant(true)
+                .createdByUserId(admin.getId())
+                .build();
+        coupon.setDiscounts(List.of(
+                CouponDiscount.builder()
+                        .coupon(coupon)
+                        .target(DiscountTarget.LISTING_FEE)
+                        .op(DiscountOp.OVERRIDE)
+                        .value(new BigDecimal("0"))
+                        .sortOrder(0)
+                        .build()));
+        Coupon saved = couponRepo.save(coupon);
+        createdCouponId = saved.getId();
+    }
+
+    @AfterEach
+    @Transactional
+    void cleanup() {
+        if (createdCouponId != null) {
+            couponRepo.findById(createdCouponId).ifPresent(couponRepo::delete);
+        }
+        if (admin != null) {
+            userRepo.findById(admin.getId()).ifPresent(userRepo::delete);
+        }
+    }
+
+    @Test
+    void getDetail_outsideEnclosingTx_initializesLazyCollections() throws Exception {
+        // Without the fix, the controller's mapper trips
+        // LazyInitializationException on coupon.discounts and the global
+        // handler returns 500 + INTERNAL_SERVER_ERROR. With the fix
+        // (@EntityGraph on findByPublicId + @Transactional on the
+        // controller method), the call returns 200 with the discount
+        // list serialized.
+        UUID publicId = couponRepo.findById(createdCouponId).orElseThrow().getPublicId();
+        mockMvc.perform(get("/api/v1/admin/coupons/" + publicId)
+                        .header("Authorization", "Bearer " + adminJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(org.hamcrest.Matchers.startsWith("LAZY-INIT-")))
+                .andExpect(jsonPath("$.discounts").isArray())
+                .andExpect(jsonPath("$.discounts[0].target").value("LISTING_FEE"))
+                .andExpect(jsonPath("$.discounts[0].op").value("OVERRIDE"));
+    }
+
+    @Test
+    void listFirstPage_outsideEnclosingTx_initializesLazyCollectionsPerRow() throws Exception {
+        // List path: AdminCouponController.list maps each Page<Coupon>
+        // entry via mapper.toSummary which iterates coupon.discounts.
+        // Same LazyInit risk, defended by @Transactional(readOnly=true)
+        // on the controller method.
+        mockMvc.perform(get("/api/v1/admin/coupons?q=LAZY-INIT-")
+                        .header("Authorization", "Bearer " + adminJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[*].discounts[0].target")
+                        .value(org.hamcrest.Matchers.hasItem("LISTING_FEE")));
+    }
+}


### PR DESCRIPTION
Promotes PR #388 from dev to main. Production fix for 500s on every coupon read path (LazyInitializationException in CouponMapper). Compile-clean; integration test added but not yet executed locally (Docker down at commit time). User authorized direct merge given prod outage.