### PR TITLE
fix(bot): refresh IdlePark chair UUIDs after seat re-rez

### DIFF
--- a/bot/src/Slpa.Bot/Options/IdleParkOptions.cs
+++ b/bot/src/Slpa.Bot/Options/IdleParkOptions.cs
@@ -31,13 +31,13 @@ public sealed class IdleParkOptions
     /// </summary>
     public List<string> Chairs { get; set; } = new()
     {
-        "d28b2fea-8020-b875-777b-6e432a7d9317",
-        "65f7f3e4-1a06-0a07-9233-a3f9a44ff88c",
-        "273a9a21-9a23-ca63-58e0-fe817f0a524a",
-        "02080632-9fcc-1e1f-36b3-8dd54a694f12",
-        "6a8106b7-d771-4c5c-ee19-62b4291de07a",
-        "0c852666-669a-9670-e663-380e18d748b7",
-        "cd2dbb84-8b18-f28e-c19c-f40468036fc6",
-        "ca2c885f-d3fd-2368-1ea7-4c57e014ea5a",
+        "b5c8a4c0-d0fb-1580-6fa8-36a6374d2ff4",
+        "22bf826a-4417-c637-0817-88832307c8e2",
+        "a24e89f1-ae46-95a4-a87f-e0e2a4809f74",
+        "78978fa7-2c43-c2f2-5b1a-89bffadbafc7",
+        "cabbcc98-e89b-bd4b-76d0-c0a0343205e4",
+        "861de5a1-92ec-c9c3-124f-e2f74de342dd",
+        "24584ae7-dfa1-2be0-4bfa-589d422d62e9",
+        "828d2785-722c-a755-28bd-9b1460001117",
     };
 }

--- a/bot/src/Slpa.Bot/appsettings.json
+++ b/bot/src/Slpa.Bot/appsettings.json
@@ -33,14 +33,14 @@
     "Z": 25,
     "ParkCooldownSeconds": 180,
     "Chairs": [
-      "d28b2fea-8020-b875-777b-6e432a7d9317",
-      "65f7f3e4-1a06-0a07-9233-a3f9a44ff88c",
-      "273a9a21-9a23-ca63-58e0-fe817f0a524a",
-      "02080632-9fcc-1e1f-36b3-8dd54a694f12",
-      "6a8106b7-d771-4c5c-ee19-62b4291de07a",
-      "0c852666-669a-9670-e663-380e18d748b7",
-      "cd2dbb84-8b18-f28e-c19c-f40468036fc6",
-      "ca2c885f-d3fd-2368-1ea7-4c57e014ea5a"
+      "b5c8a4c0-d0fb-1580-6fa8-36a6374d2ff4",
+      "22bf826a-4417-c637-0817-88832307c8e2",
+      "a24e89f1-ae46-95a4-a87f-e0e2a4809f74",
+      "78978fa7-2c43-c2f2-5b1a-89bffadbafc7",
+      "cabbcc98-e89b-bd4b-76d0-c0a0343205e4",
+      "861de5a1-92ec-c9c3-124f-e2f74de342dd",
+      "24584ae7-dfa1-2be0-4bfa-589d422d62e9",
+      "828d2785-722c-a755-28bd-9b1460001117"
     ]
   },
   "Heartbeat": {


### PR DESCRIPTION
The 8 chairs in the Hadron idle-park rectangle were re-rezzed; the previous UUIDs are stale, so bots can sit nowhere and never enter their idle state. Updates both bot/src/Slpa.Bot/appsettings.json (operative in prod, bundled into the image) and bot/src/Slpa.Bot/Options/IdleParkOptions.cs defaults (source-of-truth fallback) with the new 8 UUIDs.

No code logic changes; rebuild + redeploy of the bot image is all that's needed.