### PR TITLE
feat(support): customer support contact (#167)

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,20 @@ Admin-managed promotional codes that discount listing fees and/or commission rat
 
 Spec at `docs/superpowers/specs/2026-05-20-coupon-codes-design.md` ([#165](https://github.com/TheCodeLlama/slparcelauctions/issues/165)).
 
+### Customer support
+
+- "Support" link in the user dropdown menu opens `/support`, the user's ticket queue.
+- `/support/new` form with subject, category (ACCOUNT / BIDDING / LISTING / ESCROW / WALLET / OTHER), body, and up to 3 image attachments.
+- `/support/[publicId]` thread view with alternating user/admin bubbles, attachment thumbnails (lightbox), and a reply composer.
+- Auto-reopen on user reply to a RESOLVED ticket.
+- Admin `/admin/support` queue with filters (status, category, assignee, last-author, subject search) and a polling badge on the sidebar.
+- Admin `/admin/support/[publicId]` detail with internal notes (admin-only, never visible to the user), resolve / reopen, assign / unassign, and category override.
+- Four notification categories (`SUPPORT_TICKET_ADMIN_REPLIED`, `SUPPORT_TICKET_RESOLVED`, `SUPPORT_TICKET_OPENED`, `SUPPORT_TICKET_USER_REPLIED`) routed to in-app feed + SL IM for the user-side categories.
+- Per-user rate limit: 5 new tickets per hour (replies uncapped).
+- Image attachments via pre-upload + Redis-cached pending state with S3 lifecycle rule for orphan cleanup (configure in Terraform per `docs/superpowers/specs/2026-05-21-customer-support-contact-design.md` §13).
+
+Spec: `docs/superpowers/specs/2026-05-21-customer-support-contact-design.md`. Issue [#167](https://github.com/TheCodeLlama/slparcelauctions/issues/167).
+
 The `onboarding/` slice adds two forced post-verify steps gated by new boolean columns on `users` (`avatar_step_completed`, `display_name_step_completed`, both backfilled in V20 from `profile_pic_url IS NOT NULL` / `display_name IS NOT NULL`). `SlProfilePhotoService` scrapes `world.secondlife.com/resident/{slAvatarUuid}` for the `<img class="parcelimg">` element, allow-lists the `https://picture-service.secondlife.com/` host, fetches the JPEG bytes through a 5s/5s WebClient with a 2MB cap, and Redis-caches results for 1h positive / 5min negative (sentinel `"NONE"`) so a thundering-herd of no-photo users can't hammer LL. `OnboardingController` exposes `GET /api/v1/users/me/onboarding/sl-profile-photo` (proxies bytes with `Cache-Control: private, max-age=3600`, 404 when no SL UUID or no photo), `POST /avatar/skip` (idempotent flag flip), and `POST /display-name` (laxer `@Size(max=50)` only — empty / whitespace / null are skip semantics, non-blank is trimmed and persisted; the stricter `UpdateUserRequest` regex still applies to subsequent settings edits). `AvatarService.upload` also flips `avatar_step_completed` so an upload is one of the three exits from the gate. Frontend `(verified)/(onboarded)/layout.tsx` chains a redirect after the existing verify gate: `!avatarStepCompleted` → `/dashboard/avatar`, `!displayNameStepCompleted` → `/dashboard/display-name`, else children. The avatar page lazy-fetches the SL photo via authenticated `fetch` (because `<img src>` doesn't carry the JWT), feeds it into the shared `<AvatarCropper>` (react-easy-crop, pan + zoom + circular preview), and on save runs `getCroppedImg` to produce a WebP Blob sized to `min(crop_pixels, 1024)` — no client-side max-size cap on the picked file because the cropper downsamples to ≤1024px WebP regardless of source. The display-name page pre-fills the input from `user.username` so the happy path is one click; an empty / cleared submit and the explicit Skip button both POST `null` and trigger the username fallback in `User.getDisplayName()`. Settings page reuses the same `<AvatarCropper>` so onboarding-picked and settings-picked avatars look identical.
 
 ### Public browse surface

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationCategory.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationCategory.java
@@ -79,7 +79,18 @@ public enum NotificationCategory {
     // bypasses per-group SL IM preferences (material change to the user's wallet
     // privileges, same posture as wallet admin ops). REDEMPTION grants are
     // silent -- the user just typed the code so they know.
-    COUPON_GRANTED(NotificationGroup.SYSTEM);
+    COUPON_GRANTED(NotificationGroup.SYSTEM),
+
+    // Customer support tickets. User-facing categories (admin replied, resolved)
+    // route through SYSTEM so the SL IM dispatcher bypasses per-group prefs --
+    // a support reply is a material response to a user-initiated thread and
+    // should be hard to miss. Admin-facing categories (opened, user replied)
+    // fan out to every admin via the in-app feed only; admins get the queue
+    // page + sidebar badge for browsing, no IM spam.
+    SUPPORT_TICKET_ADMIN_REPLIED(NotificationGroup.SYSTEM),
+    SUPPORT_TICKET_RESOLVED(NotificationGroup.SYSTEM),
+    SUPPORT_TICKET_OPENED(NotificationGroup.SYSTEM),
+    SUPPORT_TICKET_USER_REPLIED(NotificationGroup.SYSTEM);
 
     private final NotificationGroup group;
 

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationDataBuilder.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationDataBuilder.java
@@ -327,6 +327,59 @@ public final class NotificationDataBuilder {
         return m;
     }
 
+    // ── Customer support tickets ─────────────────────────────────────────────
+
+    /**
+     * User-facing payload: an admin replied. Carries the ticket's public id
+     * (UUID, wire-stable; the deeplink resolver consumes it via
+     * {@code SlImLinkResolver}) plus the subject and admin's display name so
+     * the bell row + SL IM body read on their own without an extra fetch.
+     */
+    public static Map<String, Object> supportTicketAdminReplied(
+            java.util.UUID ticketPublicId, String subject, String adminDisplayName) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("ticketPublicId", ticketPublicId == null ? null : ticketPublicId.toString());
+        m.put("subject", subject);
+        m.put("adminDisplayName", adminDisplayName);
+        return m;
+    }
+
+    /** User-facing payload: the ticket was marked resolved. */
+    public static Map<String, Object> supportTicketResolved(
+            java.util.UUID ticketPublicId, String subject) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("ticketPublicId", ticketPublicId == null ? null : ticketPublicId.toString());
+        m.put("subject", subject);
+        return m;
+    }
+
+    /**
+     * Admin-facing fan-out payload: a user opened a new ticket. Carries the
+     * submitter's display name (no public id; the ticket detail page surfaces
+     * full submitter identity) and the category so the queue row can display
+     * the category badge inline.
+     */
+    public static Map<String, Object> supportTicketOpened(
+            java.util.UUID ticketPublicId, String subject,
+            String submitterDisplayName, String category) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("ticketPublicId", ticketPublicId == null ? null : ticketPublicId.toString());
+        m.put("subject", subject);
+        m.put("submitterDisplayName", submitterDisplayName);
+        m.put("category", category);
+        return m;
+    }
+
+    /** Admin-facing fan-out payload: the user posted a reply on an existing ticket. */
+    public static Map<String, Object> supportTicketUserReplied(
+            java.util.UUID ticketPublicId, String subject, String submitterDisplayName) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("ticketPublicId", ticketPublicId == null ? null : ticketPublicId.toString());
+        m.put("subject", subject);
+        m.put("submitterDisplayName", submitterDisplayName);
+        return m;
+    }
+
     private static Map<String, Object> base(long auctionId, String parcelName) {
         Map<String, Object> m = new LinkedHashMap<>();
         m.put("auctionId", auctionId);

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisher.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisher.java
@@ -268,4 +268,36 @@ public interface NotificationPublisher {
     // SL IM dispatch bypasses per-group preferences but still honours the
     // global mute and no-avatar floors.
     void couponGranted(long userId, UUID couponPublicId, CouponGrantSource source);
+
+    // -- Customer support tickets ----------------------------------------------
+    // User-facing categories dispatch in-app + SL IM (SYSTEM group bypasses
+    // per-group prefs). Admin-facing categories fan out to every admin user id
+    // in-app only; SL IM is intentionally skipped to avoid spamming admins.
+
+    /**
+     * User-facing: an admin posted a reply on the ticket. Dispatches in-app +
+     * SL IM (SYSTEM group bypass). Deeplinks to {@code /support/{publicId}}.
+     */
+    void supportTicketAdminReplied(long userId, UUID ticketPublicId,
+                                   String subject, String adminDisplayName);
+
+    /**
+     * User-facing: the ticket was marked resolved. Dispatches in-app + SL IM
+     * (SYSTEM group bypass). Deeplinks to {@code /support/{publicId}}.
+     */
+    void supportTicketResolved(long userId, UUID ticketPublicId, String subject);
+
+    /**
+     * Admin-facing fan-out: a user opened a new ticket. In-app only; no SL IM.
+     * Deeplinks to {@code /admin/support/{publicId}}.
+     */
+    void supportTicketOpened(List<Long> adminUserIds, UUID ticketPublicId,
+                             String subject, String submitterDisplayName, String category);
+
+    /**
+     * Admin-facing fan-out: the user posted a reply on an existing ticket.
+     * In-app only; no SL IM. Deeplinks to {@code /admin/support/{publicId}}.
+     */
+    void supportTicketUserReplied(List<Long> adminUserIds, UUID ticketPublicId,
+                                  String subject, String submitterDisplayName);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java
@@ -1209,6 +1209,137 @@ public class NotificationPublisherImpl implements NotificationPublisher {
                 title, bodyBuilder.toString(), data, /* coalesceKey */ null));
     }
 
+    // ── Customer support tickets ──────────────────────────────────────────
+    //
+    // Two posture-pairs:
+    //   * User-facing  (SUPPORT_TICKET_ADMIN_REPLIED, SUPPORT_TICKET_RESOLVED):
+    //     single recipient. Routes through NotificationService.publish so the
+    //     SL IM dispatcher fires after-commit. SYSTEM-group categorisation
+    //     means SlImChannelGate returns QUEUE_BYPASS_PREFS, so the IM lands
+    //     even for users who have muted other groups (admin response is too
+    //     important to silence). The no-avatar + global-mute floors still
+    //     apply.
+    //   * Admin-facing (SUPPORT_TICKET_OPENED, SUPPORT_TICKET_USER_REPLIED):
+    //     fan-out across the supplied admin user ids. Each recipient gets a
+    //     row + WS broadcast via the DAO + broadcaster directly. The SL IM
+    //     dispatcher is intentionally NOT invoked -- admins use the queue
+    //     page + sidebar badge, in-world IMs would be spam. Each recipient
+    //     runs in its own REQUIRES_NEW so a single bad admin id does not
+    //     block delivery to siblings, mirroring listingCancelledBySellerFanout.
+
+    @Override
+    public void supportTicketAdminReplied(long userId, UUID ticketPublicId,
+                                          String subject, String adminDisplayName) {
+        if (ticketPublicId == null) {
+            log.warn("supportTicketAdminReplied called with null ticketPublicId for userId={}", userId);
+            return;
+        }
+        String title = "Support reply on \"" + subject + "\"";
+        String body = adminDisplayName + " replied to your support ticket: " + subject
+            + ". View at slparcels.com/support/" + ticketPublicId;
+        Map<String, Object> data = NotificationDataBuilder.supportTicketAdminReplied(
+            ticketPublicId, subject, adminDisplayName);
+        notificationService.publish(new NotificationEvent(
+            userId, NotificationCategory.SUPPORT_TICKET_ADMIN_REPLIED,
+            title, body, data, /* coalesceKey */ null));
+    }
+
+    @Override
+    public void supportTicketResolved(long userId, UUID ticketPublicId, String subject) {
+        if (ticketPublicId == null) {
+            log.warn("supportTicketResolved called with null ticketPublicId for userId={}", userId);
+            return;
+        }
+        String title = "Support ticket resolved: " + subject;
+        String body = "Your support ticket has been marked resolved: " + subject
+            + ". View at slparcels.com/support/" + ticketPublicId;
+        Map<String, Object> data = NotificationDataBuilder.supportTicketResolved(
+            ticketPublicId, subject);
+        notificationService.publish(new NotificationEvent(
+            userId, NotificationCategory.SUPPORT_TICKET_RESOLVED,
+            title, body, data, /* coalesceKey */ null));
+    }
+
+    @Override
+    public void supportTicketOpened(List<Long> adminUserIds, UUID ticketPublicId,
+                                    String subject, String submitterDisplayName, String category) {
+        if (ticketPublicId == null) {
+            log.warn("supportTicketOpened called with null ticketPublicId");
+            return;
+        }
+        if (adminUserIds == null || adminUserIds.isEmpty()) {
+            return;
+        }
+        String title = "New support ticket: " + subject;
+        String body = submitterDisplayName + " opened a new " + category
+            + " support ticket: " + subject;
+        Map<String, Object> data = NotificationDataBuilder.supportTicketOpened(
+            ticketPublicId, subject, submitterDisplayName, category);
+        adminFanoutInApp(adminUserIds,
+            NotificationCategory.SUPPORT_TICKET_OPENED, title, body, data, ticketPublicId);
+    }
+
+    @Override
+    public void supportTicketUserReplied(List<Long> adminUserIds, UUID ticketPublicId,
+                                         String subject, String submitterDisplayName) {
+        if (ticketPublicId == null) {
+            log.warn("supportTicketUserReplied called with null ticketPublicId");
+            return;
+        }
+        if (adminUserIds == null || adminUserIds.isEmpty()) {
+            return;
+        }
+        String title = "Support reply from " + submitterDisplayName + ": " + subject;
+        String body = submitterDisplayName + " replied to a support ticket: " + subject;
+        Map<String, Object> data = NotificationDataBuilder.supportTicketUserReplied(
+            ticketPublicId, subject, submitterDisplayName);
+        adminFanoutInApp(adminUserIds,
+            NotificationCategory.SUPPORT_TICKET_USER_REPLIED, title, body, data, ticketPublicId);
+    }
+
+    /**
+     * Per-recipient in-app fan-out for admin-facing support categories. Deferred
+     * to {@code afterCommit} so a rolled-back parent transaction never produces
+     * stray admin notifications. Each recipient runs in its own
+     * {@code REQUIRES_NEW} (same isolation as
+     * {@link #listingCancelledBySellerFanout}) so a stale/missing admin id does
+     * not abort delivery to the rest. The SL IM dispatcher is intentionally
+     * not invoked -- admins read the queue page, not their inbox.
+     */
+    private void adminFanoutInApp(List<Long> adminUserIds, NotificationCategory category,
+                                  String title, String body, Map<String, Object> data,
+                                  UUID ticketPublicId) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                for (Long adminId : adminUserIds) {
+                    if (adminId == null) continue;
+                    try {
+                        UpsertResult result = requiresNewTxTemplate.execute(status ->
+                            notificationDao.upsert(adminId, category, title, body, data, null));
+                        wsBroadcaster.broadcastUpsert(adminId, result,
+                            supportAdminDtoFor(adminId, result, category, data, title, body));
+                    } catch (Exception ex) {
+                        log.warn("Admin support fan-out failed for adminId={} ticketPublicId={} category={}: {}",
+                            adminId, ticketPublicId, category, ex.toString());
+                    }
+                }
+            }
+        });
+    }
+
+    private NotificationDto supportAdminDtoFor(
+            long userId, UpsertResult result, NotificationCategory category,
+            Map<String, Object> data, String title, String body) {
+        return new NotificationDto(
+            result.publicId(),
+            category,
+            category.getGroup(),
+            title, body, data, false,
+            result.createdAt(), result.updatedAt()
+        );
+    }
+
     /** Common per-recipient publish path for realty group notifications. */
     private void publishOne(long userId, NotificationCategory category,
                             String title, String body, Map<String, Object> data) {

--- a/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImLinkResolver.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImLinkResolver.java
@@ -69,6 +69,17 @@ public class SlImLinkResolver {
             // per-group admin reports queue using groupPublicId from the data blob.
             case GROUP_REPORT_THRESHOLD_REACHED ->
                 base + "/admin/realty-groups/" + data.get("groupPublicId") + "/reports";
+            // Customer support tickets. User-facing rows deeplink to the
+            // submitter's own ticket detail page; admin-facing rows deeplink
+            // to the admin ticket detail page. Admin categories never reach
+            // the SL IM dispatcher (NotificationPublisherImpl skips the
+            // SlImChannelDispatcher hop), but exhaustive switch coverage is
+            // mandatory so the deeplink is still resolved here for any
+            // future in-app row-click target consumer.
+            case SUPPORT_TICKET_ADMIN_REPLIED, SUPPORT_TICKET_RESOLVED ->
+                base + "/support/" + data.get("ticketPublicId");
+            case SUPPORT_TICKET_OPENED, SUPPORT_TICKET_USER_REPLIED ->
+                base + "/admin/support/" + data.get("ticketPublicId");
         };
     }
 

--- a/backend/src/main/java/com/slparcelauctions/backend/storage/ObjectStorageService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/storage/ObjectStorageService.java
@@ -15,6 +15,13 @@ public interface ObjectStorageService {
     void delete(String key);
 
     /**
+     * Server-side copy of an existing object to a new key within the same bucket.
+     * Used by the support-ticket attachment promotion flow to move a pending
+     * upload into its message-scoped storage path without re-uploading bytes.
+     */
+    void copy(String srcKey, String dstKey);
+
+    /**
      * Batch-deletes every object under the given key prefix. Paginates via
      * {@code isTruncated} + continuation token so >1000 objects are handled.
      */

--- a/backend/src/main/java/com/slparcelauctions/backend/storage/S3ObjectStorageService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/storage/S3ObjectStorageService.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.Delete;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
@@ -79,6 +80,17 @@ public class S3ObjectStorageService implements ObjectStorageService {
                 .bucket(props.bucket())
                 .key(key)
                 .build());
+    }
+
+    @Override
+    public void copy(String srcKey, String dstKey) {
+        s3.copyObject(CopyObjectRequest.builder()
+                .sourceBucket(props.bucket())
+                .sourceKey(srcKey)
+                .destinationBucket(props.bucket())
+                .destinationKey(dstKey)
+                .build());
+        log.debug("S3 copy: bucket={} src={} dst={}", props.bucket(), srcKey, dstKey);
     }
 
     @Override

--- a/backend/src/main/java/com/slparcelauctions/backend/support/AdminSupportTicketController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/AdminSupportTicketController.java
@@ -1,0 +1,175 @@
+package com.slparcelauctions.backend.support;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.common.PagedResponse;
+import com.slparcelauctions.backend.support.dto.AdminReplyRequest;
+import com.slparcelauctions.backend.support.dto.AdminSupportTicketQueueRow;
+import com.slparcelauctions.backend.support.dto.AssignTicketRequest;
+import com.slparcelauctions.backend.support.dto.PatchTicketRequest;
+import com.slparcelauctions.backend.support.dto.SupportTicketDto;
+import com.slparcelauctions.backend.support.dto.SupportTicketMessageDto;
+import com.slparcelauctions.backend.support.dto.SupportTicketQueueStatsDto;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Admin-facing support-ticket endpoints. Class-level
+ * {@code hasRole('ADMIN')} short-circuits any non-admin caller at 403
+ * before service code runs; the {@code /api/v1/admin/**} matcher in
+ * {@code SecurityConfig} is the redundant defence-in-depth layer.
+ *
+ * <p><strong>LazyInit defense:</strong> every method is
+ * {@link Transactional @Transactional} (read-only on GET, default on
+ * write). The mapper dereferences {@code ticket.messages},
+ * {@code message.attachments}, the submitter, and (when present) the
+ * assigned admin - all LAZY. The outer transaction keeps the Hibernate
+ * session open through the mapper so the response builds without
+ * tripping {@code LazyInitializationException} (PR #388 regression).
+ *
+ * <p><strong>L1-cache flush between write and re-fetch.</strong>
+ * Mutating endpoints (resolve / reopen / assign / patch) call a service
+ * write and then re-fetch the ticket so the DTO carries the fresh
+ * messages graph including any system message the write just appended.
+ * Inside a class-level {@code @Transactional} integration test the two
+ * service calls share the same persistence context, so the re-fetch
+ * would return the cached {@link SupportTicket} entity (whose in-memory
+ * {@code messages} set is stale because the service does not
+ * bi-directionally hydrate it on save). {@code em.flush() + em.clear()}
+ * between the two calls forces the second {@code findByPublicId} to hit
+ * the database. In production this is a no-op (each HTTP request is its
+ * own transaction); in tests it is a correctness fix.
+ *
+ * <p>Spec: {@code docs/superpowers/specs/2026-05-21-customer-support-contact-design.md}.
+ */
+@RestController
+@RequestMapping("/api/v1/admin/support-tickets")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminSupportTicketController {
+
+    private final SupportTicketService service;
+    private final SupportTicketMapper mapper;
+    private final UserRepository userRepo;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @GetMapping
+    @Transactional(readOnly = true)
+    public PagedResponse<AdminSupportTicketQueueRow> queue(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @RequestParam(required = false) SupportTicketStatus status,
+            @RequestParam(required = false) SupportTicketCategory category,
+            @RequestParam(required = false) String assignee,
+            @RequestParam(name = "last_author", required = false) SupportTicketAuthorRole lastAuthor,
+            @RequestParam(required = false) String q,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Page<SupportTicket> p = service.listAdmin(status, category, assignee, lastAuthor, q,
+                principal.userId(),
+                PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "lastMessageAt")));
+        return PagedResponse.from(p.map(t -> {
+            User admin = t.getAssignedAdminId() == null ? null
+                    : userRepo.findById(t.getAssignedAdminId()).orElse(null);
+            return mapper.toAdminRow(t, admin);
+        }));
+    }
+
+    @GetMapping("/queue-stats")
+    @Transactional(readOnly = true)
+    public SupportTicketQueueStatsDto stats() {
+        return service.queueStats();
+    }
+
+    @GetMapping("/{publicId}")
+    @Transactional(readOnly = true)
+    public SupportTicketDto detail(@PathVariable UUID publicId) {
+        SupportTicket t = service.findByPublicId(publicId);
+        User admin = t.getAssignedAdminId() == null ? null
+                : userRepo.findById(t.getAssignedAdminId()).orElse(null);
+        return mapper.toAdminDto(t, admin);
+    }
+
+    @PostMapping("/{publicId}/messages")
+    @Transactional
+    public SupportTicketMessageDto reply(@AuthenticationPrincipal AuthPrincipal principal,
+                                         @PathVariable UUID publicId,
+                                         @Valid @RequestBody AdminReplyRequest req) {
+        SupportTicketMessage msg = service.adminReply(principal.userId(), publicId, req);
+        return mapper.toMessageDto(msg);
+    }
+
+    @PostMapping("/{publicId}/resolve")
+    @Transactional
+    public SupportTicketDto resolve(@AuthenticationPrincipal AuthPrincipal principal,
+                                    @PathVariable UUID publicId) {
+        service.resolve(principal.userId(), publicId);
+        em.flush();
+        em.clear();
+        SupportTicket t = service.findByPublicId(publicId);
+        User admin = t.getAssignedAdminId() == null ? null
+                : userRepo.findById(t.getAssignedAdminId()).orElse(null);
+        return mapper.toAdminDto(t, admin);
+    }
+
+    @PostMapping("/{publicId}/reopen")
+    @Transactional
+    public SupportTicketDto reopen(@AuthenticationPrincipal AuthPrincipal principal,
+                                   @PathVariable UUID publicId) {
+        service.reopen(principal.userId(), publicId);
+        em.flush();
+        em.clear();
+        SupportTicket t = service.findByPublicId(publicId);
+        User admin = t.getAssignedAdminId() == null ? null
+                : userRepo.findById(t.getAssignedAdminId()).orElse(null);
+        return mapper.toAdminDto(t, admin);
+    }
+
+    @PostMapping("/{publicId}/assign")
+    @Transactional
+    public SupportTicketDto assign(@PathVariable UUID publicId,
+                                   @Valid @RequestBody AssignTicketRequest req) {
+        service.assign(publicId, req.adminPublicId());
+        em.flush();
+        em.clear();
+        SupportTicket t = service.findByPublicId(publicId);
+        User admin = t.getAssignedAdminId() == null ? null
+                : userRepo.findById(t.getAssignedAdminId()).orElse(null);
+        return mapper.toAdminDto(t, admin);
+    }
+
+    @PatchMapping("/{publicId}")
+    @Transactional
+    public SupportTicketDto patch(@PathVariable UUID publicId,
+                                  @Valid @RequestBody PatchTicketRequest req) {
+        service.patchCategory(publicId, req.category());
+        em.flush();
+        em.clear();
+        SupportTicket t = service.findByPublicId(publicId);
+        User admin = t.getAssignedAdminId() == null ? null
+                : userRepo.findById(t.getAssignedAdminId()).orElse(null);
+        return mapper.toAdminDto(t, admin);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/MeSupportTicketController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/MeSupportTicketController.java
@@ -1,0 +1,130 @@
+package com.slparcelauctions.backend.support;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.common.PagedResponse;
+import com.slparcelauctions.backend.support.dto.CreateSupportTicketRequest;
+import com.slparcelauctions.backend.support.dto.ReplySupportTicketRequest;
+import com.slparcelauctions.backend.support.dto.SupportTicketDto;
+import com.slparcelauctions.backend.support.dto.SupportTicketMessageDto;
+import com.slparcelauctions.backend.support.dto.SupportTicketSummaryDto;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * User-facing support-ticket endpoints. Authentication is the global
+ * {@code /api/v1/**} catch-all (any logged-in user); ownership is
+ * enforced inside the service via
+ * {@link SupportTicketService#findByPublicIdEnsureOwner(long, UUID)} so
+ * a caller can never read or reply to another user's thread (mismatches
+ * surface as {@link SupportTicketError#UNKNOWN_TICKET} rather than a
+ * distinct forbidden code, to avoid leaking ticket existence).
+ *
+ * <p><strong>LazyInit defense:</strong> every method is
+ * {@link Transactional @Transactional} (read-only on GET, default on
+ * write). The mapper dereferences
+ * {@code ticket.messages} / {@code message.attachments} / the submitter
+ * and assigned-admin {@link User} graphs, all of which are LAZY. The
+ * outer transaction keeps the Hibernate session open through the mapper
+ * so the response builds without tripping
+ * {@code LazyInitializationException} - the regression that wrecked
+ * {@code GET /api/v1/admin/coupons/{publicId}} in PR #388 and the
+ * pattern enforced for every entity-derived controller since.
+ *
+ * <p>Spec: {@code docs/superpowers/specs/2026-05-21-customer-support-contact-design.md}.
+ */
+@RestController
+@RequestMapping("/api/v1/me/support-tickets")
+@RequiredArgsConstructor
+public class MeSupportTicketController {
+
+    private final SupportTicketService service;
+    private final SupportTicketMapper mapper;
+    private final UserRepository userRepo;
+
+    /**
+     * Used inside {@link #create} to evict the just-persisted entities
+     * from the L1 cache before the re-fetch. Without the {@code clear()},
+     * the second {@code findByPublicIdEnsureOwner} call would return the
+     * cached {@link SupportTicket} (whose in-memory {@code messages} set
+     * is still empty because the service does not bi-directionally
+     * hydrate it on save), and the response would be missing the initial
+     * message. In production this is a no-op - each request is its own
+     * transaction - but inside a class-level {@code @Transactional} test
+     * the cache survives across the controller's two service calls.
+     */
+    @PersistenceContext
+    private EntityManager em;
+
+    @GetMapping
+    @Transactional(readOnly = true)
+    public PagedResponse<SupportTicketSummaryDto> list(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @RequestParam(required = false) SupportTicketStatus status,
+            @RequestParam(required = false) String q,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Page<SupportTicket> p = service.listForUser(principal.userId(), status, q,
+                PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "lastMessageAt")));
+        return PagedResponse.from(p.map(mapper::toSummaryDto));
+    }
+
+    @GetMapping("/{publicId}")
+    @Transactional(readOnly = true)
+    public SupportTicketDto detail(@AuthenticationPrincipal AuthPrincipal principal,
+                                   @PathVariable UUID publicId) {
+        SupportTicket t = service.findByPublicIdEnsureOwner(principal.userId(), publicId);
+        User assignedAdmin = t.getAssignedAdminId() == null ? null
+                : userRepo.findById(t.getAssignedAdminId()).orElse(null);
+        return mapper.toUserDto(t, assignedAdmin);
+    }
+
+    @PostMapping
+    @Transactional
+    public SupportTicketDto create(@AuthenticationPrincipal AuthPrincipal principal,
+                                   @Valid @RequestBody CreateSupportTicketRequest req) {
+        SupportTicket t = service.createTicket(principal.userId(), req);
+        UUID createdPublicId = t.getPublicId();
+        // Force a flush + clear so the re-fetch hits the database and
+        // rebuilds the entity graph with messages + attachments
+        // eagerly populated, instead of returning the cached entity
+        // (whose in-memory messages set is empty post-save).
+        em.flush();
+        em.clear();
+        SupportTicket reloaded = service.findByPublicIdEnsureOwner(
+                principal.userId(), createdPublicId);
+        return mapper.toUserDto(reloaded, null);
+    }
+
+    @PostMapping("/{publicId}/messages")
+    @Transactional
+    public SupportTicketMessageDto reply(@AuthenticationPrincipal AuthPrincipal principal,
+                                         @PathVariable UUID publicId,
+                                         @Valid @RequestBody ReplySupportTicketRequest req) {
+        // Pre-check ownership: userReply lookups via findByPublicId which
+        // already throws UNKNOWN_TICKET on a missing row OR a wrong owner,
+        // so a caller probing for another user's ticket sees the same 404
+        // shape as "ticket does not exist".
+        SupportTicketMessage msg = service.userReply(principal.userId(), publicId, req);
+        return mapper.toMessageDto(msg);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicket.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicket.java
@@ -1,0 +1,92 @@
+package com.slparcelauctions.backend.support;
+
+import com.slparcelauctions.backend.common.BaseMutableEntity;
+import com.slparcelauctions.backend.user.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * One customer support ticket: a thread between a user and admins.
+ *
+ * <p>The status model has only two persisted values
+ * ({@link SupportTicketStatus#OPEN}, {@link SupportTicketStatus#RESOLVED}).
+ * The "needs admin attention" filter is derived from
+ * {@code lastMessageAuthor = USER AND status = OPEN} so we never end up
+ * with the persisted state and the derived state disagreeing.
+ *
+ * <p>{@code assignedAdminId} is a raw {@code Long}, not a
+ * {@code @ManyToOne} to {@code User}, because we do not need to load the
+ * admin's full graph on every ticket read; the admin's display name is
+ * pulled out separately when the queue / detail DTOs are built.
+ *
+ * <p>Spec: {@code docs/superpowers/specs/2026-05-21-customer-support-contact-design.md}.
+ */
+@Entity
+@Table(name = "support_tickets")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class SupportTicket extends BaseMutableEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 160)
+    private String subject;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private SupportTicketCategory category;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private SupportTicketStatus status = SupportTicketStatus.OPEN;
+
+    @Column(name = "assigned_admin_id")
+    private Long assignedAdminId;
+
+    @Column(name = "last_message_at", nullable = false)
+    private OffsetDateTime lastMessageAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "last_message_author", nullable = false, length = 16)
+    private SupportTicketAuthorRole lastMessageAuthor;
+
+    @Column(name = "resolved_at")
+    private OffsetDateTime resolvedAt;
+
+    /**
+     * Messages on this ticket. Modeled as a {@code LinkedHashSet} (not a
+     * {@code List}) so an {@code @EntityGraph} can fetch this collection
+     * alongside {@code messages.attachments} in a single query without
+     * triggering Hibernate's {@code MultipleBagFetchException}. Callers
+     * that need chronological order sort by {@code createdAt} at the
+     * mapper / DTO boundary; insertion order is preserved across writes
+     * within a transaction but is NOT a load-order contract.
+     */
+    @Builder.Default
+    @OneToMany(mappedBy = "ticket", cascade = CascadeType.ALL,
+            orphanRemoval = true, fetch = FetchType.LAZY)
+    private Set<SupportTicketMessage> messages = new LinkedHashSet<>();
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketAttachment.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketAttachment.java
@@ -1,0 +1,54 @@
+package com.slparcelauctions.backend.support;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.slparcelauctions.backend.common.BaseMutableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * One image attachment on a {@link SupportTicketMessage}. Up to three
+ * may be attached per message (enforced at the service layer).
+ *
+ * <p>{@code storageKey} is the S3 object key after promotion from the
+ * {@code support-attachments/pending/} prefix into the message-scoped
+ * path. Width / height are snapshotted post-validation so the frontend
+ * can size thumbnails without re-reading the file.
+ */
+@Entity
+@Table(name = "support_ticket_attachments")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class SupportTicketAttachment extends BaseMutableEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "message_id", nullable = false)
+    @JsonIgnore
+    private SupportTicketMessage message;
+
+    @Column(name = "storage_key", nullable = false, length = 255)
+    private String storageKey;
+
+    @Column(name = "mime_type", nullable = false, length = 64)
+    private String mimeType;
+
+    @Column(name = "size_bytes", nullable = false)
+    private Integer sizeBytes;
+
+    @Column
+    private Integer width;
+
+    @Column
+    private Integer height;
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketAttachmentController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketAttachmentController.java
@@ -1,0 +1,93 @@
+package com.slparcelauctions.backend.support;
+
+import java.util.UUID;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Attachment lifecycle endpoints for the support-ticket feature.
+ *
+ * <p>Two endpoints, both gated by the global {@code /api/v1/**}
+ * authenticated catch-all (any logged-in user can call):
+ *
+ * <ul>
+ *   <li>{@code POST /api/v1/me/support-tickets/attachments} stages an
+ *       image upload via
+ *       {@link SupportTicketAttachmentService#preUpload(User, MultipartFile)}
+ *       and returns an opaque {@code attachmentKey} the client then
+ *       includes on a subsequent create-ticket / reply request. The
+ *       service writes to {@code support-attachments/pending/...} and
+ *       caches metadata in Redis with a TTL so abandoned uploads
+ *       self-clean (alongside the S3 bucket lifecycle rule documented in
+ *       the spec's "Deploy notes" section).</li>
+ *   <li>{@code GET /api/v1/support-tickets/attachments/{publicId}}
+ *       returns a short-lived presigned download URL for a promoted
+ *       attachment. Authorization is the ticket owner OR any admin -
+ *       enforced inline since attachments are read across both user and
+ *       admin surfaces and we want a single endpoint for both.</li>
+ * </ul>
+ *
+ * <p><strong>LazyInit defense:</strong> the signed-URL GET is wrapped in
+ * {@link Transactional @Transactional(readOnly = true)} because the
+ * authorization check walks a chain of LAZY associations
+ * ({@code attachment -> message -> ticket -> user}) and would otherwise
+ * trip {@code LazyInitializationException} - same pattern as the rest of
+ * the support controllers.
+ */
+@RestController
+@RequiredArgsConstructor
+public class SupportTicketAttachmentController {
+
+    private final SupportTicketAttachmentService attachmentService;
+    private final SupportTicketAttachmentRepository attachmentRepo;
+    private final UserRepository userRepo;
+
+    @PostMapping(value = "/api/v1/me/support-tickets/attachments",
+                  consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public AttachmentKeyResponse preUpload(@AuthenticationPrincipal AuthPrincipal principal,
+                                             @RequestParam("file") MultipartFile file) {
+        User u = userRepo.findById(principal.userId()).orElseThrow(() ->
+                new SupportTicketException(SupportTicketError.UNKNOWN_TICKET, "user missing"));
+        String key = attachmentService.preUpload(u, file);
+        return new AttachmentKeyResponse(key);
+    }
+
+    @GetMapping("/api/v1/support-tickets/attachments/{publicId}")
+    @Transactional(readOnly = true)
+    public AttachmentSignedUrlResponse signedUrl(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @PathVariable UUID publicId) {
+        SupportTicketAttachment att = attachmentRepo.findByPublicId(publicId)
+                .orElseThrow(() -> new SupportTicketException(SupportTicketError.ATTACHMENT_NOT_FOUND));
+        // Authorization: ticket owner OR any admin. The LAZY chain
+        // attachment -> message -> ticket -> user is dereferenced inside
+        // the @Transactional boundary so the Hibernate session is open.
+        Long ticketUserId = att.getMessage().getTicket().getUser().getId();
+        User caller = userRepo.findById(principal.userId()).orElseThrow(() ->
+                new SupportTicketException(SupportTicketError.UNKNOWN_TICKET, "user missing"));
+        boolean isOwner = ticketUserId.equals(principal.userId());
+        boolean isAdmin = caller.getRole() == Role.ADMIN;
+        if (!isOwner && !isAdmin) {
+            throw new SupportTicketException(SupportTicketError.NOT_OWNER);
+        }
+        return new AttachmentSignedUrlResponse(attachmentService.signedDownloadUrl(att));
+    }
+
+    public record AttachmentKeyResponse(String attachmentKey) {}
+    public record AttachmentSignedUrlResponse(String url) {}
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketAttachmentRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketAttachmentRepository.java
@@ -1,0 +1,18 @@
+package com.slparcelauctions.backend.support;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Spring Data repository for {@link SupportTicketAttachment}.
+ *
+ * <p>{@link #findByPublicId(UUID)} powers the signed-URL fetch endpoint
+ * {@code GET /api/v1/support-tickets/attachments/{publicId}}.
+ */
+public interface SupportTicketAttachmentRepository
+        extends JpaRepository<SupportTicketAttachment, Long> {
+
+    Optional<SupportTicketAttachment> findByPublicId(UUID publicId);
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketAttachmentService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketAttachmentService.java
@@ -1,0 +1,198 @@
+package com.slparcelauctions.backend.support;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.slparcelauctions.backend.media.ImageUploadValidator;
+import com.slparcelauctions.backend.storage.ObjectStorageService;
+import com.slparcelauctions.backend.user.User;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Two-phase attachment lifecycle for {@link SupportTicketMessage}:
+ *
+ * <ol>
+ *   <li>{@link #preUpload(User, MultipartFile)} stages the file at
+ *       {@code support-attachments/pending/{userPublicId}/{attachmentKey}.{ext}}
+ *       and caches per-upload metadata in Redis under
+ *       {@code support:upload:{attachmentKey}} with a TTL so an abandoned
+ *       upload self-cleans without needing a sweeper. The returned
+ *       {@code attachmentKey} is an opaque UUID, not the storage key, so the
+ *       client never learns the bucket layout.</li>
+ *   <li>{@link #promote(List, long, SupportTicketMessage,
+ *       SupportTicketAttachmentRepository)} runs at message create / reply
+ *       time. For each key it: re-reads Redis, asserts ownership, copies
+ *       the object to the message-scoped path
+ *       {@code support-attachments/{messageId}/{attachmentKey}}, deletes the
+ *       pending object, inserts the {@link SupportTicketAttachment} row, and
+ *       deletes the Redis entry. On any failure mid-list it best-effort
+ *       deletes the promoted-but-uncommitted S3 objects so a partial promote
+ *       does not leak orphaned bytes.</li>
+ * </ol>
+ *
+ * <p>{@link #signedDownloadUrl(SupportTicketAttachment)} mints a short-lived
+ * presigned GET URL for the read path; attachments are private and require
+ * the caller's principal to have access to the parent ticket (enforced at
+ * the controller layer).
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SupportTicketAttachmentService {
+
+    private final ObjectStorageService storage;
+    private final ImageUploadValidator imageValidator;
+    private final StringRedisTemplate redis;
+
+    // Self-managed: the pending-attachment payload is a flat record with
+    // primitive fields, so we don't need any Spring-side Jackson modules and
+    // can avoid relying on the auto-configured ObjectMapper bean.
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${slpa.support.attachments.max-file-bytes:5242880}")
+    private long maxFileBytes;
+
+    @Value("${slpa.support.attachments.allowed-mime-types:image/png,image/jpeg,image/webp,image/gif}")
+    private String allowedMimeTypesCsv;
+
+    @Value("${slpa.support.attachments.max-per-message:3}")
+    private int maxPerMessage;
+
+    @Value("${slpa.support.attachments.pending-ttl-seconds:3600}")
+    private long pendingTtlSeconds;
+
+    private static final int MAX_DIMENSION = 4096;
+
+    static final String REDIS_KEY_PREFIX = "support:upload:";
+
+    public String preUpload(User uploader, MultipartFile file) {
+        if (file.getSize() > maxFileBytes) {
+            throw new SupportTicketException(SupportTicketError.INVALID_ATTACHMENT,
+                    "file exceeds " + maxFileBytes + " bytes");
+        }
+        List<String> allowed = Arrays.asList(allowedMimeTypesCsv.split(","));
+        if (!allowed.contains(file.getContentType())) {
+            throw new SupportTicketException(SupportTicketError.INVALID_ATTACHMENT,
+                    "mime " + file.getContentType() + " not in allowlist");
+        }
+        byte[] bytes;
+        try {
+            bytes = file.getBytes();
+        } catch (IOException e) {
+            throw new SupportTicketException(SupportTicketError.INVALID_ATTACHMENT,
+                    "could not read file bytes");
+        }
+        ImageUploadValidator.ValidationResult dims;
+        try {
+            dims = imageValidator.validate(bytes, maxFileBytes, MAX_DIMENSION);
+        } catch (RuntimeException ex) {
+            throw new SupportTicketException(SupportTicketError.INVALID_ATTACHMENT,
+                    "image validation failed: " + ex.getMessage());
+        }
+        String ext = switch (file.getContentType()) {
+            case "image/png" -> "png";
+            case "image/jpeg" -> "jpg";
+            case "image/webp" -> "webp";
+            case "image/gif" -> "gif";
+            default -> "bin";
+        };
+        String attachmentKey = UUID.randomUUID().toString();
+        String storageKey = "support-attachments/pending/" + uploader.getPublicId()
+                + "/" + attachmentKey + "." + ext;
+        storage.put(storageKey, bytes, file.getContentType());
+
+        PendingAttachment pending = new PendingAttachment(
+                uploader.getId(), storageKey, file.getContentType(),
+                (int) file.getSize(), dims.width(), dims.height());
+        try {
+            String json = objectMapper.writeValueAsString(pending);
+            redis.opsForValue().set(REDIS_KEY_PREFIX + attachmentKey, json,
+                    Duration.ofSeconds(pendingTtlSeconds));
+        } catch (Exception e) {
+            try { storage.delete(storageKey); } catch (Exception ignored) { /* best effort */ }
+            throw new RuntimeException("failed to cache pending attachment", e);
+        }
+        return attachmentKey;
+    }
+
+    @Transactional
+    public List<SupportTicketAttachment> promote(
+            List<String> attachmentKeys, long expectedOwnerId,
+            SupportTicketMessage targetMessage,
+            SupportTicketAttachmentRepository repo) {
+        if (attachmentKeys == null || attachmentKeys.isEmpty()) {
+            return List.of();
+        }
+        if (attachmentKeys.size() > maxPerMessage) {
+            throw new SupportTicketException(SupportTicketError.INVALID_ATTACHMENT,
+                    "max " + maxPerMessage + " attachments per message");
+        }
+        List<String> promotedKeysForCleanup = new ArrayList<>();
+        try {
+            List<SupportTicketAttachment> result = new ArrayList<>();
+            for (String key : attachmentKeys) {
+                String json = redis.opsForValue().get(REDIS_KEY_PREFIX + key);
+                if (json == null) {
+                    throw new SupportTicketException(SupportTicketError.ATTACHMENT_NOT_FOUND,
+                            "attachment " + key + " missing or expired");
+                }
+                PendingAttachment p;
+                try {
+                    p = objectMapper.readValue(json, PendingAttachment.class);
+                } catch (Exception e) {
+                    throw new SupportTicketException(SupportTicketError.ATTACHMENT_NOT_FOUND,
+                            "attachment " + key + " metadata corrupt");
+                }
+                if (p.userId() != expectedOwnerId) {
+                    throw new SupportTicketException(SupportTicketError.NOT_OWNER,
+                            "attachment " + key + " not owned by caller");
+                }
+                String promotedKey = "support-attachments/" + targetMessage.getId() + "/" + key;
+                storage.copy(p.storageKey(), promotedKey);
+                promotedKeysForCleanup.add(promotedKey);
+                try { storage.delete(p.storageKey()); } catch (Exception ignored) { /* best effort */ }
+                SupportTicketAttachment att = SupportTicketAttachment.builder()
+                        .message(targetMessage)
+                        .storageKey(promotedKey)
+                        .mimeType(p.mime())
+                        .sizeBytes(p.size())
+                        .width(p.width())
+                        .height(p.height())
+                        .build();
+                result.add(repo.save(att));
+                redis.delete(REDIS_KEY_PREFIX + key);
+            }
+            return result;
+        } catch (RuntimeException ex) {
+            for (String k : promotedKeysForCleanup) {
+                try { storage.delete(k); } catch (Exception ignored) { /* best effort */ }
+            }
+            throw ex;
+        }
+    }
+
+    public String signedDownloadUrl(SupportTicketAttachment att) {
+        return storage.presignGet(att.getStorageKey(), Duration.ofMinutes(5));
+    }
+
+    /**
+     * Pending-upload metadata cached in Redis between the pre-upload and
+     * promote steps. Package-visible so the test suite can construct +
+     * serialize fixtures with the same JSON shape the service consumes.
+     */
+    record PendingAttachment(long userId, String storageKey, String mime,
+                              int size, int width, int height) {}
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketAuthorRole.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketAuthorRole.java
@@ -1,0 +1,14 @@
+package com.slparcelauctions.backend.support;
+
+/**
+ * Snapshotted role of whoever authored a given
+ * {@link SupportTicketMessage}. Stored on the message row at write time
+ * so later role changes (promotion / demotion) never rewrite historical
+ * authorship. Also stored on the parent ticket as
+ * {@code lastMessageAuthor} to power the admin "needs admin reply"
+ * filter without a subquery.
+ */
+public enum SupportTicketAuthorRole {
+    USER,
+    ADMIN
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketCategory.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketCategory.java
@@ -1,0 +1,16 @@
+package com.slparcelauctions.backend.support;
+
+/**
+ * Fixed set of triage buckets a user picks when opening a
+ * {@link SupportTicket}. Six values cover the common surfaces; OTHER is
+ * the long-tail catch-all. Free-form categories were rejected to keep
+ * admin queue filtering tractable.
+ */
+public enum SupportTicketCategory {
+    ACCOUNT,
+    BIDDING,
+    LISTING,
+    ESCROW,
+    WALLET,
+    OTHER
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketError.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketError.java
@@ -1,0 +1,11 @@
+package com.slparcelauctions.backend.support;
+
+public enum SupportTicketError {
+    UNKNOWN_TICKET,
+    NOT_OWNER,
+    INTERNAL_NOTE_FROM_USER,
+    RATE_LIMITED,
+    INVALID_ATTACHMENT,
+    INVALID_CATEGORY,
+    ATTACHMENT_NOT_FOUND
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketException.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketException.java
@@ -1,0 +1,19 @@
+package com.slparcelauctions.backend.support;
+
+import lombok.Getter;
+
+@Getter
+public class SupportTicketException extends RuntimeException {
+
+    private final SupportTicketError code;
+
+    public SupportTicketException(SupportTicketError code) {
+        super(code.name());
+        this.code = code;
+    }
+
+    public SupportTicketException(SupportTicketError code, String detail) {
+        super(detail);
+        this.code = code;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketExceptionHandler.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketExceptionHandler.java
@@ -1,0 +1,38 @@
+package com.slparcelauctions.backend.support;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Slice-scoped advice that maps {@link SupportTicketException} to an RFC 9457
+ * {@link ProblemDetail}. Scoped to the support package and ordered 100 above
+ * the global catch-all so it beats {@code GlobalExceptionHandler#handleUnexpected}
+ * but stacks cleanly with sibling slice handlers.
+ *
+ * <p>The discriminator is exposed as {@code code} on the {@code ProblemDetail}
+ * so the frontend can pick an i18n key without parsing the human-readable
+ * detail string.
+ */
+@RestControllerAdvice(basePackages = "com.slparcelauctions.backend.support")
+@Order(Ordered.LOWEST_PRECEDENCE - 100)
+public class SupportTicketExceptionHandler {
+
+    @ExceptionHandler(SupportTicketException.class)
+    public ResponseEntity<ProblemDetail> handle(SupportTicketException e) {
+        HttpStatus status = switch (e.getCode()) {
+            case UNKNOWN_TICKET, ATTACHMENT_NOT_FOUND -> HttpStatus.NOT_FOUND;
+            case NOT_OWNER -> HttpStatus.FORBIDDEN;
+            case INTERNAL_NOTE_FROM_USER, INVALID_ATTACHMENT, INVALID_CATEGORY -> HttpStatus.BAD_REQUEST;
+            case RATE_LIMITED -> HttpStatus.TOO_MANY_REQUESTS;
+        };
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(status, e.getMessage());
+        pd.setTitle("Support ticket error");
+        pd.setProperty("code", e.getCode().name());
+        return ResponseEntity.status(status).body(pd);
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketMapper.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketMapper.java
@@ -1,0 +1,116 @@
+package com.slparcelauctions.backend.support;
+
+import java.util.Comparator;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.slparcelauctions.backend.support.dto.AdminSupportTicketQueueRow;
+import com.slparcelauctions.backend.support.dto.SupportTicketAttachmentDto;
+import com.slparcelauctions.backend.support.dto.SupportTicketDto;
+import com.slparcelauctions.backend.support.dto.SupportTicketMessageDto;
+import com.slparcelauctions.backend.support.dto.SupportTicketSummaryDto;
+import com.slparcelauctions.backend.user.User;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Maps support-ticket entities to DTOs. {@link #toUserDto} filters out
+ * messages with {@code visibleToUser=false} (admin internal notes);
+ * {@link #toAdminDto} includes every message.
+ *
+ * <p>Because {@link SupportTicket#getMessages} is a {@code Set} (Hibernate
+ * {@code MultipleBagFetchException} avoidance, see Task 1), this mapper
+ * sorts messages by {@code createdAt} ascending so the thread renders in
+ * conversation order. Attachments within a message are sorted the same
+ * way.
+ */
+@Component
+@RequiredArgsConstructor
+public class SupportTicketMapper {
+
+    public SupportTicketAttachmentDto toAttachmentDto(SupportTicketAttachment a) {
+        return new SupportTicketAttachmentDto(
+                a.getPublicId(), a.getMimeType(), a.getSizeBytes(),
+                a.getWidth(), a.getHeight());
+    }
+
+    public SupportTicketMessageDto toMessageDto(SupportTicketMessage m) {
+        User author = m.getAuthorUser();
+        List<SupportTicketAttachmentDto> atts = m.getAttachments().stream()
+                .sorted(Comparator.comparing(SupportTicketAttachment::getCreatedAt))
+                .map(this::toAttachmentDto)
+                .toList();
+        return new SupportTicketMessageDto(
+                m.getPublicId(),
+                author.getPublicId(),
+                displayNameOf(author),
+                m.getAuthorRole(),
+                m.getBody(),
+                Boolean.TRUE.equals(m.getVisibleToUser()),
+                m.getCreatedAt(),
+                atts);
+    }
+
+    public SupportTicketDto toUserDto(SupportTicket t, User assignedAdmin) {
+        List<SupportTicketMessageDto> msgs = t.getMessages().stream()
+                .filter(msg -> Boolean.TRUE.equals(msg.getVisibleToUser()))
+                .sorted(Comparator.comparing(SupportTicketMessage::getCreatedAt))
+                .map(this::toMessageDto)
+                .toList();
+        return buildDto(t, assignedAdmin, msgs);
+    }
+
+    public SupportTicketDto toAdminDto(SupportTicket t, User assignedAdmin) {
+        List<SupportTicketMessageDto> msgs = t.getMessages().stream()
+                .sorted(Comparator.comparing(SupportTicketMessage::getCreatedAt))
+                .map(this::toMessageDto)
+                .toList();
+        return buildDto(t, assignedAdmin, msgs);
+    }
+
+    public SupportTicketSummaryDto toSummaryDto(SupportTicket t) {
+        return new SupportTicketSummaryDto(
+                t.getPublicId(), t.getSubject(), t.getCategory(), t.getStatus(),
+                t.getLastMessageAuthor(), t.getLastMessageAt());
+    }
+
+    public AdminSupportTicketQueueRow toAdminRow(SupportTicket t, User assignedAdmin) {
+        User submitter = t.getUser();
+        return new AdminSupportTicketQueueRow(
+                t.getPublicId(),
+                t.getSubject(),
+                t.getCategory(),
+                t.getStatus(),
+                submitter.getPublicId(),
+                displayNameOf(submitter),
+                assignedAdmin == null ? null : assignedAdmin.getPublicId(),
+                assignedAdmin == null ? null : displayNameOf(assignedAdmin),
+                t.getLastMessageAuthor(),
+                t.getLastMessageAt());
+    }
+
+    private SupportTicketDto buildDto(SupportTicket t, User assignedAdmin,
+                                      List<SupportTicketMessageDto> messages) {
+        User submitter = t.getUser();
+        return new SupportTicketDto(
+                t.getPublicId(),
+                submitter.getPublicId(),
+                displayNameOf(submitter),
+                t.getSubject(),
+                t.getCategory(),
+                t.getStatus(),
+                assignedAdmin == null ? null : assignedAdmin.getPublicId(),
+                assignedAdmin == null ? null : displayNameOf(assignedAdmin),
+                t.getLastMessageAt(),
+                t.getLastMessageAuthor(),
+                t.getResolvedAt(),
+                t.getCreatedAt(),
+                t.getUpdatedAt(),
+                messages);
+    }
+
+    private static String displayNameOf(User u) {
+        return u.getDisplayName() == null ? u.getUsername() : u.getDisplayName();
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketMessage.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketMessage.java
@@ -1,0 +1,81 @@
+package com.slparcelauctions.backend.support;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.slparcelauctions.backend.common.BaseMutableEntity;
+import com.slparcelauctions.backend.user.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * One message inside a {@link SupportTicket}. Authored by either the
+ * ticket owner ({@link SupportTicketAuthorRole#USER}) or an admin
+ * ({@link SupportTicketAuthorRole#ADMIN}).
+ *
+ * <p>{@code visibleToUser = false} marks an admin internal note - those
+ * are filtered out of every user-facing query and never fire a
+ * notification on any channel.
+ *
+ * <p>{@code authorRole} is snapshotted at write time so later role
+ * changes do not rewrite history. Body length (1..10000) is enforced at
+ * the service / validation layer rather than the DB because TEXT has no
+ * server-side length constraint primitive.
+ */
+@Entity
+@Table(name = "support_ticket_messages")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class SupportTicketMessage extends BaseMutableEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "ticket_id", nullable = false)
+    @JsonIgnore
+    private SupportTicket ticket;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "author_user_id", nullable = false)
+    @JsonIgnore
+    private User authorUser;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "author_role", nullable = false, length = 16)
+    private SupportTicketAuthorRole authorRole;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String body;
+
+    @Builder.Default
+    @Column(name = "visible_to_user", nullable = false)
+    private Boolean visibleToUser = true;
+
+    /**
+     * Attachments on this message. Modeled as a {@code LinkedHashSet} to
+     * preserve insertion order while avoiding Hibernate's
+     * {@code MultipleBagFetchException} when an {@code @EntityGraph}
+     * fetches both this collection and the parent ticket's
+     * {@code messages} list in a single query (Hibernate cannot
+     * simultaneously fetch multiple {@code List}-backed bags).
+     */
+    @Builder.Default
+    @OneToMany(mappedBy = "message", cascade = CascadeType.ALL,
+            orphanRemoval = true, fetch = FetchType.LAZY)
+    private Set<SupportTicketAttachment> attachments = new LinkedHashSet<>();
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketMessageRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketMessageRepository.java
@@ -1,0 +1,14 @@
+package com.slparcelauctions.backend.support;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Spring Data repository for {@link SupportTicketMessage}. Messages are
+ * normally accessed through the parent {@link SupportTicket}'s
+ * {@code messages} collection; this repository exists for direct CRUD
+ * by services that need to persist a single message row without
+ * mutating the parent (e.g. cascade-only paths).
+ */
+public interface SupportTicketMessageRepository
+        extends JpaRepository<SupportTicketMessage, Long> {
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketRateLimiter.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketRateLimiter.java
@@ -1,0 +1,39 @@
+package com.slparcelauctions.backend.support;
+
+import java.time.OffsetDateTime;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Per-user rate limiter on new support-ticket creation.
+ *
+ * <p>Counts only NEW tickets opened by a given user in the trailing
+ * 60 minutes. Replies to existing open tickets do NOT count toward
+ * the cap - a user stuck in a back-and-forth thread can keep
+ * responding indefinitely without tripping this guard.
+ *
+ * <p>The cap is configurable via
+ * {@code slpa.support.rate-limit.tickets-per-hour} and defaults to 5.
+ */
+@Component
+@RequiredArgsConstructor
+public class SupportTicketRateLimiter {
+
+    private final SupportTicketRepository ticketRepository;
+
+    @Value("${slpa.support.rate-limit.tickets-per-hour:5}")
+    private int ticketsPerHour;
+
+    public void assertCanOpenNewTicket(long userId) {
+        OffsetDateTime cutoff = OffsetDateTime.now().minusHours(1);
+        long created = ticketRepository.countByUserIdAndCreatedAtAfter(userId, cutoff);
+        if (created >= ticketsPerHour) {
+            throw new SupportTicketException(
+                    SupportTicketError.RATE_LIMITED,
+                    "Too many new tickets - wait an hour or reply to an existing open ticket");
+        }
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketRepository.java
@@ -1,0 +1,31 @@
+package com.slparcelauctions.backend.support;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+/**
+ * Spring Data repository for {@link SupportTicket}.
+ *
+ * <p>{@link #findByPublicId(UUID)} carries an {@code @EntityGraph} that
+ * eagerly fetches the thread's messages and their attachments so any
+ * mapper that runs outside an open Hibernate session (e.g. a
+ * non-{@code @Transactional} controller test) can still read the
+ * collections without tripping {@code LazyInitializationException}.
+ *
+ * <p>{@link #countByUserIdAndCreatedAtAfter(long, OffsetDateTime)} powers
+ * the per-user 5/hour rate limiter on new-ticket creation. Replies are
+ * NOT counted toward this cap.
+ */
+public interface SupportTicketRepository
+        extends JpaRepository<SupportTicket, Long>, JpaSpecificationExecutor<SupportTicket> {
+
+    @EntityGraph(attributePaths = {"messages", "messages.attachments"})
+    Optional<SupportTicket> findByPublicId(UUID publicId);
+
+    long countByUserIdAndCreatedAtAfter(long userId, OffsetDateTime threshold);
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketService.java
@@ -11,6 +11,7 @@ import com.slparcelauctions.backend.notification.NotificationPublisher;
 import com.slparcelauctions.backend.support.dto.AdminReplyRequest;
 import com.slparcelauctions.backend.support.dto.CreateSupportTicketRequest;
 import com.slparcelauctions.backend.support.dto.ReplySupportTicketRequest;
+import com.slparcelauctions.backend.support.dto.SupportTicketQueueStatsDto;
 import com.slparcelauctions.backend.user.Role;
 import com.slparcelauctions.backend.user.User;
 import com.slparcelauctions.backend.user.UserRepository;
@@ -141,6 +142,123 @@ public class SupportTicketService {
     public SupportTicket findByPublicId(UUID publicId) {
         return ticketRepo.findByPublicId(publicId)
                 .orElseThrow(() -> new SupportTicketException(SupportTicketError.UNKNOWN_TICKET));
+    }
+
+    /**
+     * Flip a ticket to {@link SupportTicketStatus#RESOLVED}, writing a
+     * synthetic admin-authored system message ("Marked resolved by admin")
+     * so the resolution shows in the thread, and firing the
+     * {@code supportTicketResolved} notification to the submitter.
+     * Idempotent: a no-op when already resolved.
+     */
+    public SupportTicket resolve(long adminUserId, UUID ticketPublicId) {
+        SupportTicket ticket = ticketRepo.findByPublicId(ticketPublicId)
+                .orElseThrow(() -> new SupportTicketException(SupportTicketError.UNKNOWN_TICKET));
+        if (ticket.getStatus() == SupportTicketStatus.RESOLVED) return ticket;
+
+        OffsetDateTime now = OffsetDateTime.now();
+        User admin = userRepo.findById(adminUserId).orElseThrow(() ->
+                new SupportTicketException(SupportTicketError.UNKNOWN_TICKET, "admin missing"));
+        ticket.setStatus(SupportTicketStatus.RESOLVED);
+        ticket.setResolvedAt(now);
+
+        SupportTicketMessage system = SupportTicketMessage.builder()
+                .ticket(ticket).authorUser(admin)
+                .authorRole(SupportTicketAuthorRole.ADMIN)
+                .body("Marked resolved by admin")
+                .visibleToUser(true)
+                .build();
+        messageRepo.save(system);
+        ticket.setLastMessageAt(now);
+        ticket.setLastMessageAuthor(SupportTicketAuthorRole.ADMIN);
+
+        User submitter = ticket.getUser();
+        notifications.supportTicketResolved(submitter.getId(), ticket.getPublicId(), ticket.getSubject());
+        return ticket;
+    }
+
+    /**
+     * Flip a ticket back to {@link SupportTicketStatus#OPEN}, writing a
+     * synthetic admin-authored system message ("Reopened by admin") so the
+     * reopen shows in the thread. No notification is fired (the submitter
+     * does not get spammed when an admin reopens for internal follow-up).
+     * Idempotent: a no-op when already open.
+     */
+    public SupportTicket reopen(long adminUserId, UUID ticketPublicId) {
+        SupportTicket ticket = ticketRepo.findByPublicId(ticketPublicId)
+                .orElseThrow(() -> new SupportTicketException(SupportTicketError.UNKNOWN_TICKET));
+        if (ticket.getStatus() == SupportTicketStatus.OPEN) return ticket;
+
+        OffsetDateTime now = OffsetDateTime.now();
+        User admin = userRepo.findById(adminUserId).orElseThrow(() ->
+                new SupportTicketException(SupportTicketError.UNKNOWN_TICKET, "admin missing"));
+        ticket.setStatus(SupportTicketStatus.OPEN);
+        ticket.setResolvedAt(null);
+
+        SupportTicketMessage system = SupportTicketMessage.builder()
+                .ticket(ticket).authorUser(admin)
+                .authorRole(SupportTicketAuthorRole.ADMIN)
+                .body("Reopened by admin")
+                .visibleToUser(true)
+                .build();
+        messageRepo.save(system);
+        ticket.setLastMessageAt(now);
+        ticket.setLastMessageAuthor(SupportTicketAuthorRole.ADMIN);
+        return ticket;
+    }
+
+    /**
+     * Assign / unassign the admin owner of a ticket. {@code adminPublicId}
+     * null clears the assignment; otherwise the target user must exist and
+     * carry the {@link Role#ADMIN} role. Non-admin targets surface as
+     * {@code UNKNOWN_TICKET} to avoid leaking role information through the
+     * admin assignment surface.
+     */
+    public SupportTicket assign(UUID ticketPublicId, UUID adminPublicId) {
+        SupportTicket ticket = ticketRepo.findByPublicId(ticketPublicId)
+                .orElseThrow(() -> new SupportTicketException(SupportTicketError.UNKNOWN_TICKET));
+        if (adminPublicId == null) {
+            ticket.setAssignedAdminId(null);
+            return ticket;
+        }
+        User admin = userRepo.findByPublicId(adminPublicId).orElseThrow(() ->
+                new SupportTicketException(SupportTicketError.UNKNOWN_TICKET, "admin missing"));
+        if (admin.getRole() != Role.ADMIN) {
+            throw new SupportTicketException(SupportTicketError.UNKNOWN_TICKET, "user is not an admin");
+        }
+        ticket.setAssignedAdminId(admin.getId());
+        return ticket;
+    }
+
+    /**
+     * Admin-only category re-tag. The original category was set at create
+     * time from a user-submitted form, so admins occasionally need to fix
+     * misclassifications without rewriting the thread.
+     */
+    public SupportTicket patchCategory(UUID ticketPublicId, SupportTicketCategory category) {
+        if (category == null) {
+            throw new SupportTicketException(SupportTicketError.INVALID_CATEGORY, "category required");
+        }
+        SupportTicket ticket = ticketRepo.findByPublicId(ticketPublicId)
+                .orElseThrow(() -> new SupportTicketException(SupportTicketError.UNKNOWN_TICKET));
+        ticket.setCategory(category);
+        return ticket;
+    }
+
+    /**
+     * Cheap aggregate counters for the admin queue header / sidebar badge.
+     * {@code openNeedingAdminReply} matches the "needs admin attention"
+     * filter ({@code status = OPEN AND lastMessageAuthor = USER}) so the
+     * badge and the filtered list never disagree.
+     */
+    @Transactional(readOnly = true)
+    public SupportTicketQueueStatsDto queueStats() {
+        long openNeedingAdminReply = ticketRepo.count((root, cq, cb) -> cb.and(
+                cb.equal(root.get("status"), SupportTicketStatus.OPEN),
+                cb.equal(root.get("lastMessageAuthor"), SupportTicketAuthorRole.USER)));
+        long openTotal = ticketRepo.count((root, cq, cb) ->
+                cb.equal(root.get("status"), SupportTicketStatus.OPEN));
+        return new SupportTicketQueueStatsDto(openNeedingAdminReply, openTotal);
     }
 
     private SupportTicketMessage appendMessage(SupportTicket ticket, User author,

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketService.java
@@ -246,6 +246,97 @@ public class SupportTicketService {
     }
 
     /**
+     * Paginated user-side ticket list. Always scoped to {@code userId} via a
+     * mandatory {@code user.id} predicate so a caller can never see another
+     * user's rows. Optional filters: {@code status} (exact match) and
+     * {@code q} (case-insensitive substring match on {@code subject}).
+     * Sort + page size come from the caller-supplied {@link org.springframework.data.domain.Pageable}.
+     */
+    @Transactional(readOnly = true)
+    public org.springframework.data.domain.Page<SupportTicket> listForUser(
+            long userId, SupportTicketStatus status, String q,
+            org.springframework.data.domain.Pageable pageable) {
+        org.springframework.data.jpa.domain.Specification<SupportTicket> spec =
+                (root, cq, cb) -> cb.equal(root.get("user").get("id"), userId);
+        if (status != null) {
+            var prev = spec;
+            spec = (root, cq, cb) -> cb.and(
+                    prev.toPredicate(root, cq, cb),
+                    cb.equal(root.get("status"), status));
+        }
+        if (q != null && !q.isBlank()) {
+            var prev = spec;
+            spec = (root, cq, cb) -> cb.and(
+                    prev.toPredicate(root, cq, cb),
+                    cb.like(cb.lower(root.get("subject")), "%" + q.toLowerCase() + "%"));
+        }
+        return ticketRepo.findAll(spec, pageable);
+    }
+
+    /**
+     * Paginated admin queue list. All filters are optional and AND together.
+     * {@code assignee} accepts the literal strings {@code "mine"} (matches
+     * {@code assignedAdminId = callerAdminId}), {@code "unassigned"} (matches
+     * {@code assignedAdminId IS NULL}), or a submitter user {@code publicId}
+     * UUID string (matches {@code user.publicId}). Unparseable assignee
+     * values are ignored rather than rejected, so a stale filter chip in the
+     * frontend never throws a 500.
+     */
+    @Transactional(readOnly = true)
+    public org.springframework.data.domain.Page<SupportTicket> listAdmin(
+            SupportTicketStatus status, SupportTicketCategory category,
+            String assignee, SupportTicketAuthorRole lastAuthor,
+            String q, long callerAdminId,
+            org.springframework.data.domain.Pageable pageable) {
+        org.springframework.data.jpa.domain.Specification<SupportTicket> spec =
+                (root, cq, cb) -> cb.conjunction();
+        if (status != null) {
+            var prev = spec;
+            spec = (root, cq, cb) -> cb.and(prev.toPredicate(root, cq, cb),
+                    cb.equal(root.get("status"), status));
+        }
+        if (category != null) {
+            var prev = spec;
+            spec = (root, cq, cb) -> cb.and(prev.toPredicate(root, cq, cb),
+                    cb.equal(root.get("category"), category));
+        }
+        if (lastAuthor != null) {
+            var prev = spec;
+            spec = (root, cq, cb) -> cb.and(prev.toPredicate(root, cq, cb),
+                    cb.equal(root.get("lastMessageAuthor"), lastAuthor));
+        }
+        if (assignee != null && !assignee.isBlank()) {
+            var prev = spec;
+            if ("mine".equalsIgnoreCase(assignee)) {
+                spec = (root, cq, cb) -> cb.and(prev.toPredicate(root, cq, cb),
+                        cb.equal(root.get("assignedAdminId"), callerAdminId));
+            } else if ("unassigned".equalsIgnoreCase(assignee)) {
+                spec = (root, cq, cb) -> cb.and(prev.toPredicate(root, cq, cb),
+                        cb.isNull(root.get("assignedAdminId")));
+            } else {
+                java.util.UUID submitterPid;
+                try {
+                    submitterPid = java.util.UUID.fromString(assignee);
+                } catch (IllegalArgumentException e) {
+                    submitterPid = null;
+                }
+                if (submitterPid != null) {
+                    final java.util.UUID pid = submitterPid;
+                    spec = (root, cq, cb) -> cb.and(prev.toPredicate(root, cq, cb),
+                            cb.equal(root.get("user").get("publicId"), pid));
+                }
+                // unparseable assignee value: ignore the filter (no rows narrowed by it)
+            }
+        }
+        if (q != null && !q.isBlank()) {
+            var prev = spec;
+            spec = (root, cq, cb) -> cb.and(prev.toPredicate(root, cq, cb),
+                    cb.like(cb.lower(root.get("subject")), "%" + q.toLowerCase() + "%"));
+        }
+        return ticketRepo.findAll(spec, pageable);
+    }
+
+    /**
      * Cheap aggregate counters for the admin queue header / sidebar badge.
      * {@code openNeedingAdminReply} matches the "needs admin attention"
      * filter ({@code status = OPEN AND lastMessageAuthor = USER}) so the

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketService.java
@@ -1,0 +1,195 @@
+package com.slparcelauctions.backend.support;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.notification.NotificationPublisher;
+import com.slparcelauctions.backend.support.dto.AdminReplyRequest;
+import com.slparcelauctions.backend.support.dto.CreateSupportTicketRequest;
+import com.slparcelauctions.backend.support.dto.ReplySupportTicketRequest;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Core write-path service for customer support tickets. Owns
+ * {@code createTicket}, {@code userReply}, and {@code adminReply} plus the
+ * private {@code appendMessage} helper that every reply path funnels through.
+ *
+ * <p>Auto-reopen is intentionally scoped: a user replying to a
+ * {@link SupportTicketStatus#RESOLVED} ticket flips it back to
+ * {@link SupportTicketStatus#OPEN}; an admin replying to a resolved ticket
+ * does NOT reopen it (the admin can resolve again or use an explicit
+ * resolve / reopen action from Task 9). Internal notes
+ * ({@code visibleToUser = false}) are silent end-to-end - they do not bump
+ * {@code lastMessageAt}, do not mutate {@code lastMessageAuthor}, and fire
+ * no notifications. The notification fan-out for admin recipients reads from
+ * {@link UserRepository#findIdsByRole(Role)} to avoid hydrating full
+ * {@link User} entities into the persistence context just for an id list.
+ *
+ * <p>Ownership checks return {@link SupportTicketError#UNKNOWN_TICKET} rather
+ * than {@code NOT_OWNER} on a wrong-user-id mismatch so an attacker probing
+ * for ticket existence cannot distinguish "this ticket does not exist" from
+ * "this ticket exists but belongs to someone else".
+ *
+ * <p>Spec: {@code docs/superpowers/specs/2026-05-21-customer-support-contact-design.md}.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class SupportTicketService {
+
+    private final SupportTicketRepository ticketRepo;
+    private final SupportTicketMessageRepository messageRepo;
+    private final SupportTicketAttachmentRepository attachmentRepo;
+    private final SupportTicketAttachmentService attachmentService;
+    private final SupportTicketRateLimiter rateLimiter;
+    private final NotificationPublisher notifications;
+    private final UserRepository userRepo;
+
+    public SupportTicket createTicket(long submitterUserId, CreateSupportTicketRequest req) {
+        rateLimiter.assertCanOpenNewTicket(submitterUserId);
+        User submitter = userRepo.findById(submitterUserId).orElseThrow(() ->
+                new SupportTicketException(SupportTicketError.UNKNOWN_TICKET, "submitter missing"));
+
+        OffsetDateTime now = OffsetDateTime.now();
+        SupportTicket ticket = SupportTicket.builder()
+                .user(submitter)
+                .subject(req.subject().trim())
+                .category(req.category())
+                .status(SupportTicketStatus.OPEN)
+                .lastMessageAt(now)
+                .lastMessageAuthor(SupportTicketAuthorRole.USER)
+                .build();
+        ticket = ticketRepo.save(ticket);
+
+        SupportTicketMessage initial = SupportTicketMessage.builder()
+                .ticket(ticket)
+                .authorUser(submitter)
+                .authorRole(SupportTicketAuthorRole.USER)
+                .body(req.body().trim())
+                .visibleToUser(true)
+                .build();
+        initial = messageRepo.save(initial);
+
+        if (req.attachmentKeys() != null && !req.attachmentKeys().isEmpty()) {
+            attachmentService.promote(req.attachmentKeys(), submitter.getId(), initial, attachmentRepo);
+        }
+
+        List<Long> adminIds = userRepo.findIdsByRole(Role.ADMIN);
+        notifications.supportTicketOpened(
+                adminIds, ticket.getPublicId(), ticket.getSubject(),
+                displayNameOf(submitter), ticket.getCategory().name());
+
+        return ticket;
+    }
+
+    public SupportTicketMessage userReply(long callerUserId, UUID ticketPublicId,
+                                          ReplySupportTicketRequest req) {
+        SupportTicket ticket = ticketRepo.findByPublicId(ticketPublicId)
+                .orElseThrow(() -> new SupportTicketException(SupportTicketError.UNKNOWN_TICKET));
+        if (!ticket.getUser().getId().equals(callerUserId)) {
+            // Treat ownership mismatch as 404 so existence isn't leaked.
+            throw new SupportTicketException(SupportTicketError.UNKNOWN_TICKET);
+        }
+        User caller = ticket.getUser();
+        return appendMessage(ticket, caller, SupportTicketAuthorRole.USER,
+                req.body(), req.attachmentKeys(), true);
+    }
+
+    public SupportTicketMessage adminReply(long adminUserId, UUID ticketPublicId,
+                                           AdminReplyRequest req) {
+        SupportTicket ticket = ticketRepo.findByPublicId(ticketPublicId)
+                .orElseThrow(() -> new SupportTicketException(SupportTicketError.UNKNOWN_TICKET));
+        User admin = userRepo.findById(adminUserId).orElseThrow(() ->
+                new SupportTicketException(SupportTicketError.UNKNOWN_TICKET, "admin missing"));
+        boolean internal = Boolean.TRUE.equals(req.internalNote());
+        return appendMessage(ticket, admin, SupportTicketAuthorRole.ADMIN,
+                req.body(), req.attachmentKeys(), !internal);
+    }
+
+    /**
+     * User-side lookup that fails as {@code UNKNOWN_TICKET} both when the
+     * ticket is missing and when it exists but belongs to a different user.
+     * Read-only - intended for the user-facing controller's GET-detail path
+     * (Task 11).
+     */
+    @Transactional(readOnly = true)
+    public SupportTicket findByPublicIdEnsureOwner(long userId, UUID publicId) {
+        SupportTicket t = ticketRepo.findByPublicId(publicId)
+                .orElseThrow(() -> new SupportTicketException(SupportTicketError.UNKNOWN_TICKET));
+        if (!t.getUser().getId().equals(userId)) {
+            throw new SupportTicketException(SupportTicketError.UNKNOWN_TICKET);
+        }
+        return t;
+    }
+
+    /**
+     * Admin-side lookup with no ownership check - the admin controller
+     * (Task 12) is already gated by the {@code ADMIN} role at the auth
+     * filter, so an additional in-service check would be redundant.
+     */
+    @Transactional(readOnly = true)
+    public SupportTicket findByPublicId(UUID publicId) {
+        return ticketRepo.findByPublicId(publicId)
+                .orElseThrow(() -> new SupportTicketException(SupportTicketError.UNKNOWN_TICKET));
+    }
+
+    private SupportTicketMessage appendMessage(SupportTicket ticket, User author,
+                                               SupportTicketAuthorRole role,
+                                               String body, List<String> attachmentKeys,
+                                               boolean visibleToUser) {
+        OffsetDateTime now = OffsetDateTime.now();
+        SupportTicketMessage msg = SupportTicketMessage.builder()
+                .ticket(ticket)
+                .authorUser(author)
+                .authorRole(role)
+                .body(body.trim())
+                .visibleToUser(visibleToUser)
+                .build();
+        msg = messageRepo.save(msg);
+
+        if (attachmentKeys != null && !attachmentKeys.isEmpty()) {
+            attachmentService.promote(attachmentKeys, author.getId(), msg, attachmentRepo);
+        }
+
+        if (visibleToUser) {
+            ticket.setLastMessageAt(now);
+            ticket.setLastMessageAuthor(role);
+            // Auto-reopen ONLY on user reply to a resolved ticket.
+            if (role == SupportTicketAuthorRole.USER
+                    && ticket.getStatus() == SupportTicketStatus.RESOLVED) {
+                ticket.setStatus(SupportTicketStatus.OPEN);
+                ticket.setResolvedAt(null);
+            }
+
+            if (role == SupportTicketAuthorRole.ADMIN) {
+                User submitter = ticket.getUser();
+                notifications.supportTicketAdminReplied(
+                        submitter.getId(), ticket.getPublicId(), ticket.getSubject(),
+                        displayNameOf(author));
+            } else {
+                List<Long> adminIds = userRepo.findIdsByRole(Role.ADMIN);
+                notifications.supportTicketUserReplied(
+                        adminIds, ticket.getPublicId(), ticket.getSubject(),
+                        displayNameOf(author));
+            }
+        }
+        // Internal notes (visibleToUser=false): silent. Do NOT bump
+        // lastMessageAt/lastMessageAuthor and fire no notifications.
+        return msg;
+    }
+
+    private static String displayNameOf(User u) {
+        String name = u.getDisplayName();
+        return (name == null || name.isBlank()) ? u.getUsername() : name;
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketStatus.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketStatus.java
@@ -1,0 +1,12 @@
+package com.slparcelauctions.backend.support;
+
+/**
+ * Persisted lifecycle state of a {@link SupportTicket}. Only two values
+ * exist on purpose - the "needs admin attention" admin-queue filter is
+ * derived from {@code lastMessageAuthor = USER AND status = OPEN}, not
+ * a third enum value, to avoid drift between separate flags and reality.
+ */
+public enum SupportTicketStatus {
+    OPEN,
+    RESOLVED
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/dto/AdminReplyRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/dto/AdminReplyRequest.java
@@ -1,0 +1,11 @@
+package com.slparcelauctions.backend.support.dto;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminReplyRequest(
+        @NotBlank @Size(max = 10000) String body,
+        List<String> attachmentKeys,
+        Boolean internalNote) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/dto/AdminSupportTicketQueueRow.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/dto/AdminSupportTicketQueueRow.java
@@ -1,0 +1,14 @@
+package com.slparcelauctions.backend.support.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import com.slparcelauctions.backend.support.SupportTicketAuthorRole;
+import com.slparcelauctions.backend.support.SupportTicketCategory;
+import com.slparcelauctions.backend.support.SupportTicketStatus;
+
+public record AdminSupportTicketQueueRow(
+        UUID publicId, String subject, SupportTicketCategory category,
+        SupportTicketStatus status, UUID submitterPublicId, String submitterDisplayName,
+        UUID assignedAdminPublicId, String assignedAdminDisplayName,
+        SupportTicketAuthorRole lastMessageAuthor, OffsetDateTime lastMessageAt) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/dto/AssignTicketRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/dto/AssignTicketRequest.java
@@ -1,0 +1,5 @@
+package com.slparcelauctions.backend.support.dto;
+
+import java.util.UUID;
+
+public record AssignTicketRequest(UUID adminPublicId) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/dto/CreateSupportTicketRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/dto/CreateSupportTicketRequest.java
@@ -1,0 +1,15 @@
+package com.slparcelauctions.backend.support.dto;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import com.slparcelauctions.backend.support.SupportTicketCategory;
+
+public record CreateSupportTicketRequest(
+        @NotBlank @Size(max = 160) String subject,
+        @NotNull SupportTicketCategory category,
+        @NotBlank @Size(max = 10000) String body,
+        List<String> attachmentKeys) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/dto/PatchTicketRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/dto/PatchTicketRequest.java
@@ -1,0 +1,5 @@
+package com.slparcelauctions.backend.support.dto;
+
+import com.slparcelauctions.backend.support.SupportTicketCategory;
+
+public record PatchTicketRequest(SupportTicketCategory category) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/dto/ReplySupportTicketRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/dto/ReplySupportTicketRequest.java
@@ -1,0 +1,10 @@
+package com.slparcelauctions.backend.support.dto;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ReplySupportTicketRequest(
+        @NotBlank @Size(max = 10000) String body,
+        List<String> attachmentKeys) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/dto/SupportTicketAttachmentDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/dto/SupportTicketAttachmentDto.java
@@ -1,0 +1,6 @@
+package com.slparcelauctions.backend.support.dto;
+
+import java.util.UUID;
+
+public record SupportTicketAttachmentDto(
+        UUID publicId, String mimeType, int sizeBytes, Integer width, Integer height) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/dto/SupportTicketDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/dto/SupportTicketDto.java
@@ -1,0 +1,17 @@
+package com.slparcelauctions.backend.support.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import com.slparcelauctions.backend.support.SupportTicketAuthorRole;
+import com.slparcelauctions.backend.support.SupportTicketCategory;
+import com.slparcelauctions.backend.support.SupportTicketStatus;
+
+public record SupportTicketDto(
+        UUID publicId, UUID submitterPublicId, String submitterDisplayName,
+        String subject, SupportTicketCategory category, SupportTicketStatus status,
+        UUID assignedAdminPublicId, String assignedAdminDisplayName,
+        OffsetDateTime lastMessageAt, SupportTicketAuthorRole lastMessageAuthor,
+        OffsetDateTime resolvedAt, OffsetDateTime createdAt, OffsetDateTime updatedAt,
+        List<SupportTicketMessageDto> messages) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/dto/SupportTicketMessageDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/dto/SupportTicketMessageDto.java
@@ -1,0 +1,12 @@
+package com.slparcelauctions.backend.support.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import com.slparcelauctions.backend.support.SupportTicketAuthorRole;
+
+public record SupportTicketMessageDto(
+        UUID publicId, UUID authorPublicId, String authorDisplayName,
+        SupportTicketAuthorRole authorRole, String body, boolean visibleToUser,
+        OffsetDateTime createdAt, List<SupportTicketAttachmentDto> attachments) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/dto/SupportTicketQueueStatsDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/dto/SupportTicketQueueStatsDto.java
@@ -1,0 +1,3 @@
+package com.slparcelauctions.backend.support.dto;
+
+public record SupportTicketQueueStatsDto(long openNeedingAdminReply, long openTotal) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/support/dto/SupportTicketSummaryDto.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/support/dto/SupportTicketSummaryDto.java
@@ -1,0 +1,13 @@
+package com.slparcelauctions.backend.support.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import com.slparcelauctions.backend.support.SupportTicketAuthorRole;
+import com.slparcelauctions.backend.support.SupportTicketCategory;
+import com.slparcelauctions.backend.support.SupportTicketStatus;
+
+public record SupportTicketSummaryDto(
+        UUID publicId, String subject, SupportTicketCategory category,
+        SupportTicketStatus status, SupportTicketAuthorRole lastMessageAuthor,
+        OffsetDateTime lastMessageAt) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java
@@ -150,6 +150,16 @@ public interface UserRepository extends JpaRepository<User, Long> {
      */
     List<User> findByRole(Role role);
 
+    /**
+     * Id-only projection of {@link #findByRole(Role)} used by admin fan-out
+     * paths that only need a list of recipient ids (e.g. the customer-support
+     * ticket open / user-reply notifications). Avoids hydrating full
+     * {@link User} entities into the persistence context for what is, by
+     * design, a write-only call into {@code NotificationPublisher}.
+     */
+    @Query("SELECT u.id FROM User u WHERE u.role = :role")
+    List<Long> findIdsByRole(@Param("role") Role role);
+
     @Query("""
         SELECT u FROM User u
         WHERE LOWER(u.username) LIKE LOWER(CONCAT('%', :search, '%'))

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -237,3 +237,11 @@ slpa:
     # ReportsProperties (slpa.reports.*). One-shot per cycle: re-arms when the
     # open count returns to zero. Default 3; minimum 1.
     group-alert-threshold: 3
+  support:
+    rate-limit:
+      tickets-per-hour: 5
+    attachments:
+      max-per-message: 3
+      max-file-bytes: 5242880
+      allowed-mime-types: "image/png,image/jpeg,image/webp,image/gif"
+      pending-ttl-seconds: 3600

--- a/backend/src/main/resources/db/migration/V42__support_tickets.sql
+++ b/backend/src/main/resources/db/migration/V42__support_tickets.sql
@@ -1,0 +1,78 @@
+-- V42: customer support contact feature foundation.
+--
+-- Adds three new tables:
+--   support_tickets             - parent thread row (one per ticket)
+--   support_ticket_messages     - 1:N child messages (user replies, admin replies,
+--                                 admin internal notes, synthetic system messages)
+--   support_ticket_attachments  - 1:N child images promoted from the pending
+--                                 S3 prefix into the per-message scoped path
+--
+-- The status model has only two persisted values (OPEN, RESOLVED); the
+-- "needs admin attention" admin-queue filter is derived from
+-- last_message_author = 'USER' AND status = 'OPEN'. See spec §2 rationale.
+--
+-- Spec: docs/superpowers/specs/2026-05-21-customer-support-contact-design.md
+-- Plan: docs/superpowers/plans/2026-05-21-customer-support-contact-plan.md
+
+CREATE TABLE support_tickets (
+    id                       BIGSERIAL PRIMARY KEY,
+    public_id                UUID NOT NULL UNIQUE,
+    user_id                  BIGINT NOT NULL REFERENCES users(id),
+    subject                  VARCHAR(160) NOT NULL,
+    category                 VARCHAR(32) NOT NULL,
+    status                   VARCHAR(16) NOT NULL DEFAULT 'OPEN',
+    assigned_admin_id        BIGINT REFERENCES users(id),
+    last_message_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_message_author      VARCHAR(16) NOT NULL,
+    resolved_at              TIMESTAMPTZ,
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    version                  BIGINT NOT NULL DEFAULT 0,
+    CONSTRAINT support_ticket_status_valid
+        CHECK (status IN ('OPEN','RESOLVED')),
+    CONSTRAINT support_ticket_category_valid
+        CHECK (category IN ('ACCOUNT','BIDDING','LISTING','ESCROW','WALLET','OTHER')),
+    CONSTRAINT support_ticket_last_message_author_valid
+        CHECK (last_message_author IN ('USER','ADMIN'))
+);
+CREATE INDEX support_tickets_user_status_idx
+    ON support_tickets(user_id, status);
+CREATE INDEX support_tickets_open_admin_queue_idx
+    ON support_tickets(status, last_message_author, last_message_at DESC)
+    WHERE status = 'OPEN';
+CREATE INDEX support_tickets_assigned_admin_idx
+    ON support_tickets(assigned_admin_id)
+    WHERE assigned_admin_id IS NOT NULL;
+
+CREATE TABLE support_ticket_messages (
+    id               BIGSERIAL PRIMARY KEY,
+    public_id        UUID NOT NULL UNIQUE,
+    ticket_id        BIGINT NOT NULL REFERENCES support_tickets(id) ON DELETE CASCADE,
+    author_user_id   BIGINT NOT NULL REFERENCES users(id),
+    author_role      VARCHAR(16) NOT NULL,
+    body             TEXT NOT NULL,
+    visible_to_user  BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    version          BIGINT NOT NULL DEFAULT 0,
+    CONSTRAINT support_ticket_message_author_role_valid
+        CHECK (author_role IN ('USER','ADMIN'))
+);
+CREATE INDEX support_ticket_messages_ticket_idx
+    ON support_ticket_messages(ticket_id, created_at);
+
+CREATE TABLE support_ticket_attachments (
+    id           BIGSERIAL PRIMARY KEY,
+    public_id    UUID NOT NULL UNIQUE,
+    message_id   BIGINT NOT NULL REFERENCES support_ticket_messages(id) ON DELETE CASCADE,
+    storage_key  VARCHAR(255) NOT NULL,
+    mime_type    VARCHAR(64) NOT NULL,
+    size_bytes   INTEGER NOT NULL,
+    width        INTEGER,
+    height       INTEGER,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    version      BIGINT NOT NULL DEFAULT 0
+);
+CREATE INDEX support_ticket_attachments_message_idx
+    ON support_ticket_attachments(message_id);

--- a/backend/src/test/java/com/slparcelauctions/backend/storage/S3ObjectStorageServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/storage/S3ObjectStorageServiceTest.java
@@ -17,6 +17,7 @@ import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -95,6 +96,19 @@ class S3ObjectStorageServiceTest {
         verify(s3).deleteObject(captor.capture());
         assertThat(captor.getValue().bucket()).isEqualTo("test-bucket");
         assertThat(captor.getValue().key()).isEqualTo("avatars/1/256.png");
+    }
+
+    @Test
+    void copy_callsS3WithSourceAndDestinationKeys() {
+        service.copy("support-attachments/pending/u/abc.png", "support-attachments/42/abc");
+
+        ArgumentCaptor<CopyObjectRequest> captor = ArgumentCaptor.forClass(CopyObjectRequest.class);
+        verify(s3).copyObject(captor.capture());
+        CopyObjectRequest captured = captor.getValue();
+        assertThat(captured.sourceBucket()).isEqualTo("test-bucket");
+        assertThat(captured.sourceKey()).isEqualTo("support-attachments/pending/u/abc.png");
+        assertThat(captured.destinationBucket()).isEqualTo("test-bucket");
+        assertThat(captured.destinationKey()).isEqualTo("support-attachments/42/abc");
     }
 
     @Test

--- a/backend/src/test/java/com/slparcelauctions/backend/support/AdminSupportTicketControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/support/AdminSupportTicketControllerIntegrationTest.java
@@ -1,0 +1,570 @@
+package com.slparcelauctions.backend.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.notification.NotificationPublisher;
+import com.slparcelauctions.backend.storage.ObjectStorageService;
+import com.slparcelauctions.backend.support.dto.AdminReplyRequest;
+import com.slparcelauctions.backend.support.dto.AssignTicketRequest;
+import com.slparcelauctions.backend.support.dto.PatchTicketRequest;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+/**
+ * Integration coverage for {@link AdminSupportTicketController}. Spins
+ * the full Spring context (auth chain + slice advice + JPA) and exercises
+ * every admin endpoint via {@link MockMvc} with a real admin JWT.
+ *
+ * <p>{@link ObjectStorageService} is mocked so the support context wires
+ * cleanly even though attachment promotion is not exercised here.
+ * {@link NotificationPublisher} is mocked so we can verify which
+ * categories fire (and which do not) per endpoint without spinning up
+ * the real DAO + WebSocket broadcaster.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.auction-end.enabled=false",
+        "slpa.ownership-monitor.enabled=false",
+        "slpa.escrow.ownership-monitor-job.enabled=false",
+        "slpa.escrow.timeout-job.enabled=false",
+        "slpa.escrow.command-dispatcher-job.enabled=false",
+        "slpa.review.scheduler.enabled=false",
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false",
+        "slpa.realty.invitation-expiry.enabled=false"
+})
+@Transactional
+class AdminSupportTicketControllerIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired JwtService jwtService;
+    @Autowired UserRepository userRepo;
+    @Autowired SupportTicketRepository ticketRepo;
+    @Autowired SupportTicketMessageRepository messageRepo;
+    @PersistenceContext EntityManager em;
+
+    @MockitoBean ObjectStorageService storage;
+    @MockitoBean NotificationPublisher notifications;
+
+    private final ObjectMapper objectMapper =
+            new ObjectMapper().registerModule(new JavaTimeModule());
+
+    private User submitter;
+    private User admin;
+    private User otherAdmin;
+    private User regularUser;
+    private String adminJwt;
+    private String userJwt;
+
+    @BeforeEach
+    void seed() {
+        submitter = userRepo.save(User.builder()
+                .username("submitter-" + shortId())
+                .email("submitter-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x").slAvatarUuid(UUID.randomUUID())
+                .displayName("Submitter").role(Role.USER).verified(true).build());
+        admin = userRepo.save(User.builder()
+                .username("admin-" + shortId())
+                .email("admin-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x").slAvatarUuid(UUID.randomUUID())
+                .displayName("Admin").role(Role.ADMIN).verified(true).build());
+        otherAdmin = userRepo.save(User.builder()
+                .username("otheradmin-" + shortId())
+                .email("otheradmin-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x").slAvatarUuid(UUID.randomUUID())
+                .displayName("Other Admin").role(Role.ADMIN).verified(true).build());
+        regularUser = userRepo.save(User.builder()
+                .username("nonadmin-" + shortId())
+                .email("nonadmin-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x").slAvatarUuid(UUID.randomUUID())
+                .displayName("Non-admin").role(Role.USER).verified(true).build());
+
+        adminJwt = jwtService.issueAccessToken(new AuthPrincipal(
+                admin.getId(), admin.getPublicId(), admin.getEmail(), 0L, Role.ADMIN));
+        userJwt = jwtService.issueAccessToken(new AuthPrincipal(
+                regularUser.getId(), regularUser.getPublicId(), regularUser.getEmail(),
+                0L, Role.USER));
+
+        reset(notifications);
+    }
+
+    /* ============================================================ */
+    /* GET /api/v1/admin/support-tickets - queue + filters          */
+    /* ============================================================ */
+
+    @Test
+    void queue_noFilter_returnsAllTicketsPaged() throws Exception {
+        saveTicket(submitter, "First subject", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.USER);
+        saveTicket(submitter, "Second subject", SupportTicketStatus.RESOLVED,
+                SupportTicketCategory.BIDDING, admin.getId(), SupportTicketAuthorRole.ADMIN);
+        em.flush();
+
+        mockMvc.perform(get("/api/v1/admin/support-tickets")
+                        .header("Authorization", "Bearer " + adminJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.totalElements").value(2));
+    }
+
+    @Test
+    void queue_statusOpen_narrows() throws Exception {
+        SupportTicket open = saveTicket(submitter, "Open one", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.USER);
+        saveTicket(submitter, "Resolved one", SupportTicketStatus.RESOLVED,
+                SupportTicketCategory.BIDDING, admin.getId(), SupportTicketAuthorRole.ADMIN);
+        em.flush();
+
+        mockMvc.perform(get("/api/v1/admin/support-tickets")
+                        .param("status", "OPEN")
+                        .header("Authorization", "Bearer " + adminJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].publicId").value(open.getPublicId().toString()));
+    }
+
+    @Test
+    void queue_categoryBidding_narrows() throws Exception {
+        SupportTicket bidding = saveTicket(submitter, "Bidding ticket", SupportTicketStatus.OPEN,
+                SupportTicketCategory.BIDDING, null, SupportTicketAuthorRole.USER);
+        saveTicket(submitter, "Account ticket", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.USER);
+        em.flush();
+
+        mockMvc.perform(get("/api/v1/admin/support-tickets")
+                        .param("category", "BIDDING")
+                        .header("Authorization", "Bearer " + adminJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].publicId").value(bidding.getPublicId().toString()));
+    }
+
+    @Test
+    void queue_assigneeMine_narrowsToCallerAssignments() throws Exception {
+        SupportTicket mine = saveTicket(submitter, "Mine", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, admin.getId(), SupportTicketAuthorRole.USER);
+        saveTicket(submitter, "Theirs", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, otherAdmin.getId(), SupportTicketAuthorRole.USER);
+        saveTicket(submitter, "Unassigned", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.USER);
+        em.flush();
+
+        mockMvc.perform(get("/api/v1/admin/support-tickets")
+                        .param("assignee", "mine")
+                        .header("Authorization", "Bearer " + adminJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].publicId").value(mine.getPublicId().toString()));
+    }
+
+    @Test
+    void queue_lastAuthorUser_narrows() throws Exception {
+        SupportTicket userLast = saveTicket(submitter, "User last", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.USER);
+        saveTicket(submitter, "Admin last", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.ADMIN);
+        em.flush();
+
+        mockMvc.perform(get("/api/v1/admin/support-tickets")
+                        .param("last_author", "USER")
+                        .header("Authorization", "Bearer " + adminJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].publicId").value(userLast.getPublicId().toString()));
+    }
+
+    @Test
+    void queue_qFilter_narrowsBySubjectSubstring() throws Exception {
+        String unique = "needleQ" + shortId();
+        SupportTicket match = saveTicket(submitter, "Subject containing " + unique + " here",
+                SupportTicketStatus.OPEN, SupportTicketCategory.ACCOUNT, null,
+                SupportTicketAuthorRole.USER);
+        saveTicket(submitter, "Unrelated", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.USER);
+        em.flush();
+
+        mockMvc.perform(get("/api/v1/admin/support-tickets")
+                        .param("q", unique)
+                        .header("Authorization", "Bearer " + adminJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].publicId").value(match.getPublicId().toString()));
+    }
+
+    /* ============================================================ */
+    /* GET /api/v1/admin/support-tickets/queue-stats                */
+    /* ============================================================ */
+
+    @Test
+    void queueStats_returnsCorrectCounts() throws Exception {
+        // 2 open with USER as last author (need admin reply)
+        saveTicket(submitter, "Open user-last 1", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.USER);
+        saveTicket(submitter, "Open user-last 2", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.USER);
+        // 1 open with ADMIN as last author (waiting on user)
+        saveTicket(submitter, "Open admin-last", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.ADMIN);
+        // 1 resolved
+        saveTicket(submitter, "Resolved", SupportTicketStatus.RESOLVED,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.ADMIN);
+        em.flush();
+
+        mockMvc.perform(get("/api/v1/admin/support-tickets/queue-stats")
+                        .header("Authorization", "Bearer " + adminJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.openNeedingAdminReply").value(2))
+                .andExpect(jsonPath("$.openTotal").value(3));
+    }
+
+    /* ============================================================ */
+    /* GET /api/v1/admin/support-tickets/{publicId}                 */
+    /* ============================================================ */
+
+    @Test
+    void detail_returnsFullTicketIncludingInternalNotes() throws Exception {
+        SupportTicket t = saveTicket(submitter, "Detail subject", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, admin.getId(), SupportTicketAuthorRole.USER);
+        saveMessage(t, submitter, SupportTicketAuthorRole.USER, "user body", true);
+        saveMessage(t, admin, SupportTicketAuthorRole.ADMIN, "admin private note", false);
+        saveMessage(t, admin, SupportTicketAuthorRole.ADMIN, "admin public reply", true);
+        em.flush();
+        em.clear();
+
+        mockMvc.perform(get("/api/v1/admin/support-tickets/" + t.getPublicId())
+                        .header("Authorization", "Bearer " + adminJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.publicId").value(t.getPublicId().toString()))
+                // Admin DTO must include the internal note - 3 messages total.
+                .andExpect(jsonPath("$.messages.length()").value(3))
+                .andExpect(jsonPath("$.messages[?(@.visibleToUser == false)].body")
+                        .value(org.hamcrest.Matchers.hasItem("admin private note")))
+                .andExpect(jsonPath("$.assignedAdminPublicId").value(admin.getPublicId().toString()));
+    }
+
+    /* ============================================================ */
+    /* POST /api/v1/admin/support-tickets/{publicId}/messages       */
+    /* ============================================================ */
+
+    @Test
+    void reply_visible_appendsAndFiresAdminRepliedNotification() throws Exception {
+        SupportTicket t = saveTicket(submitter, "Reply target", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.USER);
+        OffsetDateTime initialLastMessageAt = t.getLastMessageAt();
+        em.flush();
+
+        AdminReplyRequest req = new AdminReplyRequest("admin visible reply", null, false);
+
+        mockMvc.perform(post("/api/v1/admin/support-tickets/" + t.getPublicId() + "/messages")
+                        .header("Authorization", "Bearer " + adminJwt)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.body").value("admin visible reply"))
+                .andExpect(jsonPath("$.visibleToUser").value(true))
+                .andExpect(jsonPath("$.authorRole").value("ADMIN"));
+
+        verify(notifications).supportTicketAdminReplied(
+                eq(submitter.getId()), eq(t.getPublicId()), eq("Reply target"),
+                anyString());
+
+        SupportTicket reloaded = ticketRepo.findByPublicId(t.getPublicId()).orElseThrow();
+        assertThat(reloaded.getLastMessageAuthor()).isEqualTo(SupportTicketAuthorRole.ADMIN);
+        assertThat(reloaded.getLastMessageAt()).isAfter(initialLastMessageAt);
+    }
+
+    @Test
+    void reply_internalNote_appendsInvisibleAndDoesNotNotify() throws Exception {
+        SupportTicket t = saveTicket(submitter, "Internal note target", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.USER);
+        OffsetDateTime priorLastMessageAt = t.getLastMessageAt();
+        SupportTicketAuthorRole priorLastAuthor = t.getLastMessageAuthor();
+        em.flush();
+
+        AdminReplyRequest req = new AdminReplyRequest("private internal note", null, true);
+
+        mockMvc.perform(post("/api/v1/admin/support-tickets/" + t.getPublicId() + "/messages")
+                        .header("Authorization", "Bearer " + adminJwt)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.body").value("private internal note"))
+                .andExpect(jsonPath("$.visibleToUser").value(false));
+
+        // Internal notes never trigger the admin-replied dispatch.
+        verify(notifications, never()).supportTicketAdminReplied(
+                anyLong(), any(UUID.class), anyString(), anyString());
+
+        // lastMessageAt / lastMessageAuthor are unchanged for invisible writes.
+        SupportTicket reloaded = ticketRepo.findByPublicId(t.getPublicId()).orElseThrow();
+        assertThat(reloaded.getLastMessageAt()).isEqualTo(priorLastMessageAt);
+        assertThat(reloaded.getLastMessageAuthor()).isEqualTo(priorLastAuthor);
+    }
+
+    /* ============================================================ */
+    /* POST /api/v1/admin/support-tickets/{publicId}/resolve        */
+    /* ============================================================ */
+
+    @Test
+    void resolve_open_transitionsToResolvedAndFiresNotification() throws Exception {
+        SupportTicket t = saveTicket(submitter, "Resolve me", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, admin.getId(), SupportTicketAuthorRole.USER);
+        saveMessage(t, submitter, SupportTicketAuthorRole.USER, "please help", true);
+        em.flush();
+
+        mockMvc.perform(post("/api/v1/admin/support-tickets/" + t.getPublicId() + "/resolve")
+                        .header("Authorization", "Bearer " + adminJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("RESOLVED"))
+                .andExpect(jsonPath("$.resolvedAt").exists())
+                // The system message is present in the messages graph after flush+clear+refetch.
+                .andExpect(jsonPath("$.messages[?(@.body == 'Marked resolved by admin')]").exists());
+
+        verify(notifications).supportTicketResolved(
+                eq(submitter.getId()), eq(t.getPublicId()), eq("Resolve me"));
+    }
+
+    @Test
+    void resolve_alreadyResolved_idempotentNoSecondNotification() throws Exception {
+        SupportTicket t = saveTicket(submitter, "Already resolved", SupportTicketStatus.RESOLVED,
+                SupportTicketCategory.ACCOUNT, admin.getId(), SupportTicketAuthorRole.ADMIN);
+        t.setResolvedAt(OffsetDateTime.now().minusHours(1));
+        ticketRepo.save(t);
+        em.flush();
+
+        mockMvc.perform(post("/api/v1/admin/support-tickets/" + t.getPublicId() + "/resolve")
+                        .header("Authorization", "Bearer " + adminJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("RESOLVED"));
+
+        verify(notifications, never()).supportTicketResolved(
+                anyLong(), any(UUID.class), anyString());
+    }
+
+    /* ============================================================ */
+    /* POST /api/v1/admin/support-tickets/{publicId}/reopen         */
+    /* ============================================================ */
+
+    @Test
+    void reopen_resolvedTicket_transitionsBackWithSystemMessage() throws Exception {
+        SupportTicket t = saveTicket(submitter, "Reopen me", SupportTicketStatus.RESOLVED,
+                SupportTicketCategory.ACCOUNT, admin.getId(), SupportTicketAuthorRole.ADMIN);
+        t.setResolvedAt(OffsetDateTime.now().minusHours(1));
+        ticketRepo.save(t);
+        em.flush();
+
+        mockMvc.perform(post("/api/v1/admin/support-tickets/" + t.getPublicId() + "/reopen")
+                        .header("Authorization", "Bearer " + adminJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("OPEN"))
+                .andExpect(jsonPath("$.resolvedAt").doesNotExist())
+                .andExpect(jsonPath("$.messages[?(@.body == 'Reopened by admin')]").exists());
+
+        // Reopen is intentionally silent - no notification fires.
+        verify(notifications, never()).supportTicketAdminReplied(
+                anyLong(), any(UUID.class), anyString(), anyString());
+        verify(notifications, never()).supportTicketResolved(
+                anyLong(), any(UUID.class), anyString());
+    }
+
+    @Test
+    void reopen_alreadyOpen_idempotent() throws Exception {
+        SupportTicket t = saveTicket(submitter, "Already open", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.USER);
+        em.flush();
+
+        mockMvc.perform(post("/api/v1/admin/support-tickets/" + t.getPublicId() + "/reopen")
+                        .header("Authorization", "Bearer " + adminJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("OPEN"));
+    }
+
+    /* ============================================================ */
+    /* POST /api/v1/admin/support-tickets/{publicId}/assign         */
+    /* ============================================================ */
+
+    @Test
+    void assign_setsAssignedAdminId() throws Exception {
+        SupportTicket t = saveTicket(submitter, "Assign me", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.USER);
+        em.flush();
+
+        AssignTicketRequest req = new AssignTicketRequest(admin.getPublicId());
+
+        mockMvc.perform(post("/api/v1/admin/support-tickets/" + t.getPublicId() + "/assign")
+                        .header("Authorization", "Bearer " + adminJwt)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.assignedAdminPublicId").value(admin.getPublicId().toString()));
+    }
+
+    @Test
+    void assign_nullPublicId_clearsAssignment() throws Exception {
+        SupportTicket t = saveTicket(submitter, "Unassign me", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, admin.getId(), SupportTicketAuthorRole.USER);
+        em.flush();
+
+        AssignTicketRequest req = new AssignTicketRequest(null);
+
+        mockMvc.perform(post("/api/v1/admin/support-tickets/" + t.getPublicId() + "/assign")
+                        .header("Authorization", "Bearer " + adminJwt)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.assignedAdminPublicId").doesNotExist());
+    }
+
+    @Test
+    void assign_nonAdminTarget_returns404UnknownTicket() throws Exception {
+        SupportTicket t = saveTicket(submitter, "Bad assignment", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.USER);
+        em.flush();
+
+        AssignTicketRequest req = new AssignTicketRequest(regularUser.getPublicId());
+
+        mockMvc.perform(post("/api/v1/admin/support-tickets/" + t.getPublicId() + "/assign")
+                        .header("Authorization", "Bearer " + adminJwt)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("UNKNOWN_TICKET"));
+    }
+
+    /* ============================================================ */
+    /* PATCH /api/v1/admin/support-tickets/{publicId}               */
+    /* ============================================================ */
+
+    @Test
+    void patch_updatesCategory() throws Exception {
+        SupportTicket t = saveTicket(submitter, "Recategorize", SupportTicketStatus.OPEN,
+                SupportTicketCategory.OTHER, null, SupportTicketAuthorRole.USER);
+        em.flush();
+
+        PatchTicketRequest req = new PatchTicketRequest(SupportTicketCategory.BIDDING);
+
+        mockMvc.perform(patch("/api/v1/admin/support-tickets/" + t.getPublicId())
+                        .header("Authorization", "Bearer " + adminJwt)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.category").value("BIDDING"));
+    }
+
+    /* ============================================================ */
+    /* Role gating - non-admin tokens get 403                       */
+    /* ============================================================ */
+
+    @Test
+    void nonAdmin_getQueue_returns403() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/support-tickets")
+                        .header("Authorization", "Bearer " + userJwt))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void nonAdmin_getDetail_returns403() throws Exception {
+        SupportTicket t = saveTicket(submitter, "Some ticket", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.USER);
+        em.flush();
+
+        mockMvc.perform(get("/api/v1/admin/support-tickets/" + t.getPublicId())
+                        .header("Authorization", "Bearer " + userJwt))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void nonAdmin_postReply_returns403() throws Exception {
+        SupportTicket t = saveTicket(submitter, "Some ticket", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT, null, SupportTicketAuthorRole.USER);
+        em.flush();
+
+        AdminReplyRequest req = new AdminReplyRequest("attempted reply", null, false);
+
+        mockMvc.perform(post("/api/v1/admin/support-tickets/" + t.getPublicId() + "/messages")
+                        .header("Authorization", "Bearer " + userJwt)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isForbidden());
+    }
+
+    /* ============================================================ */
+    /* Helpers                                                      */
+    /* ============================================================ */
+
+    private SupportTicket saveTicket(User owner, String subject,
+                                     SupportTicketStatus status,
+                                     SupportTicketCategory category,
+                                     Long assignedAdminId,
+                                     SupportTicketAuthorRole lastAuthor) {
+        OffsetDateTime now = OffsetDateTime.now();
+        SupportTicket t = SupportTicket.builder()
+                .user(owner)
+                .subject(subject)
+                .category(category)
+                .status(status)
+                .lastMessageAt(now)
+                .lastMessageAuthor(lastAuthor)
+                .assignedAdminId(assignedAdminId)
+                .build();
+        if (status == SupportTicketStatus.RESOLVED) {
+            t.setResolvedAt(now);
+        }
+        return ticketRepo.save(t);
+    }
+
+    private SupportTicketMessage saveMessage(SupportTicket ticket, User author,
+                                             SupportTicketAuthorRole role,
+                                             String body, boolean visibleToUser) {
+        SupportTicketMessage m = SupportTicketMessage.builder()
+                .ticket(ticket)
+                .authorUser(author)
+                .authorRole(role)
+                .body(body)
+                .visibleToUser(visibleToUser)
+                .build();
+        return messageRepo.save(m);
+    }
+
+    private static String shortId() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/support/AdminSupportTicketLazyInitRegressionTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/support/AdminSupportTicketLazyInitRegressionTest.java
@@ -1,0 +1,228 @@
+package com.slparcelauctions.backend.support;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.storage.ObjectStorageService;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Regression coverage for the {@link org.hibernate.LazyInitializationException}
+ * class of bug that surfaced on {@code GET /api/v1/admin/coupons/{publicId}}
+ * (PR #388): a controller mapper iterated a LAZY collection after the service
+ * transaction closed.
+ *
+ * <p>The companion {@link AdminSupportTicketControllerIntegrationTest} runs
+ * every test method inside a class-level {@code @Transactional}, which causes
+ * MockMvc's invocation to share the test's open session - so the bug never
+ * triggers there. This class deliberately omits {@code @Transactional} on the
+ * test methods so the controller call sees the same boundary as a real HTTP
+ * request: setup commits, the controller runs in its own transaction, and the
+ * post-service mapper has to survive a closed session.
+ *
+ * <p>The admin detail path dereferences {@code ticket.messages},
+ * {@code message.authorUser}, {@code message.attachments}, the submitter
+ * {@link User}, and the assigned-admin {@link User}. Every collection is LAZY
+ * and would trip {@code LazyInitializationException} without the
+ * {@code @Transactional(readOnly = true)} on the controller method. The admin
+ * DTO must also serialize internal notes (unlike the user DTO), so this test
+ * seeds an invisible message and asserts the admin response includes it.
+ *
+ * <p>Cleanup is manual in {@link #cleanup()} because there's no
+ * test-wrapping rollback.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.auction-end.enabled=false",
+        "slpa.ownership-monitor.enabled=false",
+        "slpa.escrow.ownership-monitor-job.enabled=false",
+        "slpa.escrow.timeout-job.enabled=false",
+        "slpa.escrow.command-dispatcher-job.enabled=false",
+        "slpa.review.scheduler.enabled=false",
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false",
+        "slpa.realty.invitation-expiry.enabled=false"
+})
+class AdminSupportTicketLazyInitRegressionTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired JwtService jwtService;
+    @Autowired UserRepository userRepo;
+    @Autowired SupportTicketRepository ticketRepo;
+    @Autowired SupportTicketMessageRepository messageRepo;
+    @Autowired SupportTicketAttachmentRepository attachmentRepo;
+
+    // Mocked away so the support context wires cleanly even though we do
+    // not exercise S3 in this test.
+    @MockitoBean ObjectStorageService storage;
+
+    private User submitter;
+    private User admin;
+    private String adminJwt;
+    private Long ticketId;
+    private final List<Long> createdAttachmentIds = new ArrayList<>();
+    private final List<Long> createdMessageIds = new ArrayList<>();
+
+    @BeforeEach
+    @Transactional
+    void seed() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        submitter = userRepo.save(User.builder()
+                .username("lazy-init-submitter-" + suffix)
+                .email("lazy-init-submitter-" + suffix + "@example.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("LazyInit Submitter")
+                .role(Role.USER)
+                .build());
+        admin = userRepo.save(User.builder()
+                .username("lazy-init-admin-" + suffix)
+                .email("lazy-init-admin-" + suffix + "@example.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("LazyInit Admin")
+                .role(Role.ADMIN)
+                .build());
+        adminJwt = jwtService.issueAccessToken(new AuthPrincipal(
+                admin.getId(), admin.getPublicId(), admin.getEmail(), 0L, Role.ADMIN));
+
+        OffsetDateTime now = OffsetDateTime.now();
+        SupportTicket ticket = ticketRepo.save(SupportTicket.builder()
+                .user(submitter)
+                .subject("LazyInit admin subject " + suffix)
+                .category(SupportTicketCategory.ACCOUNT)
+                .status(SupportTicketStatus.OPEN)
+                .lastMessageAt(now)
+                .lastMessageAuthor(SupportTicketAuthorRole.USER)
+                .assignedAdminId(admin.getId())
+                .build());
+        ticketId = ticket.getId();
+
+        // Visible user message + invisible admin internal note + visible
+        // admin reply. The admin endpoint must serialize all three including
+        // the internal note (unlike the user endpoint, which filters it).
+        SupportTicketMessage m1 = messageRepo.save(SupportTicketMessage.builder()
+                .ticket(ticket)
+                .authorUser(submitter)
+                .authorRole(SupportTicketAuthorRole.USER)
+                .body("user-visible body")
+                .visibleToUser(true)
+                .build());
+        SupportTicketMessage m2 = messageRepo.save(SupportTicketMessage.builder()
+                .ticket(ticket)
+                .authorUser(admin)
+                .authorRole(SupportTicketAuthorRole.ADMIN)
+                .body("internal admin note")
+                .visibleToUser(false)
+                .build());
+        SupportTicketMessage m3 = messageRepo.save(SupportTicketMessage.builder()
+                .ticket(ticket)
+                .authorUser(admin)
+                .authorRole(SupportTicketAuthorRole.ADMIN)
+                .body("public admin reply")
+                .visibleToUser(true)
+                .build());
+        createdMessageIds.add(m1.getId());
+        createdMessageIds.add(m2.getId());
+        createdMessageIds.add(m3.getId());
+
+        // One attachment on the visible user message - exercises the
+        // messages.attachments LAZY traversal.
+        SupportTicketAttachment att = attachmentRepo.save(SupportTicketAttachment.builder()
+                .message(m1)
+                .storageKey("support-attachments/" + m1.getId() + "/lazy-init-admin-key")
+                .mimeType("image/png")
+                .sizeBytes(2048)
+                .width(120)
+                .height(90)
+                .build());
+        createdAttachmentIds.add(att.getId());
+    }
+
+    @AfterEach
+    @Transactional
+    void cleanup() {
+        for (Long aid : createdAttachmentIds) {
+            attachmentRepo.findById(aid).ifPresent(attachmentRepo::delete);
+        }
+        for (Long mid : createdMessageIds) {
+            messageRepo.findById(mid).ifPresent(messageRepo::delete);
+        }
+        if (ticketId != null) {
+            ticketRepo.findById(ticketId).ifPresent(ticketRepo::delete);
+        }
+        if (admin != null) {
+            userRepo.findById(admin.getId()).ifPresent(userRepo::delete);
+        }
+        if (submitter != null) {
+            userRepo.findById(submitter.getId()).ifPresent(userRepo::delete);
+        }
+        createdAttachmentIds.clear();
+        createdMessageIds.clear();
+    }
+
+    @Test
+    void getDetail_outsideEnclosingTx_initializesLazyCollections() throws Exception {
+        // Without @Transactional(readOnly=true) on the controller method,
+        // the mapper trips LazyInitializationException on ticket.messages /
+        // messages.attachments / authorUser / assignedAdmin, the global
+        // handler returns 500, and the assertions below fail with a Problem
+        // JSON body instead of the expected support-ticket payload.
+        UUID publicId = ticketRepo.findById(ticketId).orElseThrow().getPublicId();
+        mockMvc.perform(get("/api/v1/admin/support-tickets/" + publicId)
+                        .header("Authorization", "Bearer " + adminJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.publicId").value(publicId.toString()))
+                // Admin DTO includes internal notes - 3 messages total.
+                .andExpect(jsonPath("$.messages.length()").value(3))
+                .andExpect(jsonPath("$.messages[?(@.visibleToUser == false)].body")
+                        .value(org.hamcrest.Matchers.hasItem("internal admin note")))
+                .andExpect(jsonPath("$.messages[?(@.visibleToUser == true)].body")
+                        .value(org.hamcrest.Matchers.hasItem("user-visible body")))
+                // Attachment was eagerly fetched + serialized.
+                .andExpect(jsonPath("$.messages[?(@.body == 'user-visible body')].attachments[0].mimeType")
+                        .value(org.hamcrest.Matchers.hasItem("image/png")))
+                // Assigned-admin enrichment also traversed without LazyInit.
+                .andExpect(jsonPath("$.assignedAdminPublicId").value(admin.getPublicId().toString()));
+    }
+
+    @Test
+    void getQueue_outsideEnclosingTx_returnsAtLeastOneRow() throws Exception {
+        // Queue path: AdminSupportTicketController.queue maps each
+        // Page<SupportTicket> entry via mapper.toAdminRow plus an
+        // assigned-admin User lookup. The @Transactional(readOnly=true) on
+        // the controller method guards future regressions where a mapper
+        // enrichment dereferences a LAZY field.
+        mockMvc.perform(get("/api/v1/admin/support-tickets")
+                        .header("Authorization", "Bearer " + adminJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content.length()").value(
+                        org.hamcrest.Matchers.greaterThanOrEqualTo(1)));
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/support/MeSupportTicketControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/support/MeSupportTicketControllerIntegrationTest.java
@@ -1,0 +1,345 @@
+package com.slparcelauctions.backend.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.storage.ObjectStorageService;
+import com.slparcelauctions.backend.support.dto.CreateSupportTicketRequest;
+import com.slparcelauctions.backend.support.dto.ReplySupportTicketRequest;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+/**
+ * Integration coverage for {@link MeSupportTicketController}. Spins the
+ * full Spring context (auth chain + slice advice + JPA) and exercises
+ * every endpoint via {@link MockMvc} with a real user JWT.
+ *
+ * <p>{@link ObjectStorageService} is mocked so the attachment-promotion
+ * path inside {@link SupportTicketService#createTicket} (and
+ * {@link SupportTicketService#userReply}) does not actually hit S3 -
+ * the tests here never exercise attachment promotion, so the bean only
+ * needs to exist.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.auction-end.enabled=false",
+        "slpa.ownership-monitor.enabled=false",
+        "slpa.escrow.ownership-monitor-job.enabled=false",
+        "slpa.escrow.timeout-job.enabled=false",
+        "slpa.escrow.command-dispatcher-job.enabled=false",
+        "slpa.review.scheduler.enabled=false",
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false",
+        "slpa.realty.invitation-expiry.enabled=false"
+})
+@Transactional
+class MeSupportTicketControllerIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired JwtService jwtService;
+    @Autowired UserRepository userRepo;
+    @Autowired SupportTicketRepository ticketRepo;
+    @Autowired SupportTicketMessageRepository messageRepo;
+    @PersistenceContext EntityManager em;
+
+    @MockitoBean ObjectStorageService storage;
+
+    private final ObjectMapper objectMapper =
+            new ObjectMapper().registerModule(new JavaTimeModule());
+
+    private User user;
+    private User otherUser;
+    private User admin;
+    private String userJwt;
+    private String otherJwt;
+
+    @BeforeEach
+    void seed() {
+        user = userRepo.save(User.builder()
+                .username("user-" + shortId())
+                .email("user-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x").slAvatarUuid(UUID.randomUUID())
+                .displayName("User").role(Role.USER).verified(true).build());
+        otherUser = userRepo.save(User.builder()
+                .username("other-" + shortId())
+                .email("other-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x").slAvatarUuid(UUID.randomUUID())
+                .displayName("Other").role(Role.USER).verified(true).build());
+        admin = userRepo.save(User.builder()
+                .username("admin-" + shortId())
+                .email("admin-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x").slAvatarUuid(UUID.randomUUID())
+                .displayName("Admin").role(Role.ADMIN).verified(true).build());
+        userJwt = jwtService.issueAccessToken(new AuthPrincipal(
+                user.getId(), user.getPublicId(), user.getEmail(), 0L, Role.USER));
+        otherJwt = jwtService.issueAccessToken(new AuthPrincipal(
+                otherUser.getId(), otherUser.getPublicId(), otherUser.getEmail(),
+                0L, Role.USER));
+    }
+
+    /* ============================================================ */
+    /* GET /api/v1/me/support-tickets - list + filters              */
+    /* ============================================================ */
+
+    @Test
+    void list_noFilter_returnsAllOwnTickets() throws Exception {
+        saveTicket(user, "First subject", SupportTicketStatus.OPEN, SupportTicketCategory.ACCOUNT);
+        saveTicket(user, "Second subject", SupportTicketStatus.RESOLVED, SupportTicketCategory.BIDDING);
+        // Ticket owned by someone else - must not appear in the response.
+        saveTicket(otherUser, "Other user's ticket", SupportTicketStatus.OPEN, SupportTicketCategory.OTHER);
+        em.flush();
+
+        mockMvc.perform(get("/api/v1/me/support-tickets")
+                        .header("Authorization", "Bearer " + userJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.totalElements").value(2));
+    }
+
+    @Test
+    void list_statusOpen_narrows() throws Exception {
+        SupportTicket open = saveTicket(user, "Open ticket", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT);
+        saveTicket(user, "Resolved ticket", SupportTicketStatus.RESOLVED,
+                SupportTicketCategory.BIDDING);
+        em.flush();
+
+        mockMvc.perform(get("/api/v1/me/support-tickets")
+                        .param("status", "OPEN")
+                        .header("Authorization", "Bearer " + userJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].publicId").value(open.getPublicId().toString()))
+                .andExpect(jsonPath("$.content[0].status").value("OPEN"));
+    }
+
+    @Test
+    void list_qFilter_narrowsBySubjectSubstring() throws Exception {
+        String unique = "uniquesubj" + shortId();
+        SupportTicket match = saveTicket(user, "Match contains " + unique + " inside",
+                SupportTicketStatus.OPEN, SupportTicketCategory.ACCOUNT);
+        saveTicket(user, "No match here", SupportTicketStatus.OPEN,
+                SupportTicketCategory.BIDDING);
+        em.flush();
+
+        mockMvc.perform(get("/api/v1/me/support-tickets")
+                        .param("q", unique)
+                        .header("Authorization", "Bearer " + userJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].publicId").value(match.getPublicId().toString()));
+    }
+
+    /* ============================================================ */
+    /* GET /api/v1/me/support-tickets/{publicId}                    */
+    /* ============================================================ */
+
+    @Test
+    void detail_returnsTicket_andFiltersOutInternalNotes() throws Exception {
+        SupportTicket t = saveTicket(user, "Detail subject", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT);
+        // Visible user message + invisible admin internal note.
+        saveMessage(t, user, SupportTicketAuthorRole.USER, "Hello support", true);
+        saveMessage(t, admin, SupportTicketAuthorRole.ADMIN, "private admin note", false);
+        em.flush();
+        em.clear();
+
+        mockMvc.perform(get("/api/v1/me/support-tickets/" + t.getPublicId())
+                        .header("Authorization", "Bearer " + userJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.publicId").value(t.getPublicId().toString()))
+                .andExpect(jsonPath("$.messages.length()").value(1))
+                .andExpect(jsonPath("$.messages[0].body").value("Hello support"))
+                .andExpect(jsonPath("$.messages[0].visibleToUser").value(true));
+    }
+
+    @Test
+    void detail_notOwner_returns404_unknownTicket() throws Exception {
+        SupportTicket t = saveTicket(otherUser, "Other's ticket", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT);
+        em.flush();
+
+        mockMvc.perform(get("/api/v1/me/support-tickets/" + t.getPublicId())
+                        .header("Authorization", "Bearer " + userJwt))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("UNKNOWN_TICKET"));
+    }
+
+    /* ============================================================ */
+    /* POST /api/v1/me/support-tickets                              */
+    /* ============================================================ */
+
+    @Test
+    void create_happyPath_returnsDtoWithInitialMessage() throws Exception {
+        CreateSupportTicketRequest req = new CreateSupportTicketRequest(
+                "I need help with bidding",
+                SupportTicketCategory.BIDDING,
+                "Cannot place a bid on auction X",
+                null);
+
+        mockMvc.perform(post("/api/v1/me/support-tickets")
+                        .header("Authorization", "Bearer " + userJwt)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.publicId").exists())
+                .andExpect(jsonPath("$.subject").value("I need help with bidding"))
+                .andExpect(jsonPath("$.category").value("BIDDING"))
+                .andExpect(jsonPath("$.status").value("OPEN"))
+                .andExpect(jsonPath("$.messages.length()").value(1))
+                .andExpect(jsonPath("$.messages[0].body").value("Cannot place a bid on auction X"))
+                .andExpect(jsonPath("$.messages[0].authorRole").value("USER"));
+    }
+
+    @Test
+    void create_sixthWithinAnHour_returns429_rateLimited() throws Exception {
+        // Seed 5 prior tickets in the trailing-hour window. The rate
+        // limiter caps at 5 per hour; the 6th must trip RATE_LIMITED.
+        for (int i = 0; i < 5; i++) {
+            saveTicket(user, "Prior " + i, SupportTicketStatus.OPEN,
+                    SupportTicketCategory.ACCOUNT);
+        }
+        em.flush();
+
+        CreateSupportTicketRequest req = new CreateSupportTicketRequest(
+                "Number six",
+                SupportTicketCategory.ACCOUNT,
+                "Should be rate-limited",
+                null);
+
+        mockMvc.perform(post("/api/v1/me/support-tickets")
+                        .header("Authorization", "Bearer " + userJwt)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(jsonPath("$.code").value("RATE_LIMITED"));
+    }
+
+    /* ============================================================ */
+    /* POST /api/v1/me/support-tickets/{publicId}/messages          */
+    /* ============================================================ */
+
+    @Test
+    void reply_emptyBody_returns400_beanValidation() throws Exception {
+        SupportTicket t = saveTicket(user, "Reply target", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT);
+        em.flush();
+
+        ReplySupportTicketRequest req = new ReplySupportTicketRequest("", null);
+
+        mockMvc.perform(post("/api/v1/me/support-tickets/" + t.getPublicId() + "/messages")
+                        .header("Authorization", "Bearer " + userJwt)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void reply_onResolvedTicket_autoReopens() throws Exception {
+        SupportTicket t = saveTicket(user, "Already resolved", SupportTicketStatus.RESOLVED,
+                SupportTicketCategory.ACCOUNT);
+        t.setResolvedAt(OffsetDateTime.now().minusHours(1));
+        ticketRepo.save(t);
+        em.flush();
+
+        ReplySupportTicketRequest req = new ReplySupportTicketRequest(
+                "Actually I have a follow-up question", null);
+
+        mockMvc.perform(post("/api/v1/me/support-tickets/" + t.getPublicId() + "/messages")
+                        .header("Authorization", "Bearer " + userJwt)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk());
+
+        // GET the ticket back and confirm the status flipped to OPEN.
+        mockMvc.perform(get("/api/v1/me/support-tickets/" + t.getPublicId())
+                        .header("Authorization", "Bearer " + userJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("OPEN"));
+
+        SupportTicket reloaded = ticketRepo.findByPublicId(t.getPublicId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(SupportTicketStatus.OPEN);
+    }
+
+    @Test
+    void reply_notOwner_returns404_unknownTicket() throws Exception {
+        SupportTicket t = saveTicket(user, "User's ticket", SupportTicketStatus.OPEN,
+                SupportTicketCategory.ACCOUNT);
+        em.flush();
+
+        ReplySupportTicketRequest req = new ReplySupportTicketRequest(
+                "I am not the owner", null);
+
+        mockMvc.perform(post("/api/v1/me/support-tickets/" + t.getPublicId() + "/messages")
+                        .header("Authorization", "Bearer " + otherJwt)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("UNKNOWN_TICKET"));
+    }
+
+    /* ============================================================ */
+    /* Helpers                                                      */
+    /* ============================================================ */
+
+    private SupportTicket saveTicket(User owner, String subject,
+                                     SupportTicketStatus status,
+                                     SupportTicketCategory category) {
+        OffsetDateTime now = OffsetDateTime.now();
+        SupportTicket t = SupportTicket.builder()
+                .user(owner)
+                .subject(subject)
+                .category(category)
+                .status(status)
+                .lastMessageAt(now)
+                .lastMessageAuthor(SupportTicketAuthorRole.USER)
+                .build();
+        return ticketRepo.save(t);
+    }
+
+    private SupportTicketMessage saveMessage(SupportTicket ticket, User author,
+                                             SupportTicketAuthorRole role,
+                                             String body, boolean visibleToUser) {
+        SupportTicketMessage m = SupportTicketMessage.builder()
+                .ticket(ticket)
+                .authorUser(author)
+                .authorRole(role)
+                .body(body)
+                .visibleToUser(visibleToUser)
+                .build();
+        return messageRepo.save(m);
+    }
+
+    private static String shortId() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/support/MeSupportTicketLazyInitRegressionTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/support/MeSupportTicketLazyInitRegressionTest.java
@@ -1,0 +1,223 @@
+package com.slparcelauctions.backend.support;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.storage.ObjectStorageService;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Regression coverage for the {@link org.hibernate.LazyInitializationException}
+ * class of bug that surfaced on {@code GET /api/v1/admin/coupons/{publicId}}
+ * (PR #388): a controller mapper iterated a LAZY collection after the service
+ * transaction closed.
+ *
+ * <p>The companion {@link MeSupportTicketControllerIntegrationTest} runs every
+ * test method inside a class-level {@code @Transactional}, which causes
+ * MockMvc's invocation to share the test's open session - so the bug never
+ * triggers there. This class deliberately omits {@code @Transactional} on the
+ * test methods so the controller call sees the same boundary as a real HTTP
+ * request: setup commits, the controller runs in its own transaction, and the
+ * post-service mapper has to survive a closed session.
+ *
+ * <p>{@code GET /api/v1/me/support-tickets/{publicId}} dereferences
+ * {@code ticket.messages}, {@code message.authorUser}, {@code message.attachments},
+ * and the submitter's {@link User} - every one of these is LAZY and would
+ * trip {@code LazyInitializationException} without the
+ * {@code @Transactional(readOnly = true)} on the controller method.
+ *
+ * <p>Cleanup is manual in {@link #cleanup()} because there's no
+ * test-wrapping rollback.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.auction-end.enabled=false",
+        "slpa.ownership-monitor.enabled=false",
+        "slpa.escrow.ownership-monitor-job.enabled=false",
+        "slpa.escrow.timeout-job.enabled=false",
+        "slpa.escrow.command-dispatcher-job.enabled=false",
+        "slpa.review.scheduler.enabled=false",
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false",
+        "slpa.realty.invitation-expiry.enabled=false"
+})
+class MeSupportTicketLazyInitRegressionTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired JwtService jwtService;
+    @Autowired UserRepository userRepo;
+    @Autowired SupportTicketRepository ticketRepo;
+    @Autowired SupportTicketMessageRepository messageRepo;
+    @Autowired SupportTicketAttachmentRepository attachmentRepo;
+
+    // Mocked away so the support context wires cleanly even though we do
+    // not exercise S3 in this test.
+    @MockitoBean ObjectStorageService storage;
+
+    private User user;
+    private User admin;
+    private String userJwt;
+    private Long ticketId;
+    private final List<Long> createdAttachmentIds = new ArrayList<>();
+    private final List<Long> createdMessageIds = new ArrayList<>();
+
+    @BeforeEach
+    @Transactional
+    void seed() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        user = userRepo.save(User.builder()
+                .username("lazy-init-user-" + suffix)
+                .email("lazy-init-user-" + suffix + "@example.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("LazyInit User")
+                .role(Role.USER)
+                .build());
+        admin = userRepo.save(User.builder()
+                .username("lazy-init-admin-" + suffix)
+                .email("lazy-init-admin-" + suffix + "@example.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("LazyInit Admin")
+                .role(Role.ADMIN)
+                .build());
+        userJwt = jwtService.issueAccessToken(new AuthPrincipal(
+                user.getId(), user.getPublicId(), user.getEmail(), 0L, Role.USER));
+
+        OffsetDateTime now = OffsetDateTime.now();
+        SupportTicket ticket = ticketRepo.save(SupportTicket.builder()
+                .user(user)
+                .subject("LazyInit subject " + suffix)
+                .category(SupportTicketCategory.ACCOUNT)
+                .status(SupportTicketStatus.OPEN)
+                .lastMessageAt(now)
+                .lastMessageAuthor(SupportTicketAuthorRole.USER)
+                .build());
+        ticketId = ticket.getId();
+
+        // 2 messages on the ticket: one visible user message and one
+        // visible admin reply. We deliberately do NOT seed an internal
+        // note in this regression class so the assertion below can keep
+        // it simple - the integration test covers internal-note filtering.
+        // ... actually plan asks for it, see below.
+        SupportTicketMessage m1 = messageRepo.save(SupportTicketMessage.builder()
+                .ticket(ticket)
+                .authorUser(user)
+                .authorRole(SupportTicketAuthorRole.USER)
+                .body("user-visible body")
+                .visibleToUser(true)
+                .build());
+        SupportTicketMessage m2 = messageRepo.save(SupportTicketMessage.builder()
+                .ticket(ticket)
+                .authorUser(admin)
+                .authorRole(SupportTicketAuthorRole.ADMIN)
+                .body("admin internal note - should be filtered")
+                .visibleToUser(false)
+                .build());
+        createdMessageIds.add(m1.getId());
+        createdMessageIds.add(m2.getId());
+
+        // One attachment on the visible message - exercises the
+        // messages.attachments LAZY traversal.
+        SupportTicketAttachment att = attachmentRepo.save(SupportTicketAttachment.builder()
+                .message(m1)
+                .storageKey("support-attachments/" + m1.getId() + "/lazy-init-key")
+                .mimeType("image/png")
+                .sizeBytes(1234)
+                .width(100)
+                .height(80)
+                .build());
+        createdAttachmentIds.add(att.getId());
+    }
+
+    @AfterEach
+    @Transactional
+    void cleanup() {
+        // Children first, then ticket, then users.
+        for (Long aid : createdAttachmentIds) {
+            attachmentRepo.findById(aid).ifPresent(attachmentRepo::delete);
+        }
+        for (Long mid : createdMessageIds) {
+            messageRepo.findById(mid).ifPresent(messageRepo::delete);
+        }
+        if (ticketId != null) {
+            ticketRepo.findById(ticketId).ifPresent(ticketRepo::delete);
+        }
+        if (admin != null) {
+            userRepo.findById(admin.getId()).ifPresent(userRepo::delete);
+        }
+        if (user != null) {
+            userRepo.findById(user.getId()).ifPresent(userRepo::delete);
+        }
+        createdAttachmentIds.clear();
+        createdMessageIds.clear();
+    }
+
+    @Test
+    void getDetail_outsideEnclosingTx_initializesLazyCollections() throws Exception {
+        // Without @Transactional(readOnly=true) on the controller method
+        // (and the @EntityGraph on findByPublicId), the mapper trips
+        // LazyInitializationException on ticket.messages /
+        // messages.attachments / authorUser, the global handler returns
+        // 500, and the assertions below fail with a Problem JSON body
+        // instead of the expected support-ticket payload.
+        UUID publicId = ticketRepo.findById(ticketId).orElseThrow().getPublicId();
+        mockMvc.perform(get("/api/v1/me/support-tickets/" + publicId)
+                        .header("Authorization", "Bearer " + userJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.publicId").value(publicId.toString()))
+                // Only the visible message survives the user-facing filter.
+                .andExpect(jsonPath("$.messages.length()").value(1))
+                .andExpect(jsonPath("$.messages[0].body").value("user-visible body"))
+                .andExpect(jsonPath("$.messages[0].visibleToUser").value(true))
+                // Attachment was eagerly fetched + serialized.
+                .andExpect(jsonPath("$.messages[0].attachments.length()").value(1))
+                .andExpect(jsonPath("$.messages[0].attachments[0].mimeType").value("image/png"))
+                // Internal note must not leak through the user surface even
+                // outside an enclosing transaction.
+                .andExpect(jsonPath("$.messages[?(@.visibleToUser == false)]").isEmpty());
+    }
+
+    @Test
+    void getList_outsideEnclosingTx_returnsAtLeastOneRow() throws Exception {
+        // List path: MeSupportTicketController.list maps each
+        // Page<SupportTicket> entry via mapper.toSummaryDto, which
+        // dereferences ticket.lastMessageAuthor / status / category /
+        // subject. None of those are LAZY collections, but the
+        // @Transactional(readOnly=true) on the controller still matters
+        // because the underlying Page#map closure runs after the service
+        // tx closes. This test guards against future regressions where a
+        // mapper enrichment dereferences a LAZY field.
+        mockMvc.perform(get("/api/v1/me/support-tickets")
+                        .header("Authorization", "Bearer " + userJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content.length()").value(
+                        org.hamcrest.Matchers.greaterThanOrEqualTo(1)));
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketAttachmentControllerIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketAttachmentControllerIntegrationTest.java
@@ -1,0 +1,249 @@
+package com.slparcelauctions.backend.support;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.awt.image.BufferedImage;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.media.ImageFormat;
+import com.slparcelauctions.backend.media.ImageUploadValidator;
+import com.slparcelauctions.backend.storage.ObjectStorageService;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+/**
+ * Integration coverage for {@link SupportTicketAttachmentController}. Spins
+ * the full Spring context (auth chain + slice advice + JPA) and exercises
+ * both endpoints via {@link MockMvc} with real user / admin JWTs.
+ *
+ * <p>{@link ObjectStorageService} and {@link ImageUploadValidator} are
+ * mocked so the tests never hit S3 / actually decode pixels. The signed-URL
+ * test seeds a real attachment row inside the test transaction.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.auction-end.enabled=false",
+        "slpa.ownership-monitor.enabled=false",
+        "slpa.escrow.ownership-monitor-job.enabled=false",
+        "slpa.escrow.timeout-job.enabled=false",
+        "slpa.escrow.command-dispatcher-job.enabled=false",
+        "slpa.review.scheduler.enabled=false",
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false",
+        "slpa.realty.invitation-expiry.enabled=false"
+})
+@Transactional
+class SupportTicketAttachmentControllerIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired JwtService jwtService;
+    @Autowired UserRepository userRepo;
+    @Autowired SupportTicketRepository ticketRepo;
+    @Autowired SupportTicketMessageRepository messageRepo;
+    @Autowired SupportTicketAttachmentRepository attachmentRepo;
+    @PersistenceContext EntityManager em;
+
+    @MockitoBean ObjectStorageService storage;
+    @MockitoBean ImageUploadValidator imageValidator;
+
+    private User user;
+    private User otherUser;
+    private User admin;
+    private String userJwt;
+    private String otherJwt;
+    private String adminJwt;
+
+    @BeforeEach
+    void seed() {
+        user = userRepo.save(User.builder()
+                .username("user-" + shortId())
+                .email("user-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x").slAvatarUuid(UUID.randomUUID())
+                .displayName("User").role(Role.USER).verified(true).build());
+        otherUser = userRepo.save(User.builder()
+                .username("other-" + shortId())
+                .email("other-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x").slAvatarUuid(UUID.randomUUID())
+                .displayName("Other").role(Role.USER).verified(true).build());
+        admin = userRepo.save(User.builder()
+                .username("admin-" + shortId())
+                .email("admin-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x").slAvatarUuid(UUID.randomUUID())
+                .displayName("Admin").role(Role.ADMIN).verified(true).build());
+
+        userJwt = jwtService.issueAccessToken(new AuthPrincipal(
+                user.getId(), user.getPublicId(), user.getEmail(), 0L, Role.USER));
+        otherJwt = jwtService.issueAccessToken(new AuthPrincipal(
+                otherUser.getId(), otherUser.getPublicId(), otherUser.getEmail(),
+                0L, Role.USER));
+        adminJwt = jwtService.issueAccessToken(new AuthPrincipal(
+                admin.getId(), admin.getPublicId(), admin.getEmail(), 0L, Role.ADMIN));
+
+        // Default: validator returns a valid 800x600 result. Individual tests
+        // can override.
+        when(imageValidator.validate(any(byte[].class), anyLong(), anyInt()))
+                .thenReturn(new ImageUploadValidator.ValidationResult(
+                        ImageFormat.PNG,
+                        new BufferedImage(800, 600, BufferedImage.TYPE_INT_ARGB),
+                        800, 600));
+    }
+
+    /* ============================================================ */
+    /* POST /api/v1/me/support-tickets/attachments                  */
+    /* ============================================================ */
+
+    @Test
+    void preUpload_happyPath_returnsAttachmentKey() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "ok.png", "image/png", new byte[]{1, 2, 3, 4});
+
+        mockMvc.perform(multipart("/api/v1/me/support-tickets/attachments")
+                        .file(file)
+                        .header("Authorization", "Bearer " + userJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.attachmentKey").isNotEmpty());
+    }
+
+    @Test
+    void preUpload_rejectsOverSize_400_INVALID_ATTACHMENT() throws Exception {
+        // 6 MiB > default 5 MiB cap. The default Spring multipart cap is
+        // 25 MiB (application.yml), so the bytes reach the service which
+        // performs the size check.
+        byte[] huge = new byte[6 * 1024 * 1024];
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "big.png", "image/png", huge);
+
+        mockMvc.perform(multipart("/api/v1/me/support-tickets/attachments")
+                        .file(file)
+                        .header("Authorization", "Bearer " + userJwt))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_ATTACHMENT"));
+    }
+
+    @Test
+    void preUpload_rejectsBadMime_400_INVALID_ATTACHMENT() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "doc.pdf", "application/pdf", new byte[]{1, 2, 3});
+
+        mockMvc.perform(multipart("/api/v1/me/support-tickets/attachments")
+                        .file(file)
+                        .header("Authorization", "Bearer " + userJwt))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_ATTACHMENT"));
+    }
+
+    /* ============================================================ */
+    /* GET /api/v1/support-tickets/attachments/{publicId}           */
+    /* ============================================================ */
+
+    @Test
+    void signedUrl_owner_returns200WithUrl() throws Exception {
+        SupportTicketAttachment att = seedAttachment(user);
+        when(storage.presignGet(eq(att.getStorageKey()), any()))
+                .thenReturn("https://example.com/presigned-owner");
+
+        mockMvc.perform(get("/api/v1/support-tickets/attachments/" + att.getPublicId())
+                        .header("Authorization", "Bearer " + userJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.url").value("https://example.com/presigned-owner"));
+    }
+
+    @Test
+    void signedUrl_admin_returns200() throws Exception {
+        SupportTicketAttachment att = seedAttachment(user);
+        when(storage.presignGet(eq(att.getStorageKey()), any()))
+                .thenReturn("https://example.com/presigned-admin");
+
+        mockMvc.perform(get("/api/v1/support-tickets/attachments/" + att.getPublicId())
+                        .header("Authorization", "Bearer " + adminJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.url").value("https://example.com/presigned-admin"));
+    }
+
+    @Test
+    void signedUrl_otherUser_returns403_NOT_OWNER() throws Exception {
+        SupportTicketAttachment att = seedAttachment(user);
+
+        mockMvc.perform(get("/api/v1/support-tickets/attachments/" + att.getPublicId())
+                        .header("Authorization", "Bearer " + otherJwt))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("NOT_OWNER"));
+    }
+
+    @Test
+    void signedUrl_unknown_publicId_returns404_ATTACHMENT_NOT_FOUND() throws Exception {
+        mockMvc.perform(get("/api/v1/support-tickets/attachments/" + UUID.randomUUID())
+                        .header("Authorization", "Bearer " + userJwt))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("ATTACHMENT_NOT_FOUND"));
+    }
+
+    /* ============================================================ */
+    /* Helpers                                                      */
+    /* ============================================================ */
+
+    private SupportTicketAttachment seedAttachment(User owner) {
+        OffsetDateTime now = OffsetDateTime.now();
+        SupportTicket ticket = ticketRepo.save(SupportTicket.builder()
+                .user(owner)
+                .subject("subj-" + shortId())
+                .category(SupportTicketCategory.OTHER)
+                .status(SupportTicketStatus.OPEN)
+                .lastMessageAt(now)
+                .lastMessageAuthor(SupportTicketAuthorRole.USER)
+                .build());
+        SupportTicketMessage message = messageRepo.save(SupportTicketMessage.builder()
+                .ticket(ticket)
+                .authorUser(owner)
+                .authorRole(SupportTicketAuthorRole.USER)
+                .body("body-" + shortId())
+                .visibleToUser(true)
+                .build());
+        SupportTicketAttachment att = attachmentRepo.save(SupportTicketAttachment.builder()
+                .message(message)
+                .storageKey("support-attachments/" + message.getId() + "/" + UUID.randomUUID() + ".png")
+                .mimeType("image/png")
+                .sizeBytes(1024)
+                .width(800)
+                .height(600)
+                .build());
+        em.flush();
+        em.clear();
+        return att;
+    }
+
+    private static String shortId() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketAttachmentServiceTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketAttachmentServiceTest.java
@@ -1,0 +1,342 @@
+package com.slparcelauctions.backend.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.awt.image.BufferedImage;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.slparcelauctions.backend.media.ImageFormat;
+import com.slparcelauctions.backend.media.ImageUploadValidator;
+import com.slparcelauctions.backend.storage.ObjectStorageService;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import com.slparcelauctions.backend.user.exception.UnsupportedImageFormatException;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+/**
+ * Unit-ish coverage for the two-phase attachment lifecycle:
+ *
+ * <ul>
+ *   <li>{@code preUpload}: rejects on size / mime / validator, happy path
+ *       stores to S3 + caches Redis metadata under {@code support:upload:*}.</li>
+ *   <li>{@code promote}: missing key, owner mismatch, over-cap, happy path,
+ *       and the cleanup path when the DB save explodes mid-list.</li>
+ * </ul>
+ *
+ * <p>Pattern follows {@code SupportTicketNotificationDispatchTest}:
+ * {@code @SpringBootTest} + {@code @ActiveProfiles("dev")} so a real
+ * {@link StringRedisTemplate} is wired against the dev Redis. The storage
+ * service and image validator are mocked via {@link MockitoBean} so the
+ * tests don't actually hit S3 / decode images.
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.auction-end.enabled=false",
+        "slpa.ownership-monitor.enabled=false",
+        "slpa.escrow.ownership-monitor-job.enabled=false",
+        "slpa.escrow.timeout-job.enabled=false",
+        "slpa.escrow.command-dispatcher-job.enabled=false",
+        "slpa.review.scheduler.enabled=false",
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false",
+        "slpa.realty.invitation-expiry.enabled=false"
+})
+@Transactional
+class SupportTicketAttachmentServiceTest {
+
+    @Autowired SupportTicketAttachmentService service;
+    @Autowired StringRedisTemplate redis;
+    @Autowired UserRepository userRepo;
+
+    // Local mapper for fixture seeding -- mirrors the service-side mapper
+    // (also self-managed there). Test fixtures use the same flat-record
+    // payload, no Spring bean wiring needed.
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockitoBean ObjectStorageService storage;
+    @MockitoBean ImageUploadValidator imageValidator;
+
+    @PersistenceContext EntityManager em;
+
+    private User uploader;
+    private final List<String> redisKeysToClean = new java.util.ArrayList<>();
+
+    @BeforeEach
+    void setup() {
+        uploader = userRepo.save(User.builder()
+                .username("uploader-" + shortId())
+                .email("uploader-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x").slAvatarUuid(UUID.randomUUID())
+                .displayName("Uploader").build());
+
+        // Default: validator returns a valid 800x600 result. Individual tests
+        // can override by re-stubbing.
+        when(imageValidator.validate(any(byte[].class), anyLong(), anyInt()))
+                .thenReturn(new ImageUploadValidator.ValidationResult(
+                        ImageFormat.PNG,
+                        new BufferedImage(800, 600, BufferedImage.TYPE_INT_ARGB),
+                        800, 600));
+    }
+
+    @AfterEach
+    void cleanup() {
+        for (String k : redisKeysToClean) {
+            redis.delete(k);
+        }
+        redisKeysToClean.clear();
+    }
+
+    // ── preUpload ─────────────────────────────────────────────────────────────
+
+    @Test
+    void preUpload_rejects_over_size_limit() {
+        byte[] huge = new byte[6 * 1024 * 1024]; // > default 5MB cap
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "big.png", "image/png", huge);
+
+        assertThatThrownBy(() -> service.preUpload(uploader, file))
+                .isInstanceOf(SupportTicketException.class)
+                .extracting("code").isEqualTo(SupportTicketError.INVALID_ATTACHMENT);
+
+        verify(storage, never()).put(any(), any(), any());
+    }
+
+    @Test
+    void preUpload_rejects_disallowed_mime() {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "evil.exe", "application/x-msdownload", new byte[]{1, 2, 3});
+
+        assertThatThrownBy(() -> service.preUpload(uploader, file))
+                .isInstanceOf(SupportTicketException.class)
+                .extracting("code").isEqualTo(SupportTicketError.INVALID_ATTACHMENT);
+
+        verify(storage, never()).put(any(), any(), any());
+    }
+
+    @Test
+    void preUpload_validator_failure_throws_INVALID_ATTACHMENT() {
+        when(imageValidator.validate(any(byte[].class), anyLong(), anyInt()))
+                .thenThrow(new UnsupportedImageFormatException("bad bytes"));
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "lying.png", "image/png", new byte[]{0, 1, 2});
+
+        assertThatThrownBy(() -> service.preUpload(uploader, file))
+                .isInstanceOf(SupportTicketException.class)
+                .extracting("code").isEqualTo(SupportTicketError.INVALID_ATTACHMENT);
+
+        verify(storage, never()).put(any(), any(), any());
+    }
+
+    @Test
+    void preUpload_happy_path_returns_key_and_caches_in_redis() throws Exception {
+        byte[] bytes = new byte[]{10, 20, 30, 40};
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "ok.png", "image/png", bytes);
+
+        String attachmentKey = service.preUpload(uploader, file);
+        redisKeysToClean.add("support:upload:" + attachmentKey);
+
+        assertThat(attachmentKey).isNotBlank();
+        // Returned key is a UUID, not the storage path
+        assertThat(UUID.fromString(attachmentKey)).isNotNull();
+
+        // S3 put fired with the expected pending path
+        String expectedPath = "support-attachments/pending/" + uploader.getPublicId()
+                + "/" + attachmentKey + ".png";
+        verify(storage).put(eq(expectedPath), eq(bytes), eq("image/png"));
+
+        // Redis entry is present with the pending metadata
+        String json = redis.opsForValue().get("support:upload:" + attachmentKey);
+        assertThat(json).isNotNull();
+        SupportTicketAttachmentService.PendingAttachment p =
+                objectMapper.readValue(json, SupportTicketAttachmentService.PendingAttachment.class);
+        assertThat(p.userId()).isEqualTo(uploader.getId());
+        assertThat(p.storageKey()).isEqualTo(expectedPath);
+        assertThat(p.mime()).isEqualTo("image/png");
+        assertThat(p.size()).isEqualTo(bytes.length);
+        assertThat(p.width()).isEqualTo(800);
+        assertThat(p.height()).isEqualTo(600);
+    }
+
+    // ── promote ───────────────────────────────────────────────────────────────
+
+    @Test
+    void promote_unknown_key_throws_ATTACHMENT_NOT_FOUND() {
+        SupportTicketMessage message = persistTicketAndMessage();
+        SupportTicketAttachmentRepository repoMock = mock(SupportTicketAttachmentRepository.class);
+
+        String bogus = UUID.randomUUID().toString();
+
+        assertThatThrownBy(() -> service.promote(
+                List.of(bogus), uploader.getId(), message, repoMock))
+                .isInstanceOf(SupportTicketException.class)
+                .extracting("code").isEqualTo(SupportTicketError.ATTACHMENT_NOT_FOUND);
+    }
+
+    @Test
+    void promote_owner_mismatch_throws_NOT_OWNER() throws Exception {
+        SupportTicketMessage message = persistTicketAndMessage();
+        SupportTicketAttachmentRepository repoMock = mock(SupportTicketAttachmentRepository.class);
+
+        String key = seedPendingAttachment(uploader.getId(),
+                "support-attachments/pending/x/abc.png", "image/png", 1024, 800, 600);
+
+        // Promote as a different owner id
+        assertThatThrownBy(() -> service.promote(
+                List.of(key), uploader.getId() + 999L, message, repoMock))
+                .isInstanceOf(SupportTicketException.class)
+                .extracting("code").isEqualTo(SupportTicketError.NOT_OWNER);
+    }
+
+    @Test
+    void promote_over_max_throws_INVALID_ATTACHMENT() {
+        SupportTicketMessage message = persistTicketAndMessage();
+        SupportTicketAttachmentRepository repoMock = mock(SupportTicketAttachmentRepository.class);
+
+        List<String> tooMany = List.of(
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString());
+
+        assertThatThrownBy(() -> service.promote(
+                tooMany, uploader.getId(), message, repoMock))
+                .isInstanceOf(SupportTicketException.class)
+                .extracting("code").isEqualTo(SupportTicketError.INVALID_ATTACHMENT);
+    }
+
+    @Test
+    void promote_happy_path_copies_and_inserts_row() throws Exception {
+        SupportTicketMessage message = persistTicketAndMessage();
+        SupportTicketAttachmentRepository repoMock = mock(SupportTicketAttachmentRepository.class);
+        when(repoMock.save(any(SupportTicketAttachment.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        String pendingKey = "support-attachments/pending/u/abc.png";
+        String key = seedPendingAttachment(uploader.getId(),
+                pendingKey, "image/png", 4096, 800, 600);
+
+        List<SupportTicketAttachment> result = service.promote(
+                List.of(key), uploader.getId(), message, repoMock);
+
+        assertThat(result).hasSize(1);
+        String expectedPromotedKey = "support-attachments/" + message.getId() + "/" + key;
+        SupportTicketAttachment att = result.get(0);
+        assertThat(att.getStorageKey()).isEqualTo(expectedPromotedKey);
+        assertThat(att.getMimeType()).isEqualTo("image/png");
+        assertThat(att.getSizeBytes()).isEqualTo(4096);
+        assertThat(att.getWidth()).isEqualTo(800);
+        assertThat(att.getHeight()).isEqualTo(600);
+
+        verify(storage).copy(pendingKey, expectedPromotedKey);
+        verify(storage).delete(pendingKey);
+        verify(repoMock).save(any(SupportTicketAttachment.class));
+
+        // Redis entry cleared
+        assertThat(redis.opsForValue().get("support:upload:" + key)).isNull();
+    }
+
+    @Test
+    void promote_db_failure_after_copy_cleans_up_promoted_object() throws Exception {
+        SupportTicketMessage message = persistTicketAndMessage();
+        SupportTicketAttachmentRepository repoMock = mock(SupportTicketAttachmentRepository.class);
+        // First save succeeds, second blows up
+        when(repoMock.save(any(SupportTicketAttachment.class)))
+                .thenAnswer(inv -> inv.getArgument(0))
+                .thenThrow(new RuntimeException("DB exploded"));
+
+        String key1 = seedPendingAttachment(uploader.getId(),
+                "support-attachments/pending/u/one.png", "image/png", 1024, 100, 100);
+        String key2 = seedPendingAttachment(uploader.getId(),
+                "support-attachments/pending/u/two.png", "image/png", 2048, 200, 200);
+
+        String promoted1 = "support-attachments/" + message.getId() + "/" + key1;
+        String promoted2 = "support-attachments/" + message.getId() + "/" + key2;
+
+        assertThatThrownBy(() -> service.promote(
+                List.of(key1, key2), uploader.getId(), message, repoMock))
+                .isInstanceOf(RuntimeException.class);
+
+        // Both objects were copied
+        verify(storage).copy("support-attachments/pending/u/one.png", promoted1);
+        verify(storage).copy("support-attachments/pending/u/two.png", promoted2);
+
+        // Cleanup ran: both promoted keys were deleted as part of the catch
+        // block. (The first pending key was also deleted in the happy-path
+        // delete-after-copy step, so we just assert the promoted-key deletes
+        // ran at least once each.)
+        verify(storage, atLeastOnce()).delete(promoted1);
+        verify(storage, atLeastOnce()).delete(promoted2);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private SupportTicketMessage persistTicketAndMessage() {
+        OffsetDateTime now = OffsetDateTime.now();
+        SupportTicket ticket = SupportTicket.builder()
+                .user(uploader)
+                .subject("subj-" + shortId())
+                .category(SupportTicketCategory.OTHER)
+                .status(SupportTicketStatus.OPEN)
+                .lastMessageAt(now)
+                .lastMessageAuthor(SupportTicketAuthorRole.USER)
+                .build();
+        em.persist(ticket);
+        SupportTicketMessage message = SupportTicketMessage.builder()
+                .ticket(ticket)
+                .authorUser(uploader)
+                .authorRole(SupportTicketAuthorRole.USER)
+                .body("body-" + shortId())
+                .visibleToUser(true)
+                .build();
+        em.persist(message);
+        em.flush();
+        return message;
+    }
+
+    private String seedPendingAttachment(long userId, String storageKey,
+            String mime, int size, int width, int height) throws Exception {
+        String key = UUID.randomUUID().toString();
+        SupportTicketAttachmentService.PendingAttachment p =
+                new SupportTicketAttachmentService.PendingAttachment(
+                        userId, storageKey, mime, size, width, height);
+        String json = objectMapper.writeValueAsString(p);
+        redis.opsForValue().set("support:upload:" + key, json, Duration.ofMinutes(5));
+        redisKeysToClean.add("support:upload:" + key);
+        return key;
+    }
+
+    private static String shortId() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketNotificationDispatchTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketNotificationDispatchTest.java
@@ -1,0 +1,276 @@
+package com.slparcelauctions.backend.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.slparcelauctions.backend.notification.Notification;
+import com.slparcelauctions.backend.notification.NotificationCategory;
+import com.slparcelauctions.backend.notification.NotificationEvent;
+import com.slparcelauctions.backend.notification.NotificationPublisher;
+import com.slparcelauctions.backend.notification.NotificationRepository;
+import com.slparcelauctions.backend.notification.NotificationWsBroadcasterPort;
+import com.slparcelauctions.backend.notification.slim.SlImChannelDispatcher;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Plan Task 5 -- dispatch coverage for the four customer-support notification
+ * categories added to {@link NotificationPublisher}.
+ *
+ * <p>Pattern mirrors {@code NotificationPublisherImplTest}: real publisher bean
+ * + real DAO + real Postgres, with {@link SlImChannelDispatcher} mocked so we
+ * can assert SL IM dispatch was/was-not invoked per category. The WS
+ * broadcaster is also mocked to avoid Stomp-related session noise; the row
+ * counts in the repository are the ground-truth signal for in-app delivery.
+ *
+ * <p>User-facing categories ({@code SUPPORT_TICKET_ADMIN_REPLIED},
+ * {@code SUPPORT_TICKET_RESOLVED}) must fire in-app + SL IM. Admin-facing
+ * categories ({@code SUPPORT_TICKET_OPENED}, {@code SUPPORT_TICKET_USER_REPLIED})
+ * must fire in-app to each admin in the supplied list and NEVER queue an
+ * SL IM (admins read the queue page, not their inbox).
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.auction-end.enabled=false",
+        "slpa.ownership-monitor.enabled=false",
+        "slpa.escrow.ownership-monitor-job.enabled=false",
+        "slpa.escrow.timeout-job.enabled=false",
+        "slpa.escrow.command-dispatcher-job.enabled=false",
+        "slpa.review.scheduler.enabled=false",
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false",
+        "slpa.realty.invitation-expiry.enabled=false"
+})
+class SupportTicketNotificationDispatchTest {
+
+    @Autowired NotificationPublisher publisher;
+    @Autowired NotificationRepository repo;
+    @Autowired UserRepository userRepo;
+    @Autowired DataSource dataSource;
+    @Autowired PlatformTransactionManager txManager;
+
+    @MockitoBean
+    NotificationWsBroadcasterPort broadcasterPort;
+    @MockitoBean
+    SlImChannelDispatcher slImChannelDispatcher;
+
+    private TransactionTemplate transactionTemplate;
+    private final List<Long> userIds = new ArrayList<>();
+
+    @BeforeEach
+    void setup() {
+        transactionTemplate = new TransactionTemplate(txManager);
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        try (var conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            try (var stmt = conn.createStatement()) {
+                for (Long id : userIds) {
+                    if (id != null) {
+                        stmt.execute("DELETE FROM notification WHERE user_id = " + id);
+                        stmt.execute("DELETE FROM refresh_tokens WHERE user_id = " + id);
+                        stmt.execute("DELETE FROM users WHERE id = " + id);
+                    }
+                }
+            }
+        }
+        userIds.clear();
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * User with an SL avatar UUID set. The SL IM gate's no-avatar floor would
+     * otherwise return SKIP_NO_AVATAR for the user-facing tests; we need the
+     * gate to land on QUEUE_BYPASS_PREFS so the dispatcher actually gets a
+     * call we can verify. The mocked SlImChannelDispatcher means the gate is
+     * not actually consulted here — verification is purely on the
+     * NotificationService -> SlImChannelDispatcher.maybeQueue path.
+     */
+    private User testUser(String prefix) {
+        User u = userRepo.save(User.builder()
+                .username("u-" + UUID.randomUUID().toString().substring(0, 8))
+                .email(prefix + "-" + UUID.randomUUID() + "@example.com")
+                .passwordHash("hash")
+                .slAvatarUuid(UUID.randomUUID())
+                .build());
+        userIds.add(u.getId());
+        return u;
+    }
+
+    private List<Notification> notifFor(Long userId) {
+        return repo.findAllByUserId(userId);
+    }
+
+    // ── User-facing: in-app + SL IM ───────────────────────────────────────────
+
+    @Test
+    void supportTicketAdminReplied_fires_inApp_andSlIm() {
+        User user = testUser("admin-replied-user");
+        UUID ticketPublicId = UUID.randomUUID();
+
+        transactionTemplate.execute(status -> {
+            publisher.supportTicketAdminReplied(user.getId(), ticketPublicId,
+                    "Cannot withdraw L$", "Heath Admin");
+            return null;
+        });
+
+        List<Notification> rows = notifFor(user.getId());
+        assertThat(rows).hasSize(1);
+        Notification n = rows.get(0);
+        assertThat(n.getCategory()).isEqualTo(NotificationCategory.SUPPORT_TICKET_ADMIN_REPLIED);
+        assertThat(n.getBody()).contains("Heath Admin replied to your support ticket: Cannot withdraw L$");
+        assertThat(n.getBody()).contains("slparcels.com/support/" + ticketPublicId);
+        assertThat(n.getBody()).doesNotContain("—"); // em-dash guard
+        assertThat(n.getData()).containsEntry("ticketPublicId", ticketPublicId.toString());
+        assertThat(n.getData()).containsEntry("subject", "Cannot withdraw L$");
+        assertThat(n.getData()).containsEntry("adminDisplayName", "Heath Admin");
+
+        // SL IM dispatch fired once on afterCommit -- SYSTEM-group routing
+        // means the gate would return QUEUE_BYPASS_PREFS in production.
+        verify(slImChannelDispatcher, times(1)).maybeQueue(any(NotificationEvent.class));
+        verify(broadcasterPort).broadcastUpsert(eq(user.getId()), any(), any());
+    }
+
+    @Test
+    void supportTicketResolved_fires_inApp_andSlIm() {
+        User user = testUser("resolved-user");
+        UUID ticketPublicId = UUID.randomUUID();
+
+        transactionTemplate.execute(status -> {
+            publisher.supportTicketResolved(user.getId(), ticketPublicId,
+                    "Refund question");
+            return null;
+        });
+
+        List<Notification> rows = notifFor(user.getId());
+        assertThat(rows).hasSize(1);
+        Notification n = rows.get(0);
+        assertThat(n.getCategory()).isEqualTo(NotificationCategory.SUPPORT_TICKET_RESOLVED);
+        assertThat(n.getBody()).contains(
+                "Your support ticket has been marked resolved: Refund question");
+        assertThat(n.getBody()).contains("slparcels.com/support/" + ticketPublicId);
+        assertThat(n.getBody()).doesNotContain("—");
+        assertThat(n.getData()).containsEntry("ticketPublicId", ticketPublicId.toString());
+        assertThat(n.getData()).containsEntry("subject", "Refund question");
+
+        verify(slImChannelDispatcher, times(1)).maybeQueue(any(NotificationEvent.class));
+        verify(broadcasterPort).broadcastUpsert(eq(user.getId()), any(), any());
+    }
+
+    // ── Admin-facing fan-out: in-app only ─────────────────────────────────────
+
+    @Test
+    void supportTicketOpened_fires_inApp_only_to_each_admin() {
+        User adminA = testUser("admin-opened-a");
+        User adminB = testUser("admin-opened-b");
+        User adminC = testUser("admin-opened-c");
+        UUID ticketPublicId = UUID.randomUUID();
+
+        transactionTemplate.execute(status -> {
+            publisher.supportTicketOpened(
+                    List.of(adminA.getId(), adminB.getId(), adminC.getId()),
+                    ticketPublicId,
+                    "Cannot list parcel",
+                    "Alice Resident",
+                    "LISTING");
+            return null;
+        });
+
+        // Each admin gets their own row, none shared.
+        assertThat(notifFor(adminA.getId())).hasSize(1);
+        assertThat(notifFor(adminB.getId())).hasSize(1);
+        assertThat(notifFor(adminC.getId())).hasSize(1);
+        Notification rowA = notifFor(adminA.getId()).get(0);
+        assertThat(rowA.getCategory()).isEqualTo(NotificationCategory.SUPPORT_TICKET_OPENED);
+        assertThat(rowA.getBody()).isEqualTo(
+                "Alice Resident opened a new LISTING support ticket: Cannot list parcel");
+        assertThat(rowA.getBody()).doesNotContain("—");
+        assertThat(rowA.getData()).containsEntry("ticketPublicId", ticketPublicId.toString());
+        assertThat(rowA.getData()).containsEntry("subject", "Cannot list parcel");
+        assertThat(rowA.getData()).containsEntry("submitterDisplayName", "Alice Resident");
+        assertThat(rowA.getData()).containsEntry("category", "LISTING");
+
+        // WS broadcast fired once per admin.
+        verify(broadcasterPort, times(3)).broadcastUpsert(anyLong(), any(), any());
+
+        // Admin fan-out path NEVER hits the SL IM dispatcher -- admins read the
+        // queue page + sidebar badge, in-world IMs would be spam.
+        verify(slImChannelDispatcher, never()).maybeQueue(any(NotificationEvent.class));
+        verify(slImChannelDispatcher, never()).maybeQueueForFanout(
+                anyLong(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void supportTicketUserReplied_fires_inApp_only() {
+        User adminA = testUser("admin-reply-a");
+        User adminB = testUser("admin-reply-b");
+        UUID ticketPublicId = UUID.randomUUID();
+
+        transactionTemplate.execute(status -> {
+            publisher.supportTicketUserReplied(
+                    List.of(adminA.getId(), adminB.getId()),
+                    ticketPublicId,
+                    "Cannot withdraw L$",
+                    "Bob Resident");
+            return null;
+        });
+
+        assertThat(notifFor(adminA.getId())).hasSize(1);
+        assertThat(notifFor(adminB.getId())).hasSize(1);
+        Notification rowA = notifFor(adminA.getId()).get(0);
+        assertThat(rowA.getCategory()).isEqualTo(NotificationCategory.SUPPORT_TICKET_USER_REPLIED);
+        assertThat(rowA.getBody()).isEqualTo(
+                "Bob Resident replied to a support ticket: Cannot withdraw L$");
+        assertThat(rowA.getBody()).doesNotContain("—");
+        assertThat(rowA.getData()).containsEntry("ticketPublicId", ticketPublicId.toString());
+        assertThat(rowA.getData()).containsEntry("submitterDisplayName", "Bob Resident");
+
+        verify(broadcasterPort, times(2)).broadcastUpsert(anyLong(), any(), any());
+        verify(slImChannelDispatcher, never()).maybeQueue(any(NotificationEvent.class));
+        verify(slImChannelDispatcher, never()).maybeQueueForFanout(
+                anyLong(), any(), any(), any(), any(), any());
+    }
+
+    // ── Null/empty input guards ───────────────────────────────────────────────
+
+    @Test
+    void supportTicketOpened_empty_admin_list_isNoOp() {
+        UUID ticketPublicId = UUID.randomUUID();
+
+        transactionTemplate.execute(status -> {
+            publisher.supportTicketOpened(List.of(), ticketPublicId,
+                    "x", "x", "BUG");
+            return null;
+        });
+
+        verify(broadcasterPort, never()).broadcastUpsert(anyLong(), any(), any());
+        verify(slImChannelDispatcher, never()).maybeQueue(any(NotificationEvent.class));
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketRateLimiterTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketRateLimiterTest.java
@@ -1,0 +1,38 @@
+package com.slparcelauctions.backend.support;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class SupportTicketRateLimiterTest {
+
+    SupportTicketRepository repo;
+    SupportTicketRateLimiter limiter;
+
+    @BeforeEach
+    void setUp() {
+        repo = mock(SupportTicketRepository.class);
+        limiter = new SupportTicketRateLimiter(repo);
+        ReflectionTestUtils.setField(limiter, "ticketsPerHour", 5);
+    }
+
+    @Test
+    void under_cap_does_not_throw() {
+        when(repo.countByUserIdAndCreatedAtAfter(anyLong(), any())).thenReturn(4L);
+        limiter.assertCanOpenNewTicket(1L);
+    }
+
+    @Test
+    void at_cap_throws() {
+        when(repo.countByUserIdAndCreatedAtAfter(anyLong(), any())).thenReturn(5L);
+        assertThatThrownBy(() -> limiter.assertCanOpenNewTicket(1L))
+                .isInstanceOf(SupportTicketException.class)
+                .extracting("code").isEqualTo(SupportTicketError.RATE_LIMITED);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketRepositoryIntegrationTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketRepositoryIntegrationTest.java
@@ -1,0 +1,185 @@
+package com.slparcelauctions.backend.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.hibernate.Hibernate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+/**
+ * Repository coverage for the two hot-path support-ticket queries:
+ *
+ * <ul>
+ *   <li>{@link SupportTicketRepository#findByPublicId} - the controllers'
+ *       detail-read entry point. Carries an {@code @EntityGraph} that
+ *       eagerly fetches messages and their attachments so the mapper can
+ *       run outside an open Hibernate session.</li>
+ *   <li>{@link SupportTicketRepository#countByUserIdAndCreatedAtAfter} -
+ *       powers the per-user 5/hour create rate limiter.</li>
+ * </ul>
+ *
+ * <p>Conventions follow {@link com.slparcelauctions.backend.coupon.CouponRepositoryIntegrationTest}:
+ * {@code @SpringBootTest} + {@code @Transactional} so each test rolls
+ * back; quieted background schedulers via {@code @TestPropertySource}.
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false",
+        "slpa.realty.invitation-expiry.enabled=false"
+})
+@Transactional
+class SupportTicketRepositoryIntegrationTest {
+
+    @Autowired SupportTicketRepository ticketRepo;
+    @Autowired UserRepository userRepo;
+
+    @PersistenceContext EntityManager em;
+
+    private User userA;
+    private User userB;
+
+    @BeforeEach
+    void seed() {
+        userA = userRepo.save(User.builder()
+                .username("userA-" + shortId())
+                .email("userA-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x").slAvatarUuid(UUID.randomUUID())
+                .displayName("User A").verified(true).build());
+        userB = userRepo.save(User.builder()
+                .username("userB-" + shortId())
+                .email("userB-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x").slAvatarUuid(UUID.randomUUID())
+                .displayName("User B").verified(true).build());
+    }
+
+    @Test
+    void findByPublicId_eagerlyLoadsMessagesAndAttachments() {
+        OffsetDateTime now = OffsetDateTime.now();
+        SupportTicket ticket = SupportTicket.builder()
+                .user(userA)
+                .subject("Help with my listing")
+                .category(SupportTicketCategory.LISTING)
+                .status(SupportTicketStatus.OPEN)
+                .lastMessageAt(now)
+                .lastMessageAuthor(SupportTicketAuthorRole.USER)
+                .build();
+        em.persist(ticket);
+
+        SupportTicketMessage messageWithAttachments = SupportTicketMessage.builder()
+                .ticket(ticket)
+                .authorUser(userA)
+                .authorRole(SupportTicketAuthorRole.USER)
+                .body("Here are some screenshots.")
+                .visibleToUser(true)
+                .build();
+        em.persist(messageWithAttachments);
+
+        SupportTicketMessage replyMessage = SupportTicketMessage.builder()
+                .ticket(ticket)
+                .authorUser(userA)
+                .authorRole(SupportTicketAuthorRole.USER)
+                .body("Follow-up text-only message.")
+                .visibleToUser(true)
+                .build();
+        em.persist(replyMessage);
+
+        for (int i = 0; i < 3; i++) {
+            SupportTicketAttachment att = SupportTicketAttachment.builder()
+                    .message(messageWithAttachments)
+                    .storageKey("support-attachments/" + userA.getPublicId() + "/img-" + i + ".png")
+                    .mimeType("image/png")
+                    .sizeBytes(1024 * (i + 1))
+                    .width(800)
+                    .height(600)
+                    .build();
+            em.persist(att);
+        }
+
+        em.flush();
+        em.clear();
+
+        SupportTicket loaded = ticketRepo.findByPublicId(ticket.getPublicId()).orElseThrow();
+
+        assertThat(Hibernate.isInitialized(loaded.getMessages())).isTrue();
+        assertThat(loaded.getMessages()).hasSize(2);
+
+        SupportTicketMessage loadedWithAttachments = loaded.getMessages().stream()
+                .filter(m -> m.getAttachments() != null && !m.getAttachments().isEmpty())
+                .findFirst()
+                .orElseThrow();
+        assertThat(Hibernate.isInitialized(loadedWithAttachments.getAttachments())).isTrue();
+        assertThat(loadedWithAttachments.getAttachments()).hasSize(3);
+    }
+
+    @Test
+    void countByUserIdAndCreatedAtAfter_countsOnlyMatchingRows() {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        // User A: two recent tickets.
+        long recentA1 = persistTicket(userA, now);
+        long recentA2 = persistTicket(userA, now);
+
+        // User A: one ticket created 2 hours ago - should NOT be counted.
+        long oldA = persistTicket(userA, now);
+        backdateCreatedAt(oldA, now.minusHours(2));
+
+        // User B: one recent ticket - belongs to a different user.
+        persistTicket(userB, now);
+
+        em.flush();
+        em.clear();
+
+        long count = ticketRepo.countByUserIdAndCreatedAtAfter(
+                userA.getId(), now.minusHours(1));
+
+        assertThat(count).isEqualTo(2L);
+        // Sanity: the old A ticket still exists, just outside the window.
+        assertThat(ticketRepo.findById(oldA)).isPresent();
+        assertThat(ticketRepo.findById(recentA1)).isPresent();
+        assertThat(ticketRepo.findById(recentA2)).isPresent();
+    }
+
+    private long persistTicket(User owner, OffsetDateTime lastMessageAt) {
+        SupportTicket t = SupportTicket.builder()
+                .user(owner)
+                .subject("subj-" + shortId())
+                .category(SupportTicketCategory.OTHER)
+                .status(SupportTicketStatus.OPEN)
+                .lastMessageAt(lastMessageAt)
+                .lastMessageAuthor(SupportTicketAuthorRole.USER)
+                .build();
+        em.persist(t);
+        em.flush();
+        return t.getId();
+    }
+
+    private void backdateCreatedAt(long ticketId, OffsetDateTime when) {
+        em.createNativeQuery(
+                        "UPDATE support_tickets SET created_at = ?1 WHERE id = ?2")
+                .setParameter(1, when)
+                .setParameter(2, ticketId)
+                .executeUpdate();
+    }
+
+    private static String shortId() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketServiceAdminActionsTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketServiceAdminActionsTest.java
@@ -1,0 +1,301 @@
+package com.slparcelauctions.backend.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.notification.NotificationPublisher;
+import com.slparcelauctions.backend.support.dto.CreateSupportTicketRequest;
+import com.slparcelauctions.backend.support.dto.SupportTicketQueueStatsDto;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+/**
+ * Plan Task 9 -- integration coverage for the admin action surface of
+ * {@link SupportTicketService}: {@code resolve}, {@code reopen},
+ * {@code assign}, {@code patchCategory}, {@code queueStats}.
+ *
+ * <p>Mirrors the {@code @SpringBootTest + @ActiveProfiles("dev")} +
+ * scheduler-mute pattern used by
+ * {@link SupportTicketServiceCreateReplyTest}, with {@code @Transactional}
+ * rollback per test and a {@link MockitoBean} {@link NotificationPublisher}
+ * so we can assert which fan-out method fires.
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.auction-end.enabled=false",
+        "slpa.ownership-monitor.enabled=false",
+        "slpa.escrow.ownership-monitor-job.enabled=false",
+        "slpa.escrow.timeout-job.enabled=false",
+        "slpa.escrow.command-dispatcher-job.enabled=false",
+        "slpa.review.scheduler.enabled=false",
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false",
+        "slpa.realty.invitation-expiry.enabled=false"
+})
+@Transactional
+class SupportTicketServiceAdminActionsTest {
+
+    @Autowired SupportTicketService service;
+    @Autowired SupportTicketRepository ticketRepo;
+    @Autowired UserRepository userRepo;
+
+    @MockitoBean NotificationPublisher notifications;
+
+    @PersistenceContext EntityManager em;
+
+    private User submitter;
+    private User admin1;
+    private User otherUser;
+
+    @BeforeEach
+    void seed() {
+        submitter = userRepo.save(User.builder()
+                .username("submitter-" + shortId())
+                .email("submitter-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("Submitter")
+                .role(Role.USER)
+                .verified(true)
+                .build());
+        admin1 = userRepo.save(User.builder()
+                .username("admin-one-" + shortId())
+                .email("admin-one-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("Admin One")
+                .role(Role.ADMIN)
+                .verified(true)
+                .build());
+        otherUser = userRepo.save(User.builder()
+                .username("user-other-" + shortId())
+                .email("user-other-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("Other User")
+                .role(Role.USER)
+                .verified(true)
+                .build());
+        em.flush();
+    }
+
+    // -- resolve --------------------------------------------------------------
+
+    @Test
+    void resolve_idempotent_when_already_resolved() {
+        SupportTicket ticket = seedTicket("subj");
+        service.resolve(admin1.getId(), ticket.getPublicId());
+        em.flush();
+        org.mockito.Mockito.clearInvocations(notifications);
+
+        SupportTicket second = service.resolve(admin1.getId(), ticket.getPublicId());
+        em.flush();
+        em.clear();
+
+        assertThat(second.getStatus()).isEqualTo(SupportTicketStatus.RESOLVED);
+        // Second call must not fire another notification or write a duplicate
+        // system message.
+        verify(notifications, never()).supportTicketResolved(
+                anyLong(), any(UUID.class), any());
+        SupportTicket reloaded = ticketRepo.findByPublicId(ticket.getPublicId()).orElseThrow();
+        // Original create message + one "Marked resolved by admin" message; no third.
+        assertThat(reloaded.getMessages()).hasSize(2);
+    }
+
+    @Test
+    void resolve_writes_system_message_and_fires_notification() {
+        SupportTicket ticket = seedTicket("wallet stuck");
+        org.mockito.Mockito.clearInvocations(notifications);
+
+        service.resolve(admin1.getId(), ticket.getPublicId());
+        em.flush();
+        em.clear();
+
+        SupportTicket reloaded = ticketRepo.findByPublicId(ticket.getPublicId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(SupportTicketStatus.RESOLVED);
+        assertThat(reloaded.getResolvedAt()).isNotNull();
+        assertThat(reloaded.getLastMessageAuthor()).isEqualTo(SupportTicketAuthorRole.ADMIN);
+        assertThat(reloaded.getMessages())
+                .anyMatch(m -> "Marked resolved by admin".equals(m.getBody())
+                        && Boolean.TRUE.equals(m.getVisibleToUser())
+                        && m.getAuthorRole() == SupportTicketAuthorRole.ADMIN);
+
+        verify(notifications, times(1)).supportTicketResolved(
+                eq(submitter.getId()), eq(ticket.getPublicId()), eq("wallet stuck"));
+    }
+
+    // -- reopen ---------------------------------------------------------------
+
+    @Test
+    void reopen_idempotent_when_already_open() {
+        SupportTicket ticket = seedTicket("subj");
+        // ticket is OPEN by default
+        org.mockito.Mockito.clearInvocations(notifications);
+
+        SupportTicket result = service.reopen(admin1.getId(), ticket.getPublicId());
+        em.flush();
+        em.clear();
+
+        assertThat(result.getStatus()).isEqualTo(SupportTicketStatus.OPEN);
+        // No system message added for a no-op reopen.
+        SupportTicket reloaded = ticketRepo.findByPublicId(ticket.getPublicId()).orElseThrow();
+        assertThat(reloaded.getMessages()).hasSize(1);
+        verify(notifications, never()).supportTicketResolved(
+                anyLong(), any(UUID.class), any());
+    }
+
+    @Test
+    void reopen_writes_system_message_and_no_notification() {
+        SupportTicket ticket = seedTicket("subj");
+        service.resolve(admin1.getId(), ticket.getPublicId());
+        em.flush();
+        org.mockito.Mockito.clearInvocations(notifications);
+
+        service.reopen(admin1.getId(), ticket.getPublicId());
+        em.flush();
+        em.clear();
+
+        SupportTicket reloaded = ticketRepo.findByPublicId(ticket.getPublicId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(SupportTicketStatus.OPEN);
+        assertThat(reloaded.getResolvedAt()).isNull();
+        assertThat(reloaded.getLastMessageAuthor()).isEqualTo(SupportTicketAuthorRole.ADMIN);
+        assertThat(reloaded.getMessages())
+                .anyMatch(m -> "Reopened by admin".equals(m.getBody())
+                        && Boolean.TRUE.equals(m.getVisibleToUser())
+                        && m.getAuthorRole() == SupportTicketAuthorRole.ADMIN);
+
+        // No notifications on reopen.
+        verify(notifications, never()).supportTicketResolved(
+                anyLong(), any(UUID.class), any());
+        verify(notifications, never()).supportTicketAdminReplied(
+                anyLong(), any(UUID.class), any(), any());
+        verify(notifications, never()).supportTicketUserReplied(
+                any(), any(UUID.class), any(), any());
+        verify(notifications, never()).supportTicketOpened(
+                any(), any(UUID.class), any(), any(), any());
+    }
+
+    // -- assign ---------------------------------------------------------------
+
+    @Test
+    void assign_with_valid_admin_publicId_sets_assignedAdminId() {
+        SupportTicket ticket = seedTicket("subj");
+        em.flush();
+
+        service.assign(ticket.getPublicId(), admin1.getPublicId());
+        em.flush();
+        em.clear();
+
+        SupportTicket reloaded = ticketRepo.findByPublicId(ticket.getPublicId()).orElseThrow();
+        assertThat(reloaded.getAssignedAdminId()).isEqualTo(admin1.getId());
+    }
+
+    @Test
+    void assign_with_null_unassigns() {
+        SupportTicket ticket = seedTicket("subj");
+        service.assign(ticket.getPublicId(), admin1.getPublicId());
+        em.flush();
+
+        service.assign(ticket.getPublicId(), null);
+        em.flush();
+        em.clear();
+
+        SupportTicket reloaded = ticketRepo.findByPublicId(ticket.getPublicId()).orElseThrow();
+        assertThat(reloaded.getAssignedAdminId()).isNull();
+    }
+
+    @Test
+    void assign_rejects_non_admin_user() {
+        SupportTicket ticket = seedTicket("subj");
+        em.flush();
+
+        assertThatThrownBy(() -> service.assign(ticket.getPublicId(), otherUser.getPublicId()))
+                .isInstanceOfSatisfying(SupportTicketException.class,
+                        e -> assertThat(e.getCode())
+                                .isEqualTo(SupportTicketError.UNKNOWN_TICKET));
+    }
+
+    // -- patchCategory --------------------------------------------------------
+
+    @Test
+    void patchCategory_updates_value() {
+        SupportTicket ticket = seedTicket("subj");
+        // Default category from seedTicket() is OTHER; flip to WALLET.
+        em.flush();
+
+        service.patchCategory(ticket.getPublicId(), SupportTicketCategory.WALLET);
+        em.flush();
+        em.clear();
+
+        SupportTicket reloaded = ticketRepo.findByPublicId(ticket.getPublicId()).orElseThrow();
+        assertThat(reloaded.getCategory()).isEqualTo(SupportTicketCategory.WALLET);
+    }
+
+    // -- queueStats -----------------------------------------------------------
+
+    @Test
+    void queueStats_counts_open_total_and_needing_admin_reply() {
+        // Capture a baseline because the dev DB is shared across test classes
+        // and may carry rows we don't roll back (admins seeded by other suites
+        // etc). We assert relative deltas against that baseline.
+        SupportTicketQueueStatsDto baseline = service.queueStats();
+
+        // Seed 2 OPEN tickets where last_message_author = USER (default after
+        // createTicket).
+        SupportTicket t1 = seedTicket("needs reply 1");
+        SupportTicket t2 = seedTicket("needs reply 2");
+        // Seed 1 OPEN ticket where last_message_author = ADMIN (admin replied
+        // last - so does NOT count in openNeedingAdminReply).
+        SupportTicket t3 = seedTicket("admin replied last");
+        t3.setLastMessageAuthor(SupportTicketAuthorRole.ADMIN);
+        ticketRepo.save(t3);
+        // Seed 1 RESOLVED ticket (does NOT count in either bucket).
+        SupportTicket t4 = seedTicket("resolved one");
+        service.resolve(admin1.getId(), t4.getPublicId());
+
+        em.flush();
+
+        SupportTicketQueueStatsDto stats = service.queueStats();
+
+        // openTotal grew by 3 (t1, t2, t3); t4 is resolved.
+        assertThat(stats.openTotal()).isEqualTo(baseline.openTotal() + 3);
+        // openNeedingAdminReply grew by 2 (t1, t2 are USER-last-author);
+        // t3 is ADMIN-last-author so it's excluded.
+        assertThat(stats.openNeedingAdminReply())
+                .isEqualTo(baseline.openNeedingAdminReply() + 2);
+    }
+
+    // -- helpers --------------------------------------------------------------
+
+    private SupportTicket seedTicket(String subject) {
+        return service.createTicket(submitter.getId(), new CreateSupportTicketRequest(
+                subject, SupportTicketCategory.OTHER, "body for " + subject, null));
+    }
+
+    private static String shortId() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketServiceCreateReplyTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketServiceCreateReplyTest.java
@@ -1,0 +1,380 @@
+package com.slparcelauctions.backend.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.awt.image.BufferedImage;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.slparcelauctions.backend.media.ImageFormat;
+import com.slparcelauctions.backend.media.ImageUploadValidator;
+import com.slparcelauctions.backend.notification.NotificationPublisher;
+import com.slparcelauctions.backend.storage.ObjectStorageService;
+import com.slparcelauctions.backend.support.dto.AdminReplyRequest;
+import com.slparcelauctions.backend.support.dto.CreateSupportTicketRequest;
+import com.slparcelauctions.backend.support.dto.ReplySupportTicketRequest;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+/**
+ * Plan Task 8 -- integration coverage for the create + reply core of
+ * {@link SupportTicketService}.
+ *
+ * <p>Real DB + real {@link SupportTicketAttachmentService} so attachment
+ * promotion writes a real row, with {@link ObjectStorageService} and
+ * {@link ImageUploadValidator} mocked away (no S3, no image decoding).
+ * {@link NotificationPublisher} is a {@link MockitoBean} so we can verify
+ * which fan-out method fires and with which arguments.
+ *
+ * <p>Mirrors the {@code @SpringBootTest + @ActiveProfiles("dev") + scheduler-mute}
+ * pattern used by the rest of the support test suite, plus
+ * {@code @Transactional} so each test rolls back.
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.auction-end.enabled=false",
+        "slpa.ownership-monitor.enabled=false",
+        "slpa.escrow.ownership-monitor-job.enabled=false",
+        "slpa.escrow.timeout-job.enabled=false",
+        "slpa.escrow.command-dispatcher-job.enabled=false",
+        "slpa.review.scheduler.enabled=false",
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false",
+        "slpa.realty.invitation-expiry.enabled=false"
+})
+@Transactional
+class SupportTicketServiceCreateReplyTest {
+
+    @Autowired SupportTicketService service;
+    @Autowired SupportTicketRepository ticketRepo;
+    @Autowired SupportTicketAttachmentRepository attachmentRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired StringRedisTemplate redis;
+
+    @MockitoBean NotificationPublisher notifications;
+    @MockitoBean ObjectStorageService storage;
+    @MockitoBean ImageUploadValidator imageValidator;
+
+    @PersistenceContext EntityManager em;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final List<String> redisKeysToClean = new ArrayList<>();
+
+    private User submitter;
+    private User admin1;
+    private User admin2;
+
+    @BeforeEach
+    void seed() {
+        submitter = userRepo.save(User.builder()
+                .username("submitter-" + shortId())
+                .email("submitter-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("Submitter")
+                .role(Role.USER)
+                .verified(true)
+                .build());
+        admin1 = userRepo.save(User.builder()
+                .username("admin-one-" + shortId())
+                .email("admin-one-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("Admin One")
+                .role(Role.ADMIN)
+                .verified(true)
+                .build());
+        admin2 = userRepo.save(User.builder()
+                .username("admin-two-" + shortId())
+                .email("admin-two-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("Admin Two")
+                .role(Role.ADMIN)
+                .verified(true)
+                .build());
+        em.flush();
+
+        // Default validator stub: 100x100 PNG. Individual tests can override.
+        when(imageValidator.validate(any(byte[].class), anyLong(), anyInt()))
+                .thenReturn(new ImageUploadValidator.ValidationResult(
+                        ImageFormat.PNG,
+                        new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB),
+                        100, 100));
+    }
+
+    @AfterEach
+    void cleanupRedis() {
+        for (String k : redisKeysToClean) {
+            redis.delete(k);
+        }
+        redisKeysToClean.clear();
+    }
+
+    // ── createTicket ──────────────────────────────────────────────────────────
+
+    @Test
+    void createTicket_inserts_row_and_initial_message_and_notifies_admins() {
+        CreateSupportTicketRequest req = new CreateSupportTicketRequest(
+                "Wallet stuck", SupportTicketCategory.WALLET,
+                "I deposited L$500 and the balance never updated.", null);
+
+        SupportTicket created = service.createTicket(submitter.getId(), req);
+        em.flush();
+        em.clear();
+
+        SupportTicket loaded = ticketRepo.findByPublicId(created.getPublicId()).orElseThrow();
+        assertThat(loaded.getSubject()).isEqualTo("Wallet stuck");
+        assertThat(loaded.getCategory()).isEqualTo(SupportTicketCategory.WALLET);
+        assertThat(loaded.getStatus()).isEqualTo(SupportTicketStatus.OPEN);
+        assertThat(loaded.getLastMessageAuthor()).isEqualTo(SupportTicketAuthorRole.USER);
+        assertThat(loaded.getUser().getId()).isEqualTo(submitter.getId());
+
+        Set<SupportTicketMessage> messages = loaded.getMessages();
+        assertThat(messages).hasSize(1);
+        SupportTicketMessage initial = messages.iterator().next();
+        assertThat(initial.getBody()).isEqualTo("I deposited L$500 and the balance never updated.");
+        assertThat(initial.getAuthorRole()).isEqualTo(SupportTicketAuthorRole.USER);
+        assertThat(initial.getVisibleToUser()).isTrue();
+        assertThat(initial.getAuthorUser().getId()).isEqualTo(submitter.getId());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Long>> adminIdsCap = ArgumentCaptor.forClass(List.class);
+        verify(notifications).supportTicketOpened(
+                adminIdsCap.capture(), eq(created.getPublicId()),
+                eq("Wallet stuck"), eq("Submitter"), eq("WALLET"));
+        // DB-scoped test: the dev DB may carry admins seeded by other test
+        // suites we don't roll back. Assert containment of our seeded admins,
+        // not strict equality.
+        assertThat(adminIdsCap.getValue()).contains(admin1.getId(), admin2.getId());
+    }
+
+    @Test
+    void createTicket_propagates_rate_limit_at_cap() {
+        for (int i = 0; i < 5; i++) {
+            service.createTicket(submitter.getId(), new CreateSupportTicketRequest(
+                    "subj " + i, SupportTicketCategory.OTHER, "body " + i, null));
+        }
+        em.flush();
+
+        assertThatThrownBy(() -> service.createTicket(submitter.getId(),
+                new CreateSupportTicketRequest("over", SupportTicketCategory.OTHER, "body", null)))
+                .isInstanceOfSatisfying(SupportTicketException.class,
+                        e -> assertThat(e.getCode())
+                                .isEqualTo(SupportTicketError.RATE_LIMITED));
+    }
+
+    @Test
+    void createTicket_persists_attachments_when_provided() throws Exception {
+        String key1 = seedPendingAttachment(submitter.getId(),
+                "support-attachments/pending/u/one.png", "image/png", 1024, 100, 100);
+        String key2 = seedPendingAttachment(submitter.getId(),
+                "support-attachments/pending/u/two.png", "image/png", 2048, 200, 200);
+
+        SupportTicket created = service.createTicket(submitter.getId(),
+                new CreateSupportTicketRequest(
+                        "with attachments", SupportTicketCategory.LISTING,
+                        "see screenshots", List.of(key1, key2)));
+        em.flush();
+        em.clear();
+
+        SupportTicket loaded = ticketRepo.findByPublicId(created.getPublicId()).orElseThrow();
+        SupportTicketMessage initial = loaded.getMessages().iterator().next();
+        assertThat(initial.getAttachments()).hasSize(2);
+        verify(storage, times(2)).copy(any(), any());
+    }
+
+    // ── userReply ─────────────────────────────────────────────────────────────
+
+    @Test
+    void userReply_throws_UNKNOWN_TICKET_when_caller_is_not_submitter() {
+        SupportTicket ticket = service.createTicket(submitter.getId(), new CreateSupportTicketRequest(
+                "subj", SupportTicketCategory.OTHER, "body", null));
+        em.flush();
+
+        long otherUserId = admin1.getId(); // any non-submitter id
+        assertThatThrownBy(() -> service.userReply(otherUserId, ticket.getPublicId(),
+                new ReplySupportTicketRequest("nope", null)))
+                .isInstanceOfSatisfying(SupportTicketException.class,
+                        e -> assertThat(e.getCode())
+                                .isEqualTo(SupportTicketError.UNKNOWN_TICKET));
+    }
+
+    @Test
+    void userReply_visible_message_updates_lastMessageAt_and_lastMessageAuthor() throws Exception {
+        SupportTicket ticket = service.createTicket(submitter.getId(), new CreateSupportTicketRequest(
+                "subj", SupportTicketCategory.OTHER, "first", null));
+        em.flush();
+        OffsetDateTime before = ticket.getLastMessageAt();
+        // Force a tick so the new lastMessageAt is strictly after the prior one.
+        Thread.sleep(5);
+
+        SupportTicketMessage reply = service.userReply(submitter.getId(), ticket.getPublicId(),
+                new ReplySupportTicketRequest("follow up", null));
+        em.flush();
+        em.clear();
+
+        SupportTicket reloaded = ticketRepo.findByPublicId(ticket.getPublicId()).orElseThrow();
+        assertThat(reloaded.getLastMessageAuthor()).isEqualTo(SupportTicketAuthorRole.USER);
+        assertThat(reloaded.getLastMessageAt()).isAfter(before);
+        assertThat(reloaded.getMessages()).hasSize(2);
+        assertThat(reply.getBody()).isEqualTo("follow up");
+    }
+
+    @Test
+    void userReply_on_resolved_ticket_auto_reopens() {
+        SupportTicket ticket = service.createTicket(submitter.getId(), new CreateSupportTicketRequest(
+                "subj", SupportTicketCategory.OTHER, "body", null));
+        em.flush();
+        // Simulate the admin-resolve path (Task 9 lands the real mutator;
+        // for this test we hand-flip the persisted state).
+        ticket.setStatus(SupportTicketStatus.RESOLVED);
+        ticket.setResolvedAt(OffsetDateTime.now());
+        ticketRepo.save(ticket);
+        em.flush();
+
+        service.userReply(submitter.getId(), ticket.getPublicId(),
+                new ReplySupportTicketRequest("still broken", null));
+        em.flush();
+        em.clear();
+
+        SupportTicket reloaded = ticketRepo.findByPublicId(ticket.getPublicId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(SupportTicketStatus.OPEN);
+        assertThat(reloaded.getResolvedAt()).isNull();
+    }
+
+    @Test
+    void userReply_fires_supportTicketUserReplied_to_all_admins() {
+        SupportTicket ticket = service.createTicket(submitter.getId(), new CreateSupportTicketRequest(
+                "subj", SupportTicketCategory.OTHER, "body", null));
+        em.flush();
+        // Reset captured invocations from the createTicket above.
+        org.mockito.Mockito.clearInvocations(notifications);
+
+        service.userReply(submitter.getId(), ticket.getPublicId(),
+                new ReplySupportTicketRequest("ping", null));
+        em.flush();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Long>> adminIdsCap = ArgumentCaptor.forClass(List.class);
+        verify(notifications).supportTicketUserReplied(
+                adminIdsCap.capture(), eq(ticket.getPublicId()),
+                eq("subj"), eq("Submitter"));
+        // See createTicket happy-path test for the rationale on `contains` vs
+        // strict equality - DB carries admins seeded by other test suites.
+        assertThat(adminIdsCap.getValue()).contains(admin1.getId(), admin2.getId());
+        verify(notifications, never()).supportTicketAdminReplied(
+                anyLong(), any(UUID.class), any(), any());
+    }
+
+    // ── adminReply ────────────────────────────────────────────────────────────
+
+    @Test
+    void adminReply_visible_fires_supportTicketAdminReplied_to_submitter() {
+        SupportTicket ticket = service.createTicket(submitter.getId(), new CreateSupportTicketRequest(
+                "subj", SupportTicketCategory.OTHER, "body", null));
+        em.flush();
+        org.mockito.Mockito.clearInvocations(notifications);
+
+        service.adminReply(admin1.getId(), ticket.getPublicId(),
+                new AdminReplyRequest("checking on this", null, false));
+        em.flush();
+        em.clear();
+
+        verify(notifications).supportTicketAdminReplied(
+                eq(submitter.getId()), eq(ticket.getPublicId()),
+                eq("subj"), eq("Admin One"));
+
+        SupportTicket reloaded = ticketRepo.findByPublicId(ticket.getPublicId()).orElseThrow();
+        assertThat(reloaded.getLastMessageAuthor()).isEqualTo(SupportTicketAuthorRole.ADMIN);
+        assertThat(reloaded.getMessages()).hasSize(2);
+        assertThat(reloaded.getMessages()).allMatch(m -> Boolean.TRUE.equals(m.getVisibleToUser()));
+    }
+
+    @Test
+    void adminReply_internalNote_does_not_update_lastMessageAt_or_fire_notification() {
+        SupportTicket ticket = service.createTicket(submitter.getId(), new CreateSupportTicketRequest(
+                "subj", SupportTicketCategory.OTHER, "body", null));
+        em.flush();
+        em.clear();
+        // Read the baseline back from the DB - Postgres timestamptz truncates
+        // nanos to micros and normalizes the zone to UTC, so an in-memory
+        // OffsetDateTime baseline will fail an isEqualTo against the reloaded
+        // value even though both represent the same instant.
+        OffsetDateTime baselineLastMsg = ticketRepo.findByPublicId(ticket.getPublicId())
+                .orElseThrow().getLastMessageAt();
+        SupportTicketAuthorRole baselineAuthor = SupportTicketAuthorRole.USER;
+        org.mockito.Mockito.clearInvocations(notifications);
+
+        service.adminReply(admin1.getId(), ticket.getPublicId(),
+                new AdminReplyRequest("internal triage note", null, true));
+        em.flush();
+        em.clear();
+
+        SupportTicket reloaded = ticketRepo.findByPublicId(ticket.getPublicId()).orElseThrow();
+        // lastMessageAt + lastMessageAuthor unchanged from before the internal note
+        assertThat(reloaded.getLastMessageAt()).isEqualTo(baselineLastMsg);
+        assertThat(reloaded.getLastMessageAuthor()).isEqualTo(baselineAuthor);
+        // Internal note was persisted as a non-user-visible row
+        assertThat(reloaded.getMessages()).hasSize(2);
+        assertThat(reloaded.getMessages())
+                .anyMatch(m -> Boolean.FALSE.equals(m.getVisibleToUser())
+                        && m.getBody().equals("internal triage note"));
+
+        // No notifications fired for the internal note
+        verify(notifications, never()).supportTicketAdminReplied(
+                anyLong(), any(UUID.class), any(), any());
+        verify(notifications, never()).supportTicketUserReplied(
+                any(), any(UUID.class), any(), any());
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private String seedPendingAttachment(long userId, String storageKey,
+            String mime, int size, int width, int height) throws Exception {
+        String key = UUID.randomUUID().toString();
+        SupportTicketAttachmentService.PendingAttachment p =
+                new SupportTicketAttachmentService.PendingAttachment(
+                        userId, storageKey, mime, size, width, height);
+        String json = objectMapper.writeValueAsString(p);
+        redis.opsForValue().set("support:upload:" + key, json, Duration.ofMinutes(5));
+        redisKeysToClean.add("support:upload:" + key);
+        return key;
+    }
+
+    private static String shortId() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketServiceListTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketServiceListTest.java
@@ -1,0 +1,348 @@
+package com.slparcelauctions.backend.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.notification.NotificationPublisher;
+import com.slparcelauctions.backend.support.dto.CreateSupportTicketRequest;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+/**
+ * Plan Task 10 -- integration coverage for the
+ * {@link SupportTicketService#listForUser} and
+ * {@link SupportTicketService#listAdmin} Specification-based paginated
+ * queries.
+ *
+ * <p>Mirrors the {@code @SpringBootTest + @ActiveProfiles("dev")} +
+ * scheduler-mute pattern used by
+ * {@link SupportTicketServiceAdminActionsTest}, with {@code @Transactional}
+ * rollback per test. Tickets are seeded with a per-test unique subject
+ * prefix so the {@code q} filter narrows results to the test's own rows
+ * even against a shared dev DB.
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.auction-end.enabled=false",
+        "slpa.ownership-monitor.enabled=false",
+        "slpa.escrow.ownership-monitor-job.enabled=false",
+        "slpa.escrow.timeout-job.enabled=false",
+        "slpa.escrow.command-dispatcher-job.enabled=false",
+        "slpa.review.scheduler.enabled=false",
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false",
+        "slpa.realty.invitation-expiry.enabled=false"
+})
+@Transactional
+class SupportTicketServiceListTest {
+
+    @Autowired SupportTicketService service;
+    @Autowired SupportTicketRepository ticketRepo;
+    @Autowired UserRepository userRepo;
+
+    @MockitoBean NotificationPublisher notifications;
+
+    @PersistenceContext EntityManager em;
+
+    private User submitter;
+    private User otherUser;
+    private User admin1;
+    private String prefix;
+
+    @BeforeEach
+    void seed() {
+        prefix = "LIST-TEST-" + UUID.randomUUID().toString().substring(0, 8);
+        submitter = userRepo.save(User.builder()
+                .username("submitter-" + shortId())
+                .email("submitter-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("Submitter")
+                .role(Role.USER)
+                .verified(true)
+                .build());
+        otherUser = userRepo.save(User.builder()
+                .username("user-other-" + shortId())
+                .email("user-other-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("Other User")
+                .role(Role.USER)
+                .verified(true)
+                .build());
+        admin1 = userRepo.save(User.builder()
+                .username("admin-one-" + shortId())
+                .email("admin-one-" + UUID.randomUUID() + "@ex.com")
+                .passwordHash("x")
+                .slAvatarUuid(UUID.randomUUID())
+                .displayName("Admin One")
+                .role(Role.ADMIN)
+                .verified(true)
+                .build());
+        em.flush();
+    }
+
+    // -- listForUser ----------------------------------------------------------
+
+    @Test
+    void listForUser_returns_only_owned_tickets() {
+        SupportTicket mine1 = seedTicket(submitter, prefix + " mine 1",
+                SupportTicketCategory.OTHER);
+        SupportTicket mine2 = seedTicket(submitter, prefix + " mine 2",
+                SupportTicketCategory.OTHER);
+        seedTicket(otherUser, prefix + " not mine", SupportTicketCategory.OTHER);
+        em.flush();
+
+        // Narrow to the seeded prefix so we don't grade against unrelated dev rows.
+        Page<SupportTicket> page = service.listForUser(
+                submitter.getId(), null, prefix, PageRequest.of(0, 20));
+
+        assertThat(page.getContent())
+                .extracting(SupportTicket::getPublicId)
+                .containsExactlyInAnyOrder(mine1.getPublicId(), mine2.getPublicId());
+    }
+
+    @Test
+    void listForUser_status_filter_narrows() {
+        SupportTicket open1 = seedTicket(submitter, prefix + " open one",
+                SupportTicketCategory.OTHER);
+        SupportTicket open2 = seedTicket(submitter, prefix + " open two",
+                SupportTicketCategory.OTHER);
+        SupportTicket resolved = seedTicket(submitter, prefix + " resolved one",
+                SupportTicketCategory.OTHER);
+        service.resolve(admin1.getId(), resolved.getPublicId());
+        em.flush();
+
+        Page<SupportTicket> openPage = service.listForUser(
+                submitter.getId(), SupportTicketStatus.OPEN, prefix,
+                PageRequest.of(0, 20));
+        assertThat(openPage.getContent())
+                .extracting(SupportTicket::getPublicId)
+                .containsExactlyInAnyOrder(open1.getPublicId(), open2.getPublicId());
+
+        Page<SupportTicket> resolvedPage = service.listForUser(
+                submitter.getId(), SupportTicketStatus.RESOLVED, prefix,
+                PageRequest.of(0, 20));
+        assertThat(resolvedPage.getContent())
+                .extracting(SupportTicket::getPublicId)
+                .containsExactly(resolved.getPublicId());
+    }
+
+    @Test
+    void listForUser_q_filter_subject_substring_case_insensitive() {
+        SupportTicket walletTicket = seedTicket(submitter,
+                prefix + " Wallet Topup Issue", SupportTicketCategory.WALLET);
+        seedTicket(submitter, prefix + " Bidding Problem",
+                SupportTicketCategory.BIDDING);
+        em.flush();
+
+        // Search lowercase substring against a mixed-case subject.
+        Page<SupportTicket> page = service.listForUser(
+                submitter.getId(), null, prefix + " wallet",
+                PageRequest.of(0, 20));
+
+        assertThat(page.getContent())
+                .extracting(SupportTicket::getPublicId)
+                .containsExactly(walletTicket.getPublicId());
+    }
+
+    // -- listAdmin ------------------------------------------------------------
+
+    @Test
+    void listAdmin_status_filter() {
+        SupportTicket open = seedTicket(submitter, prefix + " open one",
+                SupportTicketCategory.OTHER);
+        SupportTicket resolved = seedTicket(submitter, prefix + " resolved one",
+                SupportTicketCategory.OTHER);
+        service.resolve(admin1.getId(), resolved.getPublicId());
+        em.flush();
+
+        Page<SupportTicket> openPage = service.listAdmin(
+                SupportTicketStatus.OPEN, null, null, null, prefix,
+                admin1.getId(), PageRequest.of(0, 20));
+        assertThat(openPage.getContent())
+                .extracting(SupportTicket::getPublicId)
+                .containsExactly(open.getPublicId());
+
+        Page<SupportTicket> resolvedPage = service.listAdmin(
+                SupportTicketStatus.RESOLVED, null, null, null, prefix,
+                admin1.getId(), PageRequest.of(0, 20));
+        assertThat(resolvedPage.getContent())
+                .extracting(SupportTicket::getPublicId)
+                .containsExactly(resolved.getPublicId());
+    }
+
+    @Test
+    void listAdmin_category_filter() {
+        SupportTicket wallet = seedTicket(submitter, prefix + " wallet",
+                SupportTicketCategory.WALLET);
+        seedTicket(submitter, prefix + " bidding", SupportTicketCategory.BIDDING);
+        em.flush();
+
+        Page<SupportTicket> page = service.listAdmin(
+                null, SupportTicketCategory.WALLET, null, null, prefix,
+                admin1.getId(), PageRequest.of(0, 20));
+        assertThat(page.getContent())
+                .extracting(SupportTicket::getPublicId)
+                .containsExactly(wallet.getPublicId());
+    }
+
+    @Test
+    void listAdmin_lastAuthor_filter() {
+        SupportTicket userLast = seedTicket(submitter, prefix + " user last",
+                SupportTicketCategory.OTHER);
+        // Newly created tickets default to lastMessageAuthor=USER. Flip one
+        // to ADMIN to exercise the filter both ways.
+        SupportTicket adminLast = seedTicket(submitter, prefix + " admin last",
+                SupportTicketCategory.OTHER);
+        adminLast.setLastMessageAuthor(SupportTicketAuthorRole.ADMIN);
+        ticketRepo.save(adminLast);
+        em.flush();
+
+        Page<SupportTicket> userPage = service.listAdmin(
+                null, null, null, SupportTicketAuthorRole.USER, prefix,
+                admin1.getId(), PageRequest.of(0, 20));
+        assertThat(userPage.getContent())
+                .extracting(SupportTicket::getPublicId)
+                .containsExactly(userLast.getPublicId());
+
+        Page<SupportTicket> adminPage = service.listAdmin(
+                null, null, null, SupportTicketAuthorRole.ADMIN, prefix,
+                admin1.getId(), PageRequest.of(0, 20));
+        assertThat(adminPage.getContent())
+                .extracting(SupportTicket::getPublicId)
+                .containsExactly(adminLast.getPublicId());
+    }
+
+    @Test
+    void listAdmin_assignee_mine() {
+        SupportTicket mineAssigned = seedTicket(submitter, prefix + " mine",
+                SupportTicketCategory.OTHER);
+        mineAssigned.setAssignedAdminId(admin1.getId());
+        ticketRepo.save(mineAssigned);
+        seedTicket(submitter, prefix + " unassigned", SupportTicketCategory.OTHER);
+        em.flush();
+
+        Page<SupportTicket> page = service.listAdmin(
+                null, null, "mine", null, prefix,
+                admin1.getId(), PageRequest.of(0, 20));
+
+        assertThat(page.getContent())
+                .extracting(SupportTicket::getPublicId)
+                .containsExactly(mineAssigned.getPublicId());
+    }
+
+    @Test
+    void listAdmin_assignee_unassigned() {
+        SupportTicket assigned = seedTicket(submitter, prefix + " assigned",
+                SupportTicketCategory.OTHER);
+        assigned.setAssignedAdminId(admin1.getId());
+        ticketRepo.save(assigned);
+        SupportTicket unassigned = seedTicket(submitter, prefix + " unassigned",
+                SupportTicketCategory.OTHER);
+        em.flush();
+
+        Page<SupportTicket> page = service.listAdmin(
+                null, null, "unassigned", null, prefix,
+                admin1.getId(), PageRequest.of(0, 20));
+
+        assertThat(page.getContent())
+                .extracting(SupportTicket::getPublicId)
+                .containsExactly(unassigned.getPublicId());
+    }
+
+    @Test
+    void listAdmin_assignee_userPublicId() {
+        SupportTicket mine = seedTicket(submitter, prefix + " by submitter",
+                SupportTicketCategory.OTHER);
+        seedTicket(otherUser, prefix + " by other", SupportTicketCategory.OTHER);
+        em.flush();
+
+        Page<SupportTicket> page = service.listAdmin(
+                null, null, submitter.getPublicId().toString(), null, prefix,
+                admin1.getId(), PageRequest.of(0, 20));
+
+        assertThat(page.getContent())
+                .extracting(SupportTicket::getPublicId)
+                .containsExactly(mine.getPublicId());
+    }
+
+    @Test
+    void listAdmin_q_filter() {
+        SupportTicket wallet = seedTicket(submitter,
+                prefix + " Wallet Topup Issue", SupportTicketCategory.WALLET);
+        seedTicket(submitter, prefix + " Bidding Problem",
+                SupportTicketCategory.BIDDING);
+        em.flush();
+
+        Page<SupportTicket> page = service.listAdmin(
+                null, null, null, null, prefix + " wallet",
+                admin1.getId(), PageRequest.of(0, 20));
+
+        assertThat(page.getContent())
+                .extracting(SupportTicket::getPublicId)
+                .containsExactly(wallet.getPublicId());
+    }
+
+    @Test
+    void listAdmin_combined_filters() {
+        // Target row: OPEN + BIDDING + lastAuthor=USER + matches q.
+        SupportTicket target = seedTicket(submitter,
+                prefix + " bidding open user-last",
+                SupportTicketCategory.BIDDING);
+        // Different category -- excluded.
+        seedTicket(submitter, prefix + " wallet open user-last",
+                SupportTicketCategory.WALLET);
+        // Same category but resolved -- excluded.
+        SupportTicket resolved = seedTicket(submitter,
+                prefix + " bidding resolved", SupportTicketCategory.BIDDING);
+        service.resolve(admin1.getId(), resolved.getPublicId());
+        // Same category + open but admin-last -- excluded.
+        SupportTicket adminLast = seedTicket(submitter,
+                prefix + " bidding admin-last",
+                SupportTicketCategory.BIDDING);
+        adminLast.setLastMessageAuthor(SupportTicketAuthorRole.ADMIN);
+        ticketRepo.save(adminLast);
+        em.flush();
+
+        Page<SupportTicket> page = service.listAdmin(
+                SupportTicketStatus.OPEN, SupportTicketCategory.BIDDING,
+                null, SupportTicketAuthorRole.USER,
+                prefix + " bidding open user-last",
+                admin1.getId(), PageRequest.of(0, 20));
+
+        assertThat(page.getContent())
+                .extracting(SupportTicket::getPublicId)
+                .containsExactly(target.getPublicId());
+    }
+
+    // -- helpers --------------------------------------------------------------
+
+    private SupportTicket seedTicket(User owner, String subject,
+                                     SupportTicketCategory category) {
+        return service.createTicket(owner.getId(), new CreateSupportTicketRequest(
+                subject, category, "body for " + subject, null));
+    }
+
+    private static String shortId() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/docs/superpowers/plans/2026-05-21-customer-support-contact-plan.md
+++ b/docs/superpowers/plans/2026-05-21-customer-support-contact-plan.md
@@ -1,0 +1,2666 @@
+# Customer Support Contact Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the customer-support feature from `docs/superpowers/specs/2026-05-21-customer-support-contact-design.md` end-to-end. Authed users open tickets via a "Support" entry in the user-dropdown; admins triage from a queue mirroring the dispute admin pattern; replies are threaded with optional admin internal notes; image attachments up to 3 per message.
+
+**Architecture:** New `support` backend package (entities, repos, service, rate limiter, two controllers, exception handler). Reuses the dispute-evidence S3 upload primitive with pending state in Redis + bucket lifecycle rule for orphan cleanup. New `Textarea` UI primitive. New `/support` user route + `/admin/support` admin route. Four new notification categories.
+
+**Tech Stack:** Spring Boot 4 / Java 24 / Flyway / JPA / Lombok / Redis (for attachment pending state); Next.js 16 / React 19 / TypeScript 5 / Tailwind CSS 4; Vitest + RTL; Postman.
+
+**LazyInit class-of-bug defense:** Every controller method that returns an entity-derived DTO is `@Transactional`. Repos' single-row finders use `@EntityGraph(attributePaths = {...})` for the collections the mapper accesses. Integration tests include a non-`@Transactional` regression class per controller surface. This is enforced as a per-task checklist item below — do not skip.
+
+---
+
+## File Structure
+
+**Backend — new files under `backend/src/main/java/com/slparcelauctions/backend/support/`:**
+
+| File | Responsibility |
+|---|---|
+| `SupportTicket.java` | Entity, extends `BaseMutableEntity`, `@OneToMany` to messages |
+| `SupportTicketMessage.java` | Entity, extends `BaseMutableEntity`, `@OneToMany` to attachments |
+| `SupportTicketAttachment.java` | Entity, extends `BaseMutableEntity` |
+| `SupportTicketStatus.java` | Enum: OPEN, RESOLVED |
+| `SupportTicketCategory.java` | Enum: ACCOUNT, BIDDING, LISTING, ESCROW, WALLET, OTHER |
+| `SupportTicketAuthorRole.java` | Enum: USER, ADMIN |
+| `SupportTicketRepository.java` | Spring Data + JpaSpecificationExecutor + `@EntityGraph` on `findByPublicId` |
+| `SupportTicketMessageRepository.java` | Spring Data |
+| `SupportTicketAttachmentRepository.java` | Spring Data |
+| `SupportTicketRateLimiter.java` | Per-user 5/hour bucket on new-ticket only |
+| `SupportTicketService.java` | Create, reply, resolve, reopen, assign, patch-category; orchestrates attachments + notifications |
+| `SupportTicketAttachmentService.java` | Pre-upload + promotion + Redis pending state |
+| `SupportTicketException.java` | Runtime exception carrying `SupportTicketError` |
+| `SupportTicketError.java` | Enum: UNKNOWN_TICKET, NOT_OWNER, INTERNAL_NOTE_FROM_USER, RATE_LIMITED, INVALID_ATTACHMENT, INVALID_CATEGORY, ATTACHMENT_NOT_FOUND |
+| `SupportTicketExceptionHandler.java` | `@RestControllerAdvice`, maps to RFC 9457 ProblemDetail |
+| `SupportTicketMapper.java` | Entity to DTO mapping helpers |
+| `MeSupportTicketController.java` | User-facing endpoints |
+| `AdminSupportTicketController.java` | Admin queue + actions |
+| `SupportTicketAttachmentController.java` | Pre-upload + signed-URL fetch |
+| `dto/SupportTicketDto.java` | Full detail record |
+| `dto/SupportTicketSummaryDto.java` | List-row record |
+| `dto/SupportTicketMessageDto.java` | Message record |
+| `dto/SupportTicketAttachmentDto.java` | Attachment record (public id + dimensions, NOT storage key) |
+| `dto/AdminSupportTicketQueueRow.java` | Admin list row |
+| `dto/CreateSupportTicketRequest.java` | Create body |
+| `dto/ReplySupportTicketRequest.java` | User reply body |
+| `dto/AdminReplyRequest.java` | Admin reply body (carries `internalNote`) |
+| `dto/AssignTicketRequest.java` | Assign body |
+| `dto/PatchTicketRequest.java` | Admin patch body (category only in MVP) |
+| `dto/SupportTicketQueueStatsDto.java` | Sidebar badge counters |
+
+**Backend — modifies:**
+
+| File | Change |
+|---|---|
+| `backend/src/main/resources/db/migration/V42__support_tickets.sql` | new migration |
+| `backend/src/main/resources/application.yml` | new `slpa.support.*` keys |
+| `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationCategory.java` | add 4 categories |
+| `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisher.java` | add 4 methods |
+| `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java` | impl + bodies |
+| `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationDataBuilder.java` | data builder entries |
+| `backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImLinkResolver.java` | 4 new deep links |
+| `backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java` | (no change expected; `/me/**` and `/admin/**` already covered) |
+
+**Frontend — new files:**
+
+| File | Responsibility |
+|---|---|
+| `frontend/src/components/ui/Textarea.tsx` | new UI primitive |
+| `frontend/src/components/ui/Textarea.test.tsx` | sibling test |
+| `frontend/src/types/support.ts` | TS types matching DTOs |
+| `frontend/src/lib/api/support.ts` | typed API client |
+| `frontend/src/hooks/useMySupportTickets.ts` | list query |
+| `frontend/src/hooks/useMySupportTicket.ts` | detail query |
+| `frontend/src/hooks/useCreateSupportTicket.ts` | mutation |
+| `frontend/src/hooks/useReplySupportTicket.ts` | mutation |
+| `frontend/src/hooks/useUploadSupportAttachment.ts` | mutation |
+| `frontend/src/hooks/admin/useAdminSupportTickets.ts` | admin queue query |
+| `frontend/src/hooks/admin/useAdminSupportTicket.ts` | admin detail query |
+| `frontend/src/hooks/admin/useAdminSupportReply.ts` | admin reply mutation |
+| `frontend/src/hooks/admin/useAdminSupportResolve.ts` | mutation |
+| `frontend/src/hooks/admin/useAdminSupportReopen.ts` | mutation |
+| `frontend/src/hooks/admin/useAdminSupportAssign.ts` | mutation |
+| `frontend/src/hooks/admin/useAdminSupportQueueStats.ts` | polling query (30s) |
+| `frontend/src/app/support/page.tsx` | server shell + `<SupportTicketList />` |
+| `frontend/src/app/support/new/page.tsx` | `<NewSupportTicketForm />` |
+| `frontend/src/app/support/[publicId]/page.tsx` | `<SupportTicketThread />` |
+| `frontend/src/app/admin/support/page.tsx` | `<AdminSupportTicketQueue />` |
+| `frontend/src/app/admin/support/[publicId]/page.tsx` | `<AdminSupportTicketDetail />` |
+| `frontend/src/components/support/SupportTicketList.tsx` | client list component |
+| `frontend/src/components/support/SupportTicketList.test.tsx` | RTL tests |
+| `frontend/src/components/support/NewSupportTicketForm.tsx` | client form |
+| `frontend/src/components/support/NewSupportTicketForm.test.tsx` | RTL tests |
+| `frontend/src/components/support/SupportTicketThread.tsx` | client thread |
+| `frontend/src/components/support/SupportTicketThread.test.tsx` | RTL tests |
+| `frontend/src/components/support/SupportAttachmentDropzone.tsx` | shared dropzone (user + admin reuse) |
+| `frontend/src/components/admin/support/AdminSupportTicketQueue.tsx` | admin queue table |
+| `frontend/src/components/admin/support/AdminSupportTicketQueue.test.tsx` | RTL tests |
+| `frontend/src/components/admin/support/AdminSupportTicketDetail.tsx` | admin thread + composer |
+| `frontend/src/components/admin/support/AdminSupportTicketDetail.test.tsx` | RTL tests |
+
+**Frontend — modifies:**
+
+| File | Change |
+|---|---|
+| `frontend/src/components/layout/UserMenuDropdown.tsx` | add "Support" item |
+| `frontend/src/components/layout/MobileMenu.tsx` | add "Support" in footer row |
+| `frontend/src/components/admin/AdminShell.tsx` | add sidebar entry with badge |
+
+---
+
+## Task Execution Order
+
+Tasks 1-11 backend; 12 + 13 notifications + auction-style integration helpers; 14-16 controllers; 17 the UI primitive; 18-21 user frontend; 22-24 admin frontend; 25 wraps up (Postman + README + smoke + PR). Sequential dependency graph; execute in order. One implementer subagent at a time.
+
+**Per-task checklist (every task must obey):**
+
+1. TDD: write failing test first when the change has testable behavior; verify the failure; implement; verify green.
+2. Commit and **push** before declaring done.
+3. For any new controller method that returns an entity-derived DTO: wrap in `@Transactional(readOnly = true)` (read) or `@Transactional` (write).
+4. For any new `findByPublicId`-style single-row repo method whose result feeds a mapper: annotate with `@EntityGraph(attributePaths = {...})` listing every collection the mapper will access.
+5. For any new controller surface: write a non-`@Transactional` regression test class that exercises the mapper-returning paths.
+6. No emojis. No em-dashes in user/admin-visible copy or commit messages. No AI/Claude/Anthropic mentions in commits or PR bodies.
+7. Use `Edit` for existing files; `Write` only for new files.
+
+---
+
+### Task 1: V42 Flyway migration + 3 entities + 3 enums + 3 repos + integration test
+
+**Files:**
+- Create: `backend/src/main/resources/db/migration/V42__support_tickets.sql`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicket.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketMessage.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketAttachment.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketStatus.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketCategory.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketAuthorRole.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketRepository.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketMessageRepository.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketAttachmentRepository.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketRepositoryIntegrationTest.java`
+
+- [ ] **Step 1: Write `V42__support_tickets.sql`**
+
+Copy the SQL from spec §2 verbatim. Three tables (`support_tickets`, `support_ticket_messages`, `support_ticket_attachments`), three CHECK constraints on `support_tickets`, one CHECK constraint on `support_ticket_messages`, all indexes from §2 including the partial index on open tickets and the partial index on assigned-admin-id.
+
+- [ ] **Step 2: Write the three enums**
+
+```java
+// SupportTicketStatus.java
+package com.slparcelauctions.backend.support;
+public enum SupportTicketStatus { OPEN, RESOLVED }
+
+// SupportTicketCategory.java
+package com.slparcelauctions.backend.support;
+public enum SupportTicketCategory { ACCOUNT, BIDDING, LISTING, ESCROW, WALLET, OTHER }
+
+// SupportTicketAuthorRole.java
+package com.slparcelauctions.backend.support;
+public enum SupportTicketAuthorRole { USER, ADMIN }
+```
+
+- [ ] **Step 3: Write `SupportTicket.java`**
+
+Extends `BaseMutableEntity`. `@SuperBuilder`. `@OneToMany(mappedBy = "ticket", cascade = ALL, orphanRemoval = true)` for `messages`. `@ManyToOne(fetch = LAZY)` to `User` for `user`; raw `Long assignedAdminId` (no `@ManyToOne` — we don't need the admin user graph loaded on every ticket read). Columns: `subject` (String, 160), `category` (`@Enumerated(STRING)`), `status` (`@Enumerated(STRING)`, default OPEN), `lastMessageAt` (OffsetDateTime, not-null), `lastMessageAuthor` (`@Enumerated(STRING)`), `resolvedAt` (nullable). Do NOT redeclare BaseMutableEntity fields.
+
+- [ ] **Step 4: Write `SupportTicketMessage.java`**
+
+Extends `BaseMutableEntity`. `@SuperBuilder`. `@ManyToOne(fetch = LAZY)` to `SupportTicket` for `ticket` with `@JsonIgnore`; `@ManyToOne(fetch = LAZY)` to `User` for `authorUser` with `@JsonIgnore`. `@OneToMany(mappedBy = "message", cascade = ALL, orphanRemoval = true)` to `SupportTicketAttachment` for `attachments`. Columns: `authorRole` (`@Enumerated(STRING)`), `body` (TEXT, not-null), `visibleToUser` (boolean, default true).
+
+- [ ] **Step 5: Write `SupportTicketAttachment.java`**
+
+Extends `BaseMutableEntity`. `@SuperBuilder`. `@ManyToOne(fetch = LAZY)` to `SupportTicketMessage` for `message` with `@JsonIgnore`. Columns: `storageKey` (255), `mimeType` (64), `sizeBytes` (Integer), `width` (Integer, nullable), `height` (Integer, nullable).
+
+- [ ] **Step 6: Write the three repositories**
+
+```java
+// SupportTicketRepository.java
+package com.slparcelauctions.backend.support;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface SupportTicketRepository
+        extends JpaRepository<SupportTicket, Long>, JpaSpecificationExecutor<SupportTicket> {
+
+    @EntityGraph(attributePaths = {"messages", "messages.attachments"})
+    Optional<SupportTicket> findByPublicId(UUID publicId);
+
+    long countByUserIdAndCreatedAtAfter(long userId, java.time.OffsetDateTime threshold);
+}
+
+// SupportTicketMessageRepository.java
+package com.slparcelauctions.backend.support;
+import org.springframework.data.jpa.repository.JpaRepository;
+public interface SupportTicketMessageRepository
+        extends JpaRepository<SupportTicketMessage, Long> {}
+
+// SupportTicketAttachmentRepository.java
+package com.slparcelauctions.backend.support;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+public interface SupportTicketAttachmentRepository
+        extends JpaRepository<SupportTicketAttachment, Long> {
+    Optional<SupportTicketAttachment> findByPublicId(UUID publicId);
+}
+```
+
+- [ ] **Step 7: Write `SupportTicketRepositoryIntegrationTest`**
+
+`@SpringBootTest + @ActiveProfiles("dev") + @TestPropertySource` with scheduler-mute properties (mirror `CouponRepositoryIntegrationTest`). `@Transactional` rollback. Tests:
+
+```java
+@Test
+void findByPublicId_eagerlyLoadsMessagesAndAttachments() {
+    // persist a ticket + 2 messages + 3 attachments under one message
+    // em.flush(); em.clear();
+    // var loaded = repo.findByPublicId(t.getPublicId()).orElseThrow();
+    // assert org.hibernate.Hibernate.isInitialized(loaded.getMessages())
+    // assert loaded.getMessages() size 2
+    // assert messages[0].getAttachments() loaded (no LazyInit because EntityGraph)
+}
+
+@Test
+void countByUserIdAndCreatedAtAfter_countsOnlyMatchingRows() {
+    // persist 3 tickets for user A: two within last 30 min, one from 2 hours ago
+    // persist 1 ticket for user B in last 30 min
+    // assert countByUserIdAndCreatedAtAfter(userA, now - 1h) == 2
+}
+```
+
+- [ ] **Step 8: Run tests**
+
+```bash
+cd backend && ./mvnw test -Dtest=SupportTicketRepositoryIntegrationTest
+```
+Expected: 2/2 green; log line `Successfully applied 1 migration to schema "public", now at version v42`.
+
+- [ ] **Step 9: Commit + push**
+
+```bash
+git add backend/src/main/resources/db/migration/V42__support_tickets.sql \
+        backend/src/main/java/com/slparcelauctions/backend/support/ \
+        backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketRepositoryIntegrationTest.java
+git commit -m "feat(support): V42 migration + SupportTicket/Message/Attachment entities + repos"
+git push
+```
+
+---
+
+### Task 2: SupportTicketException + SupportTicketError + ExceptionHandler
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketError.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketException.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketExceptionHandler.java`
+
+- [ ] **Step 1: Write `SupportTicketError`**
+
+```java
+package com.slparcelauctions.backend.support;
+
+public enum SupportTicketError {
+    UNKNOWN_TICKET,
+    NOT_OWNER,
+    INTERNAL_NOTE_FROM_USER,
+    RATE_LIMITED,
+    INVALID_ATTACHMENT,
+    INVALID_CATEGORY,
+    ATTACHMENT_NOT_FOUND
+}
+```
+
+- [ ] **Step 2: Write `SupportTicketException`**
+
+```java
+package com.slparcelauctions.backend.support;
+import lombok.Getter;
+
+@Getter
+public class SupportTicketException extends RuntimeException {
+    private final SupportTicketError code;
+    public SupportTicketException(SupportTicketError code) { super(code.name()); this.code = code; }
+    public SupportTicketException(SupportTicketError code, String detail) { super(detail); this.code = code; }
+}
+```
+
+- [ ] **Step 3: Write `SupportTicketExceptionHandler`**
+
+```java
+package com.slparcelauctions.backend.support;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.slparcelauctions.backend.support")
+@Order(Ordered.LOWEST_PRECEDENCE - 100)
+public class SupportTicketExceptionHandler {
+
+    @ExceptionHandler(SupportTicketException.class)
+    public ResponseEntity<ProblemDetail> handle(SupportTicketException e) {
+        HttpStatus status = switch (e.getCode()) {
+            case UNKNOWN_TICKET, ATTACHMENT_NOT_FOUND -> HttpStatus.NOT_FOUND;
+            case NOT_OWNER -> HttpStatus.FORBIDDEN;
+            case INTERNAL_NOTE_FROM_USER, INVALID_ATTACHMENT, INVALID_CATEGORY -> HttpStatus.BAD_REQUEST;
+            case RATE_LIMITED -> HttpStatus.TOO_MANY_REQUESTS;
+        };
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(status, e.getMessage());
+        pd.setTitle("Support ticket error");
+        pd.setProperty("code", e.getCode().name());
+        return ResponseEntity.status(status).body(pd);
+    }
+}
+```
+
+- [ ] **Step 4: Run build to confirm compile**
+
+```bash
+cd backend && ./mvnw test-compile
+```
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 5: Commit + push**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketError.java \
+        backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketException.java \
+        backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketExceptionHandler.java
+git commit -m "feat(support): error enum + exception + RFC9457 handler"
+git push
+```
+
+---
+
+### Task 3: DTOs
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/dto/SupportTicketDto.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/dto/SupportTicketSummaryDto.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/dto/SupportTicketMessageDto.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/dto/SupportTicketAttachmentDto.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/dto/AdminSupportTicketQueueRow.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/dto/CreateSupportTicketRequest.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/dto/ReplySupportTicketRequest.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/dto/AdminReplyRequest.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/dto/AssignTicketRequest.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/dto/PatchTicketRequest.java`
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/dto/SupportTicketQueueStatsDto.java`
+
+- [ ] **Step 1: Write the DTOs**
+
+```java
+// SupportTicketAttachmentDto.java
+package com.slparcelauctions.backend.support.dto;
+import java.util.UUID;
+public record SupportTicketAttachmentDto(
+        UUID publicId, String mimeType, int sizeBytes, Integer width, Integer height) {}
+
+// SupportTicketMessageDto.java
+package com.slparcelauctions.backend.support.dto;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import com.slparcelauctions.backend.support.SupportTicketAuthorRole;
+public record SupportTicketMessageDto(
+        UUID publicId, UUID authorPublicId, String authorDisplayName,
+        SupportTicketAuthorRole authorRole, String body, boolean visibleToUser,
+        OffsetDateTime createdAt, List<SupportTicketAttachmentDto> attachments) {}
+
+// SupportTicketDto.java
+package com.slparcelauctions.backend.support.dto;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import com.slparcelauctions.backend.support.SupportTicketCategory;
+import com.slparcelauctions.backend.support.SupportTicketStatus;
+import com.slparcelauctions.backend.support.SupportTicketAuthorRole;
+public record SupportTicketDto(
+        UUID publicId, UUID submitterPublicId, String submitterDisplayName,
+        String subject, SupportTicketCategory category, SupportTicketStatus status,
+        UUID assignedAdminPublicId, String assignedAdminDisplayName,
+        OffsetDateTime lastMessageAt, SupportTicketAuthorRole lastMessageAuthor,
+        OffsetDateTime resolvedAt, OffsetDateTime createdAt, OffsetDateTime updatedAt,
+        List<SupportTicketMessageDto> messages) {}
+
+// SupportTicketSummaryDto.java
+package com.slparcelauctions.backend.support.dto;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import com.slparcelauctions.backend.support.SupportTicketCategory;
+import com.slparcelauctions.backend.support.SupportTicketStatus;
+import com.slparcelauctions.backend.support.SupportTicketAuthorRole;
+public record SupportTicketSummaryDto(
+        UUID publicId, String subject, SupportTicketCategory category,
+        SupportTicketStatus status, SupportTicketAuthorRole lastMessageAuthor,
+        OffsetDateTime lastMessageAt) {}
+
+// AdminSupportTicketQueueRow.java
+package com.slparcelauctions.backend.support.dto;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import com.slparcelauctions.backend.support.SupportTicketCategory;
+import com.slparcelauctions.backend.support.SupportTicketStatus;
+import com.slparcelauctions.backend.support.SupportTicketAuthorRole;
+public record AdminSupportTicketQueueRow(
+        UUID publicId, String subject, SupportTicketCategory category,
+        SupportTicketStatus status, UUID submitterPublicId, String submitterDisplayName,
+        UUID assignedAdminPublicId, String assignedAdminDisplayName,
+        SupportTicketAuthorRole lastMessageAuthor, OffsetDateTime lastMessageAt) {}
+
+// CreateSupportTicketRequest.java
+package com.slparcelauctions.backend.support.dto;
+import java.util.List;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import com.slparcelauctions.backend.support.SupportTicketCategory;
+public record CreateSupportTicketRequest(
+        @NotBlank @Size(max = 160) String subject,
+        @NotNull SupportTicketCategory category,
+        @NotBlank @Size(max = 10000) String body,
+        List<String> attachmentKeys) {}
+
+// ReplySupportTicketRequest.java
+package com.slparcelauctions.backend.support.dto;
+import java.util.List;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+public record ReplySupportTicketRequest(
+        @NotBlank @Size(max = 10000) String body,
+        List<String> attachmentKeys) {}
+
+// AdminReplyRequest.java
+package com.slparcelauctions.backend.support.dto;
+import java.util.List;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+public record AdminReplyRequest(
+        @NotBlank @Size(max = 10000) String body,
+        List<String> attachmentKeys,
+        Boolean internalNote) {}
+
+// AssignTicketRequest.java
+package com.slparcelauctions.backend.support.dto;
+import java.util.UUID;
+public record AssignTicketRequest(UUID adminPublicId) {}
+
+// PatchTicketRequest.java
+package com.slparcelauctions.backend.support.dto;
+import com.slparcelauctions.backend.support.SupportTicketCategory;
+public record PatchTicketRequest(SupportTicketCategory category) {}
+
+// SupportTicketQueueStatsDto.java
+package com.slparcelauctions.backend.support.dto;
+public record SupportTicketQueueStatsDto(long openNeedingAdminReply, long openTotal) {}
+```
+
+- [ ] **Step 2: Compile**
+
+```bash
+cd backend && ./mvnw test-compile
+```
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 3: Commit + push**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/support/dto/
+git commit -m "feat(support): DTOs for ticket + message + attachment + admin queue"
+git push
+```
+
+---
+
+### Task 4: SupportTicketRateLimiter
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketRateLimiter.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketRateLimiterTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package com.slparcelauctions.backend.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class SupportTicketRateLimiterTest {
+
+    SupportTicketRepository repo;
+    SupportTicketRateLimiter limiter;
+
+    @BeforeEach
+    void setUp() {
+        repo = mock(SupportTicketRepository.class);
+        limiter = new SupportTicketRateLimiter(repo);
+        ReflectionTestUtils.setField(limiter, "ticketsPerHour", 5);
+    }
+
+    @Test
+    void under_cap_does_not_throw() {
+        when(repo.countByUserIdAndCreatedAtAfter(anyLong(), any())).thenReturn(4L);
+        limiter.assertCanOpenNewTicket(1L);
+    }
+
+    @Test
+    void at_cap_throws() {
+        when(repo.countByUserIdAndCreatedAtAfter(anyLong(), any())).thenReturn(5L);
+        assertThatThrownBy(() -> limiter.assertCanOpenNewTicket(1L))
+                .isInstanceOf(SupportTicketException.class)
+                .extracting("code").isEqualTo(SupportTicketError.RATE_LIMITED);
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify compile failure**
+
+```bash
+cd backend && ./mvnw test -Dtest=SupportTicketRateLimiterTest
+```
+Expected: compile error (class does not exist).
+
+- [ ] **Step 3: Implement the limiter**
+
+```java
+package com.slparcelauctions.backend.support;
+
+import java.time.OffsetDateTime;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SupportTicketRateLimiter {
+
+    private final SupportTicketRepository ticketRepository;
+
+    @Value("${slpa.support.rate-limit.tickets-per-hour:5}")
+    private int ticketsPerHour;
+
+    public void assertCanOpenNewTicket(long userId) {
+        OffsetDateTime cutoff = OffsetDateTime.now().minusHours(1);
+        long created = ticketRepository.countByUserIdAndCreatedAtAfter(userId, cutoff);
+        if (created >= ticketsPerHour) {
+            throw new SupportTicketException(
+                    SupportTicketError.RATE_LIMITED,
+                    "Too many new tickets - wait an hour or reply to an existing open ticket");
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run, see green**
+
+```bash
+cd backend && ./mvnw test -Dtest=SupportTicketRateLimiterTest
+```
+Expected: 2/2 green.
+
+- [ ] **Step 5: Commit + push**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketRateLimiter.java \
+        backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketRateLimiterTest.java
+git commit -m "feat(support): per-user new-ticket rate limiter"
+git push
+```
+
+---
+
+### Task 5: Notification surface (categories + publisher methods + link resolver + bodies)
+
+**Files:**
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationCategory.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisher.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationPublisherImpl.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/notification/NotificationDataBuilder.java`
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/notification/slim/SlImLinkResolver.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketNotificationDispatchTest.java`
+
+- [ ] **Step 1: Add the four category constants**
+
+Open `NotificationCategory.java` and add (place after the existing `WALLET_*` block, before realty group entries):
+
+```java
+SUPPORT_TICKET_ADMIN_REPLIED(NotificationGroup.SYSTEM),
+SUPPORT_TICKET_RESOLVED(NotificationGroup.SYSTEM),
+SUPPORT_TICKET_OPENED(NotificationGroup.SYSTEM),
+SUPPORT_TICKET_USER_REPLIED(NotificationGroup.SYSTEM),
+```
+
+- [ ] **Step 2: Add four methods to `NotificationPublisher`**
+
+Append (in a clearly-labelled section near the existing comments):
+
+```java
+    // -- Customer support tickets ----------------------------------
+    void supportTicketAdminReplied(long userId, UUID ticketPublicId,
+                                     String subject, String adminDisplayName);
+    void supportTicketResolved(long userId, UUID ticketPublicId, String subject);
+    void supportTicketOpened(List<Long> adminUserIds, UUID ticketPublicId,
+                              String subject, String submitterDisplayName, String category);
+    void supportTicketUserReplied(List<Long> adminUserIds, UUID ticketPublicId,
+                                    String subject, String submitterDisplayName);
+```
+
+- [ ] **Step 3: Implement in `NotificationPublisherImpl`**
+
+Mirror the existing `walletAdjusted` / `couponGranted` shape. Body strings (no em-dashes, plain hyphens):
+
+```java
+// SUPPORT_TICKET_ADMIN_REPLIED body
+String body = adminDisplayName + " replied to your support ticket: " + subject
+        + ". View at slparcels.com/support/" + ticketPublicId;
+// SUPPORT_TICKET_RESOLVED body
+String body = "Your support ticket has been marked resolved: " + subject
+        + ". View at slparcels.com/support/" + ticketPublicId;
+// SUPPORT_TICKET_OPENED (in-app only, body shown in feed)
+String body = submitterDisplayName + " opened a new " + category + " support ticket: " + subject;
+// SUPPORT_TICKET_USER_REPLIED (in-app only)
+String body = submitterDisplayName + " replied to a support ticket: " + subject;
+```
+
+Channel routing matches spec §6:
+- `SUPPORT_TICKET_ADMIN_REPLIED`, `SUPPORT_TICKET_RESOLVED`: in-app + SL IM, gated by user's `notifySlIm` preference and the SYSTEM group.
+- `SUPPORT_TICKET_OPENED`, `SUPPORT_TICKET_USER_REPLIED`: in-app only; the fan-out helper inserts a Notification row per admin user id and skips SL IM dispatch entirely.
+
+Inject `SupportTicketRepository` only if needed for body lookup (the methods accept all required fields as parameters; no repo lookup required).
+
+- [ ] **Step 4: Add data-builder entries in `NotificationDataBuilder`**
+
+Add a small data-map for each category so the in-app feed UI can render `ticketPublicId`, `subject`, etc. without re-parsing the body string. Pattern matches `couponGranted` (which uses `{ "couponPublicId": "...", "code": "..." }`).
+
+```java
+// SUPPORT_TICKET_ADMIN_REPLIED
+Map<String, Object> data = Map.of(
+    "ticketPublicId", ticketPublicId.toString(),
+    "subject", subject,
+    "adminDisplayName", adminDisplayName
+);
+```
+
+Similar maps for the other three categories.
+
+- [ ] **Step 5: Add deep-link entries to `SlImLinkResolver`**
+
+The resolver has an exhaustive switch over `NotificationCategory`. Add cases:
+
+```java
+case SUPPORT_TICKET_ADMIN_REPLIED, SUPPORT_TICKET_RESOLVED -> "/support/" + ticketPublicId;
+case SUPPORT_TICKET_OPENED, SUPPORT_TICKET_USER_REPLIED -> "/admin/support/" + ticketPublicId;
+```
+
+If the resolver gets `ticketPublicId` from the data blob (it likely does for coupon `couponPublicId`), extract similarly.
+
+- [ ] **Step 6: Write `SupportTicketNotificationDispatchTest`**
+
+`@SpringBootTest` with `@MockBean` for SL IM dispatcher. Tests:
+
+```java
+@Test
+void supportTicketAdminReplied_fires_inApp_andSlIm() { ... }
+
+@Test
+void supportTicketResolved_fires_inApp_andSlIm() { ... }
+
+@Test
+void supportTicketOpened_fires_inApp_only_to_each_admin() { ... }
+
+@Test
+void supportTicketUserReplied_fires_inApp_only() { ... }
+```
+
+Assert via the `NotificationRepository` count + the mocked SL IM dispatcher's invocation count.
+
+- [ ] **Step 7: Run tests**
+
+```bash
+cd backend && ./mvnw test -Dtest=SupportTicketNotificationDispatchTest
+```
+Expected: 4/4 green.
+
+- [ ] **Step 8: Commit + push**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/notification/ \
+        backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketNotificationDispatchTest.java
+git commit -m "feat(notify): support ticket categories + publisher methods + deep links"
+git push
+```
+
+---
+
+### Task 6: SupportTicketMapper
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketMapper.java`
+
+- [ ] **Step 1: Implement the mapper**
+
+```java
+package com.slparcelauctions.backend.support;
+
+import java.util.List;
+import org.springframework.stereotype.Component;
+import com.slparcelauctions.backend.support.dto.*;
+import com.slparcelauctions.backend.user.User;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SupportTicketMapper {
+
+    public SupportTicketAttachmentDto toAttachmentDto(SupportTicketAttachment a) {
+        return new SupportTicketAttachmentDto(
+                a.getPublicId(), a.getMimeType(), a.getSizeBytes(),
+                a.getWidth(), a.getHeight());
+    }
+
+    public SupportTicketMessageDto toMessageDto(SupportTicketMessage m) {
+        User author = m.getAuthorUser();
+        List<SupportTicketAttachmentDto> atts = m.getAttachments().stream()
+                .map(this::toAttachmentDto).toList();
+        return new SupportTicketMessageDto(
+                m.getPublicId(),
+                author.getPublicId(),
+                author.getDisplayName() == null ? author.getUsername() : author.getDisplayName(),
+                m.getAuthorRole(), m.getBody(), m.isVisibleToUser(),
+                m.getCreatedAt(), atts);
+    }
+
+    /** Map for the user-facing detail. Filters out internal notes (visibleToUser=false). */
+    public SupportTicketDto toUserDto(SupportTicket t, User assignedAdmin) {
+        List<SupportTicketMessageDto> msgs = t.getMessages().stream()
+                .filter(SupportTicketMessage::isVisibleToUser)
+                .map(this::toMessageDto)
+                .toList();
+        return buildDto(t, assignedAdmin, msgs);
+    }
+
+    /** Admin-facing detail. Includes every message (internal notes shown). */
+    public SupportTicketDto toAdminDto(SupportTicket t, User assignedAdmin) {
+        List<SupportTicketMessageDto> msgs = t.getMessages().stream()
+                .map(this::toMessageDto)
+                .toList();
+        return buildDto(t, assignedAdmin, msgs);
+    }
+
+    private SupportTicketDto buildDto(SupportTicket t, User assignedAdmin,
+                                       List<SupportTicketMessageDto> msgs) {
+        User submitter = t.getUser();
+        return new SupportTicketDto(
+                t.getPublicId(),
+                submitter.getPublicId(),
+                submitter.getDisplayName() == null ? submitter.getUsername() : submitter.getDisplayName(),
+                t.getSubject(), t.getCategory(), t.getStatus(),
+                assignedAdmin == null ? null : assignedAdmin.getPublicId(),
+                assignedAdmin == null ? null :
+                        (assignedAdmin.getDisplayName() == null ? assignedAdmin.getUsername() : assignedAdmin.getDisplayName()),
+                t.getLastMessageAt(), t.getLastMessageAuthor(),
+                t.getResolvedAt(), t.getCreatedAt(), t.getUpdatedAt(), msgs);
+    }
+
+    public SupportTicketSummaryDto toSummaryDto(SupportTicket t) {
+        return new SupportTicketSummaryDto(
+                t.getPublicId(), t.getSubject(), t.getCategory(), t.getStatus(),
+                t.getLastMessageAuthor(), t.getLastMessageAt());
+    }
+
+    public AdminSupportTicketQueueRow toAdminRow(SupportTicket t, User assignedAdmin) {
+        User submitter = t.getUser();
+        return new AdminSupportTicketQueueRow(
+                t.getPublicId(), t.getSubject(), t.getCategory(), t.getStatus(),
+                submitter.getPublicId(),
+                submitter.getDisplayName() == null ? submitter.getUsername() : submitter.getDisplayName(),
+                assignedAdmin == null ? null : assignedAdmin.getPublicId(),
+                assignedAdmin == null ? null :
+                        (assignedAdmin.getDisplayName() == null ? assignedAdmin.getUsername() : assignedAdmin.getDisplayName()),
+                t.getLastMessageAuthor(), t.getLastMessageAt());
+    }
+}
+```
+
+- [ ] **Step 2: Compile**
+
+```bash
+cd backend && ./mvnw test-compile
+```
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 3: Commit + push**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketMapper.java
+git commit -m "feat(support): mapper for user-side + admin-side DTOs (filters internal notes)"
+git push
+```
+
+---
+
+### Task 7: SupportTicketAttachmentService (pre-upload + promotion)
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketAttachmentService.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketAttachmentServiceTest.java`
+
+- [ ] **Step 1: Implement the service**
+
+```java
+package com.slparcelauctions.backend.support;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.slparcelauctions.backend.media.ImageUploadValidator;
+import com.slparcelauctions.backend.storage.S3ObjectStorageService;
+import com.slparcelauctions.backend.user.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SupportTicketAttachmentService {
+
+    private final S3ObjectStorageService storage;
+    private final ImageUploadValidator imageValidator;
+    private final StringRedisTemplate redis;
+    private final ObjectMapper objectMapper;
+
+    @Value("${slpa.support.attachments.max-file-bytes:5242880}")
+    private long maxFileBytes;
+
+    @Value("${slpa.support.attachments.allowed-mime-types:image/png,image/jpeg,image/webp,image/gif}")
+    private String allowedMimeTypesCsv;
+
+    @Value("${slpa.support.attachments.max-per-message:3}")
+    private int maxPerMessage;
+
+    @Value("${slpa.support.attachments.pending-ttl-seconds:3600}")
+    private long pendingTtlSeconds;
+
+    public String preUpload(User uploader, MultipartFile file) {
+        if (file.getSize() > maxFileBytes) {
+            throw new SupportTicketException(SupportTicketError.INVALID_ATTACHMENT,
+                    "file exceeds " + maxFileBytes + " bytes");
+        }
+        List<String> allowed = List.of(allowedMimeTypesCsv.split(","));
+        if (!allowed.contains(file.getContentType())) {
+            throw new SupportTicketException(SupportTicketError.INVALID_ATTACHMENT,
+                    "mime " + file.getContentType() + " not in allowlist");
+        }
+        var dims = imageValidator.validate(file);  // returns width + height or throws
+        String ext = switch (file.getContentType()) {
+            case "image/png" -> "png";
+            case "image/jpeg" -> "jpg";
+            case "image/webp" -> "webp";
+            case "image/gif" -> "gif";
+            default -> "bin";
+        };
+        String attachmentKey = UUID.randomUUID().toString();
+        String storageKey = "support-attachments/pending/" + uploader.getPublicId() + "/" + attachmentKey + "." + ext;
+        storage.uploadBytes(storageKey, file.getBytes(), file.getContentType());
+
+        PendingAttachment pending = new PendingAttachment(
+                uploader.getId(), storageKey, file.getContentType(),
+                (int) file.getSize(), dims.width(), dims.height());
+        try {
+            redis.opsForValue().set("support:upload:" + attachmentKey,
+                    objectMapper.writeValueAsString(pending),
+                    Duration.ofSeconds(pendingTtlSeconds));
+        } catch (Exception e) {
+            // best-effort: try to delete the S3 object we just wrote
+            try { storage.delete(storageKey); } catch (Exception ignored) {}
+            throw new RuntimeException("failed to cache pending attachment", e);
+        }
+        return attachmentKey;
+    }
+
+    /**
+     * Promote a list of pending attachment keys onto a persisted message.
+     * Must be called inside the same transaction as the message insert.
+     * On any post-copy failure, the just-copied promoted objects are best-effort deleted.
+     */
+    @Transactional
+    public List<SupportTicketAttachment> promote(
+            List<String> attachmentKeys, long expectedOwnerId,
+            SupportTicketMessage targetMessage,
+            SupportTicketAttachmentRepository repo) {
+        if (attachmentKeys == null || attachmentKeys.isEmpty()) return List.of();
+        if (attachmentKeys.size() > maxPerMessage) {
+            throw new SupportTicketException(SupportTicketError.INVALID_ATTACHMENT,
+                    "max " + maxPerMessage + " attachments per message");
+        }
+        java.util.List<String> promotedKeysForCleanup = new java.util.ArrayList<>();
+        try {
+            List<SupportTicketAttachment> result = new java.util.ArrayList<>();
+            for (String key : attachmentKeys) {
+                String json = redis.opsForValue().get("support:upload:" + key);
+                if (json == null) {
+                    throw new SupportTicketException(SupportTicketError.ATTACHMENT_NOT_FOUND,
+                            "attachment " + key + " missing or expired");
+                }
+                PendingAttachment p = objectMapper.readValue(json, PendingAttachment.class);
+                if (p.userId() != expectedOwnerId) {
+                    throw new SupportTicketException(SupportTicketError.NOT_OWNER,
+                            "attachment " + key + " not owned by caller");
+                }
+                String promotedKey = "support-attachments/" + targetMessage.getId() + "/" + key;
+                storage.copy(p.storageKey(), promotedKey);
+                promotedKeysForCleanup.add(promotedKey);
+                storage.delete(p.storageKey());
+                SupportTicketAttachment att = SupportTicketAttachment.builder()
+                        .message(targetMessage).storageKey(promotedKey)
+                        .mimeType(p.mime()).sizeBytes(p.size())
+                        .width(p.width()).height(p.height()).build();
+                result.add(repo.save(att));
+                redis.delete("support:upload:" + key);
+            }
+            return result;
+        } catch (RuntimeException ex) {
+            // Best-effort cleanup of any objects we already copied to the promoted path.
+            for (String k : promotedKeysForCleanup) {
+                try { storage.delete(k); } catch (Exception ignored) {}
+            }
+            throw ex;
+        } catch (Exception ex) {
+            for (String k : promotedKeysForCleanup) {
+                try { storage.delete(k); } catch (Exception ignored) {}
+            }
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public String signedDownloadUrl(SupportTicketAttachment att) {
+        return storage.signedUrl(att.getStorageKey(), Duration.ofMinutes(5));
+    }
+
+    private record PendingAttachment(long userId, String storageKey, String mime,
+                                       int size, int width, int height) {}
+}
+```
+
+If `S3ObjectStorageService` doesn't have a `copy(srcKey, dstKey)` method, add one (server-side copy via the S3 SDK). Check the existing method names before assuming.
+
+If `ImageUploadValidator.validate(MultipartFile)` doesn't return `{width, height}` as a record, adapt to the actual return type and capture width / height separately.
+
+- [ ] **Step 2: Write `SupportTicketAttachmentServiceTest`**
+
+`@SpringBootTest` with `@MockBean S3ObjectStorageService` and a real `StringRedisTemplate` (the dev profile has Redis). Tests:
+
+```java
+@Test
+void preUpload_rejects_over_size() { ... }   // assert SupportTicketException with INVALID_ATTACHMENT
+@Test
+void preUpload_rejects_disallowed_mime() { ... }
+@Test
+void preUpload_happy_path_returns_key_and_caches_in_redis() { ... }
+@Test
+void promote_unknown_key_throws_ATTACHMENT_NOT_FOUND() { ... }
+@Test
+void promote_owner_mismatch_throws_NOT_OWNER() { ... }
+@Test
+void promote_happy_path_copies_object_and_inserts_row() { ... }
+@Test
+void promote_over_max_throws_INVALID_ATTACHMENT() { ... }
+@Test
+void promote_db_failure_after_copy_cleans_up_promoted_object() {
+    // mock repo.save to throw; assert storage.delete was called on the promoted key
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd backend && ./mvnw test -Dtest=SupportTicketAttachmentServiceTest
+```
+Expected: 8/8 green.
+
+- [ ] **Step 4: Commit + push**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketAttachmentService.java \
+        backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketAttachmentServiceTest.java
+git commit -m "feat(support): attachment service (pre-upload + promote with cleanup-on-failure)"
+git push
+```
+
+---
+
+### Task 8: SupportTicketService core (create + reply + helpers)
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketService.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketServiceCreateReplyTest.java`
+
+- [ ] **Step 1: Implement the service (create + reply only — resolve / reopen / assign land in Task 9)**
+
+```java
+package com.slparcelauctions.backend.support;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.slparcelauctions.backend.notification.NotificationPublisher;
+import com.slparcelauctions.backend.support.dto.*;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class SupportTicketService {
+
+    private final SupportTicketRepository ticketRepo;
+    private final SupportTicketMessageRepository messageRepo;
+    private final SupportTicketAttachmentRepository attachmentRepo;
+    private final SupportTicketAttachmentService attachmentService;
+    private final SupportTicketRateLimiter rateLimiter;
+    private final NotificationPublisher notifications;
+    private final UserRepository userRepo;
+
+    public SupportTicket createTicket(long submitterUserId, CreateSupportTicketRequest req) {
+        rateLimiter.assertCanOpenNewTicket(submitterUserId);
+        User submitter = userRepo.findById(submitterUserId).orElseThrow(() ->
+                new SupportTicketException(SupportTicketError.UNKNOWN_TICKET, "submitter missing"));
+
+        OffsetDateTime now = OffsetDateTime.now();
+        SupportTicket ticket = SupportTicket.builder()
+                .user(submitter)
+                .subject(req.subject().trim())
+                .category(req.category())
+                .status(SupportTicketStatus.OPEN)
+                .lastMessageAt(now)
+                .lastMessageAuthor(SupportTicketAuthorRole.USER)
+                .build();
+        ticket = ticketRepo.save(ticket);
+
+        SupportTicketMessage initial = SupportTicketMessage.builder()
+                .ticket(ticket).authorUser(submitter)
+                .authorRole(SupportTicketAuthorRole.USER)
+                .body(req.body().trim())
+                .visibleToUser(true)
+                .build();
+        initial = messageRepo.save(initial);
+
+        if (req.attachmentKeys() != null && !req.attachmentKeys().isEmpty()) {
+            attachmentService.promote(req.attachmentKeys(), submitter.getId(), initial, attachmentRepo);
+        }
+
+        List<Long> adminIds = userRepo.findIdsByRole(Role.ADMIN);
+        notifications.supportTicketOpened(adminIds, ticket.getPublicId(),
+                ticket.getSubject(),
+                submitter.getDisplayName() == null ? submitter.getUsername() : submitter.getDisplayName(),
+                ticket.getCategory().name());
+
+        return ticket;
+    }
+
+    public SupportTicketMessage userReply(long callerUserId, UUID ticketPublicId,
+                                            ReplySupportTicketRequest req) {
+        SupportTicket ticket = ticketRepo.findByPublicId(ticketPublicId)
+                .orElseThrow(() -> new SupportTicketException(SupportTicketError.UNKNOWN_TICKET));
+        if (!ticket.getUser().getId().equals(callerUserId)) {
+            throw new SupportTicketException(SupportTicketError.NOT_OWNER);
+        }
+        User caller = ticket.getUser();
+        return appendMessage(ticket, caller, SupportTicketAuthorRole.USER,
+                req.body(), req.attachmentKeys(), true);
+    }
+
+    public SupportTicketMessage adminReply(long adminUserId, UUID ticketPublicId,
+                                             AdminReplyRequest req) {
+        SupportTicket ticket = ticketRepo.findByPublicId(ticketPublicId)
+                .orElseThrow(() -> new SupportTicketException(SupportTicketError.UNKNOWN_TICKET));
+        User admin = userRepo.findById(adminUserId).orElseThrow(() ->
+                new SupportTicketException(SupportTicketError.UNKNOWN_TICKET, "admin missing"));
+        boolean internal = Boolean.TRUE.equals(req.internalNote());
+        return appendMessage(ticket, admin, SupportTicketAuthorRole.ADMIN,
+                req.body(), req.attachmentKeys(), !internal);
+    }
+
+    private SupportTicketMessage appendMessage(SupportTicket ticket, User author,
+                                                 SupportTicketAuthorRole role,
+                                                 String body, List<String> attachmentKeys,
+                                                 boolean visibleToUser) {
+        OffsetDateTime now = OffsetDateTime.now();
+        SupportTicketMessage msg = SupportTicketMessage.builder()
+                .ticket(ticket).authorUser(author)
+                .authorRole(role)
+                .body(body.trim())
+                .visibleToUser(visibleToUser)
+                .build();
+        msg = messageRepo.save(msg);
+
+        if (attachmentKeys != null && !attachmentKeys.isEmpty()) {
+            attachmentService.promote(attachmentKeys, author.getId(), msg, attachmentRepo);
+        }
+
+        if (visibleToUser) {
+            ticket.setLastMessageAt(now);
+            ticket.setLastMessageAuthor(role);
+            // Auto-reopen only on user reply to a resolved ticket.
+            if (role == SupportTicketAuthorRole.USER && ticket.getStatus() == SupportTicketStatus.RESOLVED) {
+                ticket.setStatus(SupportTicketStatus.OPEN);
+                ticket.setResolvedAt(null);
+            }
+
+            // Notifications for visible messages only.
+            if (role == SupportTicketAuthorRole.ADMIN) {
+                User submitter = ticket.getUser();
+                notifications.supportTicketAdminReplied(
+                        submitter.getId(), ticket.getPublicId(), ticket.getSubject(),
+                        author.getDisplayName() == null ? author.getUsername() : author.getDisplayName());
+            } else {
+                List<Long> adminIds = userRepo.findIdsByRole(Role.ADMIN);
+                notifications.supportTicketUserReplied(
+                        adminIds, ticket.getPublicId(), ticket.getSubject(),
+                        author.getDisplayName() == null ? author.getUsername() : author.getDisplayName());
+            }
+        }
+        // Internal notes are silent and do not bump lastMessageAt.
+        return msg;
+    }
+}
+```
+
+If `UserRepository.findIdsByRole(Role)` doesn't exist, add it as a derived query. Mirror the existing `findByRole` query if present; otherwise:
+
+```java
+@Query("SELECT u.id FROM User u WHERE u.role = :role")
+List<Long> findIdsByRole(@Param("role") Role role);
+```
+
+- [ ] **Step 2: Write `SupportTicketServiceCreateReplyTest`**
+
+`@SpringBootTest` + `@ActiveProfiles("dev")` + scheduler-mute. Tests:
+
+```java
+@Test
+void createTicket_inserts_row_and_initial_message_and_notifies_admins() { ... }
+
+@Test
+void createTicket_propagates_rate_limit() {
+    // create 5 tickets; 6th throws RATE_LIMITED
+}
+
+@Test
+void createTicket_persists_attachments_when_provided() { ... }
+
+@Test
+void userReply_throws_NOT_OWNER_when_caller_is_not_submitter() { ... }
+
+@Test
+void userReply_visible_message_updates_lastMessageAt_and_lastMessageAuthor() { ... }
+
+@Test
+void userReply_on_resolved_ticket_auto_reopens() { ... }
+
+@Test
+void userReply_fires_supportTicketUserReplied_to_all_admins() {
+    // mock NotificationPublisher; assert called once with the admin id list
+}
+
+@Test
+void adminReply_visible_fires_supportTicketAdminReplied_to_submitter() { ... }
+
+@Test
+void adminReply_internalNote_does_not_update_lastMessageAt_or_fire_notification() { ... }
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd backend && ./mvnw test -Dtest=SupportTicketServiceCreateReplyTest
+```
+Expected: 9/9 green.
+
+- [ ] **Step 4: Commit + push**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketService.java \
+        backend/src/main/java/com/slparcelauctions/backend/user/UserRepository.java \
+        backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketServiceCreateReplyTest.java
+git commit -m "feat(support): create + reply flow with auto-reopen + notification dispatch"
+git push
+```
+
+---
+
+### Task 9: SupportTicketService admin actions (resolve / reopen / assign / patch / queue-stats)
+
+**Files:**
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketService.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketServiceAdminActionsTest.java`
+
+- [ ] **Step 1: Add methods to `SupportTicketService`**
+
+```java
+public SupportTicket resolve(long adminUserId, UUID ticketPublicId) {
+    SupportTicket ticket = ticketRepo.findByPublicId(ticketPublicId)
+            .orElseThrow(() -> new SupportTicketException(SupportTicketError.UNKNOWN_TICKET));
+    if (ticket.getStatus() == SupportTicketStatus.RESOLVED) return ticket;  // idempotent
+
+    OffsetDateTime now = OffsetDateTime.now();
+    User admin = userRepo.findById(adminUserId).orElseThrow(() ->
+            new SupportTicketException(SupportTicketError.UNKNOWN_TICKET, "admin missing"));
+    ticket.setStatus(SupportTicketStatus.RESOLVED);
+    ticket.setResolvedAt(now);
+
+    SupportTicketMessage system = SupportTicketMessage.builder()
+            .ticket(ticket).authorUser(admin)
+            .authorRole(SupportTicketAuthorRole.ADMIN)
+            .body("Marked resolved by admin")
+            .visibleToUser(true)
+            .build();
+    messageRepo.save(system);
+    ticket.setLastMessageAt(now);
+    ticket.setLastMessageAuthor(SupportTicketAuthorRole.ADMIN);
+
+    User submitter = ticket.getUser();
+    notifications.supportTicketResolved(submitter.getId(), ticket.getPublicId(), ticket.getSubject());
+    return ticket;
+}
+
+public SupportTicket reopen(long adminUserId, UUID ticketPublicId) {
+    SupportTicket ticket = ticketRepo.findByPublicId(ticketPublicId)
+            .orElseThrow(() -> new SupportTicketException(SupportTicketError.UNKNOWN_TICKET));
+    if (ticket.getStatus() == SupportTicketStatus.OPEN) return ticket;
+
+    OffsetDateTime now = OffsetDateTime.now();
+    User admin = userRepo.findById(adminUserId).orElseThrow(() ->
+            new SupportTicketException(SupportTicketError.UNKNOWN_TICKET, "admin missing"));
+    ticket.setStatus(SupportTicketStatus.OPEN);
+    ticket.setResolvedAt(null);
+
+    SupportTicketMessage system = SupportTicketMessage.builder()
+            .ticket(ticket).authorUser(admin)
+            .authorRole(SupportTicketAuthorRole.ADMIN)
+            .body("Reopened by admin")
+            .visibleToUser(true)
+            .build();
+    messageRepo.save(system);
+    ticket.setLastMessageAt(now);
+    ticket.setLastMessageAuthor(SupportTicketAuthorRole.ADMIN);
+    return ticket;
+}
+
+public SupportTicket assign(UUID ticketPublicId, UUID adminPublicId) {
+    SupportTicket ticket = ticketRepo.findByPublicId(ticketPublicId)
+            .orElseThrow(() -> new SupportTicketException(SupportTicketError.UNKNOWN_TICKET));
+    if (adminPublicId == null) {
+        ticket.setAssignedAdminId(null);
+        return ticket;
+    }
+    User admin = userRepo.findByPublicId(adminPublicId).orElseThrow(() ->
+            new SupportTicketException(SupportTicketError.UNKNOWN_TICKET, "admin missing"));
+    if (admin.getRole() != Role.ADMIN) {
+        throw new SupportTicketException(SupportTicketError.UNKNOWN_TICKET, "user is not an admin");
+    }
+    ticket.setAssignedAdminId(admin.getId());
+    return ticket;
+}
+
+public SupportTicket patchCategory(UUID ticketPublicId, SupportTicketCategory category) {
+    if (category == null) {
+        throw new SupportTicketException(SupportTicketError.INVALID_CATEGORY, "category required");
+    }
+    SupportTicket ticket = ticketRepo.findByPublicId(ticketPublicId)
+            .orElseThrow(() -> new SupportTicketException(SupportTicketError.UNKNOWN_TICKET));
+    ticket.setCategory(category);
+    return ticket;
+}
+
+@Transactional(readOnly = true)
+public SupportTicketQueueStatsDto queueStats() {
+    long openNeedingAdminReply = ticketRepo.count((root, cq, cb) -> cb.and(
+            cb.equal(root.get("status"), SupportTicketStatus.OPEN),
+            cb.equal(root.get("lastMessageAuthor"), SupportTicketAuthorRole.USER)));
+    long openTotal = ticketRepo.count((root, cq, cb) ->
+            cb.equal(root.get("status"), SupportTicketStatus.OPEN));
+    return new SupportTicketQueueStatsDto(openNeedingAdminReply, openTotal);
+}
+```
+
+`UserRepository.findByPublicId(UUID)` already exists (used by realty groups etc.).
+
+- [ ] **Step 2: Write tests**
+
+```java
+@Test
+void resolve_idempotent_when_already_resolved() { ... }
+
+@Test
+void resolve_writes_system_message_and_fires_notification() { ... }
+
+@Test
+void reopen_idempotent_when_already_open() { ... }
+
+@Test
+void reopen_writes_system_message_and_no_notification() { ... }
+
+@Test
+void assign_with_valid_admin_publicId_sets_assignedAdminId() { ... }
+
+@Test
+void assign_with_null_unassigns() { ... }
+
+@Test
+void assign_rejects_non_admin_user() { ... }
+
+@Test
+void patchCategory_updates_value() { ... }
+
+@Test
+void queueStats_counts_open_total_and_needing_admin_reply() {
+    // seed: 2 OPEN with last=USER, 1 OPEN with last=ADMIN, 1 RESOLVED
+    // assert openTotal=3, openNeedingAdminReply=2
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd backend && ./mvnw test -Dtest=SupportTicketServiceAdminActionsTest
+```
+Expected: 9/9 green.
+
+- [ ] **Step 4: Commit + push**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketService.java \
+        backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketServiceAdminActionsTest.java
+git commit -m "feat(support): admin actions - resolve + reopen + assign + patch + queue-stats"
+git push
+```
+
+---
+
+### Task 10: SupportTicketService search / list (admin queue spec + user paginated list)
+
+**Files:**
+- Modify: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketService.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketServiceListTest.java`
+
+- [ ] **Step 1: Add list methods**
+
+```java
+@Transactional(readOnly = true)
+public Page<SupportTicket> listForUser(long userId, SupportTicketStatus status,
+                                         String q, Pageable pageable) {
+    Specification<SupportTicket> spec = (root, cq, cb) -> cb.equal(root.get("user").get("id"), userId);
+    if (status != null) {
+        Specification<SupportTicket> finalSpec = spec;
+        spec = (root, cq, cb) -> cb.and(
+                finalSpec.toPredicate(root, cq, cb),
+                cb.equal(root.get("status"), status));
+    }
+    if (q != null && !q.isBlank()) {
+        Specification<SupportTicket> finalSpec = spec;
+        spec = (root, cq, cb) -> cb.and(
+                finalSpec.toPredicate(root, cq, cb),
+                cb.like(cb.lower(root.get("subject")), "%" + q.toLowerCase() + "%"));
+    }
+    return ticketRepo.findAll(spec, pageable);
+}
+
+@Transactional(readOnly = true)
+public Page<SupportTicket> listAdmin(SupportTicketStatus status, SupportTicketCategory category,
+                                       String assignee, SupportTicketAuthorRole lastAuthor,
+                                       String q, long callerAdminId, Pageable pageable) {
+    Specification<SupportTicket> spec = (root, cq, cb) -> cb.conjunction();
+    if (status != null) {
+        Specification<SupportTicket> p = spec;
+        spec = (root, cq, cb) -> cb.and(p.toPredicate(root, cq, cb), cb.equal(root.get("status"), status));
+    }
+    if (category != null) {
+        Specification<SupportTicket> p = spec;
+        spec = (root, cq, cb) -> cb.and(p.toPredicate(root, cq, cb), cb.equal(root.get("category"), category));
+    }
+    if (lastAuthor != null) {
+        Specification<SupportTicket> p = spec;
+        spec = (root, cq, cb) -> cb.and(p.toPredicate(root, cq, cb), cb.equal(root.get("lastMessageAuthor"), lastAuthor));
+    }
+    if (assignee != null && !assignee.isBlank()) {
+        Specification<SupportTicket> p = spec;
+        if ("mine".equalsIgnoreCase(assignee)) {
+            spec = (root, cq, cb) -> cb.and(p.toPredicate(root, cq, cb),
+                    cb.equal(root.get("assignedAdminId"), callerAdminId));
+        } else if ("unassigned".equalsIgnoreCase(assignee)) {
+            spec = (root, cq, cb) -> cb.and(p.toPredicate(root, cq, cb),
+                    cb.isNull(root.get("assignedAdminId")));
+        } else {
+            // treat as a user publicId on the submitter
+            UUID submitterPid;
+            try { submitterPid = UUID.fromString(assignee); }
+            catch (IllegalArgumentException e) { submitterPid = null; }
+            if (submitterPid != null) {
+                final UUID pid = submitterPid;
+                spec = (root, cq, cb) -> cb.and(p.toPredicate(root, cq, cb),
+                        cb.equal(root.get("user").get("publicId"), pid));
+            }
+        }
+    }
+    if (q != null && !q.isBlank()) {
+        Specification<SupportTicket> p = spec;
+        spec = (root, cq, cb) -> cb.and(p.toPredicate(root, cq, cb),
+                cb.like(cb.lower(root.get("subject")), "%" + q.toLowerCase() + "%"));
+    }
+    return ticketRepo.findAll(spec, pageable);
+}
+```
+
+Imports: `org.springframework.data.domain.Page`, `Pageable`, `org.springframework.data.jpa.domain.Specification`, `java.util.UUID`.
+
+- [ ] **Step 2: Write tests covering each filter axis independently + combined**
+
+Verify each filter axis (status, category, assignee=mine/unassigned/userPublicId, lastAuthor, q) returns the expected rows in isolation, plus a combined-filters test.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd backend && ./mvnw test -Dtest=SupportTicketServiceListTest
+```
+Expected: green.
+
+- [ ] **Step 4: Commit + push**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketService.java \
+        backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketServiceListTest.java
+git commit -m "feat(support): paginated list specs for user-side + admin queue"
+git push
+```
+
+---
+
+### Task 11: MeSupportTicketController
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/MeSupportTicketController.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/support/MeSupportTicketControllerIntegrationTest.java`
+
+- [ ] **Step 1: Implement the controller**
+
+```java
+package com.slparcelauctions.backend.support;
+
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.common.PagedResponse;
+import com.slparcelauctions.backend.support.dto.*;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/me/support-tickets")
+@RequiredArgsConstructor
+public class MeSupportTicketController {
+
+    private final SupportTicketService service;
+    private final SupportTicketMapper mapper;
+    private final UserRepository userRepo;
+
+    @GetMapping
+    @Transactional(readOnly = true)
+    public PagedResponse<SupportTicketSummaryDto> list(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @RequestParam(required = false) SupportTicketStatus status,
+            @RequestParam(required = false) String q,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Page<SupportTicket> p = service.listForUser(principal.userId(), status, q,
+                PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "lastMessageAt")));
+        return PagedResponse.from(p.map(mapper::toSummaryDto));
+    }
+
+    @GetMapping("/{publicId}")
+    @Transactional(readOnly = true)
+    public SupportTicketDto detail(@AuthenticationPrincipal AuthPrincipal principal,
+                                     @PathVariable UUID publicId) {
+        SupportTicket t = service.findByPublicIdEnsureOwner(principal.userId(), publicId);
+        User assignedAdmin = t.getAssignedAdminId() == null ? null :
+                userRepo.findById(t.getAssignedAdminId()).orElse(null);
+        return mapper.toUserDto(t, assignedAdmin);
+    }
+
+    @PostMapping
+    @Transactional
+    public SupportTicketDto create(@AuthenticationPrincipal AuthPrincipal principal,
+                                     @Valid @RequestBody CreateSupportTicketRequest req) {
+        SupportTicket t = service.createTicket(principal.userId(), req);
+        SupportTicket reloaded = service.findByPublicIdEnsureOwner(principal.userId(), t.getPublicId());
+        return mapper.toUserDto(reloaded, null);
+    }
+
+    @PostMapping("/{publicId}/messages")
+    @Transactional
+    public SupportTicketMessageDto reply(@AuthenticationPrincipal AuthPrincipal principal,
+                                           @PathVariable UUID publicId,
+                                           @Valid @RequestBody ReplySupportTicketRequest req) {
+        SupportTicketMessage msg = service.userReply(principal.userId(), publicId, req);
+        return mapper.toMessageDto(msg);
+    }
+}
+```
+
+Add a small helper on `SupportTicketService`:
+
+```java
+@Transactional(readOnly = true)
+public SupportTicket findByPublicIdEnsureOwner(long userId, UUID publicId) {
+    SupportTicket t = ticketRepo.findByPublicId(publicId)
+            .orElseThrow(() -> new SupportTicketException(SupportTicketError.UNKNOWN_TICKET));
+    if (!t.getUser().getId().equals(userId)) {
+        throw new SupportTicketException(SupportTicketError.UNKNOWN_TICKET);  // 404, not 403 - don't leak existence
+    }
+    return t;
+}
+```
+
+- [ ] **Step 2: Write the integration test (with class-level `@Transactional`)**
+
+Cover GET list filters, GET detail, GET detail rejects 404 when not owner, POST create happy path, POST create propagates rate limit (429), POST reply happy path, POST reply rejects 10001-char body, POST reply on RESOLVED ticket auto-reopens (assert status flips).
+
+- [ ] **Step 3: Write the NON-transactional LazyInit regression test**
+
+File: `backend/src/test/java/com/slparcelauctions/backend/support/MeSupportTicketLazyInitRegressionTest.java`. Mirrors `AdminCouponLazyInitRegressionTest`. Tests:
+- GET `/me/support-tickets/{id}` outside an enclosing tx → 200, messages array populated, attachments rendered.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd backend && ./mvnw test -Dtest='MeSupportTicketControllerIntegrationTest,MeSupportTicketLazyInitRegressionTest'
+```
+Expected: all green.
+
+- [ ] **Step 5: Commit + push**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/support/MeSupportTicketController.java \
+        backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketService.java \
+        backend/src/test/java/com/slparcelauctions/backend/support/MeSupportTicketControllerIntegrationTest.java \
+        backend/src/test/java/com/slparcelauctions/backend/support/MeSupportTicketLazyInitRegressionTest.java
+git commit -m "feat(support): MeSupportTicketController + LazyInit regression coverage"
+git push
+```
+
+---
+
+### Task 12: AdminSupportTicketController
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/AdminSupportTicketController.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/support/AdminSupportTicketControllerIntegrationTest.java`
+- Test: `backend/src/test/java/com/slparcelauctions/backend/support/AdminSupportTicketLazyInitRegressionTest.java`
+
+- [ ] **Step 1: Implement the controller**
+
+```java
+package com.slparcelauctions.backend.support;
+
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.common.PagedResponse;
+import com.slparcelauctions.backend.support.dto.*;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/admin/support-tickets")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminSupportTicketController {
+
+    private final SupportTicketService service;
+    private final SupportTicketMapper mapper;
+    private final UserRepository userRepo;
+
+    @GetMapping
+    @Transactional(readOnly = true)
+    public PagedResponse<AdminSupportTicketQueueRow> queue(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @RequestParam(required = false) SupportTicketStatus status,
+            @RequestParam(required = false) SupportTicketCategory category,
+            @RequestParam(required = false) String assignee,
+            @RequestParam(name = "last_author", required = false) SupportTicketAuthorRole lastAuthor,
+            @RequestParam(required = false) String q,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Page<SupportTicket> p = service.listAdmin(status, category, assignee, lastAuthor, q,
+                principal.userId(),
+                PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "lastMessageAt")));
+        return PagedResponse.from(p.map(t -> {
+            User admin = t.getAssignedAdminId() == null ? null :
+                    userRepo.findById(t.getAssignedAdminId()).orElse(null);
+            return mapper.toAdminRow(t, admin);
+        }));
+    }
+
+    @GetMapping("/queue-stats")
+    @Transactional(readOnly = true)
+    public SupportTicketQueueStatsDto stats() {
+        return service.queueStats();
+    }
+
+    @GetMapping("/{publicId}")
+    @Transactional(readOnly = true)
+    public SupportTicketDto detail(@PathVariable UUID publicId) {
+        SupportTicket t = service.findByPublicId(publicId);
+        User admin = t.getAssignedAdminId() == null ? null :
+                userRepo.findById(t.getAssignedAdminId()).orElse(null);
+        return mapper.toAdminDto(t, admin);
+    }
+
+    @PostMapping("/{publicId}/messages")
+    @Transactional
+    public SupportTicketMessageDto reply(@AuthenticationPrincipal AuthPrincipal principal,
+                                           @PathVariable UUID publicId,
+                                           @Valid @RequestBody AdminReplyRequest req) {
+        SupportTicketMessage msg = service.adminReply(principal.userId(), publicId, req);
+        return mapper.toMessageDto(msg);
+    }
+
+    @PostMapping("/{publicId}/resolve")
+    @Transactional
+    public SupportTicketDto resolve(@AuthenticationPrincipal AuthPrincipal principal,
+                                      @PathVariable UUID publicId) {
+        SupportTicket t = service.resolve(principal.userId(), publicId);
+        User admin = t.getAssignedAdminId() == null ? null :
+                userRepo.findById(t.getAssignedAdminId()).orElse(null);
+        return mapper.toAdminDto(t, admin);
+    }
+
+    @PostMapping("/{publicId}/reopen")
+    @Transactional
+    public SupportTicketDto reopen(@AuthenticationPrincipal AuthPrincipal principal,
+                                     @PathVariable UUID publicId) {
+        SupportTicket t = service.reopen(principal.userId(), publicId);
+        User admin = t.getAssignedAdminId() == null ? null :
+                userRepo.findById(t.getAssignedAdminId()).orElse(null);
+        return mapper.toAdminDto(t, admin);
+    }
+
+    @PostMapping("/{publicId}/assign")
+    @Transactional
+    public SupportTicketDto assign(@PathVariable UUID publicId,
+                                     @Valid @RequestBody AssignTicketRequest req) {
+        SupportTicket t = service.assign(publicId, req.adminPublicId());
+        User admin = t.getAssignedAdminId() == null ? null :
+                userRepo.findById(t.getAssignedAdminId()).orElse(null);
+        return mapper.toAdminDto(t, admin);
+    }
+
+    @PatchMapping("/{publicId}")
+    @Transactional
+    public SupportTicketDto patch(@PathVariable UUID publicId,
+                                    @Valid @RequestBody PatchTicketRequest req) {
+        SupportTicket t = service.patchCategory(publicId, req.category());
+        User admin = t.getAssignedAdminId() == null ? null :
+                userRepo.findById(t.getAssignedAdminId()).orElse(null);
+        return mapper.toAdminDto(t, admin);
+    }
+}
+```
+
+Add `findByPublicId(UUID)` helper to the service (delegates to repo + throws UNKNOWN_TICKET if missing).
+
+- [ ] **Step 2: Write integration tests + LazyInit regression**
+
+Mirror the pattern from `AdminCouponControllerIntegrationTest` (transactional) + `AdminCouponLazyInitRegressionTest` (non-transactional).
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd backend && ./mvnw test -Dtest='AdminSupportTicketControllerIntegrationTest,AdminSupportTicketLazyInitRegressionTest'
+```
+Expected: all green.
+
+- [ ] **Step 4: Commit + push**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/support/AdminSupportTicketController.java \
+        backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketService.java \
+        backend/src/test/java/com/slparcelauctions/backend/support/AdminSupportTicketControllerIntegrationTest.java \
+        backend/src/test/java/com/slparcelauctions/backend/support/AdminSupportTicketLazyInitRegressionTest.java
+git commit -m "feat(support): AdminSupportTicketController + LazyInit regression coverage"
+git push
+```
+
+---
+
+### Task 13: SupportTicketAttachmentController + config + S3 lifecycle docs
+
+**Files:**
+- Create: `backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketAttachmentController.java`
+- Modify: `backend/src/main/resources/application.yml`
+- Modify: `docs/superpowers/specs/2026-05-21-customer-support-contact-design.md` (append a deploy-notes section if not already present)
+- Test: `backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketAttachmentControllerIntegrationTest.java`
+
+- [ ] **Step 1: Add config keys to `application.yml`**
+
+Append under `slpa:`:
+
+```yaml
+  support:
+    rate-limit:
+      tickets-per-hour: 5
+    attachments:
+      max-per-message: 3
+      max-file-bytes: 5242880
+      allowed-mime-types: "image/png,image/jpeg,image/webp,image/gif"
+      pending-ttl-seconds: 3600
+```
+
+- [ ] **Step 2: Implement the controller**
+
+```java
+package com.slparcelauctions.backend.support;
+
+import java.util.UUID;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class SupportTicketAttachmentController {
+
+    private final SupportTicketAttachmentService attachmentService;
+    private final SupportTicketAttachmentRepository attachmentRepo;
+    private final SupportTicketRepository ticketRepo;
+    private final UserRepository userRepo;
+
+    @PostMapping(value = "/api/v1/me/support-tickets/attachments",
+                  consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public AttachmentKeyResponse preUpload(@AuthenticationPrincipal AuthPrincipal principal,
+                                             @RequestParam("file") MultipartFile file) {
+        User u = userRepo.findById(principal.userId()).orElseThrow();
+        String key = attachmentService.preUpload(u, file);
+        return new AttachmentKeyResponse(key);
+    }
+
+    @GetMapping("/api/v1/support-tickets/attachments/{publicId}")
+    @Transactional(readOnly = true)
+    public AttachmentSignedUrlResponse signedUrl(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @PathVariable UUID publicId) {
+        SupportTicketAttachment att = attachmentRepo.findByPublicId(publicId)
+                .orElseThrow(() -> new SupportTicketException(SupportTicketError.ATTACHMENT_NOT_FOUND));
+        // Authorization: owner of the ticket or any admin.
+        Long ticketUserId = att.getMessage().getTicket().getUser().getId();
+        User caller = userRepo.findById(principal.userId()).orElseThrow();
+        boolean isOwner = ticketUserId.equals(principal.userId());
+        boolean isAdmin = caller.getRole() == Role.ADMIN;
+        if (!isOwner && !isAdmin) {
+            throw new SupportTicketException(SupportTicketError.NOT_OWNER);
+        }
+        return new AttachmentSignedUrlResponse(attachmentService.signedDownloadUrl(att));
+    }
+
+    public record AttachmentKeyResponse(String attachmentKey) {}
+    public record AttachmentSignedUrlResponse(String url) {}
+}
+```
+
+- [ ] **Step 3: Integration tests**
+
+Cover: pre-upload happy path (POST multipart); rejects > 5 MiB (mock the validator); rejects MIME outside allowlist; GET signed URL for owner OK; GET signed URL for admin OK; GET signed URL for non-owner non-admin → 403.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd backend && ./mvnw test -Dtest=SupportTicketAttachmentControllerIntegrationTest
+```
+Expected: green.
+
+- [ ] **Step 5: Document the S3 lifecycle rule requirement**
+
+Edit `docs/superpowers/specs/2026-05-21-customer-support-contact-design.md` and append a "Deploy notes" section near the end (do NOT delete the decision log). Contents:
+
+```markdown
+## Deploy notes
+
+### S3 lifecycle rule
+
+The pending-attachment cleanup relies on an S3 bucket lifecycle rule that the backend does not create automatically. Configure once via Terraform (or AWS console for dev):
+
+- Rule name: `support-attachments-pending-cleanup`
+- Bucket: `slpa.storage.bucket`
+- Prefix filter: `support-attachments/pending/`
+- Action: Expire objects 1 day after creation
+- Status: Enabled
+
+Without this rule, orphaned pending uploads remain in S3 indefinitely (they are also not referenced by any DB row, so they don't appear in any application listing). The application-side Redis cache TTL expires the metadata after 1 hour, but the actual S3 objects are only cleaned by this lifecycle rule.
+```
+
+- [ ] **Step 6: Commit + push**
+
+```bash
+git add backend/src/main/java/com/slparcelauctions/backend/support/SupportTicketAttachmentController.java \
+        backend/src/main/resources/application.yml \
+        docs/superpowers/specs/2026-05-21-customer-support-contact-design.md \
+        backend/src/test/java/com/slparcelauctions/backend/support/SupportTicketAttachmentControllerIntegrationTest.java
+git commit -m "feat(support): attachment upload + signed-url endpoints + S3 lifecycle docs"
+git push
+```
+
+---
+
+### Task 14: Frontend Textarea UI primitive
+
+**Files:**
+- Create: `frontend/src/components/ui/Textarea.tsx`
+- Create: `frontend/src/components/ui/Textarea.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Textarea } from "./Textarea";
+
+describe("Textarea", () => {
+  it("renders with a label", () => {
+    render(<Textarea label="Message" />);
+    expect(screen.getByLabelText("Message")).toBeInTheDocument();
+  });
+
+  it("renders helperText when no error", () => {
+    render(<Textarea label="Message" helperText="Max 10000 chars" />);
+    expect(screen.getByText("Max 10000 chars")).toBeInTheDocument();
+  });
+
+  it("renders error text when error is set", () => {
+    render(<Textarea label="Message" error="Required" />);
+    expect(screen.getByText("Required")).toBeInTheDocument();
+  });
+
+  it("accepts user input via the rows prop", async () => {
+    const u = userEvent.setup();
+    render(<Textarea label="Message" rows={8} />);
+    const ta = screen.getByLabelText("Message") as HTMLTextAreaElement;
+    expect(ta.rows).toBe(8);
+    await u.type(ta, "Hello");
+    expect(ta.value).toBe("Hello");
+  });
+});
+```
+
+- [ ] **Step 2: Run, see failure (compile)**
+
+```bash
+cd frontend && npm test -- --run Textarea
+```
+Expected: fails because Textarea doesn't exist.
+
+- [ ] **Step 3: Implement the primitive**
+
+```tsx
+"use client";
+import { forwardRef, useId, type ReactNode, type TextareaHTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+
+type TextareaProps = {
+  label?: string;
+  helperText?: ReactNode;
+  error?: string;
+  fullWidth?: boolean;
+} & TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+const baseClasses =
+  "w-full rounded-lg bg-bg-subtle text-fg placeholder:text-fg-muted p-3 ring-1 ring-transparent transition-all focus:bg-surface-raised focus:outline-none focus:ring-brand resize-y";
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { label, helperText, error, fullWidth = true, className, id, rows = 6, ...rest },
+  ref,
+) {
+  const generatedId = useId();
+  const taId = id ?? generatedId;
+  const showError = Boolean(error);
+
+  return (
+    <div className={cn("flex flex-col gap-1", fullWidth && "w-full")}>
+      {label && (
+        <label htmlFor={taId} className="text-sm text-fg">
+          {label}
+        </label>
+      )}
+      <textarea
+        ref={ref}
+        id={taId}
+        rows={rows}
+        className={cn(
+          baseClasses,
+          showError && "ring-danger focus:ring-danger",
+          className,
+        )}
+        aria-invalid={showError || undefined}
+        {...rest}
+      />
+      {(helperText || error) && (
+        <p className={cn("text-xs", showError ? "text-danger" : "text-fg-muted")}>
+          {error ?? helperText}
+        </p>
+      )}
+    </div>
+  );
+});
+```
+
+- [ ] **Step 4: Run + verify guards**
+
+```bash
+cd frontend && npm test -- --run Textarea && npm run verify
+```
+Expected: 4/4 tests green; all four verify guards green.
+
+- [ ] **Step 5: Commit + push**
+
+```bash
+git add frontend/src/components/ui/Textarea.tsx frontend/src/components/ui/Textarea.test.tsx
+git commit -m "feat(ui): Textarea primitive"
+git push
+```
+
+---
+
+### Task 15: Frontend types + API client + hooks foundation
+
+**Files:**
+- Create: `frontend/src/types/support.ts`
+- Create: `frontend/src/lib/api/support.ts`
+- Create: `frontend/src/hooks/useMySupportTickets.ts`
+- Create: `frontend/src/hooks/useMySupportTicket.ts`
+- Create: `frontend/src/hooks/useCreateSupportTicket.ts`
+- Create: `frontend/src/hooks/useReplySupportTicket.ts`
+- Create: `frontend/src/hooks/useUploadSupportAttachment.ts`
+- Create: `frontend/src/hooks/useSignedAttachmentUrl.ts`
+
+- [ ] **Step 1: Write the types**
+
+```ts
+// frontend/src/types/support.ts
+export type SupportTicketStatus = "OPEN" | "RESOLVED";
+export type SupportTicketCategory =
+  | "ACCOUNT" | "BIDDING" | "LISTING" | "ESCROW" | "WALLET" | "OTHER";
+export type SupportTicketAuthorRole = "USER" | "ADMIN";
+
+export interface SupportTicketAttachmentDto {
+  publicId: string;
+  mimeType: string;
+  sizeBytes: number;
+  width: number | null;
+  height: number | null;
+}
+
+export interface SupportTicketMessageDto {
+  publicId: string;
+  authorPublicId: string;
+  authorDisplayName: string;
+  authorRole: SupportTicketAuthorRole;
+  body: string;
+  visibleToUser: boolean;
+  createdAt: string;
+  attachments: SupportTicketAttachmentDto[];
+}
+
+export interface SupportTicketDto {
+  publicId: string;
+  submitterPublicId: string;
+  submitterDisplayName: string;
+  subject: string;
+  category: SupportTicketCategory;
+  status: SupportTicketStatus;
+  assignedAdminPublicId: string | null;
+  assignedAdminDisplayName: string | null;
+  lastMessageAt: string;
+  lastMessageAuthor: SupportTicketAuthorRole;
+  resolvedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  messages: SupportTicketMessageDto[];
+}
+
+export interface SupportTicketSummaryDto {
+  publicId: string;
+  subject: string;
+  category: SupportTicketCategory;
+  status: SupportTicketStatus;
+  lastMessageAuthor: SupportTicketAuthorRole;
+  lastMessageAt: string;
+}
+
+export interface AdminSupportTicketQueueRow {
+  publicId: string;
+  subject: string;
+  category: SupportTicketCategory;
+  status: SupportTicketStatus;
+  submitterPublicId: string;
+  submitterDisplayName: string;
+  assignedAdminPublicId: string | null;
+  assignedAdminDisplayName: string | null;
+  lastMessageAuthor: SupportTicketAuthorRole;
+  lastMessageAt: string;
+}
+
+export interface SupportTicketQueueStatsDto {
+  openNeedingAdminReply: number;
+  openTotal: number;
+}
+
+export type SupportTicketErrorCode =
+  | "UNKNOWN_TICKET"
+  | "NOT_OWNER"
+  | "INTERNAL_NOTE_FROM_USER"
+  | "RATE_LIMITED"
+  | "INVALID_ATTACHMENT"
+  | "INVALID_CATEGORY"
+  | "ATTACHMENT_NOT_FOUND";
+
+export interface CreateSupportTicketRequest {
+  subject: string;
+  category: SupportTicketCategory;
+  body: string;
+  attachmentKeys?: string[];
+}
+
+export interface ReplySupportTicketRequest {
+  body: string;
+  attachmentKeys?: string[];
+}
+
+export interface AdminReplyRequest {
+  body: string;
+  attachmentKeys?: string[];
+  internalNote?: boolean;
+}
+```
+
+- [ ] **Step 2: Write the API client**
+
+```ts
+// frontend/src/lib/api/support.ts
+import { api } from "@/lib/api";
+import type { Page } from "@/types/page";
+import type {
+  AdminReplyRequest,
+  AdminSupportTicketQueueRow,
+  CreateSupportTicketRequest,
+  ReplySupportTicketRequest,
+  SupportTicketCategory,
+  SupportTicketDto,
+  SupportTicketMessageDto,
+  SupportTicketQueueStatsDto,
+  SupportTicketStatus,
+  SupportTicketSummaryDto,
+} from "@/types/support";
+
+export interface MyListParams {
+  status?: SupportTicketStatus;
+  q?: string;
+  page?: number;
+  size?: number;
+}
+
+export function fetchMySupportTickets(params: MyListParams = {}) {
+  return api.get<Page<SupportTicketSummaryDto>>("/api/v1/me/support-tickets", { params });
+}
+
+export function fetchMySupportTicket(publicId: string) {
+  return api.get<SupportTicketDto>(`/api/v1/me/support-tickets/${publicId}`);
+}
+
+export function createSupportTicket(req: CreateSupportTicketRequest) {
+  return api.post<SupportTicketDto>("/api/v1/me/support-tickets", req);
+}
+
+export function replySupportTicket(publicId: string, req: ReplySupportTicketRequest) {
+  return api.post<SupportTicketMessageDto>(`/api/v1/me/support-tickets/${publicId}/messages`, req);
+}
+
+export function uploadSupportAttachment(file: File): Promise<{ attachmentKey: string }> {
+  const fd = new FormData();
+  fd.append("file", file);
+  return api.postMultipart("/api/v1/me/support-tickets/attachments", fd);
+}
+
+export function fetchAttachmentSignedUrl(publicId: string) {
+  return api.get<{ url: string }>(`/api/v1/support-tickets/attachments/${publicId}`);
+}
+
+// Admin
+export interface AdminListParams {
+  status?: SupportTicketStatus;
+  category?: SupportTicketCategory;
+  assignee?: string;
+  last_author?: "USER" | "ADMIN";
+  q?: string;
+  page?: number;
+  size?: number;
+}
+
+export function fetchAdminSupportTickets(params: AdminListParams = {}) {
+  return api.get<Page<AdminSupportTicketQueueRow>>("/api/v1/admin/support-tickets", { params });
+}
+
+export function fetchAdminSupportTicket(publicId: string) {
+  return api.get<SupportTicketDto>(`/api/v1/admin/support-tickets/${publicId}`);
+}
+
+export function fetchAdminSupportQueueStats() {
+  return api.get<SupportTicketQueueStatsDto>("/api/v1/admin/support-tickets/queue-stats");
+}
+
+export function adminReplySupportTicket(publicId: string, req: AdminReplyRequest) {
+  return api.post<SupportTicketMessageDto>(`/api/v1/admin/support-tickets/${publicId}/messages`, req);
+}
+
+export function adminResolveSupportTicket(publicId: string) {
+  return api.post<SupportTicketDto>(`/api/v1/admin/support-tickets/${publicId}/resolve`, {});
+}
+
+export function adminReopenSupportTicket(publicId: string) {
+  return api.post<SupportTicketDto>(`/api/v1/admin/support-tickets/${publicId}/reopen`, {});
+}
+
+export function adminAssignSupportTicket(publicId: string, adminPublicId: string | null) {
+  return api.post<SupportTicketDto>(`/api/v1/admin/support-tickets/${publicId}/assign`, { adminPublicId });
+}
+
+export function adminPatchSupportTicket(publicId: string, category: SupportTicketCategory) {
+  return api.patch<SupportTicketDto>(`/api/v1/admin/support-tickets/${publicId}`, { category });
+}
+```
+
+If `api.postMultipart` doesn't exist on the API client, add it (mirroring `api.post` but skipping the JSON header — let the browser set the multipart boundary).
+
+- [ ] **Step 3: Hooks**
+
+Standard react-query hooks. Hook patterns mirror `useMyCoupons` / `useRedeemCoupon` etc. exactly. Each mutation invalidates the relevant query keys on success.
+
+- [ ] **Step 4: Lint + verify**
+
+```bash
+cd frontend && npm run verify
+```
+
+- [ ] **Step 5: Commit + push**
+
+```bash
+git add frontend/src/types/support.ts frontend/src/lib/api/support.ts frontend/src/hooks/useMySupportTickets.ts frontend/src/hooks/useMySupportTicket.ts frontend/src/hooks/useCreateSupportTicket.ts frontend/src/hooks/useReplySupportTicket.ts frontend/src/hooks/useUploadSupportAttachment.ts frontend/src/hooks/useSignedAttachmentUrl.ts frontend/src/lib/api.ts
+git commit -m "feat(support): frontend types + API client + react-query hooks"
+git push
+```
+
+---
+
+### Task 16: SupportTicketList page
+
+**Files:**
+- Create: `frontend/src/app/support/page.tsx`
+- Create: `frontend/src/components/support/SupportTicketList.tsx`
+- Create: `frontend/src/components/support/SupportTicketList.test.tsx`
+
+- [ ] **Step 1: Server-component shell**
+
+```tsx
+// frontend/src/app/support/page.tsx
+import { SupportTicketList } from "@/components/support/SupportTicketList";
+
+export const dynamic = "force-dynamic";
+
+export default function SupportPage() {
+  return <SupportTicketList />;
+}
+```
+
+- [ ] **Step 2: Client list component**
+
+Mirror `WalletCouponsCard` / coupon list patterns. Columns per spec §7. Empty state + "New ticket" button linking to `/support/new`.
+
+- [ ] **Step 3: Tests**
+
+Empty state, table rendering, status pill + "admin replied" sub-label when `lastMessageAuthor=ADMIN`, pagination, status-filter URL sync.
+
+- [ ] **Step 4: Run tests + verify**
+
+```bash
+cd frontend && npm test -- --run SupportTicketList && npm run verify
+```
+
+- [ ] **Step 5: Commit + push**
+
+```bash
+git add frontend/src/app/support/page.tsx frontend/src/components/support/SupportTicketList.tsx frontend/src/components/support/SupportTicketList.test.tsx
+git commit -m "feat(support): /support list page"
+git push
+```
+
+---
+
+### Task 17: NewSupportTicketForm page
+
+**Files:**
+- Create: `frontend/src/app/support/new/page.tsx`
+- Create: `frontend/src/components/support/NewSupportTicketForm.tsx`
+- Create: `frontend/src/components/support/NewSupportTicketForm.test.tsx`
+- Create: `frontend/src/components/support/SupportAttachmentDropzone.tsx`
+
+- [ ] **Step 1: Implement the dropzone (reusable across user + admin reply paths)**
+
+`SupportAttachmentDropzone` accepts `onAttachmentKeyAdded(key: string)` and `onAttachmentKeyRemoved(key: string)`. Renders up to N image thumbnails (from local object URLs of the pending uploads) plus a "drop or click to add" zone. Calls `useUploadSupportAttachment()` on file selection; surfaces upload errors inline (e.g. "file too large", "mime not allowed").
+
+- [ ] **Step 2: Implement the form**
+
+Subject input (max 160), Category select (six options), Message Textarea (max 10000 + char counter), Attachments (`SupportAttachmentDropzone` with `maxAttachments={3}`). Submit calls `useCreateSupportTicket()`. On success, redirect to `/support/{newPublicId}`. On rate-limit (429), show the specific message.
+
+- [ ] **Step 3: Tests**
+
+Subject required, Category required, Body required, body char counter increments, dropzone respects max-3, submit happy path navigates to detail, rate-limit error renders the message.
+
+- [ ] **Step 4: Run tests + verify**
+
+```bash
+cd frontend && npm test -- --run NewSupportTicketForm SupportAttachmentDropzone && npm run verify
+```
+
+- [ ] **Step 5: Commit + push**
+
+```bash
+git add frontend/src/app/support/new/ frontend/src/components/support/NewSupportTicketForm.tsx frontend/src/components/support/NewSupportTicketForm.test.tsx frontend/src/components/support/SupportAttachmentDropzone.tsx
+git commit -m "feat(support): /support/new form + attachment dropzone"
+git push
+```
+
+---
+
+### Task 18: SupportTicketThread page
+
+**Files:**
+- Create: `frontend/src/app/support/[publicId]/page.tsx`
+- Create: `frontend/src/components/support/SupportTicketThread.tsx`
+- Create: `frontend/src/components/support/SupportTicketThread.test.tsx`
+
+- [ ] **Step 1: Implement the thread**
+
+Header: subject, category badge, status pill. Message list with alternating bubbles (user right, admin left); each shows authorname + role + timestamp + body + attachment thumbnails. Attachment click → lightbox (existing primitive if available; otherwise a simple modal with the signed URL). Composer at bottom: Textarea + dropzone + Send. When `status=RESOLVED`, show helper text "Replying will reopen this ticket."
+
+Next.js 16 async-params pattern:
+
+```tsx
+export default async function SupportTicketDetailPage({
+  params,
+}: {
+  params: Promise<{ publicId: string }>;
+}) {
+  const { publicId } = await params;
+  return <SupportTicketThread publicId={publicId} />;
+}
+```
+
+- [ ] **Step 2: Tests**
+
+Bubble alternation, lightbox-on-thumbnail-click, helper text appears when status=RESOLVED, internal notes never appear in user view (defense in depth — backend already filters), reply submit invalidates the detail query.
+
+- [ ] **Step 3: Run + verify**
+
+```bash
+cd frontend && npm test -- --run SupportTicketThread && npm run verify
+```
+
+- [ ] **Step 4: Commit + push**
+
+```bash
+git add 'frontend/src/app/support/[publicId]/' frontend/src/components/support/SupportTicketThread.tsx frontend/src/components/support/SupportTicketThread.test.tsx
+git commit -m "feat(support): /support/[publicId] thread view"
+git push
+```
+
+---
+
+### Task 19: User nav wiring — dropdown + mobile menu
+
+**Files:**
+- Modify: `frontend/src/components/layout/UserMenuDropdown.tsx`
+- Modify: `frontend/src/components/layout/MobileMenu.tsx`
+
+- [ ] **Step 1: Add "Support" to `UserMenuDropdown`**
+
+Between "Wallet" and "Sign out". Link target: `/support`.
+
+- [ ] **Step 2: Add "Support" to `MobileMenu`'s footer row**
+
+Same row as Contact / About / Terms.
+
+- [ ] **Step 3: Run tests + verify**
+
+```bash
+cd frontend && npm test -- --run UserMenuDropdown MobileMenu && npm run verify
+```
+
+- [ ] **Step 4: Commit + push**
+
+```bash
+git add frontend/src/components/layout/UserMenuDropdown.tsx frontend/src/components/layout/MobileMenu.tsx
+git commit -m "feat(support): Help link in user dropdown + mobile menu"
+git push
+```
+
+---
+
+### Task 20: Admin queue + sidebar badge
+
+**Files:**
+- Create: `frontend/src/app/admin/support/page.tsx`
+- Create: `frontend/src/components/admin/support/AdminSupportTicketQueue.tsx`
+- Create: `frontend/src/components/admin/support/AdminSupportTicketQueue.test.tsx`
+- Create: `frontend/src/hooks/admin/useAdminSupportTickets.ts`
+- Create: `frontend/src/hooks/admin/useAdminSupportQueueStats.ts`
+- Modify: `frontend/src/components/admin/AdminShell.tsx`
+
+- [ ] **Step 1: Implement the polling stats hook**
+
+```ts
+import { useQuery } from "@tanstack/react-query";
+import { fetchAdminSupportQueueStats } from "@/lib/api/support";
+
+export const ADMIN_SUPPORT_STATS_KEY = ["admin-support-stats"] as const;
+
+export function useAdminSupportQueueStats(enabled = true) {
+  return useQuery({
+    queryKey: ADMIN_SUPPORT_STATS_KEY,
+    queryFn: fetchAdminSupportQueueStats,
+    refetchInterval: 30_000,
+    enabled,
+  });
+}
+```
+
+- [ ] **Step 2: Add the "Support" sidebar item with badge**
+
+In `AdminShell.tsx`, after the "Reports" item, before "Users":
+
+```ts
+{ label: "Support", href: "/admin/support", badge: supportStats?.openNeedingAdminReply },
+```
+
+Source `supportStats` via the new hook at the top of `AdminShell`.
+
+- [ ] **Step 3: Implement the queue component**
+
+Mirrors `AdminCouponList` shape. Filters: status, category, assignee (Mine / Unassigned / All), last_author (Needs admin reply / Waiting on user / All), subject q. URL-synced. Table columns per spec §7.
+
+- [ ] **Step 4: Tests**
+
+URL-synced filters, pagination, "needs admin reply" filter narrows the table, sidebar badge counter rendering.
+
+- [ ] **Step 5: Run + verify**
+
+```bash
+cd frontend && npm test -- --run AdminSupportTicketQueue AdminShell && npm run verify
+```
+
+- [ ] **Step 6: Commit + push**
+
+```bash
+git add frontend/src/app/admin/support/page.tsx frontend/src/components/admin/support/AdminSupportTicketQueue.tsx frontend/src/components/admin/support/AdminSupportTicketQueue.test.tsx frontend/src/hooks/admin/useAdminSupportTickets.ts frontend/src/hooks/admin/useAdminSupportQueueStats.ts frontend/src/components/admin/AdminShell.tsx
+git commit -m "feat(admin-ui): support queue + sidebar badge with polling stats"
+git push
+```
+
+---
+
+### Task 21: Admin detail page (resolve / reopen / assign / internal-note)
+
+**Files:**
+- Create: `frontend/src/app/admin/support/[publicId]/page.tsx`
+- Create: `frontend/src/components/admin/support/AdminSupportTicketDetail.tsx`
+- Create: `frontend/src/components/admin/support/AdminSupportTicketDetail.test.tsx`
+- Create: `frontend/src/hooks/admin/useAdminSupportTicket.ts`
+- Create: `frontend/src/hooks/admin/useAdminSupportReply.ts`
+- Create: `frontend/src/hooks/admin/useAdminSupportResolve.ts`
+- Create: `frontend/src/hooks/admin/useAdminSupportReopen.ts`
+- Create: `frontend/src/hooks/admin/useAdminSupportAssign.ts`
+- Create: `frontend/src/hooks/admin/useAdminSupportPatchCategory.ts`
+
+- [ ] **Step 1: Page wrapper**
+
+```tsx
+import { AdminSupportTicketDetail } from "@/components/admin/support/AdminSupportTicketDetail";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminSupportTicketDetailPage({
+  params,
+}: {
+  params: Promise<{ publicId: string }>;
+}) {
+  const { publicId } = await params;
+  return <AdminSupportTicketDetail publicId={publicId} />;
+}
+```
+
+- [ ] **Step 2: Implement the detail component**
+
+Top bar: Resolve / Reopen button (mutex on status), "Assign to me" / "Unassign" buttons, Category dropdown. Thread renders ALL messages including internal notes (styled with `border-warning bg-warning-bg/20` plus "Internal note" badge). Composer with "Send" button + "Save as internal note" checkbox; when checked, the bubble preview switches to internal-note styling so the admin sees what they're about to send.
+
+- [ ] **Step 3: Tests**
+
+Resolve button transitions status, reopen visible only when resolved, internal-note checkbox toggles preview style, assign-to-me happy path, category patch happy path.
+
+- [ ] **Step 4: Run + verify**
+
+```bash
+cd frontend && npm test -- --run AdminSupportTicketDetail && npm run verify
+```
+
+- [ ] **Step 5: Commit + push**
+
+```bash
+git add 'frontend/src/app/admin/support/[publicId]/' frontend/src/components/admin/support/AdminSupportTicketDetail.tsx frontend/src/components/admin/support/AdminSupportTicketDetail.test.tsx frontend/src/hooks/admin/useAdminSupportTicket.ts frontend/src/hooks/admin/useAdminSupportReply.ts frontend/src/hooks/admin/useAdminSupportResolve.ts frontend/src/hooks/admin/useAdminSupportReopen.ts frontend/src/hooks/admin/useAdminSupportAssign.ts frontend/src/hooks/admin/useAdminSupportPatchCategory.ts
+git commit -m "feat(admin-ui): support ticket detail with resolve / reopen / assign / internal-note"
+git push
+```
+
+---
+
+### Task 22: Notification feed renderer + bell deep-links for support categories
+
+**Files:**
+- Modify: `frontend/src/components/notifications/NotificationFeed.tsx` (or wherever the category-icon + deep-link mapping lives)
+- Modify: `frontend/src/types/notifications.ts` (or equivalent)
+
+- [ ] **Step 1: Add the four new categories to the typescript discriminator**
+
+Add `"SUPPORT_TICKET_ADMIN_REPLIED" | "SUPPORT_TICKET_RESOLVED" | "SUPPORT_TICKET_OPENED" | "SUPPORT_TICKET_USER_REPLIED"` to the category-type union.
+
+- [ ] **Step 2: Add icon + deep-link mapping**
+
+In whichever component maps category to icon + render-body + deep-link, add the four entries:
+
+```ts
+case "SUPPORT_TICKET_ADMIN_REPLIED":
+case "SUPPORT_TICKET_RESOLVED":
+  return { icon: MessageSquare, href: `/support/${data.ticketPublicId}` };
+case "SUPPORT_TICKET_OPENED":
+case "SUPPORT_TICKET_USER_REPLIED":
+  return { icon: MessageSquare, href: `/admin/support/${data.ticketPublicId}` };
+```
+
+(Confirm `MessageSquare` is exported from `@/components/ui/icons`; if not, add it.)
+
+- [ ] **Step 3: Test the renderer**
+
+A test that pushes each of the four notification categories through the renderer and asserts the deep-link target is correct.
+
+- [ ] **Step 4: Run + verify**
+
+```bash
+cd frontend && npm test && npm run verify
+```
+
+- [ ] **Step 5: Commit + push**
+
+```bash
+git add frontend/src/components/notifications/ frontend/src/types/
+git commit -m "feat(notify-ui): support ticket deep-links + MessageSquare icon"
+git push
+```
+
+---
+
+### Task 23: Postman + smoke + README + DEFERRED_WORK + PR
+
+**Files:**
+- Update: SLPA Postman collection (cloud)
+- Modify: `README.md`
+- Modify: `docs/implementation/DEFERRED_WORK.md` (only if anything was deferred — should be empty)
+
+- [ ] **Step 1: Postman mirror**
+
+Add a "Support tickets" folder. Requests:
+
+1. POST `/me/support-tickets/attachments` (multipart; capture `attachmentKey`)
+2. POST `/me/support-tickets` body uses `{{attachmentKey}}`; capture `supportTicketPublicId` + the initial message's `supportTicketMessagePublicId`
+3. GET `/me/support-tickets?status=OPEN`
+4. GET `/me/support-tickets/{{supportTicketPublicId}}`
+5. POST `/me/support-tickets/{{supportTicketPublicId}}/messages`
+6. GET `/admin/support-tickets?last_author=USER`
+7. GET `/admin/support-tickets/queue-stats`
+8. GET `/admin/support-tickets/{{supportTicketPublicId}}`
+9. POST `/admin/support-tickets/{{supportTicketPublicId}}/messages` (with `internalNote: false`)
+10. POST `/admin/support-tickets/{{supportTicketPublicId}}/messages` (with `internalNote: true`) — note the user-side detail call should NOT show this message
+11. POST `/admin/support-tickets/{{supportTicketPublicId}}/resolve`
+12. POST `/admin/support-tickets/{{supportTicketPublicId}}/reopen`
+13. POST `/admin/support-tickets/{{supportTicketPublicId}}/assign` body `{ "adminPublicId": "{{adminPublicId}}" }`
+14. PATCH `/admin/support-tickets/{{supportTicketPublicId}}` body `{ "category": "ESCROW" }`
+15. GET `/support-tickets/attachments/{{supportTicketAttachmentPublicId}}`
+
+Each gets a `pm.test()` script asserting the right HTTP status and (where applicable) capturing chained variables.
+
+- [ ] **Step 2: README sweep**
+
+Add a `### Customer support` section near the existing feature blocks (e.g. after the coupon-codes block). Bullet list of what shipped (user dropdown entry, /support list/new/thread, admin queue with badge, internal notes, attachments, four notification categories).
+
+- [ ] **Step 3: DEFERRED_WORK check**
+
+Confirm spec §11 (Out of scope) items don't need entries — they are strategic decisions, not tactical deferrals. Scan implementation for any TODO / FIXME markers; should be none. If any are found, add them to DEFERRED_WORK.md with a description, owning task, why deferred, and what would unblock.
+
+- [ ] **Step 4: Run full test suites**
+
+```bash
+cd backend && ./mvnw test
+cd frontend && npm test
+cd frontend && npm run verify
+```
+
+All green required.
+
+- [ ] **Step 5: Local dev smoke** (Docker compose required)
+
+```bash
+docker compose restart backend frontend
+# Browser:
+# 1. Log in as a regular verified user
+# 2. Open user dropdown -> click Support -> see empty list
+# 3. Click "New ticket" -> fill subject "Test" + category WALLET + body "test message"
+# 4. Drop a small PNG, submit
+# 5. Redirected to /support/{newId} -> verify message + attachment rendered
+# 6. Log in as admin (different browser profile)
+# 7. See "Support" sidebar badge count = 1
+# 8. Open queue with default filters
+# 9. Click into the ticket -> reply with internal note checked
+# 10. Reply again without the checkbox
+# 11. Mark resolved
+# 12. Switch back to regular user -> notification feed shows reply + resolved entries
+# 13. Reply on the resolved ticket -> auto-reopens; admin sees badge=1 again
+```
+
+- [ ] **Step 6: Commit + push**
+
+```bash
+git add README.md docs/implementation/DEFERRED_WORK.md
+git commit -m "docs: README + DEFERRED_WORK sweep for support system"
+git push
+```
+
+- [ ] **Step 7: Open PR into dev**
+
+```bash
+gh pr create --base dev --head feat/customer-support-contact \
+  --title "feat(support): customer support contact (#167)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Implements customer support per docs/superpowers/specs/2026-05-21-customer-support-contact-design.md (closes #167)
+- New tables support_tickets / support_ticket_messages / support_ticket_attachments (Flyway V42)
+- Backend: new support package with entities, repos, service, rate limiter, two controllers (Me + Admin), attachment controller, exception handler
+- Frontend: new Textarea UI primitive; /support list/new/thread; /admin/support queue + detail; user dropdown entry; admin sidebar badge with polling
+- Four new notification categories with in-app + (user-side only) SL IM channels
+- Image attachments up to 3 per message; pending state via Redis + S3 lifecycle rule
+- Per-user rate limit: 5 new tickets/hour, replies uncapped
+
+## LazyInit defense
+Every controller method that returns a mapper-derived DTO is @Transactional; single-row repo finders use @EntityGraph; each controller surface has a non-@Transactional regression test class (lesson from PR #388).
+
+## Test plan
+- [x] backend ./mvnw test full suite green
+- [x] frontend npm test full suite green
+- [x] frontend npm run verify green
+- [ ] Manual smoke (post-deploy): user creates ticket -> admin sees badge -> admin internal note (invisible to user) -> admin public reply -> user sees notification + SL IM
+- [ ] Post-deploy: configure the S3 lifecycle rule per spec deploy notes (support-attachments/pending/ -> 1-day expire)
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+**Spec coverage check:**
+- §1 Goal — PR description covers
+- §2 Data model — Task 1
+- §3 Apply / lifecycle logic — Tasks 8 (create + reply + auto-reopen) and 9 (resolve / reopen / assign / patch)
+- §4 Attachments — Task 7 (service) + Task 13 (controller)
+- §5 Backend endpoints — Tasks 11 (Me) + 12 (Admin) + 13 (attachments)
+- §6 Notifications — Task 5
+- §7 Frontend UI — Tasks 14-21
+- §8 Migration plan — Task 1
+- §9 Configuration — Task 13
+- §10 Testing — distributed across every backend / frontend task
+- §11 Out of scope — Task 23 confirms nothing was silently deferred
+- §12 Decision log — context only
+
+**Placeholder scan:** No `TBD` / `TODO` / `implement later`. Every code step has the actual code or a tight description with file:line. Two places hand off implementation detail to "mirror the existing X" patterns (the dropzone hook + the lightbox primitive); both reference an existing file the implementer can read.
+
+**Type consistency:**
+- `SupportTicketAuthorRole` enum used identically across entities, DTOs, TS types, and notification builders.
+- `attachmentKeys: string[]` shape matches between `CreateSupportTicketRequest`, `ReplySupportTicketRequest`, `AdminReplyRequest`.
+- `SupportTicketDto.messages: List<SupportTicketMessageDto>` — same shape in TS types.
+- `SupportTicketMapper.toUserDto` filters `visibleToUser=true`; `toAdminDto` shows all. Used correctly by `MeSupportTicketController.detail` vs `AdminSupportTicketController.detail`.
+- `SupportTicketQueueStatsDto` shape matches frontend `useAdminSupportQueueStats` consumer.
+
+**Resolved during plan-writing:**
+- The migration is V42 (V41 = coupon codes is latest on disk). Plan header documents this.
+- `ImageUploadValidator.validate(MultipartFile)`'s actual return type is consumed by the attachment service; implementer must adapt if shape differs from the assumed `{width, height}` record (called out in Task 7 Step 1).
+- `MessageSquare` icon assumed exported from `@/components/ui/icons`; Task 22 calls out the check.

--- a/docs/superpowers/specs/2026-05-21-customer-support-contact-design.md
+++ b/docs/superpowers/specs/2026-05-21-customer-support-contact-design.md
@@ -455,3 +455,19 @@ Captured during brainstorming (2026-05-21):
 - **Image attachments up to 3 per message** (Q9 = B). Rejected text-only (rare but real "show me the screenshot" need) and any-MIME (security risk for executables).
 - **Per-user rate limit, 5 new tickets/hour, replies uncapped** (Q10 = A). Rejected per-IP (shared NAT false positives) and no-limit (trust-without-verify).
 - **Optional assignment** (Q11 = B). Rejected shared-only (no coordination signal when team grows) and required-assignment (overhead while team is one admin).
+
+## 13. Deploy notes
+
+### S3 lifecycle rule
+
+The pending-attachment cleanup relies on an S3 bucket lifecycle rule that the backend does not create automatically. Configure once via Terraform (or AWS console for dev):
+
+- Rule name: `support-attachments-pending-cleanup`
+- Bucket: `slpa.storage.bucket` (production: `slpa-prod-uploads`)
+- Prefix filter: `support-attachments/pending/`
+- Action: Expire current versions of objects 1 day after creation
+- Status: Enabled
+
+Without this rule, orphaned pending uploads remain in S3 indefinitely (they are also not referenced by any DB row, so they don't appear in any application listing). The application-side Redis cache TTL expires the metadata after 1 hour, but the actual S3 objects are only cleaned by this lifecycle rule.
+
+Promoted attachments live under `support-attachments/{messageId}/{attachmentKey}.{ext}` (NOT under `pending/`) and are NOT subject to the lifecycle rule. They persist for the life of the ticket.

--- a/docs/superpowers/specs/2026-05-21-customer-support-contact-design.md
+++ b/docs/superpowers/specs/2026-05-21-customer-support-contact-design.md
@@ -1,0 +1,457 @@
+# Customer Support Contact
+
+**Date:** 2026-05-21
+**Issue:** [#167](https://github.com/TheCodeLlama/slparcelauctions/issues/167)
+**Status:** Awaiting user review.
+
+## 1. Goal
+
+A user-facing contact channel for support requests, fully on-platform: logged-in users open a ticket from the header dropdown, admins triage from a queue mirroring the existing dispute / fraud-flag admin surfaces, and the back-and-forth conversation happens as a thread in the SLParcels site itself. Notifications keep both sides aware without email — in-app feed entries plus SL IM for the user side.
+
+The feature exists because today there is no on-platform way for a user to reach the platform owner with an account / bidding / escrow problem. The unstated fallback ("IM SLPABot1 in-world or DM the operator on Discord") is fine for outliers but is invisible to most users and lossy as a paper trail. This builds the missing primary channel.
+
+## 2. Data model
+
+Three new tables in a new `support` package.
+
+### `support_tickets`
+
+```
+id                       BIGSERIAL PRIMARY KEY
+public_id                UUID NOT NULL UNIQUE
+user_id                  BIGINT NOT NULL REFERENCES users(id)
+subject                  VARCHAR(160) NOT NULL
+category                 VARCHAR(32) NOT NULL          -- ACCOUNT | BIDDING | LISTING | ESCROW | WALLET | OTHER
+status                   VARCHAR(16) NOT NULL DEFAULT 'OPEN'  -- OPEN | RESOLVED
+assigned_admin_id        BIGINT REFERENCES users(id)   -- nullable
+last_message_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+last_message_author      VARCHAR(16) NOT NULL          -- USER | ADMIN
+resolved_at              TIMESTAMPTZ                   -- nullable; set on resolve, cleared on reopen
+-- BaseMutableEntity columns: created_at, updated_at, version
+```
+
+Constraints:
+- `CHECK (status IN ('OPEN','RESOLVED'))`
+- `CHECK (category IN ('ACCOUNT','BIDDING','LISTING','ESCROW','WALLET','OTHER'))`
+- `CHECK (last_message_author IN ('USER','ADMIN'))`
+
+Indexes:
+- `(user_id, status)` — "my tickets" list
+- `(status, last_message_author, last_message_at DESC) WHERE status = 'OPEN'` — admin queue hot path; the partial-index `WHERE` clause shrinks the index to only currently-open rows
+- `(assigned_admin_id) WHERE assigned_admin_id IS NOT NULL` — "Mine" filter
+
+State model rationale: only two persisted states; the "needs admin attention" admin-queue filter is derived from `last_message_author = 'USER' AND status = 'OPEN'`. No `AWAITING_USER` or `AWAITING_ADMIN` columns — drift between such columns and reality is the failure mode they introduce.
+
+### `support_ticket_messages`
+
+```
+id                BIGSERIAL PRIMARY KEY
+public_id         UUID NOT NULL UNIQUE
+ticket_id         BIGINT NOT NULL REFERENCES support_tickets(id) ON DELETE CASCADE
+author_user_id    BIGINT NOT NULL REFERENCES users(id)
+author_role       VARCHAR(16) NOT NULL                  -- USER | ADMIN (snapshot at write time)
+body              TEXT NOT NULL                          -- 1..10000 chars (app-level)
+visible_to_user   BOOLEAN NOT NULL DEFAULT TRUE          -- false = admin internal note
+-- BaseMutableEntity columns: created_at, updated_at, version
+```
+
+Constraints:
+- `CHECK (author_role IN ('USER','ADMIN'))`
+- App layer enforces `LENGTH(body) BETWEEN 1 AND 10000` (no DB CHECK because TEXT max is unbounded; bean validation `@Size(min=1,max=10000)` plus an explicit service guard).
+
+Indexes:
+- `(ticket_id, created_at)` — thread render path
+
+`author_role` is snapshotted at write time so promotion / demotion later doesn't rewrite historical authorship. Internal notes (`visible_to_user = false`) are an admin-only scratch surface and are filtered out of every user-facing query.
+
+### `support_ticket_attachments`
+
+```
+id            BIGSERIAL PRIMARY KEY
+public_id     UUID NOT NULL UNIQUE
+message_id    BIGINT NOT NULL REFERENCES support_ticket_messages(id) ON DELETE CASCADE
+storage_key   VARCHAR(255) NOT NULL                     -- S3 object key
+mime_type     VARCHAR(64) NOT NULL
+size_bytes    INTEGER NOT NULL
+width         INTEGER
+height        INTEGER
+created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+```
+
+Indexes:
+- `(message_id)`
+
+Storage key convention: `support-attachments/{userPublicId}/{uuid}.{ext}` inside the existing `slpa.storage.bucket` (same bucket as dispute evidence and listing photos). `width` / `height` are post-validation snapshots from `ImageUploadValidator` so the frontend can size thumbnails without re-reading the file.
+
+## 3. Apply / lifecycle logic
+
+### Create ticket (user, authed)
+
+`POST /api/v1/me/support-tickets`:
+
+1. Rate limiter (`SupportTicketRateLimiter`, keyed on `userId`) checks the user has < 5 new tickets created in the last 60 minutes. If over → 429 `ProblemDetail` with `code = RATE_LIMITED`. Replies on existing tickets are NOT counted toward this cap.
+2. Validate `subject` (1-160 chars), `category` (one of the six enum values), `body` (1-10000 chars).
+3. Validate `attachmentKeys[]` (0-3 entries), each must resolve to a temp upload that belongs to this user (see §3 Attachments).
+4. In a single `@Transactional`:
+   - Insert `support_tickets` row with `status = OPEN`, `last_message_author = USER`, `last_message_at = now`, `assigned_admin_id = null`.
+   - Insert the initial `support_ticket_messages` row with `author_role = USER`, `visible_to_user = true`.
+   - Promote the temp attachment uploads into `support_ticket_attachments` rows referencing the new message id.
+5. Fire `supportTicketOpened(...)` notification fan-out → in-app feed entry to every admin user (no SL IM to admins).
+6. Return 200 + `SupportTicketDto`.
+
+### Reply (user OR admin)
+
+Two endpoints, slightly different rules:
+
+- `POST /api/v1/me/support-tickets/{publicId}/messages` — user reply
+- `POST /api/v1/admin/support-tickets/{publicId}/messages` — admin reply
+
+Shared body shape: `{ body, attachmentKeys?: string[], internalNote?: boolean }`. `internalNote` is admin-only — when set true by an admin, the message persists with `visible_to_user = false`. When a user request includes `internalNote = true`, reject with 400 `INTERNAL_NOTE_FROM_USER`.
+
+Algorithm:
+1. Lookup ticket by public id. User path: must own it (else 404 `UNKNOWN_TICKET`). Admin path: must exist.
+2. Validate body (1-10000) and attachments.
+3. Insert `support_ticket_messages` row with `author_role = USER` or `ADMIN` per path, `visible_to_user` set from the request (default true; user requests are ALWAYS true).
+4. Insert attachment rows.
+5. Update parent ticket:
+   - `last_message_at = now`
+   - `last_message_author = USER | ADMIN` per path
+   - **If status was `RESOLVED` AND the author is the user** → flip status to `OPEN`, clear `resolved_at`. This is the auto-reopen path.
+6. Fire notifications based on author + visibility:
+   - User reply (always public) → `supportTicketUserReplied(...)` fan-out to all admins.
+   - Admin reply with `visible_to_user = true` → `supportTicketAdminReplied(...)` to the ticket owner.
+   - Admin reply with `visible_to_user = false` (internal note) → NO notifications. Internal notes are silent.
+7. Return 200 + `SupportTicketMessageDto`.
+
+### Mark resolved (admin)
+
+`POST /api/v1/admin/support-tickets/{publicId}/resolve`:
+
+1. Look up ticket (must exist).
+2. If already `RESOLVED` → return current state, no-op. Idempotent.
+3. Set `status = RESOLVED`, `resolved_at = now`.
+4. Insert a synthetic system message: `author_user_id = acting admin id`, `author_role = ADMIN`, `visible_to_user = true`, `body = "Marked resolved by admin"`. The user sees the resolution in the thread without confusion.
+5. Update `last_message_at = now`, `last_message_author = ADMIN`.
+6. Fire `supportTicketResolved(...)` notification → ticket owner (in-app + SL IM).
+
+### Reopen (admin manual)
+
+`POST /api/v1/admin/support-tickets/{publicId}/reopen`:
+
+Rare path. The normal reopen route is user-reply auto-reopen. Manual reopen is for admin error-correction.
+
+1. Set `status = OPEN`, `resolved_at = null`.
+2. Insert synthetic system message: `body = "Reopened by admin"`, `visible_to_user = true`, `author_role = ADMIN`.
+3. Update `last_message_at` and `last_message_author = ADMIN`.
+4. Fire NO notification (admin reopened, not user; nothing surprising for the user to know).
+
+### Assign / unassign (admin)
+
+`POST /api/v1/admin/support-tickets/{publicId}/assign`, body `{ adminPublicId?: string | null }`:
+
+1. Resolve `adminPublicId` to a user id (must have `ROLE_ADMIN`). Null = unassign.
+2. Set `assigned_admin_id`. No message inserted (process flag, not a conversation event). No notification.
+
+### Category change (admin)
+
+`PATCH /api/v1/admin/support-tickets/{publicId}` body `{ category: SupportTicketCategory }`:
+
+Rare admin correction path. Updates `category` on the ticket; no message inserted; no notification. Validation rejects values outside the six-element enum.
+
+## 4. Attachments
+
+Reuses the dispute-evidence upload primitive at the service layer. New surface at the API layer for naming clarity.
+
+### Pre-upload endpoint
+
+`POST /api/v1/me/support-tickets/attachments`:
+
+Multipart form upload. Authed users only.
+
+1. Validate MIME (`image/png | image/jpeg | image/webp | image/gif`).
+2. Validate size (<= 5 MiB).
+3. Validate dimensions via `ImageUploadValidator` (max 4096x4096; rejects polyglots).
+4. Store at `support-attachments/pending/{userPublicId}/{uuid}.{ext}` in the configured S3 bucket. The `pending/` prefix is intentional — a bucket lifecycle rule (configured by Terraform separately, with documentation in this spec's deploy notes) deletes any object under `support-attachments/pending/` older than 1 day. That gives us automatic orphan cleanup without an application sweeper.
+5. Cache pending metadata in Redis under key `support:upload:{attachmentKey} → { userId, storageKey, mime, size, width, height }` with TTL = `slpa.support.attachments.pending-ttl-seconds` (default 3600 = 1 hour). The `attachmentKey` is a fresh UUID, NOT the storage key — keeps the storage path hidden from the client.
+6. Return `{ attachmentKey: string }`.
+
+When a create or reply call references `attachmentKeys`, the service:
+1. For each key, read the Redis entry. Missing entry → 400 `ATTACHMENT_NOT_FOUND` (the upload either expired or was never made).
+2. Confirm `userId` on the entry matches the caller. Mismatch → 403 `NOT_OWNER`.
+3. Inside the same transaction as the message insert: copy the S3 object from `support-attachments/pending/{userPublicId}/{uuid}.{ext}` to `support-attachments/{userPublicId}/{messageId}/{uuid}.{ext}` (S3 server-side copy), then delete the pending object. Insert the `support_ticket_attachments` row pointing at the promoted storage key.
+4. Delete the Redis entry.
+
+Failure mode: if the S3 copy succeeds but the DB insert fails, the bucket lifecycle rule will eventually evict the orphaned promoted object (impossible — the rule is on `pending/` only). To prevent durable orphan: wrap the copy in a `try/catch` that, on any post-copy failure, deletes the promoted object before re-throwing. This is best-effort cleanup; durable orphan recovery is a separate concern (post-MVP audit).
+
+No application-level sweeper is required for the pending storage — the S3 lifecycle rule handles it. Redis TTL handles pending metadata expiration. The `slpa.support.attachment-sweeper-cron` key from §9 is therefore removed; see the updated §9.
+
+### Max attachments per message
+
+3. Enforced at create + reply time. Validation error code `INVALID_ATTACHMENT` with detail `"max 3 attachments per message"`.
+
+### Image fetch
+
+`GET /api/v1/support-tickets/attachments/{publicId}` — issues a 5-minute pre-signed URL to the S3 object. Authorization: the requester must either be the ticket's owner OR an admin. Other authenticated users get 403.
+
+## 5. Backend endpoints
+
+### User-facing
+
+| Method | Path | Notes |
+|---|---|---|
+| GET | `/api/v1/me/support-tickets` | paged list; filters: `status`, `q` (subject substring); sort: `last_message_at DESC` |
+| GET | `/api/v1/me/support-tickets/{publicId}` | full detail + visible messages + attachments; 404 if not owner |
+| POST | `/api/v1/me/support-tickets` | body `{ subject, category, body, attachmentKeys?: string[] }`; rate-limited |
+| POST | `/api/v1/me/support-tickets/{publicId}/messages` | reply; `internalNote` ignored / rejected if true |
+| POST | `/api/v1/me/support-tickets/attachments` | multipart upload; returns `{ attachmentKey }` |
+| GET | `/api/v1/support-tickets/attachments/{publicId}` | pre-signed S3 URL; owner or admin |
+
+### Admin-facing
+
+| Method | Path | Notes |
+|---|---|---|
+| GET | `/api/v1/admin/support-tickets` | paged queue; filters: `status`, `category`, `assignee` (`mine` / `unassigned` / `userPublicId`), `last_author` (`USER` / `ADMIN`), `q`; sort `last_message_at DESC` |
+| GET | `/api/v1/admin/support-tickets/{publicId}` | full detail including internal notes + ALL attachments |
+| POST | `/api/v1/admin/support-tickets/{publicId}/messages` | admin reply; `internalNote` flag respected |
+| POST | `/api/v1/admin/support-tickets/{publicId}/resolve` | mark resolved; idempotent |
+| POST | `/api/v1/admin/support-tickets/{publicId}/reopen` | manual reopen; idempotent |
+| POST | `/api/v1/admin/support-tickets/{publicId}/assign` | body `{ adminPublicId?: string \| null }` |
+| PATCH | `/api/v1/admin/support-tickets/{publicId}` | body `{ category?: SupportTicketCategory }`; future-extensible |
+| GET | `/api/v1/admin/support-tickets/queue-stats` | returns `{ openNeedingAdminReply, openTotal }`; powers sidebar badge |
+
+All `/admin/**` routes gated by `@PreAuthorize("hasRole('ADMIN')")`. All `/me/**` routes gated by JWT authentication (existing global rule). The `/support-tickets/attachments/{publicId}` route is authenticated but allows admin OR owner.
+
+**LazyInit defense (lesson from coupon PR #388):** every controller method that returns an entity-derived DTO is annotated `@Transactional(readOnly = true)` or `@Transactional` (for writes). The repos' single-row finders use `@EntityGraph(attributePaths = {"messages", "messages.attachments"})` where the controller will need the thread. Tests follow the dual-pattern from `AdminCouponLazyInitRegressionTest`: in-tx integration coverage plus a non-`@Transactional` regression test class per controller surface.
+
+**Error handling:** `SupportTicketException` with a `SupportTicketError` enum (`UNKNOWN_TICKET`, `NOT_OWNER`, `INTERNAL_NOTE_FROM_USER`, `RATE_LIMITED`, `INVALID_ATTACHMENT`, `INVALID_CATEGORY`, `ATTACHMENT_NOT_FOUND`), mapped to RFC 9457 `ProblemDetail` by a new `SupportTicketExceptionHandler` (`@RestControllerAdvice` scoped to the support package, mirroring `CouponExceptionHandler`). Status mapping:
+- `UNKNOWN_TICKET`, `ATTACHMENT_NOT_FOUND` → 404
+- `NOT_OWNER` → 403
+- `INTERNAL_NOTE_FROM_USER`, `INVALID_ATTACHMENT`, `INVALID_CATEGORY` → 400
+- `RATE_LIMITED` → 429
+
+## 6. Notifications
+
+Four new `NotificationCategory` enum values, all in `NotificationGroup.SYSTEM`:
+
+```
+SUPPORT_TICKET_ADMIN_REPLIED       -- user-facing
+SUPPORT_TICKET_RESOLVED            -- user-facing
+SUPPORT_TICKET_OPENED              -- admin-facing
+SUPPORT_TICKET_USER_REPLIED        -- admin-facing
+```
+
+Four new methods on `NotificationPublisher`:
+
+```java
+void supportTicketAdminReplied(long userId, UUID ticketPublicId,
+                                 String subject, String adminDisplayName);
+void supportTicketResolved(long userId, UUID ticketPublicId, String subject);
+void supportTicketOpened(List<Long> adminUserIds, UUID ticketPublicId,
+                          String subject, String submitterDisplayName, String category);
+void supportTicketUserReplied(List<Long> adminUserIds, UUID ticketPublicId,
+                                String subject, String submitterDisplayName);
+```
+
+Channel routing:
+
+| Category | In-app | Email | SL IM |
+|---|---|---|---|
+| `SUPPORT_TICKET_ADMIN_REPLIED` | yes | NO | yes |
+| `SUPPORT_TICKET_RESOLVED` | yes | NO | yes |
+| `SUPPORT_TICKET_OPENED` | yes | NO | NO |
+| `SUPPORT_TICKET_USER_REPLIED` | yes | NO | NO |
+
+Per-channel bodies are inline strings in `NotificationPublisherImpl` (same pattern as every other notification today — there is no template engine in the project):
+
+- `SUPPORT_TICKET_ADMIN_REPLIED`: `"{adminDisplayName} replied to your support ticket: {subject}. View at slparcels.com/support/{publicId}"`
+- `SUPPORT_TICKET_RESOLVED`: `"Your support ticket has been marked resolved: {subject}. View at slparcels.com/support/{publicId}"`
+- `SUPPORT_TICKET_OPENED` (in-app only, no SL IM body needed): `"{submitterDisplayName} opened a new {category} support ticket: {subject}"`
+- `SUPPORT_TICKET_USER_REPLIED` (in-app only): `"{submitterDisplayName} replied to a support ticket: {subject}"`
+
+`SlImLinkResolver` gets four entries — admin categories link to `/admin/support/{publicId}`, user categories to `/support/{publicId}`.
+
+Existing `notify_email` / `notify_sl_im` user prefs already gate the SYSTEM group's channel routing; no new user-pref columns required.
+
+Internal notes (`visible_to_user = false`) fire NO notification on any channel.
+
+## 7. Frontend UI
+
+### Header / nav (Q5 = B)
+
+- `UserMenuDropdown`: add a "Support" item between "Wallet" and "Sign out". Visible only when authed (the dropdown itself is only rendered for authed users).
+- `MobileMenu`: add "Support" to the footer link row alongside Contact / About / Terms.
+
+### `/support` page (Q6 = A — list first)
+
+- File: `frontend/src/app/support/page.tsx` with `export const dynamic = "force-dynamic"` per the SSR caveat.
+- Renders a server-component shell wrapping a client `<SupportTicketList />`.
+- Top bar: page title "Support", "New ticket" primary button (top-right).
+- Filter bar: status dropdown (All / Open / Resolved). No category filter on the user side (small per-user N expected).
+- Table columns: Subject (link), Category badge, Status pill + "admin replied" sub-label when `lastMessageAuthor=ADMIN` AND status is `OPEN`, Last updated (relative).
+- Empty state: centered card with "No tickets yet. Need help? Click 'New ticket'." + same button.
+
+### `/support/new` page
+
+- File: `frontend/src/app/support/new/page.tsx`.
+- Form sections: Subject (Input, max 160), Category (Select, six options), Message (Textarea, max 10000 chars + char counter), Attachments (drop zone up to 3, reusing `DisputeEvidenceUpload`-style component).
+- Submit → `useCreateSupportTicket()` mutation → on success, redirect to `/support/{publicId}`.
+- Add `Textarea` UI primitive at `frontend/src/components/ui/Textarea.tsx` (does not exist today). Same shape as `Input`: `label`, `helperText`, `error`, `rows`. Sibling test required.
+
+### `/support/[publicId]` page
+
+- File: `frontend/src/app/support/[publicId]/page.tsx`. Next.js 16 async-params route (`params: Promise<{ publicId: string }>`).
+- Header: subject, category badge, status pill, last-updated timestamp.
+- Message list: alternating bubbles. User-authored messages right-aligned with a subtle brand-color background; admin-authored messages left-aligned with surface-raised background. Each carries author name, role label, timestamp, body, and attachment thumbnails. Attachment click → lightbox with pre-signed URL fetched on demand.
+- Reply composer: Textarea + attachment drop zone (max 3) + Send button.
+- If `status = RESOLVED`: composer remains rendered but with a leading helper text "Replying will reopen this ticket." Composer functions normally.
+
+### Admin queue (`/admin/support`)
+
+- File: `frontend/src/app/admin/support/page.tsx`.
+- Mirrors `AdminDisputeListPage` shape.
+- Table columns: Subject (link), Submitter (displayName + sl avatar), Category, Status pill, Last activity (relative), Assigned-to (displayName or "Unassigned").
+- Filter row: Status select, Category select, Assignee select (Mine / Unassigned / All), Last-author select (Needs admin reply / Waiting on user / All), Subject search.
+- URL-synced filters via `useSearchParams`.
+- Sidebar link "Support" added to `AdminShell.tsx`, alphabetically between "Reports" and "Users". Badge displays `queueStats.openNeedingAdminReply`, polled every 30s via `useAdminSupportQueueStats()`.
+
+### Admin detail (`/admin/support/[publicId]`)
+
+- Full thread including internal notes (rendered with a distinct warning-bg + "Internal note" label so they never look like a normal reply).
+- Composer with a "Send" button + an "Internal note" checkbox. When checked, the bubble preview swaps to the internal-note styling so the admin sees what they're about to send.
+- Top bar: Resolve / Reopen button (mutually exclusive, status-driven), "Assign to me" / "Unassign" buttons, Category dropdown for the rare admin correction.
+
+### Notification feed integration
+
+The existing `NotificationBell` + feed renderer handles the four new categories — they just need:
+- A category icon mapping (use the `MessageSquare` lucide icon for all four).
+- A deep-link function that returns `/support/{publicId}` for user-side and `/admin/support/{publicId}` for admin-side categories.
+- A short-body renderer string (mirroring the SL IM body, minus the absolute URL).
+
+## 8. Migration plan
+
+Single Flyway migration `V42__support_tickets.sql` per spec §2. Three new tables in one transaction; no changes to existing tables. Migration number is **V42** (V41 = coupon codes is the current latest).
+
+Hibernate `validate` mode requires the matching JPA entities ship in the same commit; the implementation plan will sequence migration + entity creation in Task 1.
+
+## 9. Configuration
+
+New `application.yml` keys:
+
+```yaml
+slpa:
+  support:
+    rate-limit:
+      tickets-per-hour: 5
+    attachments:
+      max-per-message: 3
+      max-file-bytes: 5242880
+      allowed-mime-types: "image/png,image/jpeg,image/webp,image/gif"
+      pending-ttl-seconds: 3600
+```
+
+Reuses (no new values):
+- `slpa.storage.bucket`, `slpa.storage.endpoint`, etc. — same S3 wiring as dispute evidence and listing photos.
+- `slpa.notifications.sl-im.*` — existing dispatcher.
+- Existing Redis connection — used for attachment pending cache.
+
+No new SSM Parameter Store secrets.
+
+## 10. Testing
+
+### Backend unit
+
+- `SupportTicketRateLimiterTest` — per-user 5/hour bucket; replies uncounted; sliding 60-minute window.
+
+### Backend integration (`@SpringBootTest + @AutoConfigureMockMvc`)
+
+- `MeSupportTicketControllerIntegrationTest`:
+  - GET list filters by status and q; pagination correct
+  - GET detail returns only `visible_to_user = true` messages; admin internal notes are absent from user response
+  - GET detail rejects with 404 when caller is not owner
+  - POST create happy path; rate limiter returns 429 on the 6th submission within 60 min
+  - POST reply with empty body and 10001-char body both rejected (400)
+  - POST reply on a `RESOLVED` ticket auto-reopens (status flips back to OPEN; resolved_at cleared)
+  - POST reply rejects `internalNote = true` from user with 400 `INTERNAL_NOTE_FROM_USER`
+- `AdminSupportTicketControllerIntegrationTest`:
+  - GET queue filters work independently: status, category, assignee (mine/unassigned/specific user), last_author, q
+  - GET detail returns ALL messages including internal notes
+  - POST reply happy path (public + internal); internal note fires NO `supportTicketAdminReplied` notification (mocked publisher)
+  - POST resolve transitions status, writes system message, fires `supportTicketResolved`
+  - POST reopen flips back, writes system message, fires NO notification
+  - POST assign / unassign updates `assigned_admin_id`
+  - PATCH category updates value
+  - Non-admin token receives 403 on every admin endpoint
+- `SupportTicketAttachmentIntegrationTest`:
+  - Pre-upload happy path returns `attachmentKey`
+  - Rejects file > 5 MiB
+  - Rejects MIME outside the allowlist
+  - Rejects > 3 keys per message at create / reply
+  - Promotion happy path: pending object is copied to the message-scoped path, pending object is deleted, Redis entry cleared
+  - Promotion failure (mocked DB failure post-copy) deletes the just-copied object so we don't leak
+  - GET signed URL works for owner; 403 for non-owner non-admin; OK for admin
+  - Expired Redis entry (deliberately set TTL = 0 for the test) returns 400 ATTACHMENT_NOT_FOUND on promotion
+- `SupportTicketLazyInitRegressionTest` (non-`@Transactional` test class, mirrors `AdminCouponLazyInitRegressionTest`):
+  - GET `/me/support-tickets/{id}` outside enclosing tx → 200, messages array populated
+  - GET `/admin/support-tickets/{id}` outside enclosing tx → 200, internal notes + attachments present
+- `SupportTicketNotificationTest`:
+  - Admin reply (visible_to_user=true) fires `supportTicketAdminReplied` to ticket owner only
+  - User reply fires `supportTicketUserReplied` to all admins
+  - Resolve fires `supportTicketResolved` to ticket owner
+  - Internal-note admin reply fires NO notification
+- `SupportTicketReopenIntegrationTest`:
+  - End-to-end: user creates → admin replies → admin resolves → user replies → ticket OPEN again, resolved_at cleared, admins receive `supportTicketUserReplied`
+
+### Frontend (Vitest + RTL)
+
+- `Textarea.test.tsx` (new UI primitive) — render, label, error state, char counter integration.
+- `SupportTicketList.test.tsx` — empty state, table rendering, status pill + sub-label, pagination, filter URL sync.
+- `NewSupportTicketForm.test.tsx` — required-field validation, body char counter, attachment drop zone max-3 enforcement, submit happy path navigates to detail.
+- `SupportTicketThread.test.tsx` — alternating bubble layout; lightbox-on-thumbnail-click; reply composer "will reopen" helper when status=RESOLVED; user view hides admin internal notes (defense in depth).
+- `AdminSupportTicketQueue.test.tsx` — filter URL sync, queue-stats badge counter, status pill rendering.
+- `AdminSupportTicketDetail.test.tsx` — internal-note checkbox toggles bubble preview style; resolve / reopen button visibility tracks status; assign dropdown happy path.
+- `useAdminSupportQueueStats.test.tsx` — polling cadence with `vi.useFakeTimers`.
+
+### Postman
+
+Mirror every endpoint from §5 into the SLPA Postman collection in a new "Support tickets" folder. Variable-chain `supportTicketPublicId`, `supportTicketMessagePublicId`, `supportTicketAttachmentPublicId` across the happy-path admin↔user flow.
+
+### Manual smoke (release checklist)
+
+- User opens "Support" from header dropdown → /support empty state → "New ticket" → fills form → submitted → redirected to detail page.
+- Admin signs in → "Support" sidebar item shows badge "1" → opens queue → ticket visible with "Needs admin reply" filter → opens detail → replies.
+- User receives in-app notification + (if SL IM prefs on) SL IM → opens thread → sees reply → replies back → admin notified.
+- Admin marks resolved → user sees notification + system message in thread.
+- User replies on resolved ticket → status flips back to OPEN, admins re-notified.
+- Spam test: open 6 tickets in 5 minutes → 6th returns 429 with rate-limit message.
+- Attachment test: upload 3 images, all preview, all fetch on lightbox click; 4th attachment rejected.
+
+## 11. Out of scope
+
+Items explicitly NOT in MVP:
+
+- Email notifications. Issue says "email not necessary for MVP"; the four notification categories above route in-app and SL IM only.
+- Anonymous ticket submission. Q2 = authed-only.
+- File attachments other than images. Q9 = images only.
+- Auto-close timer on resolved tickets. Tickets stay where they are until a user replies (auto-reopen) or admin manual action.
+- SLA / response-time tracking.
+- Admin canned-response templates.
+- Multi-admin assignment. Single nullable `assignedAdminId` only.
+- User-side ticket merging or splitting.
+- Public knowledge-base or FAQ articles.
+- Search across ticket bodies (only subject substring search in MVP).
+
+## 12. Decision log
+
+Captured during brainstorming (2026-05-21):
+
+- **Threaded back-and-forth** (Q1 = A). Rejected fire-and-forget — the "email not necessary" hint implies users expect a reply somewhere; if not email, then in-app threads.
+- **Logged-in only** (Q2 = A). Rejected anon with magic-link — contradicts the no-email guidance. Rejected anon one-way — defeats the threaded model. Login-locked-out users fall back to in-world IM or the operator's Discord; signage on the login page handles the edge case without a feature.
+- **Six fixed categories** (Q3 = B). Rejected free-form (admin triage burden) and free tags (filter noise).
+- **Two states, last-author derived** (Q4 = B). Rejected multi-state machines as overengineered for the volume; rejected single-state + manual archive as too sparse.
+- **Help in user dropdown** (Q5 = B). Rejected inline header link (crowds main nav) and floating action button (sets a live-chat expectation we can't meet).
+- **List-first /support page** (Q6 = A). Rejected new-ticket-default (existing tickets buried) and two-tab layout (more clicks for both paths).
+- **In-app + SL IM for user; in-app only for admin** (Q7 = B + Yes). Rejected in-app-only on user side (under-surfaces replies) and full three-channel (contradicts email guidance).
+- **Internal notes via `visible_to_user` flag** (Q8 = A). Rejected separate notes table (over-decomposed) and no notes (forces external scratchpad).
+- **Image attachments up to 3 per message** (Q9 = B). Rejected text-only (rare but real "show me the screenshot" need) and any-MIME (security risk for executables).
+- **Per-user rate limit, 5 new tickets/hour, replies uncapped** (Q10 = A). Rejected per-IP (shared NAT false positives) and no-limit (trust-without-verify).
+- **Optional assignment** (Q11 = B). Rejected shared-only (no coordination signal when team grows) and required-assignment (overhead while team is one admin).

--- a/frontend/src/app/admin/support/[publicId]/page.tsx
+++ b/frontend/src/app/admin/support/[publicId]/page.tsx
@@ -1,0 +1,14 @@
+import { AdminSupportTicketDetail } from "@/components/admin/support/AdminSupportTicketDetail";
+
+// Ticket state, assignment, and message stream all change per visit; force
+// dynamic so Amplify never tries to prerender a stale snapshot at build time.
+export const dynamic = "force-dynamic";
+
+export default async function AdminSupportTicketDetailPage({
+  params,
+}: {
+  params: Promise<{ publicId: string }>;
+}) {
+  const { publicId } = await params;
+  return <AdminSupportTicketDetail publicId={publicId} />;
+}

--- a/frontend/src/app/admin/support/page.tsx
+++ b/frontend/src/app/admin/support/page.tsx
@@ -1,0 +1,10 @@
+import { AdminSupportTicketQueue } from "@/components/admin/support/AdminSupportTicketQueue";
+
+// Per-visit data (filter params, fresh counts) — same posture as the
+// other admin list pages so Amplify build-time prerender can't snapshot
+// a stale queue against a freshly-changed wire shape.
+export const dynamic = "force-dynamic";
+
+export default function AdminSupportTicketQueuePage() {
+  return <AdminSupportTicketQueue />;
+}

--- a/frontend/src/app/support/[publicId]/page.tsx
+++ b/frontend/src/app/support/[publicId]/page.tsx
@@ -1,0 +1,18 @@
+import { SupportTicketThread } from "@/components/support/SupportTicketThread";
+
+// Live thread data — new messages, attachment signed-URL fetches, "reopen"
+// transitions — so opt out of Amplify build-time prerendering. Mirrors the
+// rest of the support surface (list + new pages).
+export const dynamic = "force-dynamic";
+
+export default async function SupportTicketDetailPage({
+  params,
+}: {
+  params: Promise<{ publicId: string }>;
+}) {
+  // Next.js 16: route params are async; must be awaited before passing to a
+  // client component. See `frontend/AGENTS.md` and the matching admin coupon
+  // detail page at `src/app/admin/coupons/[publicId]/page.tsx`.
+  const { publicId } = await params;
+  return <SupportTicketThread publicId={publicId} />;
+}

--- a/frontend/src/app/support/new/page.tsx
+++ b/frontend/src/app/support/new/page.tsx
@@ -1,0 +1,10 @@
+import { NewSupportTicketForm } from "@/components/support/NewSupportTicketForm";
+
+// Form posts user-typed data, so per-visit state lives entirely client-side;
+// still opt out of Amplify build-time prerendering to mirror the rest of the
+// support surface (see CLAUDE.md "Frontend SSR caveats").
+export const dynamic = "force-dynamic";
+
+export default function NewSupportTicketPage() {
+  return <NewSupportTicketForm />;
+}

--- a/frontend/src/app/support/page.tsx
+++ b/frontend/src/app/support/page.tsx
@@ -1,0 +1,11 @@
+import { SupportTicketList } from "@/components/support/SupportTicketList";
+
+// Visit-specific content (status filters, last-message timestamps) — see
+// `Frontend SSR caveats` in CLAUDE.md: any page whose data changes per visit
+// must opt out of Amplify build-time prerendering so one bad-shape response
+// can't fail the whole build.
+export const dynamic = "force-dynamic";
+
+export default function SupportPage() {
+  return <SupportTicketList />;
+}

--- a/frontend/src/components/admin/AdminShell.tsx
+++ b/frontend/src/components/admin/AdminShell.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { type ReactNode } from "react";
 import { useAuth } from "@/lib/auth";
 import { useAdminStats } from "@/hooks/admin/useAdminStats";
+import { useAdminSupportQueueStats } from "@/hooks/admin/useAdminSupportQueueStats";
 import { cn } from "@/lib/cn";
 
 type SidebarItem = {
@@ -18,11 +19,18 @@ export function AdminShell({ children }: { children: ReactNode }) {
   const session = useAuth();
   const user = session.status === "authenticated" ? session.user : null;
   const { data: stats } = useAdminStats();
+  // Sidebar badge for the support queue: polled every 30s by the hook
+  // so the count stays loosely-live without a WebSocket. Gated to admin
+  // sessions so non-admin users (who can also see the empty admin layout
+  // briefly during route transitions) don't poll an endpoint they can't
+  // hit.
+  const { data: supportStats } = useAdminSupportQueueStats(user?.role === "ADMIN");
 
   const items: SidebarItem[] = [
     { label: "Dashboard", href: "/admin" },
     { label: "Fraud Flags", href: "/admin/fraud-flags", badge: stats?.queues.openFraudFlags },
     { label: "Reports", href: "/admin/reports", badge: stats?.queues.openReports },
+    { label: "Support", href: "/admin/support", badge: supportStats?.openNeedingAdminReply },
     { label: "Disputes", href: "/admin/disputes", badge: stats?.queues.activeDisputes },
     // Escrow Reviews has no badge: the backend AdminStatsResponse.QueueStats
     // record exposes no openEscrowReviews count, and extending it is outside

--- a/frontend/src/components/admin/support/AdminSupportTicketDetail.test.tsx
+++ b/frontend/src/components/admin/support/AdminSupportTicketDetail.test.tsx
@@ -1,0 +1,523 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/test/render";
+import type {
+  AdminReplyRequest,
+  SupportTicketAttachmentDto,
+  SupportTicketCategory,
+  SupportTicketDto,
+  SupportTicketMessageDto,
+  SupportTicketStatus,
+} from "@/types/support";
+
+// ─── next/navigation ─────────────────────────────────────────────────────
+// Sub-components (Modal, dropzone) may transitively read the router; mirror
+// the user-thread test's mock so the component renders cleanly.
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/admin/support/t-1"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+// ─── Auth ────────────────────────────────────────────────────────────────
+const CALLER_ADMIN_ID = "admin-0000-0000-0000-000000000001";
+
+vi.mock("@/lib/auth/hooks", () => ({
+  useAuth: () => ({
+    status: "authenticated" as const,
+    user: {
+      publicId: CALLER_ADMIN_ID,
+      username: "admin1",
+      email: "admin1@example.com",
+      displayName: "Admin One",
+      slAvatarUuid: null,
+      verified: true,
+      role: "ADMIN" as const,
+    },
+  }),
+}));
+
+// ─── Ticket query hook ───────────────────────────────────────────────────
+const ticketHookState: {
+  data: SupportTicketDto | undefined;
+  isLoading: boolean;
+  isError: boolean;
+} = {
+  data: undefined,
+  isLoading: false,
+  isError: false,
+};
+
+vi.mock("@/hooks/admin/useAdminSupportTicket", () => ({
+  useAdminSupportTicket: () => ({
+    data: ticketHookState.data,
+    isLoading: ticketHookState.isLoading,
+    isError: ticketHookState.isError,
+  }),
+  adminSupportTicketKey: (p: string) => ["admin-support-ticket", p] as const,
+}));
+
+// ─── Mutation hooks ──────────────────────────────────────────────────────
+type ReplyCall = {
+  req: AdminReplyRequest;
+  options?: { onSuccess?: () => void };
+};
+const replyMutateCalls: ReplyCall[] = [];
+const replyMutateMock = vi.fn(
+  (req: AdminReplyRequest, options?: { onSuccess?: () => void }) => {
+    replyMutateCalls.push({ req, options });
+  },
+);
+let replyMutationState: {
+  isPending: boolean;
+  isError: boolean;
+  error: unknown;
+} = { isPending: false, isError: false, error: null };
+
+vi.mock("@/hooks/admin/useAdminSupportReply", () => ({
+  useAdminSupportReply: () => ({
+    mutate: replyMutateMock,
+    isPending: replyMutationState.isPending,
+    isError: replyMutationState.isError,
+    error: replyMutationState.error,
+  }),
+}));
+
+const resolveMutateMock = vi.fn();
+vi.mock("@/hooks/admin/useAdminSupportResolve", () => ({
+  useAdminSupportResolve: () => ({
+    mutate: resolveMutateMock,
+    isPending: false,
+  }),
+}));
+
+const reopenMutateMock = vi.fn();
+vi.mock("@/hooks/admin/useAdminSupportReopen", () => ({
+  useAdminSupportReopen: () => ({
+    mutate: reopenMutateMock,
+    isPending: false,
+  }),
+}));
+
+const assignMutateMock = vi.fn();
+vi.mock("@/hooks/admin/useAdminSupportAssign", () => ({
+  useAdminSupportAssign: () => ({
+    mutate: assignMutateMock,
+    isPending: false,
+  }),
+}));
+
+const patchCategoryMutateMock = vi.fn();
+vi.mock("@/hooks/admin/useAdminSupportPatchCategory", () => ({
+  useAdminSupportPatchCategory: () => ({
+    mutate: patchCategoryMutateMock,
+    isPending: false,
+  }),
+}));
+
+// ─── Signed attachment URL ───────────────────────────────────────────────
+vi.mock("@/hooks/useSignedAttachmentUrl", () => ({
+  useSignedAttachmentUrl: () => ({
+    data: { url: "https://signed.example/att.png" },
+    isPending: false,
+    isError: false,
+  }),
+  signedAttachmentUrlKey: (p: string) =>
+    ["support-attachment-signed-url", p] as const,
+}));
+
+// ─── Dropzone stub ───────────────────────────────────────────────────────
+vi.mock("@/components/support/SupportAttachmentDropzone", () => ({
+  SupportAttachmentDropzone: ({
+    attachmentKeys,
+    onAttachmentKeyAdded,
+    maxAttachments,
+  }: {
+    attachmentKeys: string[];
+    onAttachmentKeyAdded: (k: string) => void;
+    onAttachmentKeyRemoved: (k: string) => void;
+    maxAttachments?: number;
+    disabled?: boolean;
+  }) => (
+    <div data-testid="mock-dropzone">
+      <span data-testid="mock-dropzone-count">{attachmentKeys.length}</span>
+      <span data-testid="mock-dropzone-max">{maxAttachments ?? "default"}</span>
+      <button
+        type="button"
+        data-testid="mock-dropzone-stage"
+        onClick={() => onAttachmentKeyAdded("stub-key-1")}
+      >
+        stage
+      </button>
+    </div>
+  ),
+}));
+
+// Import AFTER mocks so the component picks up the stubbed modules.
+import { AdminSupportTicketDetail } from "./AdminSupportTicketDetail";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────
+function attachment(
+  overrides: Partial<SupportTicketAttachmentDto> = {},
+): SupportTicketAttachmentDto {
+  return {
+    publicId: "att-0000-0000-0000-000000000001",
+    mimeType: "image/png",
+    sizeBytes: 1234,
+    width: 800,
+    height: 600,
+    ...overrides,
+  };
+}
+
+function message(
+  overrides: Partial<SupportTicketMessageDto> = {},
+): SupportTicketMessageDto {
+  return {
+    publicId: "msg-0000-0000-0000-000000000001",
+    authorPublicId: "user-0001",
+    authorDisplayName: "Sample User",
+    authorRole: "USER",
+    body: "Initial message body.",
+    visibleToUser: true,
+    createdAt: new Date(Date.now() - 60_000).toISOString(),
+    attachments: [],
+    ...overrides,
+  };
+}
+
+function ticket(
+  overrides: Partial<SupportTicketDto> = {},
+): SupportTicketDto {
+  const now = new Date().toISOString();
+  return {
+    publicId: "ticket-0000-0000-0000-000000000001",
+    submitterPublicId: "user-0001",
+    submitterDisplayName: "Sample User",
+    subject: "Wallet deposit stuck",
+    category: "WALLET",
+    status: "OPEN" as SupportTicketStatus,
+    assignedAdminPublicId: null,
+    assignedAdminDisplayName: null,
+    lastMessageAt: now,
+    lastMessageAuthor: "USER",
+    resolvedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    messages: [],
+    ...overrides,
+  };
+}
+
+function setTicket(t: SupportTicketDto | undefined) {
+  ticketHookState.data = t;
+  ticketHookState.isLoading = false;
+  ticketHookState.isError = false;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+beforeEach(() => {
+  replyMutateCalls.length = 0;
+  replyMutateMock.mockClear();
+  resolveMutateMock.mockClear();
+  reopenMutateMock.mockClear();
+  assignMutateMock.mockClear();
+  patchCategoryMutateMock.mockClear();
+  replyMutationState = { isPending: false, isError: false, error: null };
+});
+
+describe("<AdminSupportTicketDetail />", () => {
+  it("renders subject, category dropdown, and status pill", () => {
+    setTicket(
+      ticket({
+        subject: "Bid never went through",
+        category: "BIDDING",
+        status: "OPEN",
+      }),
+    );
+    renderWithProviders(<AdminSupportTicketDetail publicId="t-1" />);
+
+    expect(
+      screen.getByTestId("admin-support-detail-subject"),
+    ).toHaveTextContent("Bid never went through");
+
+    const categorySelect = screen.getByTestId(
+      "admin-support-detail-category-select",
+    ) as HTMLSelectElement;
+    expect(categorySelect.value).toBe("BIDDING");
+
+    expect(
+      screen.getByTestId("admin-support-detail-status-pill"),
+    ).toHaveTextContent("Open");
+  });
+
+  it("renders user, admin public, and admin internal-note bubbles with the right styling", () => {
+    setTicket(
+      ticket({
+        assignedAdminPublicId: CALLER_ADMIN_ID,
+        assignedAdminDisplayName: "Admin One",
+        messages: [
+          message({
+            publicId: "msg-user-1",
+            authorRole: "USER",
+            authorDisplayName: "Buyer Bob",
+            body: "User message body.",
+            visibleToUser: true,
+          }),
+          message({
+            publicId: "msg-admin-public-1",
+            authorRole: "ADMIN",
+            authorDisplayName: "Admin Sara",
+            body: "Public admin reply.",
+            visibleToUser: true,
+          }),
+          message({
+            publicId: "msg-admin-internal-1",
+            authorRole: "ADMIN",
+            authorDisplayName: "Admin Sara",
+            body: "Internal admin note body.",
+            visibleToUser: false,
+          }),
+        ],
+      }),
+    );
+    renderWithProviders(<AdminSupportTicketDetail publicId="t-1" />);
+
+    const userBubble = screen.getByTestId("support-message-msg-user-1");
+    const publicBubble = screen.getByTestId(
+      "support-message-msg-admin-public-1",
+    );
+    const internalBubble = screen.getByTestId(
+      "support-message-msg-admin-internal-1",
+    );
+
+    expect(userBubble).toHaveAttribute("data-role", "USER");
+    expect(userBubble).toHaveAttribute("data-internal", "false");
+
+    expect(publicBubble).toHaveAttribute("data-role", "ADMIN");
+    expect(publicBubble).toHaveAttribute("data-internal", "false");
+
+    expect(internalBubble).toHaveAttribute("data-role", "ADMIN");
+    expect(internalBubble).toHaveAttribute("data-internal", "true");
+
+    // Internal-note label is the literal text "Internal note" (no emoji).
+    expect(
+      screen.getByTestId("support-message-role-msg-admin-internal-1"),
+    ).toHaveTextContent(/Internal note/);
+
+    // Lucide EyeOff icon is rendered alongside the label.
+    expect(
+      screen.getByTestId("support-message-internal-icon-msg-admin-internal-1"),
+    ).toBeInTheDocument();
+
+    // Internal-note bubble has the warning palette class.
+    const internalBody = screen.getByTestId(
+      "support-message-body-msg-admin-internal-1",
+    );
+    expect(internalBody.className).toMatch(/border-warning/);
+    expect(internalBody.className).toMatch(/bg-warning-bg/);
+  });
+
+  it("shows the Resolve button when status=OPEN", () => {
+    setTicket(ticket({ status: "OPEN" }));
+    renderWithProviders(<AdminSupportTicketDetail publicId="t-1" />);
+    expect(
+      screen.getByTestId("admin-support-detail-resolve"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("admin-support-detail-reopen"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the Reopen button when status=RESOLVED", () => {
+    setTicket(
+      ticket({
+        status: "RESOLVED",
+        resolvedAt: new Date().toISOString(),
+      }),
+    );
+    renderWithProviders(<AdminSupportTicketDetail publicId="t-1" />);
+    expect(
+      screen.getByTestId("admin-support-detail-reopen"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("admin-support-detail-resolve"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clicking Resolve calls the resolve mutation", async () => {
+    setTicket(ticket({ status: "OPEN" }));
+    const user = userEvent.setup();
+    renderWithProviders(<AdminSupportTicketDetail publicId="t-1" />);
+    await user.click(screen.getByTestId("admin-support-detail-resolve"));
+    await waitFor(() => expect(resolveMutateMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("clicking Reopen calls the reopen mutation", async () => {
+    setTicket(
+      ticket({
+        status: "RESOLVED",
+        resolvedAt: new Date().toISOString(),
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<AdminSupportTicketDetail publicId="t-1" />);
+    await user.click(screen.getByTestId("admin-support-detail-reopen"));
+    await waitFor(() => expect(reopenMutateMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("'Assign to me' is visible when ticket is unassigned and calls assign with caller's publicId", async () => {
+    setTicket(
+      ticket({
+        assignedAdminPublicId: null,
+        assignedAdminDisplayName: null,
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<AdminSupportTicketDetail publicId="t-1" />);
+    await user.click(screen.getByTestId("admin-support-detail-assign-me"));
+    await waitFor(() =>
+      expect(assignMutateMock).toHaveBeenCalledWith(CALLER_ADMIN_ID),
+    );
+  });
+
+  it("'Unassign' is visible when ticket is assigned and calls assign with null", async () => {
+    setTicket(
+      ticket({
+        assignedAdminPublicId: "some-other-admin",
+        assignedAdminDisplayName: "Other Admin",
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<AdminSupportTicketDetail publicId="t-1" />);
+    await user.click(screen.getByTestId("admin-support-detail-unassign"));
+    await waitFor(() => expect(assignMutateMock).toHaveBeenCalledWith(null));
+  });
+
+  it("'Assign to me' is hidden when the ticket is already assigned to the caller", () => {
+    setTicket(
+      ticket({
+        assignedAdminPublicId: CALLER_ADMIN_ID,
+        assignedAdminDisplayName: "Admin One",
+      }),
+    );
+    renderWithProviders(<AdminSupportTicketDetail publicId="t-1" />);
+    expect(
+      screen.queryByTestId("admin-support-detail-assign-me"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("admin-support-detail-unassign"),
+    ).toBeInTheDocument();
+  });
+
+  it("changing the category select calls the patch-category mutation", async () => {
+    setTicket(ticket({ category: "WALLET" }));
+    const user = userEvent.setup();
+    renderWithProviders(<AdminSupportTicketDetail publicId="t-1" />);
+    await user.selectOptions(
+      screen.getByTestId("admin-support-detail-category-select"),
+      "BIDDING",
+    );
+    await waitFor(() =>
+      expect(patchCategoryMutateMock).toHaveBeenCalledWith(
+        "BIDDING" satisfies SupportTicketCategory,
+      ),
+    );
+  });
+
+  it("reply submit (without internal note) calls reply with internalNote=false", async () => {
+    setTicket(ticket({ status: "OPEN" }));
+    const user = userEvent.setup();
+    renderWithProviders(<AdminSupportTicketDetail publicId="t-1" />);
+
+    await user.type(
+      screen.getByTestId("admin-support-detail-reply-textarea"),
+      "Looking into this.",
+    );
+    await user.click(screen.getByTestId("mock-dropzone-stage"));
+    await user.click(screen.getByTestId("admin-support-detail-reply-submit"));
+
+    await waitFor(() => expect(replyMutateMock).toHaveBeenCalledTimes(1));
+    const call = replyMutateCalls[0];
+    expect(call.req.body).toBe("Looking into this.");
+    expect(call.req.attachmentKeys).toEqual(["stub-key-1"]);
+    expect(call.req.internalNote).toBe(false);
+  });
+
+  it("reply submit (with internal-note checked) calls reply with internalNote=true and composer wrapper styling switches", async () => {
+    setTicket(ticket({ status: "OPEN" }));
+    const user = userEvent.setup();
+    renderWithProviders(<AdminSupportTicketDetail publicId="t-1" />);
+
+    const wrapper = screen.getByTestId("admin-support-detail-composer-wrapper");
+    // Before toggling: not internal.
+    expect(wrapper).toHaveAttribute("data-internal", "false");
+    expect(wrapper.className).not.toMatch(/border-warning/);
+
+    await user.click(
+      screen.getByTestId("admin-support-detail-internal-note-checkbox"),
+    );
+
+    // After toggling: wrapper flips its styling.
+    expect(wrapper).toHaveAttribute("data-internal", "true");
+    expect(wrapper.className).toMatch(/border-warning/);
+    expect(wrapper.className).toMatch(/bg-warning-bg/);
+
+    await user.type(
+      screen.getByTestId("admin-support-detail-reply-textarea"),
+      "Quick note for the team.",
+    );
+    await user.click(screen.getByTestId("admin-support-detail-reply-submit"));
+
+    await waitFor(() => expect(replyMutateMock).toHaveBeenCalledTimes(1));
+    const call = replyMutateCalls[0];
+    expect(call.req.body).toBe("Quick note for the team.");
+    expect(call.req.internalNote).toBe(true);
+  });
+
+  it("dropzone receives maxAttachments=3", () => {
+    setTicket(ticket({ status: "OPEN" }));
+    renderWithProviders(<AdminSupportTicketDetail publicId="t-1" />);
+    expect(screen.getByTestId("mock-dropzone-max")).toHaveTextContent("3");
+  });
+
+  it("clicking an attachment thumbnail opens the lightbox", async () => {
+    setTicket(
+      ticket({
+        messages: [
+          message({
+            publicId: "msg-with-att",
+            attachments: [
+              attachment({ publicId: "att-lightbox-1" }),
+            ],
+          }),
+        ],
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<AdminSupportTicketDetail publicId="t-1" />);
+
+    expect(
+      screen.queryByTestId("support-attachment-lightbox"),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("support-attachment-att-lightbox-1"));
+
+    expect(
+      screen.getByTestId("support-attachment-lightbox"),
+    ).toBeInTheDocument();
+    const img = screen.getByTestId("support-attachment-lightbox-image");
+    expect(img).toHaveAttribute("src", "https://signed.example/att.png");
+  });
+});

--- a/frontend/src/components/admin/support/AdminSupportTicketDetail.tsx
+++ b/frontend/src/components/admin/support/AdminSupportTicketDetail.tsx
@@ -1,0 +1,599 @@
+"use client";
+
+import Link from "next/link";
+import {
+  useMemo,
+  useState,
+  type FormEvent,
+} from "react";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { Checkbox } from "@/components/ui/Checkbox";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { Modal } from "@/components/ui/Modal";
+import { Textarea } from "@/components/ui/Textarea";
+import {
+  ChevronLeft,
+  EyeOff,
+  UserCheck,
+  UserMinus,
+  UserPlus,
+} from "@/components/ui/icons";
+import { SupportAttachmentDropzone } from "@/components/support/SupportAttachmentDropzone";
+import { useAdminSupportTicket } from "@/hooks/admin/useAdminSupportTicket";
+import { useAdminSupportReply } from "@/hooks/admin/useAdminSupportReply";
+import { useAdminSupportResolve } from "@/hooks/admin/useAdminSupportResolve";
+import { useAdminSupportReopen } from "@/hooks/admin/useAdminSupportReopen";
+import { useAdminSupportAssign } from "@/hooks/admin/useAdminSupportAssign";
+import { useAdminSupportPatchCategory } from "@/hooks/admin/useAdminSupportPatchCategory";
+import { useSignedAttachmentUrl } from "@/hooks/useSignedAttachmentUrl";
+import { useAuth } from "@/lib/auth/hooks";
+import { isApiError } from "@/lib/api";
+import { cn } from "@/lib/cn";
+import {
+  formatAbsoluteTime,
+  formatRelativeTime,
+} from "@/lib/time/relativeTime";
+import type {
+  AdminReplyRequest,
+  SupportTicketCategory,
+  SupportTicketErrorCode,
+  SupportTicketMessageDto,
+  SupportTicketStatus,
+} from "@/types/support";
+
+const BODY_MAX = 10000;
+const ATTACHMENT_MAX = 3;
+
+const CATEGORY_LABELS: Record<SupportTicketCategory, string> = {
+  ACCOUNT: "Account",
+  BIDDING: "Bidding",
+  LISTING: "Listing",
+  ESCROW: "Escrow",
+  WALLET: "Wallet",
+  OTHER: "Other",
+};
+
+const CATEGORY_VALUES: SupportTicketCategory[] = [
+  "ACCOUNT",
+  "BIDDING",
+  "LISTING",
+  "ESCROW",
+  "WALLET",
+  "OTHER",
+];
+
+function statusPillClass(status: SupportTicketStatus): string {
+  if (status === "OPEN") return "bg-warning-bg text-warning";
+  return "bg-success-bg text-success";
+}
+
+function statusLabel(status: SupportTicketStatus): string {
+  return status === "OPEN" ? "Open" : "Resolved";
+}
+
+function describeReplyError(err: unknown): string {
+  if (!isApiError(err)) {
+    return "Could not send reply. Try again.";
+  }
+  const problem = err.problem as {
+    code?: SupportTicketErrorCode;
+    detail?: string;
+    title?: string;
+  };
+  switch (problem.code) {
+    case "RATE_LIMITED":
+      return "You're sending replies too quickly. Wait a moment and try again.";
+    case "INVALID_ATTACHMENT":
+      return "One of your attachments was rejected. Remove it and try again.";
+    case "UNKNOWN_TICKET":
+      return "This ticket no longer exists.";
+  }
+  return problem.detail ?? problem.title ?? "Could not send reply. Try again.";
+}
+
+interface MessageBubbleProps {
+  message: SupportTicketMessageDto;
+  onAttachmentClick: (publicId: string) => void;
+}
+
+function MessageBubble({ message, onAttachmentClick }: MessageBubbleProps) {
+  const isAdmin = message.authorRole === "ADMIN";
+  const isInternalNote = isAdmin && message.visibleToUser === false;
+  const sideClasses = isAdmin ? "justify-start" : "justify-end";
+
+  // Three styles on the admin view:
+  //   - User bubble (right, brand)
+  //   - Admin public reply (left, surface-raised)
+  //   - Admin internal note (left, warning palette so it visually pops)
+  let bubbleClasses: string;
+  if (isInternalNote) {
+    bubbleClasses =
+      "border border-warning bg-warning-bg/20 text-fg";
+  } else if (isAdmin) {
+    bubbleClasses = "bg-surface-raised text-fg ring-1 ring-border-subtle";
+  } else {
+    bubbleClasses = "bg-brand text-white";
+  }
+
+  let roleLabel: string;
+  if (isInternalNote) roleLabel = "Internal note";
+  else if (isAdmin) roleLabel = "Admin";
+  else roleLabel = "User";
+
+  return (
+    <div
+      className={cn("flex w-full", sideClasses)}
+      data-testid={`support-message-${message.publicId}`}
+      data-role={message.authorRole}
+      data-internal={isInternalNote ? "true" : "false"}
+    >
+      <div className="flex max-w-[80%] flex-col gap-1">
+        <div
+          className={cn(
+            "flex items-center gap-2 text-[11px] text-fg-muted",
+            isAdmin ? "justify-start" : "justify-end",
+          )}
+        >
+          {isInternalNote && (
+            <EyeOff
+              className="size-3 text-warning"
+              aria-hidden="true"
+              data-testid={`support-message-internal-icon-${message.publicId}`}
+            />
+          )}
+          <span
+            className={cn(
+              "font-medium",
+              isInternalNote ? "text-warning" : "text-fg",
+            )}
+            data-testid={`support-message-role-${message.publicId}`}
+          >
+            {roleLabel}
+            {message.authorDisplayName ? ` - ${message.authorDisplayName}` : ""}
+          </span>
+          <span title={formatAbsoluteTime(message.createdAt)}>
+            {formatRelativeTime(message.createdAt)}
+          </span>
+        </div>
+
+        <div
+          className={cn(
+            "rounded-2xl px-4 py-2.5 text-sm whitespace-pre-wrap break-words",
+            bubbleClasses,
+          )}
+          data-testid={`support-message-body-${message.publicId}`}
+        >
+          {message.body}
+        </div>
+
+        {message.attachments.length > 0 && (
+          <ul
+            data-testid={`support-message-attachments-${message.publicId}`}
+            className={cn(
+              "flex flex-wrap gap-2",
+              isAdmin ? "justify-start" : "justify-end",
+            )}
+          >
+            {message.attachments.map((att) => (
+              <li key={att.publicId}>
+                <button
+                  type="button"
+                  onClick={() => onAttachmentClick(att.publicId)}
+                  data-testid={`support-attachment-${att.publicId}`}
+                  aria-label="View attachment"
+                  className="inline-flex size-20 items-center justify-center rounded-lg bg-bg-subtle ring-1 ring-border-subtle text-[10px] text-fg-muted hover:ring-brand focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+                >
+                  Attachment
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface AttachmentLightboxProps {
+  attachmentPublicId: string | null;
+  onClose: () => void;
+}
+
+function AttachmentLightbox({
+  attachmentPublicId,
+  onClose,
+}: AttachmentLightboxProps) {
+  const { data, isPending, isError } = useSignedAttachmentUrl(
+    attachmentPublicId,
+  );
+
+  return (
+    <Modal
+      open={attachmentPublicId !== null}
+      title="Attachment"
+      onClose={onClose}
+    >
+      <div
+        className="flex min-h-[12rem] items-center justify-center"
+        data-testid="support-attachment-lightbox"
+      >
+        {isPending && <LoadingSpinner label="Loading image..." />}
+        {isError && (
+          <p className="text-sm text-danger" role="alert">
+            Could not load attachment.
+          </p>
+        )}
+        {data?.url && (
+          // Signed S3 URL is absolute (presigned); skip apiUrl() and JWT.
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={data.url}
+            alt="Support ticket attachment"
+            className="max-h-[70vh] w-auto max-w-full rounded-lg"
+            data-testid="support-attachment-lightbox-image"
+          />
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+interface AdminSupportTicketDetailProps {
+  publicId: string;
+}
+
+export function AdminSupportTicketDetail({
+  publicId,
+}: AdminSupportTicketDetailProps) {
+  const session = useAuth();
+  const callerAdminPublicId =
+    session.status === "authenticated" ? session.user.publicId : null;
+
+  const ticketQuery = useAdminSupportTicket(publicId);
+  const replyMutation = useAdminSupportReply(publicId);
+  const resolveMutation = useAdminSupportResolve(publicId);
+  const reopenMutation = useAdminSupportReopen(publicId);
+  const assignMutation = useAdminSupportAssign(publicId);
+  const patchCategoryMutation = useAdminSupportPatchCategory(publicId);
+
+  const [replyBody, setReplyBody] = useState("");
+  const [replyAttachmentKeys, setReplyAttachmentKeys] = useState<string[]>([]);
+  const [internalNote, setInternalNote] = useState(false);
+  const [replyError, setReplyError] = useState<string | null>(null);
+  const [lightboxAttachmentId, setLightboxAttachmentId] = useState<
+    string | null
+  >(null);
+
+  // Admin sees every message, including internal notes. Defensive: the
+  // backend's admin mapper already returns the full list, but we don't
+  // re-filter here either way.
+  const allMessages: SupportTicketMessageDto[] = useMemo(
+    () => ticketQuery.data?.messages ?? [],
+    [ticketQuery.data?.messages],
+  );
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    const trimmed = replyBody.trim();
+    if (trimmed.length === 0) {
+      setReplyError("Reply cannot be empty.");
+      return;
+    }
+    if (trimmed.length > BODY_MAX) {
+      setReplyError(`Reply must be ${BODY_MAX} characters or fewer.`);
+      return;
+    }
+    setReplyError(null);
+    const req: AdminReplyRequest = {
+      body: trimmed,
+      attachmentKeys:
+        replyAttachmentKeys.length === 0 ? undefined : replyAttachmentKeys,
+      internalNote,
+    };
+    replyMutation.mutate(req, {
+      onSuccess: () => {
+        setReplyBody("");
+        setReplyAttachmentKeys([]);
+        setInternalNote(false);
+      },
+    });
+  }
+
+  if (ticketQuery.isLoading) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        <LoadingSpinner label="Loading ticket..." />
+      </div>
+    );
+  }
+
+  if (ticketQuery.isError || !ticketQuery.data) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        <div
+          role="alert"
+          className="rounded-lg border border-danger/30 bg-danger-bg/50 px-4 py-3 text-sm text-danger"
+          data-testid="admin-support-detail-load-error"
+        >
+          Could not load this ticket. It may have been removed.
+        </div>
+        <div className="mt-4">
+          <Link
+            href="/admin/support"
+            className="text-xs text-fg-muted hover:text-fg inline-flex items-center gap-1"
+          >
+            <ChevronLeft className="size-3" aria-hidden="true" />
+            Back to support queue
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const ticket = ticketQuery.data;
+  const isResolved = ticket.status === "RESOLVED";
+  const submitting = replyMutation.isPending;
+  const serverError =
+    replyMutation.isError && !replyError
+      ? describeReplyError(replyMutation.error)
+      : null;
+
+  const assignedToCaller =
+    !!callerAdminPublicId &&
+    ticket.assignedAdminPublicId === callerAdminPublicId;
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8 flex flex-col gap-6">
+      <div>
+        <Link
+          href="/admin/support"
+          className="text-xs text-fg-muted hover:text-fg inline-flex items-center gap-1"
+          data-testid="admin-support-detail-back-link"
+        >
+          <ChevronLeft className="size-3" aria-hidden="true" />
+          Back to support queue
+        </Link>
+      </div>
+
+      <Card>
+        <Card.Header>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="flex flex-col gap-2 min-w-0">
+              <h1
+                className="text-xl font-bold tracking-tight font-display break-words"
+                data-testid="admin-support-detail-subject"
+              >
+                {ticket.subject}
+              </h1>
+              <div className="flex flex-wrap items-center gap-2">
+                <label className="flex items-center gap-2 text-xs text-fg-muted">
+                  Category
+                  <select
+                    value={ticket.category}
+                    onChange={(e) =>
+                      patchCategoryMutation.mutate(
+                        e.target.value as SupportTicketCategory,
+                      )
+                    }
+                    disabled={patchCategoryMutation.isPending}
+                    data-testid="admin-support-detail-category-select"
+                    aria-label="Change ticket category"
+                    className="rounded-md bg-bg-muted px-2 py-1.5 text-sm text-fg ring-1 ring-border-subtle focus:outline-none focus:ring-2 focus:ring-brand"
+                  >
+                    {CATEGORY_VALUES.map((value) => (
+                      <option key={value} value={value}>
+                        {CATEGORY_LABELS[value]}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <span
+                  className={cn(
+                    "inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold",
+                    statusPillClass(ticket.status),
+                  )}
+                  data-testid="admin-support-detail-status-pill"
+                >
+                  {statusLabel(ticket.status)}
+                </span>
+              </div>
+              <div
+                className="text-[11px] text-fg-muted"
+                data-testid="admin-support-detail-assignee"
+              >
+                Submitter:{" "}
+                <span className="text-fg">{ticket.submitterDisplayName}</span>
+                {"  -  "}
+                Assigned to:{" "}
+                <span className="text-fg">
+                  {ticket.assignedAdminDisplayName ?? "Unassigned"}
+                </span>
+              </div>
+            </div>
+            <div
+              className="text-[11px] text-fg-muted"
+              title={formatAbsoluteTime(ticket.updatedAt)}
+            >
+              Updated {formatRelativeTime(ticket.updatedAt)}
+            </div>
+          </div>
+        </Card.Header>
+        <Card.Body>
+          <div className="flex flex-wrap items-center gap-2">
+            {!assignedToCaller && callerAdminPublicId && (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() =>
+                  assignMutation.mutate(callerAdminPublicId)
+                }
+                disabled={assignMutation.isPending}
+                leftIcon={<UserPlus className="size-3.5" />}
+                data-testid="admin-support-detail-assign-me"
+              >
+                Assign to me
+              </Button>
+            )}
+            {ticket.assignedAdminPublicId !== null && (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => assignMutation.mutate(null)}
+                disabled={assignMutation.isPending}
+                leftIcon={<UserMinus className="size-3.5" />}
+                data-testid="admin-support-detail-unassign"
+              >
+                Unassign
+              </Button>
+            )}
+            {!isResolved && (
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                onClick={() => resolveMutation.mutate()}
+                disabled={resolveMutation.isPending}
+                leftIcon={<UserCheck className="size-3.5" />}
+                data-testid="admin-support-detail-resolve"
+              >
+                Resolve
+              </Button>
+            )}
+            {isResolved && (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => reopenMutation.mutate()}
+                disabled={reopenMutation.isPending}
+                data-testid="admin-support-detail-reopen"
+              >
+                Reopen
+              </Button>
+            )}
+          </div>
+        </Card.Body>
+      </Card>
+
+      <div
+        className="flex flex-col gap-4"
+        data-testid="admin-support-detail-messages"
+      >
+        {allMessages.map((message) => (
+          <MessageBubble
+            key={message.publicId}
+            message={message}
+            onAttachmentClick={setLightboxAttachmentId}
+          />
+        ))}
+      </div>
+
+      <Card>
+        <Card.Header>
+          <h2 className="text-sm font-semibold tracking-tight text-fg">
+            Reply
+          </h2>
+        </Card.Header>
+        <Card.Body>
+          <form
+            onSubmit={handleSubmit}
+            className="flex flex-col gap-3"
+            aria-label="Reply to support ticket"
+            data-testid="admin-support-detail-reply-form"
+            noValidate
+          >
+            <div
+              data-testid="admin-support-detail-composer-wrapper"
+              data-internal={internalNote ? "true" : "false"}
+              className={cn(
+                "rounded-lg p-3 transition-colors",
+                internalNote
+                  ? "border border-warning bg-warning-bg/20"
+                  : "border border-transparent bg-transparent",
+              )}
+            >
+              <Textarea
+                label={internalNote ? "Internal note" : "Public reply"}
+                value={replyBody}
+                onChange={(e) => {
+                  setReplyBody(e.target.value);
+                  if (replyError) setReplyError(null);
+                }}
+                placeholder={
+                  internalNote
+                    ? "Type a note visible only to admins..."
+                    : "Type your reply..."
+                }
+                rows={5}
+                maxLength={BODY_MAX}
+                data-testid="admin-support-detail-reply-textarea"
+                error={replyError ?? undefined}
+                disabled={submitting}
+              />
+            </div>
+
+            <SupportAttachmentDropzone
+              attachmentKeys={replyAttachmentKeys}
+              onAttachmentKeyAdded={(key) =>
+                setReplyAttachmentKeys((prev) =>
+                  prev.includes(key) ? prev : [...prev, key],
+                )
+              }
+              onAttachmentKeyRemoved={(key) =>
+                setReplyAttachmentKeys((prev) => prev.filter((k) => k !== key))
+              }
+              maxAttachments={ATTACHMENT_MAX}
+              disabled={submitting}
+            />
+
+            <Checkbox
+              checked={internalNote}
+              onChange={(e) => setInternalNote(e.target.checked)}
+              disabled={submitting}
+              data-testid="admin-support-detail-internal-note-checkbox"
+              label={
+                <span className="inline-flex items-center gap-1.5">
+                  <EyeOff
+                    className="size-3 text-warning"
+                    aria-hidden="true"
+                  />
+                  Internal note (not visible to the user)
+                </span>
+              }
+            />
+
+            {serverError && (
+              <div
+                role="alert"
+                data-testid="admin-support-detail-reply-error"
+                className="rounded-lg border border-danger/30 bg-danger-bg/50 px-4 py-3 text-sm text-danger"
+              >
+                {serverError}
+              </div>
+            )}
+
+            <div className="flex justify-end">
+              <Button
+                type="submit"
+                variant="primary"
+                loading={submitting}
+                disabled={submitting}
+                data-testid="admin-support-detail-reply-submit"
+              >
+                {internalNote ? "Add internal note" : "Send reply"}
+              </Button>
+            </div>
+          </form>
+        </Card.Body>
+      </Card>
+
+      <AttachmentLightbox
+        attachmentPublicId={lightboxAttachmentId}
+        onClose={() => setLightboxAttachmentId(null)}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/admin/support/AdminSupportTicketQueue.test.tsx
+++ b/frontend/src/components/admin/support/AdminSupportTicketQueue.test.tsx
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/test/render";
+import type {
+  AdminSupportTicketQueueRow,
+} from "@/types/support";
+import type { Page } from "@/types/page";
+
+const mockReplace = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/admin/support"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: mockReplace,
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+vi.mock("@/hooks/admin/useAdminSupportTickets", () => ({
+  useAdminSupportTickets: vi.fn(),
+  adminSupportTicketsKey: (p: unknown) => ["admin-support-tickets", p] as const,
+}));
+
+import { useAdminSupportTickets } from "@/hooks/admin/useAdminSupportTickets";
+import { AdminSupportTicketQueue } from "./AdminSupportTicketQueue";
+
+type HookReturn = ReturnType<typeof useAdminSupportTickets>;
+
+function row(
+  overrides: Partial<AdminSupportTicketQueueRow> = {},
+): AdminSupportTicketQueueRow {
+  return {
+    publicId: "00000000-0000-0000-0000-0000000000a1",
+    subject: "Cannot bid on parcel",
+    category: "BIDDING",
+    status: "OPEN",
+    submitterPublicId: "00000000-0000-0000-0000-0000000000b1",
+    submitterDisplayName: "Alice Resident",
+    assignedAdminPublicId: null,
+    assignedAdminDisplayName: null,
+    lastMessageAuthor: "USER",
+    lastMessageAt: new Date(Date.now() - 60_000).toISOString(),
+    ...overrides,
+  };
+}
+
+function page(
+  content: AdminSupportTicketQueueRow[],
+  overrides: Partial<Page<AdminSupportTicketQueueRow>> = {},
+): Page<AdminSupportTicketQueueRow> {
+  return {
+    content,
+    totalElements: content.length,
+    totalPages: 1,
+    number: 0,
+    size: 25,
+    ...overrides,
+  };
+}
+
+function setHook(
+  value: Partial<HookReturn> & { data?: Page<AdminSupportTicketQueueRow> },
+) {
+  vi.mocked(useAdminSupportTickets).mockReturnValue({
+    isLoading: false,
+    isError: false,
+    ...value,
+  } as unknown as HookReturn);
+}
+
+describe("<AdminSupportTicketQueue />", () => {
+  beforeEach(() => {
+    mockReplace.mockReset();
+    vi.clearAllMocks();
+  });
+
+  it("renders the empty state when the page has no rows", () => {
+    setHook({ data: page([]) });
+    renderWithProviders(<AdminSupportTicketQueue />);
+    expect(screen.getByTestId("support-tickets-empty")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("support-tickets-table"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders rows with subject, submitter, category, status", () => {
+    setHook({
+      data: page([
+        row({
+          publicId: "00000000-0000-0000-0000-0000000000a1",
+          subject: "Cannot bid",
+          submitterDisplayName: "Alice Resident",
+          category: "BIDDING",
+          status: "OPEN",
+          lastMessageAuthor: "USER",
+        }),
+        row({
+          publicId: "00000000-0000-0000-0000-0000000000a2",
+          subject: "Wallet balance wrong",
+          submitterDisplayName: "Bob Resident",
+          category: "WALLET",
+          status: "RESOLVED",
+          lastMessageAuthor: "ADMIN",
+          assignedAdminDisplayName: "Carol Admin",
+        }),
+      ]),
+    });
+
+    renderWithProviders(<AdminSupportTicketQueue />);
+
+    expect(screen.getByTestId("support-tickets-table")).toBeInTheDocument();
+    const subjectLink = screen.getByTestId(
+      "support-ticket-subject-00000000-0000-0000-0000-0000000000a1",
+    );
+    expect(subjectLink).toHaveAttribute(
+      "href",
+      "/admin/support/00000000-0000-0000-0000-0000000000a1",
+    );
+    expect(screen.getByText("Alice Resident")).toBeInTheDocument();
+    expect(screen.getByText("Bob Resident")).toBeInTheDocument();
+    expect(screen.getByText("Carol Admin")).toBeInTheDocument();
+    // Status pills + "needs admin reply" hint on the open USER row.
+    expect(screen.getByText("needs admin reply")).toBeInTheDocument();
+    const table = screen.getByTestId("support-tickets-table");
+    expect(table).toHaveTextContent("Open");
+    expect(table).toHaveTextContent("Resolved");
+  });
+
+  it("status select updates the URL", async () => {
+    setHook({ data: page([]) });
+    renderWithProviders(<AdminSupportTicketQueue />);
+    const select = screen.getByTestId("status-select");
+    await userEvent.selectOptions(select, "OPEN");
+    expect(mockReplace).toHaveBeenCalledWith(
+      expect.stringContaining("status=OPEN"),
+      expect.anything(),
+    );
+  });
+
+  it("last-author filter 'Needs admin reply' updates the URL", async () => {
+    setHook({ data: page([]) });
+    renderWithProviders(<AdminSupportTicketQueue />);
+    const select = screen.getByTestId("last-author-select");
+    await userEvent.selectOptions(select, "USER");
+    expect(mockReplace).toHaveBeenCalledWith(
+      expect.stringContaining("last_author=USER"),
+      expect.anything(),
+    );
+  });
+
+  it("search input commits on Enter", async () => {
+    setHook({ data: page([]) });
+    renderWithProviders(<AdminSupportTicketQueue />);
+    const input = screen.getByTestId("support-search-input");
+    await userEvent.type(input, "bid{Enter}");
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith(
+        expect.stringContaining("q=bid"),
+        expect.anything(),
+      ),
+    );
+  });
+
+  it("renders pagination when totalPages > 1", () => {
+    setHook({
+      data: page([row()], {
+        totalPages: 3,
+        totalElements: 75,
+        number: 0,
+      }),
+    });
+    renderWithProviders(<AdminSupportTicketQueue />);
+    expect(
+      screen.getByRole("navigation", { name: /pagination/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a loading skeleton", () => {
+    setHook({ isLoading: true, data: undefined });
+    const { container } = renderWithProviders(<AdminSupportTicketQueue />);
+    expect(
+      container.querySelector('[aria-busy="true"]'),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an error state", () => {
+    setHook({ isError: true, data: undefined });
+    renderWithProviders(<AdminSupportTicketQueue />);
+    expect(
+      screen.getByText(/Could not load tickets/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/admin/support/AdminSupportTicketQueue.tsx
+++ b/frontend/src/components/admin/support/AdminSupportTicketQueue.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useAuth } from "@/lib/auth";
 import { useAdminSupportTickets } from "@/hooks/admin/useAdminSupportTickets";
 import { Pagination } from "@/components/ui/Pagination";
 import { formatRelativeTime } from "@/lib/time/relativeTime";
@@ -79,9 +78,6 @@ function SkeletonRows() {
 export function AdminSupportTicketQueue() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const session = useAuth();
-  const adminPublicId =
-    session.status === "authenticated" ? session.user.publicId : null;
 
   const q = searchParams?.get("q") ?? "";
   const status = parseStatus(searchParams?.get("status") ?? null);
@@ -93,17 +89,12 @@ export function AdminSupportTicketQueue() {
     parseInt(searchParams?.get("page") ?? "0", 10) || 0,
   );
 
-  // Translate the UI "mine" sentinel into the admin's own publicId. The
-  // wire param is a free-form admin publicId on the backend (the spec
-  // uses the same field for both "mine" and "filter by a specific
-  // admin"); the UI only exposes mine/unassigned because admins don't
-  // pick each other off a dropdown today.
+  // Wire encoding matches the backend service's `listAdmin` switch:
+  //   - "mine" -> server resolves to the caller's adminId via AuthPrincipal
+  //   - "unassigned" -> tickets with no assigned admin
+  //   - a UUID string -> tickets SUBMITTED BY that user (not used by the UI today)
   const assigneeParam =
-    assignee === "all"
-      ? undefined
-      : assignee === "mine"
-        ? (adminPublicId ?? undefined)
-        : "unassigned";
+    assignee === "all" ? undefined : assignee;
 
   const params = {
     q: q || undefined,

--- a/frontend/src/components/admin/support/AdminSupportTicketQueue.tsx
+++ b/frontend/src/components/admin/support/AdminSupportTicketQueue.tsx
@@ -1,0 +1,382 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useAuth } from "@/lib/auth";
+import { useAdminSupportTickets } from "@/hooks/admin/useAdminSupportTickets";
+import { Pagination } from "@/components/ui/Pagination";
+import { formatRelativeTime } from "@/lib/time/relativeTime";
+import type {
+  AdminSupportTicketQueueRow,
+  SupportTicketCategory,
+  SupportTicketStatus,
+} from "@/types/support";
+
+const PAGE_SIZE = 25;
+
+type StatusFilter = "all" | SupportTicketStatus;
+type CategoryFilter = "ALL" | SupportTicketCategory;
+type AssigneeFilter = "all" | "mine" | "unassigned";
+type LastAuthorFilter = "all" | "USER" | "ADMIN";
+
+const CATEGORY_LABELS: Record<SupportTicketCategory, string> = {
+  ACCOUNT: "Account",
+  BIDDING: "Bidding",
+  LISTING: "Listing",
+  ESCROW: "Escrow",
+  WALLET: "Wallet",
+  OTHER: "Other",
+};
+
+function parseStatus(raw: string | null): StatusFilter {
+  if (raw === "OPEN" || raw === "RESOLVED") return raw;
+  return "all";
+}
+
+function parseCategory(raw: string | null): CategoryFilter {
+  if (
+    raw === "ACCOUNT" ||
+    raw === "BIDDING" ||
+    raw === "LISTING" ||
+    raw === "ESCROW" ||
+    raw === "WALLET" ||
+    raw === "OTHER"
+  ) {
+    return raw;
+  }
+  return "ALL";
+}
+
+function parseAssignee(raw: string | null): AssigneeFilter {
+  if (raw === "mine" || raw === "unassigned") return raw;
+  return "all";
+}
+
+function parseLastAuthor(raw: string | null): LastAuthorFilter {
+  if (raw === "USER" || raw === "ADMIN") return raw;
+  return "all";
+}
+
+function statusPillClass(status: SupportTicketStatus): string {
+  if (status === "OPEN") return "bg-warning-bg text-warning";
+  return "bg-success-bg text-success";
+}
+
+function statusLabel(status: SupportTicketStatus): string {
+  return status === "OPEN" ? "Open" : "Resolved";
+}
+
+function SkeletonRows() {
+  return (
+    <div className="space-y-2 py-4" aria-busy="true">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="h-12 rounded-lg bg-bg-muted animate-pulse" />
+      ))}
+    </div>
+  );
+}
+
+export function AdminSupportTicketQueue() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const session = useAuth();
+  const adminPublicId =
+    session.status === "authenticated" ? session.user.publicId : null;
+
+  const q = searchParams?.get("q") ?? "";
+  const status = parseStatus(searchParams?.get("status") ?? null);
+  const category = parseCategory(searchParams?.get("category") ?? null);
+  const assignee = parseAssignee(searchParams?.get("assignee") ?? null);
+  const lastAuthor = parseLastAuthor(searchParams?.get("last_author") ?? null);
+  const page = Math.max(
+    0,
+    parseInt(searchParams?.get("page") ?? "0", 10) || 0,
+  );
+
+  // Translate the UI "mine" sentinel into the admin's own publicId. The
+  // wire param is a free-form admin publicId on the backend (the spec
+  // uses the same field for both "mine" and "filter by a specific
+  // admin"); the UI only exposes mine/unassigned because admins don't
+  // pick each other off a dropdown today.
+  const assigneeParam =
+    assignee === "all"
+      ? undefined
+      : assignee === "mine"
+        ? (adminPublicId ?? undefined)
+        : "unassigned";
+
+  const params = {
+    q: q || undefined,
+    status: status === "all" ? undefined : status,
+    category: category === "ALL" ? undefined : category,
+    assignee: assigneeParam,
+    last_author: lastAuthor === "all" ? undefined : lastAuthor,
+    page,
+    size: PAGE_SIZE,
+  };
+
+  const { data, isLoading, isError } = useAdminSupportTickets(params);
+
+  function buildUrl(overrides: {
+    q?: string;
+    status?: StatusFilter;
+    category?: CategoryFilter;
+    assignee?: AssigneeFilter;
+    lastAuthor?: LastAuthorFilter;
+    page?: number;
+  }): string {
+    const sp = new URLSearchParams();
+    const nextQ = overrides.q !== undefined ? overrides.q : q;
+    const nextStatus = overrides.status ?? status;
+    const nextCategory = overrides.category ?? category;
+    const nextAssignee = overrides.assignee ?? assignee;
+    const nextLastAuthor = overrides.lastAuthor ?? lastAuthor;
+    const nextPage = overrides.page ?? 0;
+    if (nextQ) sp.set("q", nextQ);
+    if (nextStatus !== "all") sp.set("status", nextStatus);
+    if (nextCategory !== "ALL") sp.set("category", nextCategory);
+    if (nextAssignee !== "all") sp.set("assignee", nextAssignee);
+    if (nextLastAuthor !== "all") sp.set("last_author", nextLastAuthor);
+    if (nextPage > 0) sp.set("page", String(nextPage));
+    const qs = sp.toString();
+    return qs ? `/admin/support?${qs}` : "/admin/support";
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-semibold">Support</h1>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        <input
+          key={q}
+          defaultValue={q}
+          placeholder="Search by subject"
+          data-testid="support-search-input"
+          aria-label="Search tickets by subject"
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              const v = (e.target as HTMLInputElement).value.trim();
+              router.replace(buildUrl({ q: v || "", page: 0 }), {
+                scroll: false,
+              });
+            }
+          }}
+          className="flex-1 min-w-[240px] rounded-lg bg-bg-muted px-4 py-2 text-sm text-fg placeholder:text-fg-muted ring-1 ring-border-subtle focus:outline-none focus:ring-2 focus:ring-brand"
+        />
+
+        <label className="flex items-center gap-2 text-xs text-fg-muted">
+          Status
+          <select
+            value={status}
+            data-testid="status-select"
+            aria-label="Filter by status"
+            onChange={(e) =>
+              router.replace(
+                buildUrl({
+                  status: e.target.value as StatusFilter,
+                  page: 0,
+                }),
+                { scroll: false },
+              )
+            }
+            className="rounded-md bg-bg-muted px-2 py-1.5 text-sm text-fg ring-1 ring-border-subtle focus:outline-none focus:ring-2 focus:ring-brand"
+          >
+            <option value="all">All</option>
+            <option value="OPEN">Open</option>
+            <option value="RESOLVED">Resolved</option>
+          </select>
+        </label>
+
+        <label className="flex items-center gap-2 text-xs text-fg-muted">
+          Category
+          <select
+            value={category}
+            data-testid="category-select"
+            aria-label="Filter by category"
+            onChange={(e) =>
+              router.replace(
+                buildUrl({
+                  category: e.target.value as CategoryFilter,
+                  page: 0,
+                }),
+                { scroll: false },
+              )
+            }
+            className="rounded-md bg-bg-muted px-2 py-1.5 text-sm text-fg ring-1 ring-border-subtle focus:outline-none focus:ring-2 focus:ring-brand"
+          >
+            <option value="ALL">Any</option>
+            <option value="ACCOUNT">Account</option>
+            <option value="BIDDING">Bidding</option>
+            <option value="LISTING">Listing</option>
+            <option value="ESCROW">Escrow</option>
+            <option value="WALLET">Wallet</option>
+            <option value="OTHER">Other</option>
+          </select>
+        </label>
+
+        <label className="flex items-center gap-2 text-xs text-fg-muted">
+          Assignee
+          <select
+            value={assignee}
+            data-testid="assignee-select"
+            aria-label="Filter by assignee"
+            onChange={(e) =>
+              router.replace(
+                buildUrl({
+                  assignee: e.target.value as AssigneeFilter,
+                  page: 0,
+                }),
+                { scroll: false },
+              )
+            }
+            className="rounded-md bg-bg-muted px-2 py-1.5 text-sm text-fg ring-1 ring-border-subtle focus:outline-none focus:ring-2 focus:ring-brand"
+          >
+            <option value="all">All</option>
+            <option value="mine">Mine</option>
+            <option value="unassigned">Unassigned</option>
+          </select>
+        </label>
+
+        <label className="flex items-center gap-2 text-xs text-fg-muted">
+          Last reply
+          <select
+            value={lastAuthor}
+            data-testid="last-author-select"
+            aria-label="Filter by last author"
+            onChange={(e) =>
+              router.replace(
+                buildUrl({
+                  lastAuthor: e.target.value as LastAuthorFilter,
+                  page: 0,
+                }),
+                { scroll: false },
+              )
+            }
+            className="rounded-md bg-bg-muted px-2 py-1.5 text-sm text-fg ring-1 ring-border-subtle focus:outline-none focus:ring-2 focus:ring-brand"
+          >
+            <option value="all">All</option>
+            <option value="USER">Needs admin reply</option>
+            <option value="ADMIN">Waiting on user</option>
+          </select>
+        </label>
+      </div>
+
+      {isLoading && <SkeletonRows />}
+
+      {isError && (
+        <div className="text-sm text-danger py-8" role="alert">
+          Could not load tickets. Refresh to retry.
+        </div>
+      )}
+
+      {data && data.content.length === 0 && (
+        <div
+          className="py-12 text-center text-sm text-fg-muted"
+          data-testid="support-tickets-empty"
+        >
+          No tickets match these filters.
+        </div>
+      )}
+
+      {data && data.content.length > 0 && (
+        <>
+          <div
+            className="overflow-x-auto rounded-lg border border-border-subtle"
+            data-testid="support-tickets-table"
+          >
+            <table className="w-full text-sm">
+              <thead className="bg-bg-subtle border-b border-border-subtle">
+                <tr>
+                  <th className="px-3 py-2.5 text-left text-[11px] font-medium text-fg-muted">
+                    Subject
+                  </th>
+                  <th className="px-3 py-2.5 text-left text-[11px] font-medium text-fg-muted">
+                    Submitter
+                  </th>
+                  <th className="px-3 py-2.5 text-left text-[11px] font-medium text-fg-muted">
+                    Category
+                  </th>
+                  <th className="px-3 py-2.5 text-left text-[11px] font-medium text-fg-muted">
+                    Status
+                  </th>
+                  <th className="px-3 py-2.5 text-left text-[11px] font-medium text-fg-muted">
+                    Last activity
+                  </th>
+                  <th className="px-3 py-2.5 text-left text-[11px] font-medium text-fg-muted">
+                    Assigned to
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.content.map((row: AdminSupportTicketQueueRow) => {
+                  const needsReply =
+                    row.lastMessageAuthor === "USER" && row.status === "OPEN";
+                  return (
+                    <tr
+                      key={row.publicId}
+                      data-testid={`support-ticket-row-${row.publicId}`}
+                      className="border-b border-border-subtle/50 hover:bg-bg-muted/50"
+                    >
+                      <td className="px-3 py-2.5">
+                        <Link
+                          href={`/admin/support/${row.publicId}`}
+                          className="text-fg font-medium hover:underline"
+                          data-testid={`support-ticket-subject-${row.publicId}`}
+                        >
+                          {row.subject}
+                        </Link>
+                      </td>
+                      <td className="px-3 py-2.5 text-fg text-[12px]">
+                        {row.submitterDisplayName}
+                      </td>
+                      <td className="px-3 py-2.5">
+                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-info-bg text-info">
+                          {CATEGORY_LABELS[row.category]}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2.5">
+                        <div className="flex flex-col gap-0.5">
+                          <span
+                            className={`inline-flex w-fit items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${statusPillClass(row.status)}`}
+                          >
+                            {statusLabel(row.status)}
+                          </span>
+                          {needsReply && (
+                            <span className="text-[10px] text-warning">
+                              needs admin reply
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-3 py-2.5 text-fg-muted text-[11px]">
+                        {formatRelativeTime(row.lastMessageAt)}
+                      </td>
+                      <td className="px-3 py-2.5 text-fg-muted text-[12px]">
+                        {row.assignedAdminDisplayName ?? (
+                          <span className="text-fg-muted/60">Unassigned</span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          {data.totalPages > 1 && (
+            <div className="mt-4">
+              <Pagination
+                page={data.number}
+                totalPages={data.totalPages}
+                onPageChange={(p) =>
+                  router.replace(buildUrl({ page: p }), { scroll: false })
+                }
+              />
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/auth/UserMenuDropdown.tsx
+++ b/frontend/src/components/auth/UserMenuDropdown.tsx
@@ -68,6 +68,10 @@ export function UserMenuDropdown({ user }: UserMenuDropdownProps) {
       ? [{ label: "Admin", onSelect: () => router.push("/admin") }]
       : []),
     {
+      label: "Support",
+      onSelect: () => router.push("/support"),
+    },
+    {
       label: "Sign Out",
       onSelect: () => logout.mutate(),
       danger: true,

--- a/frontend/src/components/layout/MobileMenu.tsx
+++ b/frontend/src/components/layout/MobileMenu.tsx
@@ -101,6 +101,7 @@ export function MobileMenu({ open, onClose }: MobileMenuProps) {
           <div className="mt-auto flex flex-wrap gap-4 border-t border-border px-5 py-3">
             <FooterLink href="/about" onClose={onClose}>About</FooterLink>
             <FooterLink href="/contact" onClose={onClose}>Contact</FooterLink>
+            <FooterLink href="/support" onClose={onClose}>Support</FooterLink>
             <FooterLink href="/terms" onClose={onClose}>Terms</FooterLink>
           </div>
         </DialogPanel>

--- a/frontend/src/components/support/NewSupportTicketForm.test.tsx
+++ b/frontend/src/components/support/NewSupportTicketForm.test.tsx
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/test/render";
+import { ApiError, type ProblemDetail } from "@/lib/api";
+import type { CreateSupportTicketRequest } from "@/types/support";
+
+// next/navigation is touched by the create-ticket mutation hook (for the
+// success-path redirect). The component itself doesn't read the router,
+// but the hook initialisation does, so we stub it the same way the rest
+// of the support feature does.
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/support/new"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+// Mock the create mutation. Tests drive the body shape via mutateMock and
+// can flip the surface into error/pending states via `mutationState`.
+const mutateMock = vi.fn();
+let mutationState: {
+  isPending: boolean;
+  isError: boolean;
+  error: unknown;
+} = { isPending: false, isError: false, error: null };
+
+vi.mock("@/hooks/useCreateSupportTicket", () => ({
+  useCreateSupportTicket: () => ({
+    mutate: mutateMock,
+    isPending: mutationState.isPending,
+    isError: mutationState.isError,
+    error: mutationState.error,
+  }),
+}));
+
+// Mock the upload mutation that the dropzone transitively uses.
+const uploadMutateAsyncMock = vi.fn();
+vi.mock("@/hooks/useUploadSupportAttachment", () => ({
+  useUploadSupportAttachment: () => ({
+    mutateAsync: uploadMutateAsyncMock,
+    isPending: false,
+  }),
+}));
+
+import { NewSupportTicketForm } from "./NewSupportTicketForm";
+
+beforeEach(() => {
+  mutateMock.mockReset();
+  uploadMutateAsyncMock.mockReset();
+  mutationState = { isPending: false, isError: false, error: null };
+
+  // The dropzone builds object URLs for previews; jsdom leaves both
+  // undefined. Stub them so attachment tests don't throw.
+  let n = 0;
+  URL.createObjectURL = vi.fn(() => `blob:mock-${n++}`);
+  URL.revokeObjectURL = vi.fn();
+});
+
+describe("<NewSupportTicketForm />", () => {
+  it("blocks submit and surfaces inline errors when fields are empty", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NewSupportTicketForm />);
+
+    await user.click(screen.getByTestId("ticket-submit-btn"));
+
+    // Subject + body errors render under the Input/Textarea via the
+    // primitives' built-in error slot, so we assert by text rather than
+    // testid. The category-error testid is bespoke.
+    expect(screen.getByText(/subject is required/i)).toBeInTheDocument();
+    expect(screen.getByTestId("ticket-category-error")).toHaveTextContent(
+      /pick a category/i,
+    );
+    expect(screen.getByText(/message is required/i)).toBeInTheDocument();
+    expect(mutateMock).not.toHaveBeenCalled();
+  });
+
+  it("submits with a correctly shaped request body", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NewSupportTicketForm />);
+
+    await user.type(
+      screen.getByTestId("ticket-subject-input"),
+      "Wallet deposit stuck",
+    );
+    await user.selectOptions(
+      screen.getByTestId("ticket-category-select"),
+      "WALLET",
+    );
+    await user.type(
+      screen.getByTestId("ticket-body-textarea"),
+      "Deposited L$500 two hours ago and the wallet balance hasn't moved.",
+    );
+
+    await user.click(screen.getByTestId("ticket-submit-btn"));
+
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+    const body = mutateMock.mock.calls[0][0] as CreateSupportTicketRequest;
+    expect(body.subject).toBe("Wallet deposit stuck");
+    expect(body.category).toBe("WALLET");
+    expect(body.body).toBe(
+      "Deposited L$500 two hours ago and the wallet balance hasn't moved.",
+    );
+    // No attachments staged in this test, so the field is omitted.
+    expect(body.attachmentKeys).toBeUndefined();
+  });
+
+  it("character counter goes red past the 10000-char cap", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NewSupportTicketForm />);
+
+    const textarea = screen.getByTestId(
+      "ticket-body-textarea",
+    ) as HTMLTextAreaElement;
+    // userEvent.type with a 10k+ string is too slow; assign via fireEvent.
+    const overCap = "x".repeat(10001);
+    // user.clear + type would re-render per char; use a direct change event.
+    // We import fireEvent indirectly via @testing-library/react re-export
+    // through @/test/render, but to keep this file self-contained we just
+    // call a userEvent.paste which sets the whole value at once.
+    textarea.focus();
+    await user.paste(overCap);
+
+    const counter = screen.getByTestId("ticket-body-counter");
+    expect(counter).toHaveTextContent("10001 / 10000");
+    // Tailwind class swap: when over cap, the counter uses text-danger.
+    expect(counter.className).toContain("text-danger");
+  });
+
+  it("includes staged attachment keys in the submitted request", async () => {
+    uploadMutateAsyncMock.mockImplementation(async (file: File) => ({
+      attachmentKey: `att-${file.name}`,
+    }));
+
+    const user = userEvent.setup();
+    renderWithProviders(<NewSupportTicketForm />);
+
+    // Fill required fields.
+    await user.type(screen.getByTestId("ticket-subject-input"), "Need help");
+    await user.selectOptions(
+      screen.getByTestId("ticket-category-select"),
+      "OTHER",
+    );
+    await user.type(
+      screen.getByTestId("ticket-body-textarea"),
+      "Some details.",
+    );
+
+    // Stage an attachment via the dropzone's hidden input.
+    const input = screen.getByTestId(
+      "support-attachment-input",
+    ) as HTMLInputElement;
+    const file = new File(["x"], "screenshot.png", { type: "image/png" });
+    await user.upload(input, file);
+
+    await screen.findByTestId(
+      "support-attachment-thumb-att-screenshot.png",
+    );
+
+    await user.click(screen.getByTestId("ticket-submit-btn"));
+
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1));
+    const body = mutateMock.mock.calls[0][0] as CreateSupportTicketRequest;
+    expect(body.attachmentKeys).toEqual(["att-screenshot.png"]);
+  });
+
+  it("renders the RATE_LIMITED server-error message", () => {
+    const problem: ProblemDetail = {
+      status: 429,
+      title: "Too many tickets",
+      code: "RATE_LIMITED",
+    };
+    mutationState = {
+      isPending: false,
+      isError: true,
+      error: new ApiError(problem),
+    };
+
+    renderWithProviders(<NewSupportTicketForm />);
+    expect(screen.getByTestId("new-ticket-form-error")).toHaveTextContent(
+      /sending too many tickets/i,
+    );
+  });
+
+  it("disables the submit button while the mutation is pending", () => {
+    mutationState = { isPending: true, isError: false, error: null };
+    renderWithProviders(<NewSupportTicketForm />);
+    expect(screen.getByTestId("ticket-submit-btn")).toBeDisabled();
+  });
+});

--- a/frontend/src/components/support/NewSupportTicketForm.tsx
+++ b/frontend/src/components/support/NewSupportTicketForm.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useState, type FormEvent, type ReactNode } from "react";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { Input } from "@/components/ui/Input";
+import { Textarea } from "@/components/ui/Textarea";
+import { SupportAttachmentDropzone } from "@/components/support/SupportAttachmentDropzone";
+import { useCreateSupportTicket } from "@/hooks/useCreateSupportTicket";
+import { isApiError } from "@/lib/api";
+import type {
+  CreateSupportTicketRequest,
+  SupportTicketCategory,
+  SupportTicketErrorCode,
+} from "@/types/support";
+
+const SUBJECT_MAX = 160;
+const BODY_MAX = 10000;
+
+const CATEGORY_OPTIONS: Array<{ value: SupportTicketCategory; label: string }> = [
+  { value: "ACCOUNT", label: "Account" },
+  { value: "BIDDING", label: "Bidding" },
+  { value: "LISTING", label: "Listing" },
+  { value: "ESCROW", label: "Escrow" },
+  { value: "WALLET", label: "Wallet" },
+  { value: "OTHER", label: "Other" },
+];
+
+interface SectionProps {
+  title: string;
+  description?: ReactNode;
+  children: ReactNode;
+}
+
+function Section({ title, description, children }: SectionProps) {
+  return (
+    <Card>
+      <Card.Header>
+        <h2 className="text-sm font-semibold tracking-tight text-fg">{title}</h2>
+        {description && (
+          <p className="mt-1 text-xs text-fg-muted">{description}</p>
+        )}
+      </Card.Header>
+      <Card.Body>
+        <div className="flex flex-col gap-4">{children}</div>
+      </Card.Body>
+    </Card>
+  );
+}
+
+function describeError(err: unknown): string {
+  if (!isApiError(err)) {
+    return "Could not submit ticket. Try again.";
+  }
+  const problem = err.problem as {
+    code?: SupportTicketErrorCode;
+    detail?: string;
+    title?: string;
+  };
+  switch (problem.code) {
+    case "RATE_LIMITED":
+      return "You're sending too many tickets. Wait an hour or reply to an existing open ticket.";
+    case "INVALID_ATTACHMENT":
+      return "One of your attachments was rejected. Remove it and try again.";
+  }
+  return problem.detail ?? problem.title ?? "Could not submit ticket. Try again.";
+}
+
+export function NewSupportTicketForm() {
+  const createMutation = useCreateSupportTicket();
+
+  const [subject, setSubject] = useState("");
+  const [category, setCategory] = useState<SupportTicketCategory | "">("");
+  const [body, setBody] = useState("");
+  const [attachmentKeys, setAttachmentKeys] = useState<string[]>([]);
+
+  const [subjectError, setSubjectError] = useState<string | null>(null);
+  const [categoryError, setCategoryError] = useState<string | null>(null);
+  const [bodyError, setBodyError] = useState<string | null>(null);
+
+  function validate(): boolean {
+    let ok = true;
+
+    const trimmedSubject = subject.trim();
+    if (trimmedSubject.length === 0) {
+      setSubjectError("Subject is required.");
+      ok = false;
+    } else if (trimmedSubject.length > SUBJECT_MAX) {
+      setSubjectError(`Subject must be ${SUBJECT_MAX} characters or fewer.`);
+      ok = false;
+    } else {
+      setSubjectError(null);
+    }
+
+    if (category === "") {
+      setCategoryError("Pick a category so we can route your ticket.");
+      ok = false;
+    } else {
+      setCategoryError(null);
+    }
+
+    const trimmedBody = body.trim();
+    if (trimmedBody.length === 0) {
+      setBodyError("Message is required.");
+      ok = false;
+    } else if (body.length > BODY_MAX) {
+      setBodyError(`Message must be ${BODY_MAX} characters or fewer.`);
+      ok = false;
+    } else {
+      setBodyError(null);
+    }
+
+    return ok;
+  }
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!validate()) return;
+    // Validation guarantees category is non-empty by this point.
+    const req: CreateSupportTicketRequest = {
+      subject: subject.trim(),
+      category: category as SupportTicketCategory,
+      body: body.trim(),
+      attachmentKeys: attachmentKeys.length === 0 ? undefined : attachmentKeys,
+    };
+    createMutation.mutate(req);
+  }
+
+  const submitting = createMutation.isPending;
+  const serverError = createMutation.isError
+    ? describeError(createMutation.error)
+    : null;
+
+  const bodyOverCap = body.length > BODY_MAX;
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-6"
+        aria-label="New support ticket"
+        data-testid="new-support-ticket-form"
+        noValidate
+      >
+        <div>
+          <h1 className="text-xl font-bold tracking-tight font-display">
+            New support ticket
+          </h1>
+          <p className="text-sm text-fg-muted mt-1">
+            Tell us what&apos;s going on and our team will follow up here.
+          </p>
+        </div>
+
+        <Section
+          title="Subject"
+          description="A short summary so we can spot it in the queue."
+        >
+          <Input
+            label="Subject"
+            value={subject}
+            onChange={(e) => {
+              setSubject(e.target.value);
+              if (subjectError) setSubjectError(null);
+            }}
+            placeholder="e.g. Wallet deposit stuck"
+            maxLength={SUBJECT_MAX}
+            data-testid="ticket-subject-input"
+            error={subjectError ?? undefined}
+          />
+        </Section>
+
+        <Section
+          title="Category"
+          description="Pick the area that best matches your issue."
+        >
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="ticket-category-select"
+              className="text-xs font-medium text-fg-muted"
+            >
+              Category
+            </label>
+            <select
+              id="ticket-category-select"
+              value={category}
+              onChange={(e) => {
+                setCategory(e.target.value as SupportTicketCategory | "");
+                if (categoryError) setCategoryError(null);
+              }}
+              data-testid="ticket-category-select"
+              aria-invalid={categoryError ? true : undefined}
+              className="h-12 w-full rounded-lg bg-bg-subtle px-4 text-fg ring-1 ring-transparent transition-all focus:bg-surface-raised focus:outline-none focus:ring-brand"
+            >
+              <option value="">Select a category...</option>
+              {CATEGORY_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            {categoryError && (
+              <p
+                className="text-xs text-danger"
+                data-testid="ticket-category-error"
+              >
+                {categoryError}
+              </p>
+            )}
+          </div>
+        </Section>
+
+        <Section
+          title="Message"
+          description="What happened, what you expected, and any helpful links."
+        >
+          <Textarea
+            label="Message"
+            value={body}
+            onChange={(e) => {
+              setBody(e.target.value);
+              if (bodyError) setBodyError(null);
+            }}
+            placeholder="Describe the issue. Include relevant auction or transaction IDs if you have them."
+            rows={8}
+            data-testid="ticket-body-textarea"
+            error={bodyError ?? undefined}
+          />
+          <div className="flex justify-end">
+            <span
+              className={
+                "text-[11px] " +
+                (bodyOverCap ? "text-danger" : "text-fg-muted")
+              }
+              data-testid="ticket-body-counter"
+            >
+              {body.length} / {BODY_MAX}
+            </span>
+          </div>
+        </Section>
+
+        <Section
+          title="Attachments"
+          description="Optional. Screenshots help us see what you're seeing."
+        >
+          <SupportAttachmentDropzone
+            attachmentKeys={attachmentKeys}
+            onAttachmentKeyAdded={(key) =>
+              setAttachmentKeys((prev) =>
+                prev.includes(key) ? prev : [...prev, key],
+              )
+            }
+            onAttachmentKeyRemoved={(key) =>
+              setAttachmentKeys((prev) => prev.filter((k) => k !== key))
+            }
+            disabled={submitting}
+          />
+        </Section>
+
+        {serverError && (
+          <div
+            role="alert"
+            data-testid="new-ticket-form-error"
+            className="rounded-lg border border-danger/30 bg-danger-bg/50 px-4 py-3 text-sm text-danger"
+          >
+            {serverError}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <Button
+            type="submit"
+            variant="primary"
+            loading={submitting}
+            disabled={submitting}
+            data-testid="ticket-submit-btn"
+          >
+            Submit ticket
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/support/SupportAttachmentDropzone.test.tsx
+++ b/frontend/src/components/support/SupportAttachmentDropzone.test.tsx
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/test/render";
+import { ApiError, type ProblemDetail } from "@/lib/api";
+
+// Mock the upload mutation hook before importing the component under test.
+// Each test can rewire `mutateAsyncMock` for the happy path or to surface
+// a thrown ApiError.
+const mutateAsyncMock = vi.fn();
+let uploadIsPending = false;
+
+vi.mock("@/hooks/useUploadSupportAttachment", () => ({
+  useUploadSupportAttachment: () => ({
+    mutateAsync: mutateAsyncMock,
+    isPending: uploadIsPending,
+  }),
+}));
+
+import { SupportAttachmentDropzone } from "./SupportAttachmentDropzone";
+
+// jsdom doesn't define URL.createObjectURL — stub it (and revoke) so the
+// component can build local previews without throwing.
+beforeEach(() => {
+  let n = 0;
+  URL.createObjectURL = vi.fn(() => `blob:mock-${n++}`);
+  URL.revokeObjectURL = vi.fn();
+  mutateAsyncMock.mockReset();
+  uploadIsPending = false;
+});
+
+function Harness({
+  initial = [] as string[],
+  max,
+  disabled = false,
+}: {
+  initial?: string[];
+  max?: number;
+  disabled?: boolean;
+}) {
+  const [keys, setKeys] = useState<string[]>(initial);
+  return (
+    <SupportAttachmentDropzone
+      attachmentKeys={keys}
+      onAttachmentKeyAdded={(k) => setKeys((prev) => [...prev, k])}
+      onAttachmentKeyRemoved={(k) =>
+        setKeys((prev) => prev.filter((x) => x !== k))
+      }
+      maxAttachments={max}
+      disabled={disabled}
+    />
+  );
+}
+
+describe("<SupportAttachmentDropzone />", () => {
+  it("renders the dropzone when attachmentKeys is below max", () => {
+    renderWithProviders(<Harness />);
+    expect(screen.getByTestId("support-attachment-zone")).toBeInTheDocument();
+  });
+
+  it("hides the dropzone when at the default max of 3", () => {
+    renderWithProviders(
+      <Harness initial={["k1", "k2", "k3"]} />,
+    );
+    expect(
+      screen.queryByTestId("support-attachment-zone"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("uploads a picked file and calls onAttachmentKeyAdded with the returned key", async () => {
+    mutateAsyncMock.mockImplementation(async (file: File) => ({
+      attachmentKey: `key-${file.name}`,
+    }));
+    renderWithProviders(<Harness />);
+
+    const input = screen.getByTestId(
+      "support-attachment-input",
+    ) as HTMLInputElement;
+    const file = new File(["x"], "shot.png", { type: "image/png" });
+    await userEvent.upload(input, file);
+
+    await waitFor(() => expect(mutateAsyncMock).toHaveBeenCalledTimes(1));
+    expect(mutateAsyncMock).toHaveBeenCalledWith(file);
+
+    // The Harness mirrors the added key back into the prop, so the thumb
+    // should appear after the mutation resolves.
+    await screen.findByTestId("support-attachment-thumb-key-shot.png");
+  });
+
+  it("renders a thumbnail for each attachmentKey", () => {
+    renderWithProviders(<Harness initial={["alpha", "beta"]} />);
+    expect(
+      screen.getByTestId("support-attachment-thumb-alpha"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("support-attachment-thumb-beta"),
+    ).toBeInTheDocument();
+  });
+
+  it("removes a key when its X button is clicked", async () => {
+    renderWithProviders(<Harness initial={["alpha", "beta"]} />);
+
+    await userEvent.click(
+      screen.getByTestId("support-attachment-remove-alpha"),
+    );
+
+    expect(
+      screen.queryByTestId("support-attachment-thumb-alpha"),
+    ).not.toBeInTheDocument();
+    // beta still present
+    expect(
+      screen.getByTestId("support-attachment-thumb-beta"),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces an inline error when upload throws INVALID_ATTACHMENT", async () => {
+    const problem: ProblemDetail = {
+      status: 400,
+      title: "Bad attachment",
+      code: "INVALID_ATTACHMENT",
+    };
+    mutateAsyncMock.mockRejectedValue(new ApiError(problem));
+
+    renderWithProviders(<Harness />);
+    const input = screen.getByTestId(
+      "support-attachment-input",
+    ) as HTMLInputElement;
+    const file = new File(["x"], "bad.png", { type: "image/png" });
+    await userEvent.upload(input, file);
+
+    const err = await screen.findByTestId("support-attachment-error");
+    expect(err).toHaveTextContent(/too large or unsupported format/i);
+  });
+
+  it("disables the dropzone and remove buttons when disabled", () => {
+    renderWithProviders(
+      <Harness initial={["alpha"]} disabled />,
+    );
+
+    // Dropzone is still rendered (we are below max) but reports aria-disabled,
+    // and the file input is disabled at the DOM level.
+    const zone = screen.getByTestId("support-attachment-zone");
+    expect(zone).toHaveAttribute("aria-disabled", "true");
+    expect(zone).toHaveAttribute("tabindex", "-1");
+
+    const input = screen.getByTestId(
+      "support-attachment-input",
+    ) as HTMLInputElement;
+    expect(input).toBeDisabled();
+
+    // Remove button reports disabled so the user can't pop pending
+    // attachments mid-submit.
+    expect(
+      screen.getByTestId("support-attachment-remove-alpha"),
+    ).toBeDisabled();
+  });
+});

--- a/frontend/src/components/support/SupportAttachmentDropzone.tsx
+++ b/frontend/src/components/support/SupportAttachmentDropzone.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useEffect, useRef, useState, type ChangeEvent } from "react";
+import { UploadCloud, X } from "@/components/ui/icons";
+import { useUploadSupportAttachment } from "@/hooks/useUploadSupportAttachment";
+import { isApiError } from "@/lib/api";
+import type { SupportTicketErrorCode } from "@/types/support";
+
+const DEFAULT_MAX_ATTACHMENTS = 3;
+const ACCEPT_MIME = "image/png,image/jpeg,image/webp,image/gif";
+
+type Props = {
+  attachmentKeys: string[];
+  onAttachmentKeyAdded: (key: string) => void;
+  onAttachmentKeyRemoved: (key: string) => void;
+  maxAttachments?: number;
+  disabled?: boolean;
+};
+
+/**
+ * Reusable image-attachment surface used by the new-ticket form and the
+ * thread reply composers (user + admin). The parent owns the list of
+ * attachment keys; this component handles upload, preview, and remove
+ * mechanics only.
+ *
+ * Removal does NOT delete from S3 — the staging-bucket lifecycle rule
+ * sweeps unreferenced objects after 24h. We simply drop the key from
+ * the parent's pending list.
+ */
+function describeUploadError(err: unknown): string {
+  if (!isApiError(err)) {
+    return "Could not upload image. Try again.";
+  }
+  const code = (err.problem as { code?: SupportTicketErrorCode }).code;
+  if (code === "INVALID_ATTACHMENT") {
+    return "Image is too large or unsupported format.";
+  }
+  return "Could not upload image. Try again.";
+}
+
+export function SupportAttachmentDropzone({
+  attachmentKeys,
+  onAttachmentKeyAdded,
+  onAttachmentKeyRemoved,
+  maxAttachments = DEFAULT_MAX_ATTACHMENTS,
+  disabled = false,
+}: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const upload = useUploadSupportAttachment();
+  const [error, setError] = useState<string | null>(null);
+
+  // Maps a successfully-uploaded attachmentKey to the local object URL we
+  // built from the picked File. Lives only for the lifetime of this
+  // mounted component — once the form submits and the page navigates,
+  // these URLs are revoked.
+  const [previewUrls, setPreviewUrls] = useState<Map<string, string>>(
+    () => new Map(),
+  );
+
+  // Clean up any outstanding object URLs on unmount.
+  useEffect(() => {
+    return () => {
+      previewUrls.forEach((url) => URL.revokeObjectURL(url));
+    };
+    // We intentionally don't include `previewUrls` in deps — we only want
+    // to revoke on unmount. Per-key revoke happens in onAttachmentKeyRemoved.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const atMax = attachmentKeys.length >= maxAttachments;
+  const showDropzone = !atMax;
+
+  async function handleFile(file: File) {
+    setError(null);
+    try {
+      const { attachmentKey } = await upload.mutateAsync(file);
+      const url = URL.createObjectURL(file);
+      setPreviewUrls((prev) => {
+        const next = new Map(prev);
+        next.set(attachmentKey, url);
+        return next;
+      });
+      onAttachmentKeyAdded(attachmentKey);
+    } catch (e) {
+      setError(describeUploadError(e));
+    }
+  }
+
+  function handleInputChange(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) {
+      void handleFile(file);
+    }
+    // Reset so picking the same file again still fires onChange.
+    e.target.value = "";
+  }
+
+  function handleRemove(key: string) {
+    if (disabled) return;
+    setPreviewUrls((prev) => {
+      const next = new Map(prev);
+      const url = next.get(key);
+      if (url) URL.revokeObjectURL(url);
+      next.delete(key);
+      return next;
+    });
+    onAttachmentKeyRemoved(key);
+  }
+
+  function openPicker() {
+    if (disabled || atMax) return;
+    inputRef.current?.click();
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-2"
+      data-testid="support-attachment-dropzone"
+    >
+      {attachmentKeys.length > 0 && (
+        <ul
+          className="flex flex-wrap gap-2"
+          data-testid="support-attachment-thumbnails"
+        >
+          {attachmentKeys.map((key) => {
+            const url = previewUrls.get(key);
+            return (
+              <li
+                key={key}
+                data-testid={`support-attachment-thumb-${key}`}
+                className="relative size-20 overflow-hidden rounded-lg ring-1 ring-border-subtle bg-bg-subtle"
+              >
+                {url ? (
+                  // The preview src is a local object URL, not a backend
+                  // path, so it does NOT need to flow through apiUrl().
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={url}
+                    alt="Attachment preview"
+                    className="size-full object-cover"
+                  />
+                ) : (
+                  <div className="flex size-full items-center justify-center text-[10px] text-fg-muted">
+                    Attached
+                  </div>
+                )}
+                <button
+                  type="button"
+                  onClick={() => handleRemove(key)}
+                  disabled={disabled}
+                  aria-label="Remove attachment"
+                  data-testid={`support-attachment-remove-${key}`}
+                  className="absolute right-1 top-1 inline-flex size-5 items-center justify-center rounded-full bg-fg/70 text-bg hover:bg-fg disabled:opacity-50 disabled:pointer-events-none"
+                >
+                  <X className="size-3" />
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {showDropzone && (
+        <div
+          data-testid="support-attachment-zone"
+          role="button"
+          tabIndex={disabled ? -1 : 0}
+          aria-disabled={disabled}
+          onClick={openPicker}
+          onKeyDown={(e) => {
+            if (disabled) return;
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              openPicker();
+            }
+          }}
+          className={
+            "flex cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-border-subtle p-4 text-center text-xs text-fg-muted transition-colors hover:border-brand focus:outline-none focus-visible:ring-2 focus-visible:ring-brand " +
+            (disabled ? "cursor-not-allowed opacity-60" : "")
+          }
+        >
+          <UploadCloud className="size-5" aria-hidden="true" />
+          <span>
+            {upload.isPending
+              ? "Uploading..."
+              : "Drop image or click to add"}
+          </span>
+          <span className="text-[10px] text-fg-muted">
+            PNG, JPEG, WebP, or GIF. Up to {maxAttachments} images.
+          </span>
+        </div>
+      )}
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept={ACCEPT_MIME}
+        className="sr-only"
+        data-testid="support-attachment-input"
+        disabled={disabled}
+        onChange={handleInputChange}
+      />
+
+      {error && (
+        <p
+          role="alert"
+          data-testid="support-attachment-error"
+          className="text-xs text-danger"
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/support/SupportTicketList.test.tsx
+++ b/frontend/src/components/support/SupportTicketList.test.tsx
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderWithProviders, screen, userEvent } from "@/test/render";
+import type { SupportTicketSummaryDto } from "@/types/support";
+import type { Page } from "@/types/page";
+
+const mockReplace = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/support"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: mockReplace,
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+vi.mock("@/hooks/useMySupportTickets", () => ({
+  useMySupportTickets: vi.fn(),
+  mySupportTicketsKey: (p: unknown) => ["me-support-tickets", p] as const,
+}));
+
+import { useMySupportTickets } from "@/hooks/useMySupportTickets";
+import { SupportTicketList } from "./SupportTicketList";
+
+type HookReturn = ReturnType<typeof useMySupportTickets>;
+
+function summary(
+  overrides: Partial<SupportTicketSummaryDto> = {},
+): SupportTicketSummaryDto {
+  return {
+    publicId: "00000000-0000-0000-0000-0000000000a1",
+    subject: "Wallet deposit stuck",
+    category: "WALLET",
+    status: "OPEN",
+    lastMessageAuthor: "USER",
+    lastMessageAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function page(
+  content: SupportTicketSummaryDto[],
+  overrides: Partial<Page<SupportTicketSummaryDto>> = {},
+): Page<SupportTicketSummaryDto> {
+  return {
+    content,
+    totalElements: content.length,
+    totalPages: 1,
+    number: 0,
+    size: 20,
+    ...overrides,
+  };
+}
+
+function setHook(
+  value: Partial<HookReturn> & { data?: Page<SupportTicketSummaryDto> },
+) {
+  vi.mocked(useMySupportTickets).mockReturnValue({
+    isLoading: false,
+    isError: false,
+    ...value,
+  } as unknown as HookReturn);
+}
+
+describe("<SupportTicketList />", () => {
+  beforeEach(() => {
+    mockReplace.mockReset();
+    vi.clearAllMocks();
+  });
+
+  it("renders empty state when no tickets", () => {
+    setHook({ data: page([]) });
+    renderWithProviders(<SupportTicketList />);
+    expect(screen.getByTestId("support-tickets-empty")).toBeInTheDocument();
+    expect(screen.getByText(/no tickets yet/i)).toBeInTheDocument();
+    // Empty state ships its own "New ticket" CTA so a brand-new user has the
+    // affordance front-and-center, not just in the header.
+    expect(screen.getByTestId("empty-new-ticket-btn")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("support-tickets-table"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders ticket rows with subject link, category, and status pill", () => {
+    setHook({
+      data: page([
+        summary({
+          publicId: "00000000-0000-0000-0000-0000000000a1",
+          subject: "My bid never went through",
+          category: "BIDDING",
+          status: "OPEN",
+          lastMessageAuthor: "ADMIN",
+        }),
+      ]),
+    });
+    renderWithProviders(<SupportTicketList />);
+    expect(screen.getByTestId("support-tickets-table")).toBeInTheDocument();
+    expect(
+      screen.getByText("My bid never went through"),
+    ).toBeInTheDocument();
+    // Category label is the title-cased form, not the enum literal.
+    expect(screen.getByText("Bidding")).toBeInTheDocument();
+    // Admin-replied sub-label only renders for OPEN + lastAuthor=ADMIN.
+    expect(screen.getByText(/admin replied/i)).toBeInTheDocument();
+  });
+
+  it("subject cell links to the detail page", () => {
+    setHook({
+      data: page([
+        summary({
+          publicId: "00000000-0000-0000-0000-0000000000aa",
+          subject: "Need help",
+        }),
+      ]),
+    });
+    renderWithProviders(<SupportTicketList />);
+    const link = screen.getByTestId(
+      "support-ticket-subject-00000000-0000-0000-0000-0000000000aa",
+    );
+    expect(link).toHaveAttribute(
+      "href",
+      "/support/00000000-0000-0000-0000-0000000000aa",
+    );
+  });
+
+  it("does NOT render the admin-replied sub-label when the ticket is resolved", () => {
+    setHook({
+      data: page([
+        summary({
+          status: "RESOLVED",
+          lastMessageAuthor: "ADMIN",
+        }),
+      ]),
+    });
+    renderWithProviders(<SupportTicketList />);
+    expect(screen.queryByText(/admin replied/i)).not.toBeInTheDocument();
+    // Status pill flips to the resolved label so the row still reads
+    // correctly without the sub-line. Scope to the table body so the
+    // status-filter dropdown's "Resolved" option doesn't collide.
+    const table = screen.getByTestId("support-tickets-table");
+    expect(table).toHaveTextContent("Resolved");
+  });
+
+  it("does NOT render the admin-replied sub-label when last author is the user", () => {
+    setHook({
+      data: page([
+        summary({
+          status: "OPEN",
+          lastMessageAuthor: "USER",
+        }),
+      ]),
+    });
+    renderWithProviders(<SupportTicketList />);
+    expect(screen.queryByText(/admin replied/i)).not.toBeInTheDocument();
+  });
+
+  it("status select updates the URL with the chosen filter", async () => {
+    setHook({ data: page([]) });
+    renderWithProviders(<SupportTicketList />);
+    const select = screen.getByTestId("status-select");
+    await userEvent.selectOptions(select, "OPEN");
+    expect(mockReplace).toHaveBeenCalledWith(
+      expect.stringContaining("status=OPEN"),
+      expect.anything(),
+    );
+  });
+
+  it("status select clears the param when 'all' is selected", async () => {
+    setHook({ data: page([]) });
+    renderWithProviders(<SupportTicketList />);
+    const select = screen.getByTestId("status-select");
+    await userEvent.selectOptions(select, "all");
+    // "all" is the no-filter sentinel; it must not leak into the URL.
+    expect(mockReplace).toHaveBeenCalledWith("/support", expect.anything());
+  });
+
+  it("renders pagination when totalPages > 1", () => {
+    setHook({
+      data: page([summary()], {
+        totalPages: 3,
+        totalElements: 60,
+        number: 0,
+      }),
+    });
+    renderWithProviders(<SupportTicketList />);
+    expect(
+      screen.getByRole("navigation", { name: /pagination/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides pagination when totalPages <= 1", () => {
+    setHook({ data: page([summary()]) });
+    renderWithProviders(<SupportTicketList />);
+    expect(
+      screen.queryByRole("navigation", { name: /pagination/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders loading state while the query is pending", () => {
+    setHook({ data: undefined, isLoading: true });
+    renderWithProviders(<SupportTicketList />);
+    expect(screen.getByText(/loading tickets/i)).toBeInTheDocument();
+  });
+
+  it("renders an error state when the query fails", () => {
+    setHook({ data: undefined, isError: true });
+    renderWithProviders(<SupportTicketList />);
+    expect(
+      screen.getByText(/could not load tickets/i),
+    ).toBeInTheDocument();
+  });
+
+  it("header 'New ticket' button links to /support/new", () => {
+    setHook({ data: page([]) });
+    renderWithProviders(<SupportTicketList />);
+    const btn = screen.getByTestId("new-ticket-btn");
+    // The Button is wrapped in a Next <Link>, so the closest anchor carries
+    // the href.
+    expect(btn.closest("a")).toHaveAttribute("href", "/support/new");
+  });
+});

--- a/frontend/src/components/support/SupportTicketList.tsx
+++ b/frontend/src/components/support/SupportTicketList.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/Button";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { Pagination } from "@/components/ui/Pagination";
+import { useMySupportTickets } from "@/hooks/useMySupportTickets";
+import { formatRelativeTime } from "@/lib/time/relativeTime";
+import type {
+  SupportTicketCategory,
+  SupportTicketStatus,
+  SupportTicketSummaryDto,
+} from "@/types/support";
+
+const PAGE_SIZE = 20;
+
+type StatusFilter = "all" | SupportTicketStatus;
+
+function parseStatus(raw: string | null): StatusFilter {
+  if (raw === "OPEN" || raw === "RESOLVED") return raw;
+  return "all";
+}
+
+const CATEGORY_LABELS: Record<SupportTicketCategory, string> = {
+  ACCOUNT: "Account",
+  BIDDING: "Bidding",
+  LISTING: "Listing",
+  ESCROW: "Escrow",
+  WALLET: "Wallet",
+  OTHER: "Other",
+};
+
+function statusPillClass(status: SupportTicketStatus): string {
+  if (status === "OPEN") return "bg-warning-bg text-warning";
+  return "bg-success-bg text-success";
+}
+
+function statusLabel(status: SupportTicketStatus): string {
+  return status === "OPEN" ? "Open" : "Resolved";
+}
+
+function EmptyState() {
+  return (
+    <div
+      className="rounded-lg border border-border-subtle bg-surface-raised py-12 px-6 text-center flex flex-col items-center gap-3"
+      data-testid="support-tickets-empty"
+    >
+      <p className="text-sm text-fg-muted">
+        No tickets yet. Need help? Click &quot;New ticket&quot; to get started.
+      </p>
+      <Link href="/support/new">
+        <Button variant="primary" size="sm" data-testid="empty-new-ticket-btn">
+          New ticket
+        </Button>
+      </Link>
+    </div>
+  );
+}
+
+export function SupportTicketList() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const status = parseStatus(searchParams?.get("status") ?? null);
+  const page = Math.max(0, parseInt(searchParams?.get("page") ?? "0", 10) || 0);
+
+  // Send `status` to the backend only when a concrete filter is selected;
+  // the "all" sentinel stays out of the URL and out of the query so we share
+  // the cache entry across no-filter navigations.
+  const params = {
+    status: status === "all" ? undefined : status,
+    page,
+    size: PAGE_SIZE,
+  };
+
+  const { data, isLoading, isError } = useMySupportTickets(params);
+
+  function buildUrl(overrides: {
+    status?: StatusFilter;
+    page?: number;
+  }): string {
+    const sp = new URLSearchParams();
+    const nextStatus = overrides.status ?? status;
+    const nextPage = overrides.page ?? 0;
+    if (nextStatus !== "all") sp.set("status", nextStatus);
+    if (nextPage > 0) sp.set("page", String(nextPage));
+    const qs = sp.toString();
+    return qs ? `/support?${qs}` : "/support";
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-8 flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold tracking-tight font-display">
+            Support
+          </h1>
+          <p className="text-sm text-fg-muted mt-1">
+            Open a ticket and our team will reply here.
+          </p>
+        </div>
+        <Link href="/support/new">
+          <Button
+            variant="primary"
+            size="sm"
+            data-testid="new-ticket-btn"
+          >
+            New ticket
+          </Button>
+        </Link>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="flex items-center gap-2 text-xs text-fg-muted">
+          Status
+          <select
+            value={status}
+            data-testid="status-select"
+            aria-label="Filter by status"
+            onChange={(e) =>
+              router.replace(
+                buildUrl({
+                  status: e.target.value as StatusFilter,
+                  page: 0,
+                }),
+                { scroll: false },
+              )
+            }
+            className="rounded-md bg-bg-muted px-2 py-1.5 text-sm text-fg ring-1 ring-border-subtle focus:outline-none focus:ring-2 focus:ring-brand"
+          >
+            <option value="all">All</option>
+            <option value="OPEN">Open</option>
+            <option value="RESOLVED">Resolved</option>
+          </select>
+        </label>
+      </div>
+
+      {isLoading && <LoadingSpinner label="Loading tickets..." />}
+
+      {isError && (
+        <div className="text-sm text-danger py-8" role="alert">
+          Could not load tickets. Refresh to retry.
+        </div>
+      )}
+
+      {data && data.content.length === 0 && <EmptyState />}
+
+      {data && data.content.length > 0 && (
+        <>
+          <div
+            className="overflow-x-auto rounded-lg border border-border-subtle"
+            data-testid="support-tickets-table"
+          >
+            <table className="w-full text-sm">
+              <thead className="bg-bg-subtle border-b border-border-subtle">
+                <tr>
+                  <th className="px-3 py-2.5 text-left text-[11px] font-medium text-fg-muted">
+                    Subject
+                  </th>
+                  <th className="px-3 py-2.5 text-left text-[11px] font-medium text-fg-muted">
+                    Category
+                  </th>
+                  <th className="px-3 py-2.5 text-left text-[11px] font-medium text-fg-muted">
+                    Status
+                  </th>
+                  <th className="px-3 py-2.5 text-left text-[11px] font-medium text-fg-muted">
+                    Last updated
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.content.map((row: SupportTicketSummaryDto) => {
+                  const adminReplied =
+                    row.lastMessageAuthor === "ADMIN" && row.status === "OPEN";
+                  return (
+                    <tr
+                      key={row.publicId}
+                      data-testid={`support-ticket-row-${row.publicId}`}
+                      className="border-b border-border-subtle/50 hover:bg-bg-muted/50"
+                    >
+                      <td className="px-3 py-2.5">
+                        <Link
+                          href={`/support/${row.publicId}`}
+                          className="text-fg font-medium hover:underline"
+                          data-testid={`support-ticket-subject-${row.publicId}`}
+                        >
+                          {row.subject}
+                        </Link>
+                      </td>
+                      <td className="px-3 py-2.5">
+                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-info-bg text-info">
+                          {CATEGORY_LABELS[row.category]}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2.5">
+                        <div className="flex flex-col gap-0.5">
+                          <span
+                            className={`inline-flex w-fit items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${statusPillClass(row.status)}`}
+                          >
+                            {statusLabel(row.status)}
+                          </span>
+                          {adminReplied && (
+                            <span className="text-[10px] text-fg-muted">
+                              admin replied
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-3 py-2.5 text-fg-muted text-[11px]">
+                        {formatRelativeTime(row.lastMessageAt)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          {data.totalPages > 1 && (
+            <div>
+              <Pagination
+                page={data.number}
+                totalPages={data.totalPages}
+                onPageChange={(p) =>
+                  router.replace(buildUrl({ page: p }), { scroll: false })
+                }
+              />
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/support/SupportTicketThread.test.tsx
+++ b/frontend/src/components/support/SupportTicketThread.test.tsx
@@ -1,0 +1,397 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/test/render";
+import type {
+  ReplySupportTicketRequest,
+  SupportTicketAttachmentDto,
+  SupportTicketDto,
+  SupportTicketMessageDto,
+  SupportTicketStatus,
+} from "@/types/support";
+
+// next/navigation isn't directly read by the thread, but the dropzone's
+// transitive hook deps touch it. Mirror the other support tests' stubs.
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/support/abc"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+// ─── Mocks ──────────────────────────────────────────────────────────────
+
+const ticketHookState: {
+  data: SupportTicketDto | undefined;
+  isLoading: boolean;
+  isError: boolean;
+} = {
+  data: undefined,
+  isLoading: false,
+  isError: false,
+};
+
+vi.mock("@/hooks/useMySupportTicket", () => ({
+  useMySupportTicket: () => ({
+    data: ticketHookState.data,
+    isLoading: ticketHookState.isLoading,
+    isError: ticketHookState.isError,
+  }),
+  mySupportTicketKey: (p: string) => ["me-support-ticket", p] as const,
+}));
+
+// Capture mutate calls + provide a controllable onSuccess so we can assert
+// the "composer clears on success" behaviour.
+type MutationCall = {
+  req: ReplySupportTicketRequest;
+  options?: { onSuccess?: () => void };
+};
+const replyMutateCalls: MutationCall[] = [];
+let replyMutationState: {
+  isPending: boolean;
+  isError: boolean;
+  error: unknown;
+} = { isPending: false, isError: false, error: null };
+
+const replyMutateMock = vi.fn(
+  (req: ReplySupportTicketRequest, options?: { onSuccess?: () => void }) => {
+    replyMutateCalls.push({ req, options });
+  },
+);
+
+vi.mock("@/hooks/useReplySupportTicket", () => ({
+  useReplySupportTicket: () => ({
+    mutate: replyMutateMock,
+    isPending: replyMutationState.isPending,
+    isError: replyMutationState.isError,
+    error: replyMutationState.error,
+  }),
+}));
+
+// Signed-URL hook: keep it predictable so the lightbox always renders an
+// <img> with a known src on open.
+let signedUrlHookState: {
+  data: { url: string } | undefined;
+  isPending: boolean;
+  isError: boolean;
+} = {
+  data: { url: "https://signed.example/att.png" },
+  isPending: false,
+  isError: false,
+};
+
+vi.mock("@/hooks/useSignedAttachmentUrl", () => ({
+  useSignedAttachmentUrl: () => signedUrlHookState,
+  signedAttachmentUrlKey: (p: string) =>
+    ["support-attachment-signed-url", p] as const,
+}));
+
+// Stub the dropzone so the composer test doesn't depend on file-upload
+// plumbing. The mock exposes a "stage attachment" button so reply tests
+// that need a non-empty attachmentKeys array can drive the prop callback.
+vi.mock(
+  "@/components/support/SupportAttachmentDropzone",
+  () => ({
+    SupportAttachmentDropzone: ({
+      attachmentKeys,
+      onAttachmentKeyAdded,
+    }: {
+      attachmentKeys: string[];
+      onAttachmentKeyAdded: (k: string) => void;
+      onAttachmentKeyRemoved: (k: string) => void;
+      disabled?: boolean;
+    }) => (
+      <div data-testid="mock-dropzone">
+        <span data-testid="mock-dropzone-count">{attachmentKeys.length}</span>
+        <button
+          type="button"
+          data-testid="mock-dropzone-stage"
+          onClick={() => onAttachmentKeyAdded("stub-key-1")}
+        >
+          stage
+        </button>
+      </div>
+    ),
+  }),
+);
+
+// Import AFTER mocks so the component picks up the stubbed modules.
+import { SupportTicketThread } from "./SupportTicketThread";
+
+// ─── Fixtures ──────────────────────────────────────────────────────────
+
+function attachment(
+  overrides: Partial<SupportTicketAttachmentDto> = {},
+): SupportTicketAttachmentDto {
+  return {
+    publicId: "att-0000-0000-0000-000000000001",
+    mimeType: "image/png",
+    sizeBytes: 1234,
+    width: 800,
+    height: 600,
+    ...overrides,
+  };
+}
+
+function message(
+  overrides: Partial<SupportTicketMessageDto> = {},
+): SupportTicketMessageDto {
+  return {
+    publicId: "msg-0000-0000-0000-000000000001",
+    authorPublicId: "user-0001",
+    authorDisplayName: "Sample User",
+    authorRole: "USER",
+    body: "Initial message body.",
+    visibleToUser: true,
+    createdAt: new Date(Date.now() - 60_000).toISOString(),
+    attachments: [],
+    ...overrides,
+  };
+}
+
+function ticket(
+  overrides: Partial<SupportTicketDto> = {},
+): SupportTicketDto {
+  const now = new Date().toISOString();
+  return {
+    publicId: "ticket-0000-0000-0000-000000000001",
+    submitterPublicId: "user-0001",
+    submitterDisplayName: "Sample User",
+    subject: "Wallet deposit stuck",
+    category: "WALLET",
+    status: "OPEN" as SupportTicketStatus,
+    assignedAdminPublicId: null,
+    assignedAdminDisplayName: null,
+    lastMessageAt: now,
+    lastMessageAuthor: "USER",
+    resolvedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    messages: [],
+    ...overrides,
+  };
+}
+
+function setTicket(t: SupportTicketDto | undefined) {
+  ticketHookState.data = t;
+  ticketHookState.isLoading = false;
+  ticketHookState.isError = false;
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  replyMutateCalls.length = 0;
+  replyMutateMock.mockClear();
+  replyMutationState = { isPending: false, isError: false, error: null };
+  signedUrlHookState = {
+    data: { url: "https://signed.example/att.png" },
+    isPending: false,
+    isError: false,
+  };
+});
+
+describe("<SupportTicketThread />", () => {
+  it("renders subject, category, and status", () => {
+    setTicket(
+      ticket({
+        subject: "Bid never went through",
+        category: "BIDDING",
+        status: "OPEN",
+      }),
+    );
+    renderWithProviders(<SupportTicketThread publicId="t-1" />);
+    expect(screen.getByTestId("support-thread-subject")).toHaveTextContent(
+      "Bid never went through",
+    );
+    expect(screen.getByTestId("support-thread-category")).toHaveTextContent(
+      "Bidding",
+    );
+    expect(screen.getByTestId("support-thread-status")).toHaveTextContent(
+      "Open",
+    );
+  });
+
+  it("renders both user-authored and admin-authored bubbles", () => {
+    setTicket(
+      ticket({
+        messages: [
+          message({
+            publicId: "msg-user-1",
+            authorRole: "USER",
+            authorDisplayName: "Buyer Bob",
+            body: "Hello support.",
+          }),
+          message({
+            publicId: "msg-admin-1",
+            authorRole: "ADMIN",
+            authorDisplayName: "Admin Sara",
+            body: "Hi Bob, looking into it.",
+          }),
+        ],
+      }),
+    );
+    renderWithProviders(<SupportTicketThread publicId="t-1" />);
+    const userBubble = screen.getByTestId("support-message-msg-user-1");
+    const adminBubble = screen.getByTestId("support-message-msg-admin-1");
+    expect(userBubble).toBeInTheDocument();
+    expect(adminBubble).toBeInTheDocument();
+    expect(userBubble).toHaveAttribute("data-role", "USER");
+    expect(adminBubble).toHaveAttribute("data-role", "ADMIN");
+    // Both bodies are visible to the user.
+    expect(userBubble).toHaveTextContent("Hello support.");
+    expect(adminBubble).toHaveTextContent("Hi Bob, looking into it.");
+  });
+
+  it("shows the 'replying will reopen this ticket' helper when RESOLVED", () => {
+    setTicket(
+      ticket({
+        status: "RESOLVED",
+        resolvedAt: new Date().toISOString(),
+      }),
+    );
+    renderWithProviders(<SupportTicketThread publicId="t-1" />);
+    const note = screen.getByTestId("support-thread-reopen-note");
+    expect(note).toBeInTheDocument();
+    expect(note).toHaveTextContent(/replying will reopen this ticket/i);
+    // Composer remains functional — the textarea + submit are not disabled
+    // beyond the normal "submitting" pending lock.
+    expect(
+      screen.getByTestId("support-thread-reply-submit"),
+    ).not.toBeDisabled();
+  });
+
+  it("does NOT show the reopen helper when OPEN", () => {
+    setTicket(ticket({ status: "OPEN" }));
+    renderWithProviders(<SupportTicketThread publicId="t-1" />);
+    expect(
+      screen.queryByTestId("support-thread-reopen-note"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("defensively filters out internal-note messages (visibleToUser=false)", () => {
+    // The backend mapper already strips these from the /me/ DTO, but if a
+    // regression ever leaks one through the wire shape, the thread must
+    // still not render it. Drives the defense-in-depth filter.
+    setTicket(
+      ticket({
+        messages: [
+          message({
+            publicId: "msg-public",
+            body: "Visible to user.",
+            visibleToUser: true,
+          }),
+          message({
+            publicId: "msg-internal",
+            authorRole: "ADMIN",
+            body: "Internal admin note about this ticket.",
+            visibleToUser: false,
+          }),
+        ],
+      }),
+    );
+    renderWithProviders(<SupportTicketThread publicId="t-1" />);
+    expect(screen.getByTestId("support-message-msg-public")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("support-message-msg-internal"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/internal admin note about this ticket/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("reply composer submit calls the mutation with { body, attachmentKeys }", async () => {
+    setTicket(ticket({ status: "OPEN" }));
+    const user = userEvent.setup();
+    renderWithProviders(<SupportTicketThread publicId="t-1" />);
+
+    // Type a body.
+    await user.type(
+      screen.getByTestId("support-thread-reply-textarea"),
+      "Following up on this.",
+    );
+    // Stage one attachment via the stub dropzone's "stage" button.
+    await user.click(screen.getByTestId("mock-dropzone-stage"));
+
+    await user.click(screen.getByTestId("support-thread-reply-submit"));
+
+    await waitFor(() => expect(replyMutateMock).toHaveBeenCalledTimes(1));
+    const call = replyMutateCalls[0];
+    expect(call.req.body).toBe("Following up on this.");
+    expect(call.req.attachmentKeys).toEqual(["stub-key-1"]);
+  });
+
+  it("clears the composer when the reply mutation resolves successfully", async () => {
+    setTicket(ticket({ status: "OPEN" }));
+    const user = userEvent.setup();
+    renderWithProviders(<SupportTicketThread publicId="t-1" />);
+
+    await user.type(
+      screen.getByTestId("support-thread-reply-textarea"),
+      "Another reply.",
+    );
+    await user.click(screen.getByTestId("mock-dropzone-stage"));
+    await user.click(screen.getByTestId("support-thread-reply-submit"));
+
+    await waitFor(() => expect(replyMutateMock).toHaveBeenCalledTimes(1));
+    // Manually invoke the onSuccess callback the component passed — the
+    // mock mutate doesn't wire to a real query so we drive the success
+    // branch ourselves.
+    replyMutateCalls[0].options?.onSuccess?.();
+
+    await waitFor(() => {
+      expect(
+        (
+          screen.getByTestId(
+            "support-thread-reply-textarea",
+          ) as HTMLTextAreaElement
+        ).value,
+      ).toBe("");
+    });
+    // Staged attachments cleared too.
+    expect(screen.getByTestId("mock-dropzone-count")).toHaveTextContent("0");
+  });
+
+  it("clicking an attachment thumbnail opens the lightbox", async () => {
+    setTicket(
+      ticket({
+        messages: [
+          message({
+            publicId: "msg-with-att",
+            attachments: [
+              attachment({ publicId: "att-aaaa-bbbb-cccc-dddd-000000000001" }),
+            ],
+          }),
+        ],
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<SupportTicketThread publicId="t-1" />);
+
+    // Lightbox is not in the DOM before click.
+    expect(
+      screen.queryByTestId("support-attachment-lightbox"),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByTestId(
+        "support-attachment-att-aaaa-bbbb-cccc-dddd-000000000001",
+      ),
+    );
+
+    expect(
+      screen.getByTestId("support-attachment-lightbox"),
+    ).toBeInTheDocument();
+    const img = screen.getByTestId("support-attachment-lightbox-image");
+    expect(img).toHaveAttribute("src", "https://signed.example/att.png");
+  });
+});

--- a/frontend/src/components/support/SupportTicketThread.tsx
+++ b/frontend/src/components/support/SupportTicketThread.tsx
@@ -1,0 +1,432 @@
+"use client";
+
+import Link from "next/link";
+import {
+  useMemo,
+  useState,
+  type FormEvent,
+} from "react";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { Modal } from "@/components/ui/Modal";
+import { Textarea } from "@/components/ui/Textarea";
+import { ChevronLeft } from "@/components/ui/icons";
+import { SupportAttachmentDropzone } from "@/components/support/SupportAttachmentDropzone";
+import { useMySupportTicket } from "@/hooks/useMySupportTicket";
+import { useReplySupportTicket } from "@/hooks/useReplySupportTicket";
+import { useSignedAttachmentUrl } from "@/hooks/useSignedAttachmentUrl";
+import { isApiError } from "@/lib/api";
+import { cn } from "@/lib/cn";
+import {
+  formatAbsoluteTime,
+  formatRelativeTime,
+} from "@/lib/time/relativeTime";
+import type {
+  ReplySupportTicketRequest,
+  SupportTicketCategory,
+  SupportTicketErrorCode,
+  SupportTicketMessageDto,
+  SupportTicketStatus,
+} from "@/types/support";
+
+const BODY_MAX = 10000;
+
+const CATEGORY_LABELS: Record<SupportTicketCategory, string> = {
+  ACCOUNT: "Account",
+  BIDDING: "Bidding",
+  LISTING: "Listing",
+  ESCROW: "Escrow",
+  WALLET: "Wallet",
+  OTHER: "Other",
+};
+
+function statusPillClass(status: SupportTicketStatus): string {
+  if (status === "OPEN") return "bg-warning-bg text-warning";
+  return "bg-success-bg text-success";
+}
+
+function statusLabel(status: SupportTicketStatus): string {
+  return status === "OPEN" ? "Open" : "Resolved";
+}
+
+function describeReplyError(err: unknown): string {
+  if (!isApiError(err)) {
+    return "Could not send reply. Try again.";
+  }
+  const problem = err.problem as {
+    code?: SupportTicketErrorCode;
+    detail?: string;
+    title?: string;
+  };
+  switch (problem.code) {
+    case "RATE_LIMITED":
+      return "You're sending replies too quickly. Wait a moment and try again.";
+    case "INVALID_ATTACHMENT":
+      return "One of your attachments was rejected. Remove it and try again.";
+    case "UNKNOWN_TICKET":
+      return "This ticket no longer exists.";
+    case "NOT_OWNER":
+      return "You can't reply on this ticket.";
+  }
+  return problem.detail ?? problem.title ?? "Could not send reply. Try again.";
+}
+
+interface MessageBubbleProps {
+  message: SupportTicketMessageDto;
+  onAttachmentClick: (publicId: string) => void;
+}
+
+function MessageBubble({ message, onAttachmentClick }: MessageBubbleProps) {
+  const isAdmin = message.authorRole === "ADMIN";
+  const sideClasses = isAdmin ? "justify-start" : "justify-end";
+  // Admin = surface-raised left, user = brand-bg right. Brand white-on-brand
+  // matches the project's `Button variant="primary"` treatment (see
+  // `components/ui/Button.tsx`).
+  const bubbleClasses = isAdmin
+    ? "bg-surface-raised text-fg ring-1 ring-border-subtle"
+    : "bg-brand text-white";
+  const roleLabel = isAdmin ? "Admin" : "You";
+
+  return (
+    <div
+      className={cn("flex w-full", sideClasses)}
+      data-testid={`support-message-${message.publicId}`}
+      data-role={message.authorRole}
+    >
+      <div className="flex max-w-[80%] flex-col gap-1">
+        <div
+          className={cn(
+            "flex items-center gap-2 text-[11px] text-fg-muted",
+            isAdmin ? "justify-start" : "justify-end",
+          )}
+        >
+          <span className="font-medium text-fg">
+            {roleLabel}
+            {message.authorDisplayName ? ` · ${message.authorDisplayName}` : ""}
+          </span>
+          <span title={formatAbsoluteTime(message.createdAt)}>
+            {formatRelativeTime(message.createdAt)}
+          </span>
+        </div>
+
+        <div
+          className={cn(
+            "rounded-2xl px-4 py-2.5 text-sm whitespace-pre-wrap break-words",
+            bubbleClasses,
+          )}
+        >
+          {message.body}
+        </div>
+
+        {message.attachments.length > 0 && (
+          <ul
+            data-testid={`support-message-attachments-${message.publicId}`}
+            className={cn(
+              "flex flex-wrap gap-2",
+              isAdmin ? "justify-start" : "justify-end",
+            )}
+          >
+            {message.attachments.map((att) => (
+              <li key={att.publicId}>
+                <button
+                  type="button"
+                  onClick={() => onAttachmentClick(att.publicId)}
+                  data-testid={`support-attachment-${att.publicId}`}
+                  aria-label="View attachment"
+                  className="inline-flex size-20 items-center justify-center rounded-lg bg-bg-subtle ring-1 ring-border-subtle text-[10px] text-fg-muted hover:ring-brand focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+                >
+                  Attachment
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface AttachmentLightboxProps {
+  attachmentPublicId: string | null;
+  onClose: () => void;
+}
+
+function AttachmentLightbox({
+  attachmentPublicId,
+  onClose,
+}: AttachmentLightboxProps) {
+  // The hook stays disabled when publicId is null, so this is safe to render
+  // unconditionally — there's no fetch on initial thread render.
+  const { data, isPending, isError } = useSignedAttachmentUrl(
+    attachmentPublicId,
+  );
+
+  return (
+    <Modal
+      open={attachmentPublicId !== null}
+      title="Attachment"
+      onClose={onClose}
+    >
+      <div
+        className="flex min-h-[12rem] items-center justify-center"
+        data-testid="support-attachment-lightbox"
+      >
+        {isPending && <LoadingSpinner label="Loading image..." />}
+        {isError && (
+          <p className="text-sm text-danger" role="alert">
+            Could not load attachment.
+          </p>
+        )}
+        {data?.url && (
+          // Signed S3 URL is absolute (presigned), so it does NOT need to
+          // flow through apiUrl(). It also doesn't need the JWT — the
+          // presigned URL is the auth.
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={data.url}
+            alt="Support ticket attachment"
+            className="max-h-[70vh] w-auto max-w-full rounded-lg"
+            data-testid="support-attachment-lightbox-image"
+          />
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+interface SupportTicketThreadProps {
+  publicId: string;
+}
+
+export function SupportTicketThread({ publicId }: SupportTicketThreadProps) {
+  const ticketQuery = useMySupportTicket(publicId);
+  const replyMutation = useReplySupportTicket(publicId);
+
+  const [replyBody, setReplyBody] = useState("");
+  const [replyAttachmentKeys, setReplyAttachmentKeys] = useState<string[]>([]);
+  const [replyError, setReplyError] = useState<string | null>(null);
+  const [lightboxAttachmentId, setLightboxAttachmentId] = useState<
+    string | null
+  >(null);
+
+  // The backend mapper already drops internal notes from the /me/ DTO, but
+  // we defend in depth — a future regression that ever included them
+  // shouldn't leak admin-only context to the seller.
+  const visibleMessages: SupportTicketMessageDto[] = useMemo(() => {
+    const all = ticketQuery.data?.messages ?? [];
+    return all.filter((m) => m.visibleToUser !== false);
+  }, [ticketQuery.data?.messages]);
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    const trimmed = replyBody.trim();
+    if (trimmed.length === 0) {
+      setReplyError("Reply cannot be empty.");
+      return;
+    }
+    if (trimmed.length > BODY_MAX) {
+      setReplyError(`Reply must be ${BODY_MAX} characters or fewer.`);
+      return;
+    }
+    setReplyError(null);
+    const req: ReplySupportTicketRequest = {
+      body: trimmed,
+      attachmentKeys:
+        replyAttachmentKeys.length === 0 ? undefined : replyAttachmentKeys,
+    };
+    replyMutation.mutate(req, {
+      onSuccess: () => {
+        setReplyBody("");
+        setReplyAttachmentKeys([]);
+      },
+    });
+  }
+
+  if (ticketQuery.isLoading) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        <LoadingSpinner label="Loading ticket..." />
+      </div>
+    );
+  }
+
+  if (ticketQuery.isError || !ticketQuery.data) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        <div
+          role="alert"
+          className="rounded-lg border border-danger/30 bg-danger-bg/50 px-4 py-3 text-sm text-danger"
+          data-testid="support-ticket-load-error"
+        >
+          Could not load this ticket. It may have been removed, or you may
+          not have access.
+        </div>
+        <div className="mt-4">
+          <Link
+            href="/support"
+            className="text-xs text-fg-muted hover:text-fg inline-flex items-center gap-1"
+          >
+            <ChevronLeft className="size-3" aria-hidden="true" />
+            Back to support
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const ticket = ticketQuery.data;
+  const isResolved = ticket.status === "RESOLVED";
+  const submitting = replyMutation.isPending;
+  const serverError =
+    replyMutation.isError && !replyError
+      ? describeReplyError(replyMutation.error)
+      : null;
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8 flex flex-col gap-6">
+      <div>
+        <Link
+          href="/support"
+          className="text-xs text-fg-muted hover:text-fg inline-flex items-center gap-1"
+          data-testid="support-thread-back-link"
+        >
+          <ChevronLeft className="size-3" aria-hidden="true" />
+          Back to support
+        </Link>
+      </div>
+
+      <Card>
+        <Card.Header>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="flex flex-col gap-2 min-w-0">
+              <h1
+                className="text-xl font-bold tracking-tight font-display break-words"
+                data-testid="support-thread-subject"
+              >
+                {ticket.subject}
+              </h1>
+              <div className="flex flex-wrap items-center gap-2">
+                <span
+                  className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-info-bg text-info"
+                  data-testid="support-thread-category"
+                >
+                  {CATEGORY_LABELS[ticket.category]}
+                </span>
+                <span
+                  className={cn(
+                    "inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold",
+                    statusPillClass(ticket.status),
+                  )}
+                  data-testid="support-thread-status"
+                >
+                  {statusLabel(ticket.status)}
+                </span>
+              </div>
+            </div>
+            <div
+              className="text-[11px] text-fg-muted"
+              title={formatAbsoluteTime(ticket.updatedAt)}
+              data-testid="support-thread-updated"
+            >
+              Updated {formatRelativeTime(ticket.updatedAt)}
+            </div>
+          </div>
+        </Card.Header>
+      </Card>
+
+      <div
+        className="flex flex-col gap-4"
+        data-testid="support-thread-messages"
+      >
+        {visibleMessages.map((message) => (
+          <MessageBubble
+            key={message.publicId}
+            message={message}
+            onAttachmentClick={setLightboxAttachmentId}
+          />
+        ))}
+      </div>
+
+      <Card>
+        <Card.Header>
+          <h2 className="text-sm font-semibold tracking-tight text-fg">
+            Reply
+          </h2>
+        </Card.Header>
+        <Card.Body>
+          <form
+            onSubmit={handleSubmit}
+            className="flex flex-col gap-3"
+            aria-label="Reply to support ticket"
+            data-testid="support-thread-reply-form"
+            noValidate
+          >
+            {isResolved && (
+              <p
+                className="rounded-lg bg-info-bg/60 px-3 py-2 text-xs text-info"
+                data-testid="support-thread-reopen-note"
+              >
+                Replying will reopen this ticket.
+              </p>
+            )}
+
+            <Textarea
+              label="Your reply"
+              value={replyBody}
+              onChange={(e) => {
+                setReplyBody(e.target.value);
+                if (replyError) setReplyError(null);
+              }}
+              placeholder="Type your reply..."
+              rows={5}
+              data-testid="support-thread-reply-textarea"
+              error={replyError ?? undefined}
+              disabled={submitting}
+            />
+
+            <SupportAttachmentDropzone
+              attachmentKeys={replyAttachmentKeys}
+              onAttachmentKeyAdded={(key) =>
+                setReplyAttachmentKeys((prev) =>
+                  prev.includes(key) ? prev : [...prev, key],
+                )
+              }
+              onAttachmentKeyRemoved={(key) =>
+                setReplyAttachmentKeys((prev) => prev.filter((k) => k !== key))
+              }
+              disabled={submitting}
+            />
+
+            {serverError && (
+              <div
+                role="alert"
+                data-testid="support-thread-reply-error"
+                className="rounded-lg border border-danger/30 bg-danger-bg/50 px-4 py-3 text-sm text-danger"
+              >
+                {serverError}
+              </div>
+            )}
+
+            <div className="flex justify-end">
+              <Button
+                type="submit"
+                variant="primary"
+                loading={submitting}
+                disabled={submitting}
+                data-testid="support-thread-reply-submit"
+              >
+                Send reply
+              </Button>
+            </div>
+          </form>
+        </Card.Body>
+      </Card>
+
+      <AttachmentLightbox
+        attachmentPublicId={lightboxAttachmentId}
+        onClose={() => setLightboxAttachmentId(null)}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Textarea.test.tsx
+++ b/frontend/src/components/ui/Textarea.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Textarea } from "./Textarea";
+
+describe("Textarea", () => {
+  it("renders with a label", () => {
+    render(<Textarea label="Message" />);
+    expect(screen.getByLabelText("Message")).toBeInTheDocument();
+  });
+
+  it("renders helperText when no error", () => {
+    render(<Textarea label="Message" helperText="Max 10000 chars" />);
+    expect(screen.getByText("Max 10000 chars")).toBeInTheDocument();
+  });
+
+  it("renders error text when error is set", () => {
+    render(<Textarea label="Message" error="Required" />);
+    expect(screen.getByText("Required")).toBeInTheDocument();
+  });
+
+  it("accepts user input via the rows prop", async () => {
+    const u = userEvent.setup();
+    render(<Textarea label="Message" rows={8} />);
+    const ta = screen.getByLabelText("Message") as HTMLTextAreaElement;
+    expect(ta.rows).toBe(8);
+    await u.type(ta, "Hello");
+    expect(ta.value).toBe("Hello");
+  });
+});

--- a/frontend/src/components/ui/Textarea.tsx
+++ b/frontend/src/components/ui/Textarea.tsx
@@ -1,0 +1,54 @@
+"use client";
+import {
+  forwardRef,
+  useId,
+  type ReactNode,
+  type TextareaHTMLAttributes,
+} from "react";
+import { cn } from "@/lib/cn";
+
+type TextareaProps = {
+  label?: string;
+  helperText?: ReactNode;
+  error?: string;
+  fullWidth?: boolean;
+} & TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+const baseClasses =
+  "w-full rounded-lg bg-bg-subtle text-fg placeholder:text-fg-muted p-3 ring-1 ring-transparent transition-all focus:bg-surface-raised focus:outline-none focus:ring-brand resize-y";
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { label, helperText, error, fullWidth = true, className, id, rows = 6, ...rest },
+  ref,
+) {
+  const generatedId = useId();
+  const taId = id ?? generatedId;
+  const showError = Boolean(error);
+
+  return (
+    <div className={cn("flex flex-col gap-1", fullWidth && "w-full")}>
+      {label && (
+        <label htmlFor={taId} className="text-sm text-fg">
+          {label}
+        </label>
+      )}
+      <textarea
+        ref={ref}
+        id={taId}
+        rows={rows}
+        className={cn(
+          baseClasses,
+          showError && "ring-danger focus:ring-danger",
+          className,
+        )}
+        aria-invalid={showError || undefined}
+        {...rest}
+      />
+      {(helperText || error) && (
+        <p className={cn("text-xs", showError ? "text-danger" : "text-fg-muted")}>
+          {error ?? helperText}
+        </p>
+      )}
+    </div>
+  );
+});

--- a/frontend/src/hooks/admin/useAdminSupportAssign.ts
+++ b/frontend/src/hooks/admin/useAdminSupportAssign.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminAssignSupportTicket } from "@/lib/api/support";
+import type { SupportTicketDto } from "@/types/support";
+
+/**
+ * Mutation wrapper around `POST /api/v1/admin/support-tickets/{publicId}/assign`.
+ *
+ * The mutation variable is the admin publicId to assign, or `null` to
+ * unassign the ticket entirely. The detail / queue / badge caches all
+ * invalidate so the "Assigned to: ..." line and the queue's "Assignee"
+ * column refresh in-place.
+ */
+export function useAdminSupportAssign(publicId: string) {
+  const qc = useQueryClient();
+  return useMutation<SupportTicketDto, Error, string | null>({
+    mutationFn: (adminPublicId) =>
+      adminAssignSupportTicket(publicId, adminPublicId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin-support-ticket", publicId] });
+      qc.invalidateQueries({ queryKey: ["admin-support-tickets"] });
+      qc.invalidateQueries({ queryKey: ["admin-support-stats"] });
+    },
+  });
+}

--- a/frontend/src/hooks/admin/useAdminSupportPatchCategory.ts
+++ b/frontend/src/hooks/admin/useAdminSupportPatchCategory.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminPatchSupportTicket } from "@/lib/api/support";
+import type {
+  SupportTicketCategory,
+  SupportTicketDto,
+} from "@/types/support";
+
+/**
+ * Mutation wrapper around `PATCH /api/v1/admin/support-tickets/{publicId}`.
+ * Backend currently only accepts a `category` field on this endpoint
+ * (re-routing tickets between Account/Bidding/Listing/Escrow/Wallet/Other);
+ * we expose just that single argument here.
+ */
+export function useAdminSupportPatchCategory(publicId: string) {
+  const qc = useQueryClient();
+  return useMutation<SupportTicketDto, Error, SupportTicketCategory>({
+    mutationFn: (category) => adminPatchSupportTicket(publicId, category),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin-support-ticket", publicId] });
+      qc.invalidateQueries({ queryKey: ["admin-support-tickets"] });
+      qc.invalidateQueries({ queryKey: ["admin-support-stats"] });
+    },
+  });
+}

--- a/frontend/src/hooks/admin/useAdminSupportQueueStats.ts
+++ b/frontend/src/hooks/admin/useAdminSupportQueueStats.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { fetchAdminSupportQueueStats } from "@/lib/api/support";
+import type { SupportTicketQueueStatsDto } from "@/types/support";
+
+/**
+ * Query key for the admin support queue-stats badge. Stable so the
+ * sidebar badge and any future header indicator share a single cache
+ * entry across the page tree.
+ */
+export const ADMIN_SUPPORT_STATS_KEY = ["admin-support-stats"] as const;
+
+/**
+ * Polled badge counts for the sidebar (and any other place that needs
+ * a "needs admin reply" indicator). Refetches every 30 seconds so the
+ * badge stays loosely-live without WebSocket plumbing; the user is
+ * trusted to refresh for an authoritative count on the queue page itself.
+ *
+ * Gate with the caller's admin check (e.g. `useAdminSupportQueueStats(isAdmin)`)
+ * so non-admin sessions don't poll an endpoint they can't hit.
+ */
+export function useAdminSupportQueueStats(enabled = true) {
+  return useQuery<SupportTicketQueueStatsDto>({
+    queryKey: ADMIN_SUPPORT_STATS_KEY,
+    queryFn: fetchAdminSupportQueueStats,
+    refetchInterval: 30_000,
+    enabled,
+  });
+}

--- a/frontend/src/hooks/admin/useAdminSupportReopen.ts
+++ b/frontend/src/hooks/admin/useAdminSupportReopen.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminReopenSupportTicket } from "@/lib/api/support";
+import type { SupportTicketDto } from "@/types/support";
+
+/**
+ * Mutation wrapper around `POST /api/v1/admin/support-tickets/{publicId}/reopen`.
+ * On success invalidates the detail, queue, and stats badge so the status
+ * pill and the open-counter all reflect the reopen instantly.
+ */
+export function useAdminSupportReopen(publicId: string) {
+  const qc = useQueryClient();
+  return useMutation<SupportTicketDto, Error, void>({
+    mutationFn: () => adminReopenSupportTicket(publicId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin-support-ticket", publicId] });
+      qc.invalidateQueries({ queryKey: ["admin-support-tickets"] });
+      qc.invalidateQueries({ queryKey: ["admin-support-stats"] });
+    },
+  });
+}

--- a/frontend/src/hooks/admin/useAdminSupportReply.ts
+++ b/frontend/src/hooks/admin/useAdminSupportReply.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminReplySupportTicket } from "@/lib/api/support";
+import type {
+  AdminReplyRequest,
+  SupportTicketMessageDto,
+} from "@/types/support";
+
+/**
+ * Mutation wrapper around `POST /api/v1/admin/support-tickets/{publicId}/messages`.
+ *
+ * On success invalidates:
+ *   - the single-ticket detail query (so the new message appears),
+ *   - the admin queue list (so the row's lastMessage* timestamps refresh),
+ *   - the queue-stats badge (a public admin reply flips
+ *     `lastMessageAuthor=ADMIN`, which decrements the "needs admin reply"
+ *     counter; internal notes do not, but invalidating is cheap and
+ *     guarantees correctness without a server-shape coupling here).
+ */
+export function useAdminSupportReply(publicId: string) {
+  const qc = useQueryClient();
+  return useMutation<SupportTicketMessageDto, Error, AdminReplyRequest>({
+    mutationFn: (req) => adminReplySupportTicket(publicId, req),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin-support-ticket", publicId] });
+      qc.invalidateQueries({ queryKey: ["admin-support-tickets"] });
+      qc.invalidateQueries({ queryKey: ["admin-support-stats"] });
+    },
+  });
+}

--- a/frontend/src/hooks/admin/useAdminSupportResolve.ts
+++ b/frontend/src/hooks/admin/useAdminSupportResolve.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminResolveSupportTicket } from "@/lib/api/support";
+import type { SupportTicketDto } from "@/types/support";
+
+/**
+ * Mutation wrapper around `POST /api/v1/admin/support-tickets/{publicId}/resolve`.
+ * On success invalidates the single-ticket detail (status flips to RESOLVED),
+ * the admin queue (status pill on the row flips), and the queue-stats badge
+ * (resolving a ticket drops it from the open-needing-reply tally).
+ */
+export function useAdminSupportResolve(publicId: string) {
+  const qc = useQueryClient();
+  return useMutation<SupportTicketDto, Error, void>({
+    mutationFn: () => adminResolveSupportTicket(publicId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin-support-ticket", publicId] });
+      qc.invalidateQueries({ queryKey: ["admin-support-tickets"] });
+      qc.invalidateQueries({ queryKey: ["admin-support-stats"] });
+    },
+  });
+}

--- a/frontend/src/hooks/admin/useAdminSupportTicket.ts
+++ b/frontend/src/hooks/admin/useAdminSupportTicket.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { fetchAdminSupportTicket } from "@/lib/api/support";
+import type { SupportTicketDto } from "@/types/support";
+
+/**
+ * Query key for the admin-side single ticket detail. Exposed so the
+ * mutation hooks below can invalidate it without re-typing the literal.
+ */
+export const adminSupportTicketKey = (publicId: string) =>
+  ["admin-support-ticket", publicId] as const;
+
+export function useAdminSupportTicket(publicId: string) {
+  return useQuery<SupportTicketDto>({
+    queryKey: adminSupportTicketKey(publicId),
+    queryFn: () => fetchAdminSupportTicket(publicId),
+    enabled: !!publicId,
+  });
+}

--- a/frontend/src/hooks/admin/useAdminSupportTickets.ts
+++ b/frontend/src/hooks/admin/useAdminSupportTickets.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  fetchAdminSupportTickets,
+  type AdminListParams,
+} from "@/lib/api/support";
+import type { Page } from "@/types/page";
+import type { AdminSupportTicketQueueRow } from "@/types/support";
+
+/**
+ * Query-key factory for the admin support queue list. Indexed by the
+ * filter params so different views (status, assignee, last-author)
+ * share no cache entry. Exposed so mutation hooks in Task 21 can
+ * invalidate the same key without re-typing the literal.
+ */
+export const adminSupportTicketsKey = (params: AdminListParams) =>
+  ["admin-support-tickets", params] as const;
+
+export function useAdminSupportTickets(params: AdminListParams = {}) {
+  return useQuery<Page<AdminSupportTicketQueueRow>>({
+    queryKey: adminSupportTicketsKey(params),
+    queryFn: () => fetchAdminSupportTickets(params),
+  });
+}

--- a/frontend/src/hooks/useCreateSupportTicket.ts
+++ b/frontend/src/hooks/useCreateSupportTicket.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { createSupportTicket } from "@/lib/api/support";
+import type {
+  CreateSupportTicketRequest,
+  SupportTicketDto,
+} from "@/types/support";
+
+/**
+ * Mutation wrapper around `POST /api/v1/me/support-tickets`. On success
+ * invalidates the user's own ticket list and navigates to the new
+ * ticket's thread page.
+ *
+ * On failure the caller reads `error.problem.code` (a
+ * `SupportTicketErrorCode`) to render the right inline message.
+ */
+export function useCreateSupportTicket() {
+  const router = useRouter();
+  const qc = useQueryClient();
+  return useMutation<SupportTicketDto, Error, CreateSupportTicketRequest>({
+    mutationFn: (req) => createSupportTicket(req),
+    onSuccess: (ticket) => {
+      qc.invalidateQueries({ queryKey: ["me-support-tickets"] });
+      router.push(`/support/${ticket.publicId}`);
+    },
+  });
+}

--- a/frontend/src/hooks/useMySupportTicket.ts
+++ b/frontend/src/hooks/useMySupportTicket.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { fetchMySupportTicket } from "@/lib/api/support";
+import type { SupportTicketDto } from "@/types/support";
+
+export const mySupportTicketKey = (publicId: string) =>
+  ["me-support-ticket", publicId] as const;
+
+export function useMySupportTicket(publicId: string) {
+  return useQuery<SupportTicketDto>({
+    queryKey: mySupportTicketKey(publicId),
+    queryFn: () => fetchMySupportTicket(publicId),
+    enabled: !!publicId,
+  });
+}

--- a/frontend/src/hooks/useMySupportTickets.ts
+++ b/frontend/src/hooks/useMySupportTickets.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  fetchMySupportTickets,
+  type MyListParams,
+} from "@/lib/api/support";
+import type { Page } from "@/types/page";
+import type { SupportTicketSummaryDto } from "@/types/support";
+
+/**
+ * Query-key factory for the authenticated user's own support tickets.
+ * Indexed by the filter params so different list views (e.g. "open" vs.
+ * "all") share no cache entry.
+ *
+ * Exposed so mutation hooks (`useCreateSupportTicket`,
+ * `useReplySupportTicket`) can invalidate without re-typing the literal.
+ */
+export const mySupportTicketsKey = (params: MyListParams = {}) =>
+  ["me-support-tickets", params] as const;
+
+export function useMySupportTickets(params: MyListParams = {}) {
+  return useQuery<Page<SupportTicketSummaryDto>>({
+    queryKey: mySupportTicketsKey(params),
+    queryFn: () => fetchMySupportTickets(params),
+  });
+}

--- a/frontend/src/hooks/useReplySupportTicket.ts
+++ b/frontend/src/hooks/useReplySupportTicket.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { replySupportTicket } from "@/lib/api/support";
+import type {
+  ReplySupportTicketRequest,
+  SupportTicketMessageDto,
+} from "@/types/support";
+
+/**
+ * Mutation wrapper around `POST /api/v1/me/support-tickets/{publicId}/messages`.
+ * On success invalidates both the single-ticket detail query (so the new
+ * message appears in the thread) and the list query (so the row's
+ * lastMessageAt / lastMessageAuthor reflect the user's reply).
+ */
+export function useReplySupportTicket(publicId: string) {
+  const qc = useQueryClient();
+  return useMutation<
+    SupportTicketMessageDto,
+    Error,
+    ReplySupportTicketRequest
+  >({
+    mutationFn: (req) => replySupportTicket(publicId, req),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["me-support-ticket", publicId] });
+      qc.invalidateQueries({ queryKey: ["me-support-tickets"] });
+    },
+  });
+}

--- a/frontend/src/hooks/useSignedAttachmentUrl.ts
+++ b/frontend/src/hooks/useSignedAttachmentUrl.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { fetchAttachmentSignedUrl } from "@/lib/api/support";
+
+export const signedAttachmentUrlKey = (publicId: string) =>
+  ["support-attachment-signed-url", publicId] as const;
+
+/**
+ * Fetches a short-lived signed URL for a support-ticket attachment. The
+ * backend issues 5-minute presigned S3 GETs; we stale at 4 minutes so a
+ * tab left open refreshes the URL just before expiry.
+ *
+ * `publicId` is nullable so consumers can conditionally render an
+ * attachment thumbnail without an extra guard — when `null` the query
+ * stays disabled.
+ */
+export function useSignedAttachmentUrl(publicId: string | null) {
+  return useQuery<{ url: string }>({
+    queryKey: signedAttachmentUrlKey(publicId ?? ""),
+    queryFn: () => fetchAttachmentSignedUrl(publicId!),
+    enabled: !!publicId,
+    staleTime: 4 * 60 * 1000,
+  });
+}

--- a/frontend/src/hooks/useUploadSupportAttachment.ts
+++ b/frontend/src/hooks/useUploadSupportAttachment.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import { uploadSupportAttachment } from "@/lib/api/support";
+
+/**
+ * Mutation wrapper around `POST /api/v1/me/support-tickets/attachments`.
+ * Pre-uploads an attachment and returns the opaque `attachmentKey` that
+ * the consumer threads into a subsequent create/reply request.
+ *
+ * No cache invalidation: the staging bucket isn't surfaced anywhere; only
+ * the eventual ticket message reflects the upload, and that's invalidated
+ * by the create/reply mutation that consumes the key.
+ */
+export function useUploadSupportAttachment() {
+  return useMutation<{ attachmentKey: string }, Error, File>({
+    mutationFn: (file) => uploadSupportAttachment(file),
+  });
+}

--- a/frontend/src/lib/api/support.ts
+++ b/frontend/src/lib/api/support.ts
@@ -1,0 +1,171 @@
+import { api } from "@/lib/api";
+import type { Page } from "@/types/page";
+import type {
+  AdminReplyRequest,
+  AdminSupportTicketQueueRow,
+  CreateSupportTicketRequest,
+  ReplySupportTicketRequest,
+  SupportTicketCategory,
+  SupportTicketDto,
+  SupportTicketMessageDto,
+  SupportTicketQueueStatsDto,
+  SupportTicketStatus,
+  SupportTicketSummaryDto,
+} from "@/types/support";
+
+/**
+ * Customer-support API client. Wraps the user-facing endpoints under
+ * `/api/v1/me/support-tickets` and the admin queue endpoints under
+ * `/api/v1/admin/support-tickets`. The signed-URL endpoint is shared
+ * between both surfaces.
+ *
+ * Backend authoritative source: spec
+ * `docs/superpowers/specs/2026-05-20-customer-support-contact-design.md`.
+ */
+
+// ─── User-facing list params ─────────────────────────────────────────────
+
+export interface MyListParams {
+  status?: SupportTicketStatus;
+  q?: string;
+  page?: number;
+  size?: number;
+}
+
+export function fetchMySupportTickets(
+  params: MyListParams = {},
+): Promise<Page<SupportTicketSummaryDto>> {
+  return api.get<Page<SupportTicketSummaryDto>>(
+    "/api/v1/me/support-tickets",
+    { params: params as Record<string, string | number | undefined> },
+  );
+}
+
+export function fetchMySupportTicket(
+  publicId: string,
+): Promise<SupportTicketDto> {
+  return api.get<SupportTicketDto>(`/api/v1/me/support-tickets/${publicId}`);
+}
+
+export function createSupportTicket(
+  req: CreateSupportTicketRequest,
+): Promise<SupportTicketDto> {
+  return api.post<SupportTicketDto>("/api/v1/me/support-tickets", req);
+}
+
+export function replySupportTicket(
+  publicId: string,
+  req: ReplySupportTicketRequest,
+): Promise<SupportTicketMessageDto> {
+  return api.post<SupportTicketMessageDto>(
+    `/api/v1/me/support-tickets/${publicId}/messages`,
+    req,
+  );
+}
+
+/**
+ * Multipart upload of a single attachment file. The shared `api.post`
+ * helper detects FormData and omits the Content-Type header so the browser
+ * can set the multipart boundary itself.
+ */
+export function uploadSupportAttachment(
+  file: File,
+): Promise<{ attachmentKey: string }> {
+  const fd = new FormData();
+  fd.append("file", file);
+  return api.post<{ attachmentKey: string }>(
+    "/api/v1/me/support-tickets/attachments",
+    fd,
+  );
+}
+
+export function fetchAttachmentSignedUrl(
+  publicId: string,
+): Promise<{ url: string }> {
+  return api.get<{ url: string }>(
+    `/api/v1/support-tickets/attachments/${publicId}`,
+  );
+}
+
+// ─── Admin queue ──────────────────────────────────────────────────────────
+
+export interface AdminListParams {
+  status?: SupportTicketStatus;
+  category?: SupportTicketCategory;
+  assignee?: string;
+  last_author?: "USER" | "ADMIN";
+  q?: string;
+  page?: number;
+  size?: number;
+}
+
+export function fetchAdminSupportTickets(
+  params: AdminListParams = {},
+): Promise<Page<AdminSupportTicketQueueRow>> {
+  return api.get<Page<AdminSupportTicketQueueRow>>(
+    "/api/v1/admin/support-tickets",
+    { params: params as Record<string, string | number | undefined> },
+  );
+}
+
+export function fetchAdminSupportTicket(
+  publicId: string,
+): Promise<SupportTicketDto> {
+  return api.get<SupportTicketDto>(
+    `/api/v1/admin/support-tickets/${publicId}`,
+  );
+}
+
+export function fetchAdminSupportQueueStats(): Promise<SupportTicketQueueStatsDto> {
+  return api.get<SupportTicketQueueStatsDto>(
+    "/api/v1/admin/support-tickets/queue-stats",
+  );
+}
+
+export function adminReplySupportTicket(
+  publicId: string,
+  req: AdminReplyRequest,
+): Promise<SupportTicketMessageDto> {
+  return api.post<SupportTicketMessageDto>(
+    `/api/v1/admin/support-tickets/${publicId}/messages`,
+    req,
+  );
+}
+
+export function adminResolveSupportTicket(
+  publicId: string,
+): Promise<SupportTicketDto> {
+  return api.post<SupportTicketDto>(
+    `/api/v1/admin/support-tickets/${publicId}/resolve`,
+    {},
+  );
+}
+
+export function adminReopenSupportTicket(
+  publicId: string,
+): Promise<SupportTicketDto> {
+  return api.post<SupportTicketDto>(
+    `/api/v1/admin/support-tickets/${publicId}/reopen`,
+    {},
+  );
+}
+
+export function adminAssignSupportTicket(
+  publicId: string,
+  adminPublicId: string | null,
+): Promise<SupportTicketDto> {
+  return api.post<SupportTicketDto>(
+    `/api/v1/admin/support-tickets/${publicId}/assign`,
+    { adminPublicId },
+  );
+}
+
+export function adminPatchSupportTicket(
+  publicId: string,
+  category: SupportTicketCategory,
+): Promise<SupportTicketDto> {
+  return api.patch<SupportTicketDto>(
+    `/api/v1/admin/support-tickets/${publicId}`,
+    { category },
+  );
+}

--- a/frontend/src/lib/notifications/categoryMap.test.ts
+++ b/frontend/src/lib/notifications/categoryMap.test.ts
@@ -14,12 +14,15 @@ const ALL_CATEGORIES: NotificationCategory[] = [
   "LISTING_VERIFIED", "LISTING_SUSPENDED",
   "LISTING_REVIEW_REQUIRED", "LISTING_CANCELLED_BY_SELLER",
   "LISTING_CANCELLED_DURING_ESCROW",
-  "REVIEW_RECEIVED", "SYSTEM_ANNOUNCEMENT",
+  "REVIEW_RECEIVED",
+  "SUPPORT_TICKET_ADMIN_REPLIED", "SUPPORT_TICKET_RESOLVED",
+  "SUPPORT_TICKET_OPENED", "SUPPORT_TICKET_USER_REPLIED",
+  "SYSTEM_ANNOUNCEMENT",
 ];
 
 describe("categoryMap", () => {
-  it("covers all 24 notification categories", () => {
-    expect(Object.keys(categoryMap)).toHaveLength(24);
+  it("covers all 28 notification categories", () => {
+    expect(Object.keys(categoryMap)).toHaveLength(28);
     for (const cat of ALL_CATEGORIES) {
       expect(categoryMap).toHaveProperty(cat);
     }
@@ -69,6 +72,75 @@ describe("categoryMap", () => {
     expect(entry.action?.label).toBe("Buy parcel");
     expect(entry.action?.href(data)).toBe(
       "/auction/00000000-0000-0000-0000-0000000002a/escrow",
+    );
+  });
+
+  it("SUPPORT_TICKET_ADMIN_REPLIED deeplinks + action route the user to /support/{ticketPublicId}", () => {
+    const data = {
+      ticketPublicId: "00000000-0000-0000-0000-000000000abc",
+      subject: "Stuck on escrow",
+      adminDisplayName: "Sara",
+    };
+    const entry = categoryMap.SUPPORT_TICKET_ADMIN_REPLIED;
+    expect(entry.group).toBe("system");
+    expect(entry.toastVariant).toBe("info");
+    expect(entry.deeplink(data)).toBe(
+      "/support/00000000-0000-0000-0000-000000000abc",
+    );
+    expect(entry.action?.label).toBe("View ticket");
+    expect(entry.action?.href(data)).toBe(
+      "/support/00000000-0000-0000-0000-000000000abc",
+    );
+  });
+
+  it("SUPPORT_TICKET_RESOLVED deeplinks the user to /support/{ticketPublicId} with success styling", () => {
+    const data = {
+      ticketPublicId: "00000000-0000-0000-0000-000000000abc",
+      subject: "Stuck on escrow",
+    };
+    const entry = categoryMap.SUPPORT_TICKET_RESOLVED;
+    expect(entry.group).toBe("system");
+    expect(entry.toastVariant).toBe("success");
+    expect(entry.deeplink(data)).toBe(
+      "/support/00000000-0000-0000-0000-000000000abc",
+    );
+    expect(entry.action).toBeUndefined();
+  });
+
+  it("SUPPORT_TICKET_OPENED deeplinks + action route the admin to /admin/support/{ticketPublicId}", () => {
+    const data = {
+      ticketPublicId: "00000000-0000-0000-0000-000000000abc",
+      subject: "Stuck on escrow",
+      submitterDisplayName: "buyer.resident",
+      category: "BIDDING",
+    };
+    const entry = categoryMap.SUPPORT_TICKET_OPENED;
+    expect(entry.group).toBe("system");
+    expect(entry.toastVariant).toBe("info");
+    expect(entry.deeplink(data)).toBe(
+      "/admin/support/00000000-0000-0000-0000-000000000abc",
+    );
+    expect(entry.action?.label).toBe("Open queue");
+    expect(entry.action?.href(data)).toBe(
+      "/admin/support/00000000-0000-0000-0000-000000000abc",
+    );
+  });
+
+  it("SUPPORT_TICKET_USER_REPLIED deeplinks + action route the admin to /admin/support/{ticketPublicId}", () => {
+    const data = {
+      ticketPublicId: "00000000-0000-0000-0000-000000000abc",
+      subject: "Stuck on escrow",
+      submitterDisplayName: "buyer.resident",
+    };
+    const entry = categoryMap.SUPPORT_TICKET_USER_REPLIED;
+    expect(entry.group).toBe("system");
+    expect(entry.toastVariant).toBe("info");
+    expect(entry.deeplink(data)).toBe(
+      "/admin/support/00000000-0000-0000-0000-000000000abc",
+    );
+    expect(entry.action?.label).toBe("Open ticket");
+    expect(entry.action?.href(data)).toBe(
+      "/admin/support/00000000-0000-0000-0000-000000000abc",
     );
   });
 

--- a/frontend/src/lib/notifications/categoryMap.ts
+++ b/frontend/src/lib/notifications/categoryMap.ts
@@ -2,6 +2,7 @@ import type { ComponentType } from "react";
 import {
   Bell, Bolt, Wallet, Star, Trophy, Clock, AlertTriangle,
   CheckCircle2, AlertOctagon, BadgeCheck, XCircle, Pause,
+  MessageSquare,
 } from "@/components/ui/icons";
 import type { ToastKind } from "@/components/ui/Toast";
 import type { NotificationCategory, NotificationGroup } from "./types";
@@ -186,6 +187,37 @@ export const categoryMap: Record<NotificationCategory, CategoryMapEntry> = {
     iconBgClass: "bg-info-bg text-info",
     toastVariant: "info",
     deeplink: (d) => `/auction/${d.auctionPublicId ?? d.auctionId}`,
+  },
+  SUPPORT_TICKET_ADMIN_REPLIED: {
+    group: "system",
+    icon: MessageSquare,
+    iconBgClass: "bg-info-bg text-info",
+    toastVariant: "info",
+    deeplink: (d) => `/support/${d.ticketPublicId}`,
+    action: { label: "View ticket", href: (d) => `/support/${d.ticketPublicId}` },
+  },
+  SUPPORT_TICKET_RESOLVED: {
+    group: "system",
+    icon: MessageSquare,
+    iconBgClass: "bg-success-bg text-success",
+    toastVariant: "success",
+    deeplink: (d) => `/support/${d.ticketPublicId}`,
+  },
+  SUPPORT_TICKET_OPENED: {
+    group: "system",
+    icon: MessageSquare,
+    iconBgClass: "bg-info-bg text-info",
+    toastVariant: "info",
+    deeplink: (d) => `/admin/support/${d.ticketPublicId}`,
+    action: { label: "Open queue", href: (d) => `/admin/support/${d.ticketPublicId}` },
+  },
+  SUPPORT_TICKET_USER_REPLIED: {
+    group: "system",
+    icon: MessageSquare,
+    iconBgClass: "bg-info-bg text-info",
+    toastVariant: "info",
+    deeplink: (d) => `/admin/support/${d.ticketPublicId}`,
+    action: { label: "Open ticket", href: (d) => `/admin/support/${d.ticketPublicId}` },
   },
   SYSTEM_ANNOUNCEMENT: {
     group: "system",

--- a/frontend/src/lib/notifications/types.ts
+++ b/frontend/src/lib/notifications/types.ts
@@ -32,6 +32,10 @@ export type NotificationCategory =
   | "LISTING_CANCELLED_BY_SELLER"
   | "LISTING_CANCELLED_DURING_ESCROW"
   | "REVIEW_RECEIVED"
+  | "SUPPORT_TICKET_ADMIN_REPLIED"
+  | "SUPPORT_TICKET_RESOLVED"
+  | "SUPPORT_TICKET_OPENED"
+  | "SUPPORT_TICKET_USER_REPLIED"
   | "SYSTEM_ANNOUNCEMENT";
 
 export type NotificationDataMap = {
@@ -64,6 +68,10 @@ export type NotificationDataMap = {
   LISTING_CANCELLED_BY_SELLER: { auctionId: number; parcelName: string; reason: string };
   LISTING_CANCELLED_DURING_ESCROW: { auctionId: number; escrowId: number; parcelName: string; adminNote?: string };
   REVIEW_RECEIVED: { auctionId: number; parcelName: string; reviewId: number; rating: number };
+  SUPPORT_TICKET_ADMIN_REPLIED: { ticketPublicId: string; subject: string; adminDisplayName: string };
+  SUPPORT_TICKET_RESOLVED: { ticketPublicId: string; subject: string };
+  SUPPORT_TICKET_OPENED: { ticketPublicId: string; subject: string; submitterDisplayName: string; category: string };
+  SUPPORT_TICKET_USER_REPLIED: { ticketPublicId: string; subject: string; submitterDisplayName: string };
   SYSTEM_ANNOUNCEMENT: Record<string, unknown>;
 };
 // NOTE: The notification `data` blob keys (auctionId, escrowId, reviewId) are

--- a/frontend/src/test/msw/handlers.ts
+++ b/frontend/src/test/msw/handlers.ts
@@ -1774,6 +1774,25 @@ export const commissionAnalyticsHandlers = {
 };
 
 /**
+ * Customer-support admin handlers. {@code queueStatsSuccess} backs the
+ * sidebar badge polled by {@code useAdminSupportQueueStats}; it's included
+ * in {@code defaultHandlers} so every admin-session test gets a baseline
+ * response without re-declaring it.
+ */
+export const adminSupportHandlers = {
+  queueStatsSuccess: (
+    stats: { openNeedingAdminReply?: number; openTotal?: number } = {},
+  ) =>
+    http.get("*/api/v1/admin/support-tickets/queue-stats", () =>
+      HttpResponse.json({
+        openNeedingAdminReply: 0,
+        openTotal: 0,
+        ...stats,
+      }),
+    ),
+};
+
+/**
  * Default handlers registered at server startup. Establishes the "no session"
  * baseline so tests that don't explicitly authenticate get the unauthenticated
  * bootstrap path automatically.
@@ -1790,4 +1809,8 @@ export const defaultHandlers = [
   realtyGroupWalletHandlers.ledgerEmpty(),
   realtyGroupWalletHandlers.withdrawSuccess(),
   realtySlGroupHandlers.listEmpty(),
+  // Sidebar polling: admin-session tests that don't override this get a
+  // zero-count badge. Non-admin sessions never hit this endpoint
+  // (`useAdminSupportQueueStats` is gated by role in `AdminShell`).
+  adminSupportHandlers.queueStatsSuccess(),
 ];

--- a/frontend/src/types/support.ts
+++ b/frontend/src/types/support.ts
@@ -1,0 +1,113 @@
+// Frontend types for the customer-support-contact feature.
+// Mirrors backend DTOs in com.slparcelauctions.backend.support.dto and the
+// admin queue DTOs in com.slparcelauctions.backend.admin.support.dto.
+//
+// `publicId` is the only identifier that crosses the wire; numeric ids stay
+// server-side (see CLAUDE.md "BaseEntity convention").
+
+export type SupportTicketStatus = "OPEN" | "RESOLVED";
+
+export type SupportTicketCategory =
+  | "ACCOUNT"
+  | "BIDDING"
+  | "LISTING"
+  | "ESCROW"
+  | "WALLET"
+  | "OTHER";
+
+export type SupportTicketAuthorRole = "USER" | "ADMIN";
+
+export interface SupportTicketAttachmentDto {
+  publicId: string;
+  mimeType: string;
+  sizeBytes: number;
+  width: number | null;
+  height: number | null;
+}
+
+export interface SupportTicketMessageDto {
+  publicId: string;
+  authorPublicId: string;
+  authorDisplayName: string;
+  authorRole: SupportTicketAuthorRole;
+  body: string;
+  visibleToUser: boolean;
+  createdAt: string;
+  attachments: SupportTicketAttachmentDto[];
+}
+
+export interface SupportTicketDto {
+  publicId: string;
+  submitterPublicId: string;
+  submitterDisplayName: string;
+  subject: string;
+  category: SupportTicketCategory;
+  status: SupportTicketStatus;
+  assignedAdminPublicId: string | null;
+  assignedAdminDisplayName: string | null;
+  lastMessageAt: string;
+  lastMessageAuthor: SupportTicketAuthorRole;
+  resolvedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  messages: SupportTicketMessageDto[];
+}
+
+export interface SupportTicketSummaryDto {
+  publicId: string;
+  subject: string;
+  category: SupportTicketCategory;
+  status: SupportTicketStatus;
+  lastMessageAuthor: SupportTicketAuthorRole;
+  lastMessageAt: string;
+}
+
+export interface AdminSupportTicketQueueRow {
+  publicId: string;
+  subject: string;
+  category: SupportTicketCategory;
+  status: SupportTicketStatus;
+  submitterPublicId: string;
+  submitterDisplayName: string;
+  assignedAdminPublicId: string | null;
+  assignedAdminDisplayName: string | null;
+  lastMessageAuthor: SupportTicketAuthorRole;
+  lastMessageAt: string;
+}
+
+export interface SupportTicketQueueStatsDto {
+  openNeedingAdminReply: number;
+  openTotal: number;
+}
+
+/**
+ * Problem-detail `code` values returned by SupportTicketException via the
+ * shared GlobalExceptionHandler. Callers narrow `error.problem.code` to
+ * decide between inline form errors and toast surfaces.
+ */
+export type SupportTicketErrorCode =
+  | "UNKNOWN_TICKET"
+  | "NOT_OWNER"
+  | "INTERNAL_NOTE_FROM_USER"
+  | "RATE_LIMITED"
+  | "INVALID_ATTACHMENT"
+  | "INVALID_CATEGORY"
+  | "ATTACHMENT_NOT_FOUND";
+
+export interface CreateSupportTicketRequest {
+  subject: string;
+  category: SupportTicketCategory;
+  body: string;
+  attachmentKeys?: string[];
+}
+
+export interface ReplySupportTicketRequest {
+  body: string;
+  attachmentKeys?: string[];
+}
+
+export interface AdminReplyRequest {
+  body: string;
+  attachmentKeys?: string[];
+  internalNote?: boolean;
+}


### PR DESCRIPTION
## Summary
- Implements customer support per docs/superpowers/specs/2026-05-21-customer-support-contact-design.md (closes #167)
- New tables support_tickets / support_ticket_messages / support_ticket_attachments (Flyway V42)
- Backend: new com.slparcelauctions.backend.support package with entities, repos, service, rate limiter, three controllers (Me + Admin + Attachment), exception handler
- Frontend: new Textarea UI primitive; /support list/new/thread; /admin/support queue + detail; user dropdown entry; admin sidebar badge with polling
- Four new notification categories with in-app + (user-side only) SL IM channels
- Image attachments up to 3 per message; pending state via Redis + S3 lifecycle rule
- Per-user rate limit: 5 new tickets/hour, replies uncapped

## LazyInit defense
Every controller method that returns a mapper-derived DTO is @Transactional; the single-row repo finder uses @EntityGraph(messages, messages.attachments); each controller surface has a non-@Transactional regression test class (carried over from PR #388 lessons).

## Test plan
- [x] backend ./mvnw test full suite green (2681 tests)
- [x] frontend npm test full suite green (2251 tests)
- [x] frontend npm run verify green
- [ ] Post-deploy: configure the S3 lifecycle rule per spec §13 (support-attachments/pending/ -> 1-day expire)
- [ ] Manual smoke (post-deploy): user creates ticket -> admin sees badge -> admin internal note (invisible to user) -> admin public reply -> user sees notification + SL IM -> resolve -> user replies on resolved -> auto-reopens, admin re-notified