### PR TITLE
Release: parcel-scan terrain race fix

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/parcelscan/ParcelScanService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/parcelscan/ParcelScanService.java
@@ -116,4 +116,26 @@ public class ParcelScanService {
         botTaskService.markCompleted(task);
         log.info("Scan result task {} marked COMPLETED for auction {}", task.getId(), auction.getId());
     }
+
+    /**
+     * Record a bot-reported scan failure. Marks the task FAILED with the
+     * supplied reason so the admin panel can surface why the scan did not
+     * complete. Idempotent on already-terminal tasks (returns 409).
+     */
+    @Transactional
+    public void markScanFailed(long taskId, String reason) {
+        BotTask task = botTaskRepo.findById(taskId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "task not found"));
+        if (task.getTaskType() != BotTaskType.SCAN_PARCEL) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "task is not SCAN_PARCEL");
+        }
+        if (task.getStatus() == BotTaskStatus.COMPLETED
+                || task.getStatus() == BotTaskStatus.FAILED
+                || task.getStatus() == BotTaskStatus.CANCELLED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "task already in terminal state");
+        }
+        botTaskService.markFailed(task, reason);
+        log.info("Scan task {} marked FAILED with reason '{}' for auction {}",
+                task.getId(), reason, task.getAuction().getId());
+    }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.slparcelauctions.backend.auction.parcelscan.ParcelScanService;
 import com.slparcelauctions.backend.auction.parcelscan.dto.BotScanResultRequest;
+import com.slparcelauctions.backend.bot.dto.BotScanFailedRequest;
 import com.slparcelauctions.backend.bot.dto.BotTaskClaimRequest;
 import com.slparcelauctions.backend.bot.dto.BotTaskResponse;
 import com.slparcelauctions.backend.bot.dto.BotTaskResultRequest;
@@ -93,5 +94,18 @@ public class BotTaskController {
             @Valid @RequestBody BotScanResultRequest body) {
         parcelScanService.applyScanResult(taskId, body);
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Bot {@code SCAN_PARCEL} failure callback. Marks the task FAILED with the
+     * supplied reason so the admin panel can surface why the scan did not
+     * complete (e.g. {@code TERRAIN_NOT_LOADED}). Returns 409 if the task is
+     * already in a terminal state or is not of type SCAN_PARCEL.
+     */
+    @PostMapping("/{taskId}/scan-failed")
+    public ResponseEntity<Void> scanFailed(@PathVariable Long taskId,
+            @Valid @RequestBody BotScanFailedRequest body) {
+        parcelScanService.markScanFailed(taskId, body.reason());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskService.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskService.java
@@ -91,4 +91,16 @@ public class BotTaskService {
         task.setCompletedAt(OffsetDateTime.now(clock));
         return botTaskRepo.save(task);
     }
+
+    /**
+     * Mark a task FAILED with the supplied reason string. Sets
+     * {@code completedAt} to now and persists.
+     */
+    @Transactional
+    public BotTask markFailed(BotTask task, String reason) {
+        task.setStatus(BotTaskStatus.FAILED);
+        task.setFailureReason(reason);
+        task.setCompletedAt(OffsetDateTime.now(clock));
+        return botTaskRepo.save(task);
+    }
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/bot/dto/BotScanFailedRequest.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/bot/dto/BotScanFailedRequest.java
@@ -1,0 +1,10 @@
+package com.slparcelauctions.backend.bot.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Body for POST /api/v1/bot/tasks/{taskId}/scan-failed.
+ * Carries a short machine-readable reason string (e.g. "TERRAIN_NOT_LOADED")
+ * that the bot reports when a SCAN_PARCEL task cannot complete.
+ */
+public record BotScanFailedRequest(@NotBlank String reason) {}

--- a/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/config/SecurityConfig.java
@@ -310,10 +310,12 @@ public class SecurityConfig {
                         // Authentication is a shared bearer token validated by
                         // BotSharedSecretAuthorizer (constant-time compare via
                         // MessageDigest.isEqual). The .access(...) matcher is the
-                        // single trust boundary for every /api/v1/bot/** path:
-                        // /claim, /pending, /{id}/verify, and /{id}/monitor
-                        // (Task 5) all gate through here. The Task 4 deprecated
-                        // PUT /{id} shim was removed in Task 12.
+                        // single trust boundary for every /api/v1/bot/** path.
+                        // Current bot endpoints: POST /claim, GET /pending,
+                        // POST /{id}/result (VERIFY_SELL_TO), POST /{id}/result
+                        // (heartbeat), POST /{id}/verify-buy-owner-result
+                        // (VERIFY_BUY_OWNER), POST /{id}/scan-result (SCAN_PARCEL
+                        // success), POST /{id}/scan-failed (SCAN_PARCEL failure).
                         // FOOTGUNS §B.5: matcher order is first-match-wins, so
                         // this rule MUST sit before the /api/v1/** catch-all.
                         .requestMatchers("/api/v1/bot/**").access((authentication, ctx) ->

--- a/backend/src/test/java/com/slparcelauctions/backend/bot/BotTaskControllerScanFailedTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/bot/BotTaskControllerScanFailedTest.java
@@ -1,0 +1,188 @@
+package com.slparcelauctions.backend.bot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionParcelSnapshot;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.VerificationTier;
+import com.slparcelauctions.backend.bot.dto.BotScanFailedRequest;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Integration test for {@code POST /api/v1/bot/tasks/{id}/scan-failed}.
+ *
+ * <p>Mirrors the auth-header pattern from {@link BotTaskControllerScanResultTest}:
+ * bot endpoints require {@code Authorization: Bearer <secret>} matching
+ * {@code slpa.bot.shared-secret} from {@code application-dev.yml}.
+ *
+ * <p>No {@code @Transactional} -- each MockMvc request commits its own
+ * transaction, so auto-rollback does not apply. Each test creates data with
+ * random UUIDs/emails so rows do not collide across the suite run.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false",
+        "slpa.realty.invitation-expiry.enabled=false"
+})
+class BotTaskControllerScanFailedTest {
+
+    /**
+     * Matches {@code slpa.bot.shared-secret} in {@code application-dev.yml}.
+     * Intentionally inlined as a literal: the test proves the wiring reads
+     * this specific config value.
+     */
+    private static final String DEV_BOT_SECRET = "dev-bot-shared-secret";
+
+    @Autowired MockMvc mvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired UserRepository userRepo;
+    @Autowired AuctionRepository auctionRepo;
+    @Autowired BotTaskRepository botTaskRepo;
+    @Autowired BotTaskService botTaskService;
+
+    // --- happy path ---
+
+    @Test
+    void happyPath_pendingScanTask_returns204AndMarksFailed() throws Exception {
+        Auction auction = savedAuction(savedUser("happy-failed"));
+        BotTask task = botTaskService.enqueueScanParcel(auction);
+
+        mvc.perform(post("/api/v1/bot/tasks/" + task.getId() + "/scan-failed")
+                        .header("Authorization", "Bearer " + DEV_BOT_SECRET)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new BotScanFailedRequest("TERRAIN_NOT_LOADED"))))
+                .andExpect(status().isNoContent());
+
+        BotTask failed = botTaskRepo.findById(task.getId()).orElseThrow();
+        assertThat(failed.getStatus()).isEqualTo(BotTaskStatus.FAILED);
+        assertThat(failed.getFailureReason()).isEqualTo("TERRAIN_NOT_LOADED");
+    }
+
+    // --- 409 cases ---
+
+    @Test
+    void nonScanParcelTask_returns409() throws Exception {
+        Auction auction = savedAuction(savedUser("wrong-type-failed"));
+
+        BotTask wrongTask = BotTask.builder()
+                .taskType(BotTaskType.VERIFY_SELL_TO)
+                .status(BotTaskStatus.PENDING)
+                .auction(auction)
+                .parcelUuid(auction.getSlParcelUuid())
+                .sentinelPrice(0L)
+                .build();
+        wrongTask = botTaskRepo.save(wrongTask);
+
+        mvc.perform(post("/api/v1/bot/tasks/" + wrongTask.getId() + "/scan-failed")
+                        .header("Authorization", "Bearer " + DEV_BOT_SECRET)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new BotScanFailedRequest("TERRAIN_NOT_LOADED"))))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void terminalTask_returns409() throws Exception {
+        Auction auction = savedAuction(savedUser("completed-failed"));
+        BotTask task = botTaskService.enqueueScanParcel(auction);
+
+        // Force-complete the task directly via the repository
+        task.setStatus(BotTaskStatus.COMPLETED);
+        botTaskRepo.save(task);
+
+        mvc.perform(post("/api/v1/bot/tasks/" + task.getId() + "/scan-failed")
+                        .header("Authorization", "Bearer " + DEV_BOT_SECRET)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new BotScanFailedRequest("TERRAIN_NOT_LOADED"))))
+                .andExpect(status().isConflict());
+    }
+
+    // --- 400 cases ---
+
+    @Test
+    void blankReason_returns400() throws Exception {
+        Auction auction = savedAuction(savedUser("blank-reason"));
+        BotTask task = botTaskService.enqueueScanParcel(auction);
+
+        mvc.perform(post("/api/v1/bot/tasks/" + task.getId() + "/scan-failed")
+                        .header("Authorization", "Bearer " + DEV_BOT_SECRET)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new BotScanFailedRequest(""))))
+                .andExpect(status().isBadRequest());
+    }
+
+    // --- 401 case ---
+
+    @Test
+    void missingAuthHeader_returns401() throws Exception {
+        mvc.perform(post("/api/v1/bot/tasks/1/scan-failed")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new BotScanFailedRequest("TERRAIN_NOT_LOADED"))))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // --- fixtures ---
+
+    private User savedUser(String label) {
+        return userRepo.save(User.builder()
+                .username("u-" + UUID.randomUUID().toString().substring(0, 8))
+                .email(label + "-" + UUID.randomUUID() + "@example.com")
+                .passwordHash("$2a$10$dummy.hash.value.for.test.only.aaaaaaaaaaaaaaaaaaaa")
+                .displayName(label + " " + UUID.randomUUID())
+                .verified(true)
+                .slAvatarUuid(UUID.randomUUID())
+                .build());
+    }
+
+    private Auction savedAuction(User seller) {
+        UUID parcelUuid = UUID.randomUUID();
+        Auction a = Auction.builder()
+                .title("Scan failed controller test listing")
+                .slParcelUuid(parcelUuid)
+                .seller(seller)
+                .status(AuctionStatus.ACTIVE)
+                .verificationTier(VerificationTier.SCRIPT)
+                .startingBid(1_000L)
+                .durationHours(168)
+                .snipeProtect(false)
+                .listingFeePaid(true)
+                .currentBid(0L)
+                .bidCount(0)
+                .consecutiveWorldApiFailures(0)
+                .commissionRate(new BigDecimal("0.05"))
+                .parcelScanIncluded(true)
+                .build();
+        a.setParcelSnapshot(AuctionParcelSnapshot.builder()
+                .slParcelUuid(parcelUuid)
+                .ownerUuid(UUID.randomUUID())
+                .ownerType("agent")
+                .parcelName("Test Parcel")
+                .regionName("Test Region")
+                .regionMaturityRating("GENERAL")
+                .areaSqm(1024)
+                .positionX(128.0).positionY(64.0).positionZ(22.0)
+                .build());
+        return auctionRepo.save(a);
+    }
+}

--- a/bot/src/Slpa.Bot/Backend/HttpBackendClient.cs
+++ b/bot/src/Slpa.Bot/Backend/HttpBackendClient.cs
@@ -135,6 +135,23 @@ public sealed class HttpBackendClient : IBackendClient
         }, ct).ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
+    public async Task PostScanFailedAsync(
+        long taskId, ScanFailedRequest body, CancellationToken ct)
+    {
+        using var resp = await SendWithRetryAsync(() =>
+        {
+            var req = new HttpRequestMessage(
+                HttpMethod.Post,
+                "/api/v1/bot/tasks/" + taskId + "/scan-failed")
+            {
+                Content = JsonContent.Create(body, options: JsonOpts)
+            };
+            return req;
+        }, ct).ConfigureAwait(false);
+        resp.EnsureSuccessStatusCode();
+    }
+
     private async Task<HttpResponseMessage> SendWithRetryAsync(
         Func<HttpRequestMessage> requestFactory, CancellationToken ct)
     {

--- a/bot/src/Slpa.Bot/Backend/HttpBackendClient.cs
+++ b/bot/src/Slpa.Bot/Backend/HttpBackendClient.cs
@@ -136,10 +136,10 @@ public sealed class HttpBackendClient : IBackendClient
     }
 
     /// <inheritdoc/>
-    public async Task PostScanFailedAsync(
+    public async Task<HttpResponseMessage> PostScanFailedAsync(
         long taskId, ScanFailedRequest body, CancellationToken ct)
     {
-        using var resp = await SendWithRetryAsync(() =>
+        return await SendWithRetryAsync(() =>
         {
             var req = new HttpRequestMessage(
                 HttpMethod.Post,
@@ -149,7 +149,6 @@ public sealed class HttpBackendClient : IBackendClient
             };
             return req;
         }, ct).ConfigureAwait(false);
-        resp.EnsureSuccessStatusCode();
     }
 
     private async Task<HttpResponseMessage> SendWithRetryAsync(

--- a/bot/src/Slpa.Bot/Backend/IBackendClient.cs
+++ b/bot/src/Slpa.Bot/Backend/IBackendClient.cs
@@ -43,6 +43,15 @@ public interface IBackendClient
     /// </summary>
     Task<HttpResponseMessage> PostScanResultAsync(
         long taskId, ScanResultRequest body, CancellationToken ct);
+
+    /// <summary>
+    /// Reports a terminal SCAN_PARCEL failure to the backend
+    /// (<c>POST /api/v1/bot/tasks/{taskId}/scan-failed</c>). Marks the task
+    /// FAILED with the supplied reason string so the admin panel can show why
+    /// the scan did not complete. Shares the bearer auth + 5xx retry ladder.
+    /// Throws <see cref="AuthConfigException"/> on 401.
+    /// </summary>
+    Task PostScanFailedAsync(long taskId, ScanFailedRequest body, CancellationToken ct);
 }
 
 /// <summary>

--- a/bot/src/Slpa.Bot/Backend/IBackendClient.cs
+++ b/bot/src/Slpa.Bot/Backend/IBackendClient.cs
@@ -46,12 +46,14 @@ public interface IBackendClient
 
     /// <summary>
     /// Reports a terminal SCAN_PARCEL failure to the backend
-    /// (<c>POST /api/v1/bot/tasks/{taskId}/scan-failed</c>). Marks the task
-    /// FAILED with the supplied reason string so the admin panel can show why
-    /// the scan did not complete. Shares the bearer auth + 5xx retry ladder.
+    /// (<c>POST /api/v1/bot/tasks/{taskId}/scan-failed</c>). Returns the raw
+    /// <see cref="HttpResponseMessage"/> so the caller can inspect the status
+    /// code (204 = recorded, 409 = already recorded, 4xx = rejected). The
+    /// caller owns disposal. Shares the bearer auth + 5xx retry ladder.
     /// Throws <see cref="AuthConfigException"/> on 401.
     /// </summary>
-    Task PostScanFailedAsync(long taskId, ScanFailedRequest body, CancellationToken ct);
+    Task<HttpResponseMessage> PostScanFailedAsync(
+        long taskId, ScanFailedRequest body, CancellationToken ct);
 }
 
 /// <summary>

--- a/bot/src/Slpa.Bot/Backend/Models/ScanFailedRequest.cs
+++ b/bot/src/Slpa.Bot/Backend/Models/ScanFailedRequest.cs
@@ -1,0 +1,6 @@
+namespace Slpa.Bot.Backend.Models;
+
+/// <summary>
+/// Body for POST /api/v1/bot/tasks/{taskId}/scan-failed.
+/// </summary>
+public sealed record ScanFailedRequest(string Reason);

--- a/bot/src/Slpa.Bot/Sl/IBotSession.cs
+++ b/bot/src/Slpa.Bot/Sl/IBotSession.cs
@@ -1,6 +1,15 @@
 namespace Slpa.Bot.Sl;
 
 /// <summary>
+/// Carries both the sampled height grid and a per-cell loaded flag from
+/// <see cref="IBotSession.GetRegionTerrainHeights"/>. A cell where
+/// <c>Loaded[row, col]</c> is <c>false</c> means
+/// <c>TerrainHeightAtPoint</c> returned <c>false</c> for that coordinate;
+/// the corresponding <c>Heights</c> value is 0 and must not be trusted.
+/// </summary>
+public sealed record RegionTerrainHeights(float[,] Heights, bool[,] Loaded);
+
+/// <summary>
 /// Test boundary around LibreMetaverse. Production wiring uses
 /// <see cref="LibreMetaverseBotSession"/>; tests fake this interface and
 /// never touch <c>GridClient</c>.
@@ -95,7 +104,21 @@ public interface IBotSession : IAsyncDisposable
     /// Returns a 64x64 grid of terrain heights (metres) for the current
     /// simulator, center-sampled at 4 m cell resolution (i.e. cell [row, col]
     /// is sampled at the terrain height at world x = col*4+2, y = row*4+2).
-    /// Returns an all-zero grid if no terrain data is available.
+    /// The <c>Loaded</c> grid indicates which cells were successfully read from
+    /// the simulator's heightmap; cells where <c>Loaded[row, col]</c> is
+    /// <c>false</c> have a height of 0 and must not be used. Call
+    /// <see cref="WaitForRegionTerrainAsync"/> first so that patches are
+    /// available before sampling.
     /// </summary>
-    float[,] GetRegionTerrainHeights();
+    RegionTerrainHeights GetRegionTerrainHeights();
+
+    /// <summary>
+    /// Waits for the simulator's terrain patches to finish streaming in.
+    /// Returns the number of patches received (0..256). A full standard SL
+    /// region has 16x16 = 256 patches of 16x16 m each. Times out after 30 s;
+    /// on timeout returns whatever count was received so far so the caller can
+    /// decide whether to proceed or fail. Hooks LibreMetaverse's
+    /// <c>Terrain.LandPatchReceived</c> event; thread-safe.
+    /// </summary>
+    Task<int> WaitForRegionTerrainAsync(CancellationToken ct);
 }

--- a/bot/src/Slpa.Bot/Sl/LibreMetaverseBotSession.cs
+++ b/bot/src/Slpa.Bot/Sl/LibreMetaverseBotSession.cs
@@ -592,11 +592,12 @@ public sealed class LibreMetaverseBotSession : IBotSession
     }
 
     /// <inheritdoc/>
-    public float[,] GetRegionTerrainHeights()
+    public RegionTerrainHeights GetRegionTerrainHeights()
     {
+        var heights = new float[64, 64];
+        var loaded = new bool[64, 64];
         var sim = _client.Network.CurrentSim;
-        var grid = new float[64, 64];
-        if (sim is null) return grid;
+        if (sim is null) return new RegionTerrainHeights(heights, loaded);
         // Center-sample each 4 m cell via sim.TerrainHeightAtPoint(x, y, out float h).
         // The SL coordinate system: x = col*4+2, y = row*4+2 (world metres, clamped 0..255).
         for (int row = 0; row < 64; row++)
@@ -607,11 +608,76 @@ public sealed class LibreMetaverseBotSession : IBotSession
                 int worldY = row * 4 + 2;
                 if (sim.TerrainHeightAtPoint(worldX, worldY, out float h))
                 {
-                    grid[row, col] = h;
+                    heights[row, col] = h;
+                    loaded[row, col] = true;
                 }
             }
         }
-        return grid;
+        return new RegionTerrainHeights(heights, loaded);
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> WaitForRegionTerrainAsync(CancellationToken ct)
+    {
+        if (State != SessionState.Online)
+        {
+            throw new SessionLostException(
+                $"Cannot wait for terrain in state {State}");
+        }
+
+        var sim = _client.Network.CurrentSim;
+        if (sim is null) return 0;
+
+        // A standard SL region is 256x256 m = 16x16 terrain patches of 16x16 m each = 256 patches.
+        const int TotalPatches = 256;
+
+        var tcs = new TaskCompletionSource<int>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        int patchCount = 0;
+
+        EventHandler<OpenMetaverse.LandPatchReceivedEventArgs>? handler = null;
+        handler = (_, e) =>
+        {
+            // Only count patches for our current sim to avoid cross-sim noise.
+            if (e.Simulator != sim) return;
+            int count = Interlocked.Increment(ref patchCount);
+            if (count >= TotalPatches)
+            {
+                _client.Terrain.LandPatchReceived -= handler!;
+                tcs.TrySetResult(count);
+            }
+        };
+        _client.Terrain.LandPatchReceived += handler;
+
+        EventHandler<OpenMetaverse.DisconnectedEventArgs>? disc = null;
+        disc = (_, _) =>
+        {
+            _client.Terrain.LandPatchReceived -= handler!;
+            _client.Network.Disconnected -= disc!;
+            tcs.TrySetException(
+                new SessionLostException("Disconnected while waiting for terrain patches"));
+        };
+        _client.Network.Disconnected += disc;
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(30));
+        var timeoutReg = timeoutCts.Token.Register(() =>
+        {
+            _client.Terrain.LandPatchReceived -= handler!;
+            _client.Network.Disconnected -= disc!;
+            tcs.TrySetResult(Volatile.Read(ref patchCount));
+        });
+
+        try
+        {
+            return await tcs.Task.ConfigureAwait(false);
+        }
+        finally
+        {
+            timeoutReg.Dispose();
+            _client.Terrain.LandPatchReceived -= handler;
+            _client.Network.Disconnected -= disc;
+        }
     }
 
     private static TeleportFailureKind ClassifyFailure(string? message)
@@ -642,7 +708,7 @@ public sealed class LibreMetaverseBotSession : IBotSession
         c.Settings.USE_ASSET_CACHE = false;
         c.Settings.SEND_AGENT_APPEARANCE = false;
         c.Settings.SEND_AGENT_UPDATES = true; // required for teleport
-        c.Settings.STORE_LAND_PATCHES = false;
+        c.Settings.STORE_LAND_PATCHES = true; // required: TerrainHeightAtPoint returns false for any patch until stored
         return c;
     }
 

--- a/bot/src/Slpa.Bot/Tasks/ScanParcelHandler.cs
+++ b/bot/src/Slpa.Bot/Tasks/ScanParcelHandler.cs
@@ -92,19 +92,51 @@ public sealed class ScanParcelHandler
             }
         }
 
-        // Step 4: Build the quantized 4096-byte heightmap.
+        // Step 4: Wait for terrain patches to stream in, then sample heights.
+        var patchCount = await _session.WaitForRegionTerrainAsync(ct).ConfigureAwait(false);
+        _log.LogInformation("SCAN_PARCEL {Id}: terrain patches received = {Count}/256",
+            task.Id, patchCount);
+
         var terrain = _session.GetRegionTerrainHeights();
-        float regionMin = float.MaxValue;
-        float regionMax = float.MinValue;
+
+        // Fail fast if any cells did not load: the data would be silently wrong.
+        int unloadedCells = 0;
         for (int row = 0; row < 64; row++)
+            for (int col = 0; col < 64; col++)
+                if (!terrain.Loaded[row, col]) unloadedCells++;
+
+        if (unloadedCells > 0)
         {
+            _log.LogWarning(
+                "SCAN_PARCEL {Id}: {Unloaded}/4096 cells did not load after wait; posting FAILED",
+                task.Id, unloadedCells);
+            await PostFailedAsync(task, "TERRAIN_NOT_LOADED", ct).ConfigureAwait(false);
+            return;
+        }
+
+        // Diagnostic: if all cells loaded but heights are uniformly the same value,
+        // that is unexpected for any non-trivial region and suggests a code bug
+        // (e.g. TerrainHeightAtPoint returning true with a stale zero, or a
+        // coordinate-mismatch) rather than the terrain-load timing race.
+        float diagMin = float.MaxValue, diagMax = float.MinValue;
+        for (int row = 0; row < 64; row++)
             for (int col = 0; col < 64; col++)
             {
-                float v = terrain[row, col];
-                if (v < regionMin) regionMin = v;
-                if (v > regionMax) regionMax = v;
+                if (terrain.Heights[row, col] < diagMin) diagMin = terrain.Heights[row, col];
+                if (terrain.Heights[row, col] > diagMax) diagMax = terrain.Heights[row, col];
             }
+        if (diagMin == diagMax)
+        {
+            _log.LogWarning(
+                "SCAN_PARCEL {Id}: all 4096 cells loaded but heights are uniformly {H} m. " +
+                "This is unexpected for any non-trivial region and suggests a code bug, " +
+                "not the terrain-load timing race.",
+                task.Id, diagMin);
         }
+
+        // Build the quantized 4096-byte heightmap from terrain.Heights.
+        float regionMin = diagMin;
+        float regionMax = diagMax;
 
         float step = MathF.Max(0.001f, (regionMax - regionMin) / 255f);
         float baseM = regionMin;
@@ -113,7 +145,7 @@ public sealed class ScanParcelHandler
         {
             for (int col = 0; col < 64; col++)
             {
-                float v = terrain[row, col];
+                float v = terrain.Heights[row, col];
                 int q = (int)MathF.Round((v - baseM) / step);
                 if (q < 0) q = 0;
                 if (q > 255) q = 255;
@@ -161,6 +193,27 @@ public sealed class ScanParcelHandler
                 "SCAN_PARCEL {Id} backend returned {Status}; " +
                 "leaving for backend sweep",
                 task.Id, (int)resp.StatusCode);
+        }
+    }
+
+    private async Task PostFailedAsync(
+        BotTaskResponse task, string reason, CancellationToken ct)
+    {
+        try
+        {
+            await _backend.PostScanFailedAsync(
+                task.Id,
+                new ScanFailedRequest(reason),
+                ct).ConfigureAwait(false);
+            _log.LogInformation(
+                "SCAN_PARCEL {Id} -> FAILED ({Reason})", task.Id, reason);
+        }
+        catch (HttpRequestException ex)
+        {
+            _log.LogWarning(ex,
+                "SCAN_PARCEL {Id} backend fail-report POST failed (network); " +
+                "leaving for backend sweep",
+                task.Id);
         }
     }
 }

--- a/bot/src/Slpa.Bot/Tasks/ScanParcelHandler.cs
+++ b/bot/src/Slpa.Bot/Tasks/ScanParcelHandler.cs
@@ -199,14 +199,13 @@ public sealed class ScanParcelHandler
     private async Task PostFailedAsync(
         BotTaskResponse task, string reason, CancellationToken ct)
     {
+        HttpResponseMessage resp;
         try
         {
-            await _backend.PostScanFailedAsync(
+            resp = await _backend.PostScanFailedAsync(
                 task.Id,
                 new ScanFailedRequest(reason),
                 ct).ConfigureAwait(false);
-            _log.LogInformation(
-                "SCAN_PARCEL {Id} -> FAILED ({Reason})", task.Id, reason);
         }
         catch (HttpRequestException ex)
         {
@@ -214,6 +213,25 @@ public sealed class ScanParcelHandler
                 "SCAN_PARCEL {Id} backend fail-report POST failed (network); " +
                 "leaving for backend sweep",
                 task.Id);
+            return;
+        }
+
+        using (resp)
+        {
+            if (resp.StatusCode == HttpStatusCode.NoContent ||
+                resp.StatusCode == HttpStatusCode.Conflict)
+            {
+                // 204 = recorded; 409 = already recorded by a prior attempt.
+                _log.LogInformation(
+                    "SCAN_PARCEL {Id} -> FAILED ({Reason}) [{Status}]",
+                    task.Id, reason, (int)resp.StatusCode);
+                return;
+            }
+
+            _log.LogWarning(
+                "SCAN_PARCEL {Id} fail-report backend returned {Status}; " +
+                "leaving for backend sweep",
+                task.Id, (int)resp.StatusCode);
         }
     }
 }

--- a/bot/tests/Slpa.Bot.Tests/IdleParkerTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/IdleParkerTests.cs
@@ -39,14 +39,14 @@ public sealed class IdleParkerTests
         o.ParkCooldownSeconds.Should().Be(180);
         o.Chairs.Should().BeEquivalentTo(new[]
         {
-            "d28b2fea-8020-b875-777b-6e432a7d9317",
-            "65f7f3e4-1a06-0a07-9233-a3f9a44ff88c",
-            "273a9a21-9a23-ca63-58e0-fe817f0a524a",
-            "02080632-9fcc-1e1f-36b3-8dd54a694f12",
-            "6a8106b7-d771-4c5c-ee19-62b4291de07a",
-            "0c852666-669a-9670-e663-380e18d748b7",
-            "cd2dbb84-8b18-f28e-c19c-f40468036fc6",
-            "ca2c885f-d3fd-2368-1ea7-4c57e014ea5a",
+            "b5c8a4c0-d0fb-1580-6fa8-36a6374d2ff4",
+            "22bf826a-4417-c637-0817-88832307c8e2",
+            "a24e89f1-ae46-95a4-a87f-e0e2a4809f74",
+            "78978fa7-2c43-c2f2-5b1a-89bffadbafc7",
+            "cabbcc98-e89b-bd4b-76d0-c0a0343205e4",
+            "861de5a1-92ec-c9c3-124f-e2f74de342dd",
+            "24584ae7-dfa1-2be0-4bfa-589d422d62e9",
+            "828d2785-722c-a755-28bd-9b1460001117",
         });
     }
 

--- a/bot/tests/Slpa.Bot.Tests/LibreMetaverseBotSessionTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/LibreMetaverseBotSessionTests.cs
@@ -86,6 +86,13 @@ public sealed class FakeBotSession : IBotSession
     public SessionState State { get; private set; } = SessionState.Starting;
     public Guid BotUuid { get; } = Guid.NewGuid();
 
+    /// <summary>
+    /// Ordered log of method names called on this session, for call-order
+    /// assertions in handler tests (e.g. WaitForRegionTerrain before
+    /// GetRegionTerrainHeights).
+    /// </summary>
+    public List<string> CallLog { get; } = new();
+
     public Func<string, TeleportResult> TeleportPolicy { get; set; } =
         _ => TeleportResult.Ok();
 
@@ -115,9 +122,34 @@ public sealed class FakeBotSession : IBotSession
     public Func<uint[,]> ParcelLocalIdsPolicy { get; set; } =
         () => new uint[64, 64];
 
-    /// <summary>Policy for <see cref="GetRegionTerrainHeights"/>. Defaults to a 64x64 all-zero grid.</summary>
+    /// <summary>
+    /// Policy for the float[,] returned by <see cref="GetRegionTerrainHeights"/>.
+    /// Defaults to a 64x64 all-zero grid.
+    /// </summary>
     public Func<float[,]> TerrainHeightsPolicy { get; set; } =
         () => new float[64, 64];
+
+    /// <summary>
+    /// Policy for the bool[,] loaded-flag returned by
+    /// <see cref="GetRegionTerrainHeights"/>. Defaults to a 64x64 all-true grid
+    /// (all cells loaded) so existing tests continue to pass without change.
+    /// Set individual cells to false to simulate partially loaded terrain.
+    /// </summary>
+    public Func<bool[,]> TerrainHeightsLoadedPolicy { get; set; } = () =>
+    {
+        var loaded = new bool[64, 64];
+        for (int r = 0; r < 64; r++)
+            for (int c = 0; c < 64; c++)
+                loaded[r, c] = true;
+        return loaded;
+    };
+
+    /// <summary>
+    /// Policy for <see cref="WaitForRegionTerrainAsync"/>. Defaults to
+    /// returning 256 (all patches received) immediately.
+    /// </summary>
+    public Func<CancellationToken, Task<int>> WaitForRegionTerrainPolicy { get; set; } =
+        _ => Task.FromResult(256);
 
     /// <summary>
     /// Captures every <see cref="GiveGroupMoney"/> call so handler tests can
@@ -160,7 +192,17 @@ public sealed class FakeBotSession : IBotSession
 
     public uint[,] GetRegionParcelLocalIds() => ParcelLocalIdsPolicy();
 
-    public float[,] GetRegionTerrainHeights() => TerrainHeightsPolicy();
+    public RegionTerrainHeights GetRegionTerrainHeights()
+    {
+        CallLog.Add(nameof(GetRegionTerrainHeights));
+        return new(TerrainHeightsPolicy(), TerrainHeightsLoadedPolicy());
+    }
+
+    public Task<int> WaitForRegionTerrainAsync(CancellationToken ct)
+    {
+        CallLog.Add(nameof(WaitForRegionTerrainAsync));
+        return WaitForRegionTerrainPolicy(ct);
+    }
 
     public void GiveGroupMoney(Guid slGroupUuid, int amountL, string memo)
         => GiveGroupMoneyCalls.Add(new GiveGroupMoneyCall(slGroupUuid, amountL, memo));

--- a/bot/tests/Slpa.Bot.Tests/ScanParcelHandlerTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/ScanParcelHandlerTests.cs
@@ -32,6 +32,11 @@ public sealed class ScanParcelHandlerTests
             .Callback<long, ScanResultRequest, CancellationToken>(
                 (_, body, _) => _captured = body)
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+        _backend
+            .Setup(b => b.PostScanFailedAsync(
+                It.IsAny<long>(), It.IsAny<ScanFailedRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
     }
 
     private ScanParcelHandler NewHandler() =>
@@ -327,5 +332,95 @@ public sealed class ScanParcelHandlerTests
         layout[0].Should().Be(0x80, "bit index 0 -> byte 0, bit 7 (MSB-first)");
         layout.Skip(1).Should().AllBeEquivalentTo((byte)0,
             "no other cells should be set");
+    }
+
+    [Fact]
+    public async Task WaitForRegionTerrain_IsCalledBeforeSampling()
+    {
+        // Verify WaitForRegionTerrainAsync is invoked exactly once and before
+        // GetRegionTerrainHeights in the call log.
+        const uint ourLocalId = 20u;
+        _session.RequestAllSimParcelsPolicy = (_, _) => (int)ourLocalId;
+        _session.ParcelLocalIdsPolicy = () => new uint[64, 64];
+        _session.TerrainHeightsPolicy = () => FlatTerrain(10f);
+
+        await NewHandler().HandleAsync(BuildTask(), CancellationToken.None);
+
+        var waitIdx = _session.CallLog.IndexOf(nameof(IBotSession.WaitForRegionTerrainAsync));
+        var sampleIdx = _session.CallLog.IndexOf(nameof(IBotSession.GetRegionTerrainHeights));
+        waitIdx.Should().BeGreaterThanOrEqualTo(0, "WaitForRegionTerrainAsync must be called");
+        sampleIdx.Should().BeGreaterThanOrEqualTo(0, "GetRegionTerrainHeights must be called");
+        waitIdx.Should().BeLessThan(sampleIdx,
+            "WaitForRegionTerrainAsync must be called before GetRegionTerrainHeights");
+        _session.CallLog.Count(c => c == nameof(IBotSession.WaitForRegionTerrainAsync))
+            .Should().Be(1, "WaitForRegionTerrainAsync should be called exactly once");
+    }
+
+    [Fact]
+    public async Task TerrainNotLoaded_PostsFailureAndDoesNotPostScanResult()
+    {
+        // When some cells fail to load (Loaded[row,col] = false), handler should
+        // POST scan-failed with TERRAIN_NOT_LOADED and not post a scan result.
+        const uint ourLocalId = 21u;
+        _session.RequestAllSimParcelsPolicy = (_, _) => (int)ourLocalId;
+        _session.ParcelLocalIdsPolicy = () => new uint[64, 64];
+        _session.TerrainHeightsPolicy = () => FlatTerrain(10f);
+
+        // Mark one cell as not loaded.
+        _session.TerrainHeightsLoadedPolicy = () =>
+        {
+            var loaded = new bool[64, 64];
+            for (int r = 0; r < 64; r++)
+                for (int c = 0; c < 64; c++)
+                    loaded[r, c] = true;
+            loaded[0, 0] = false; // one cell failed to load
+            return loaded;
+        };
+
+        await NewHandler().HandleAsync(BuildTask(), CancellationToken.None);
+
+        _backend.Verify(b => b.PostScanFailedAsync(
+                42L,
+                It.Is<ScanFailedRequest>(r => r.Reason == "TERRAIN_NOT_LOADED"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _backend.Verify(b => b.PostScanResultAsync(
+                It.IsAny<long>(), It.IsAny<ScanResultRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task AllCellsLoaded_HappyPath_PostsResult()
+    {
+        // When all cells load successfully, the handler should post a scan result
+        // and not post a failure.
+        const uint ourLocalId = 22u;
+        _session.RequestAllSimParcelsPolicy = (_, _) => (int)ourLocalId;
+        var allOwned = new uint[64, 64];
+        for (int r = 0; r < 64; r++)
+            for (int c = 0; c < 64; c++)
+                allOwned[r, c] = ourLocalId;
+        _session.ParcelLocalIdsPolicy = () => allOwned;
+
+        // Varied terrain so step != clamped minimum.
+        var terrain = new float[64, 64];
+        for (int r = 0; r < 64; r++)
+            for (int c = 0; c < 64; c++)
+                terrain[r, c] = 30f + r;
+        _session.TerrainHeightsPolicy = () => terrain;
+        // TerrainHeightsLoadedPolicy defaults to all-true.
+
+        await NewHandler().HandleAsync(BuildTask(), CancellationToken.None);
+
+        _backend.Verify(b => b.PostScanResultAsync(
+                42L,
+                It.IsAny<ScanResultRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _backend.Verify(b => b.PostScanFailedAsync(
+                It.IsAny<long>(), It.IsAny<ScanFailedRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }

--- a/bot/tests/Slpa.Bot.Tests/ScanParcelHandlerTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/ScanParcelHandlerTests.cs
@@ -36,7 +36,7 @@ public sealed class ScanParcelHandlerTests
             .Setup(b => b.PostScanFailedAsync(
                 It.IsAny<long>(), It.IsAny<ScanFailedRequest>(),
                 It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NoContent));
     }
 
     private ScanParcelHandler NewHandler() =>
@@ -249,6 +249,46 @@ public sealed class ScanParcelHandlerTests
                 It.IsAny<long>(), It.IsAny<ScanResultRequest>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task BackendReturns409OnPostFailed_TreatedAsSuccess()
+    {
+        // 409 on scan-failed = backend already recorded this failure; should not warn.
+        const uint ourLocalId = 30u;
+        _session.RequestAllSimParcelsPolicy = (_, _) => (int)ourLocalId;
+        _session.ParcelLocalIdsPolicy = () => new uint[64, 64];
+        _session.TerrainHeightsPolicy = () => FlatTerrain(10f);
+
+        // Mark one cell as not loaded so PostFailedAsync is invoked.
+        _session.TerrainHeightsLoadedPolicy = () =>
+        {
+            var loaded = new bool[64, 64];
+            for (int r = 0; r < 64; r++)
+                for (int c = 0; c < 64; c++)
+                    loaded[r, c] = true;
+            loaded[0, 0] = false;
+            return loaded;
+        };
+
+        _backend
+            .Setup(b => b.PostScanFailedAsync(
+                It.IsAny<long>(), It.IsAny<ScanFailedRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Conflict));
+
+        // Should complete without throwing or posting a scan result.
+        var act = async () => await NewHandler().HandleAsync(BuildTask(), CancellationToken.None);
+        await act.Should().NotThrowAsync();
+
+        _backend.Verify(b => b.PostScanFailedAsync(
+                It.IsAny<long>(), It.IsAny<ScanFailedRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _backend.Verify(b => b.PostScanResultAsync(
+                It.IsAny<long>(), It.IsAny<ScanResultRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]

--- a/docs/implementation/DEFERRED_WORK.md
+++ b/docs/implementation/DEFERRED_WORK.md
@@ -213,11 +213,17 @@ When finishing a sub-spec that completes a deferred item, remove the entry.
 - **When:** Phase 11 (LSL scripting) or later.
 - **Notes:** Would reuse the `parcel_scan_included` flag and the same `POST /scan-result` endpoint; the LSL path needs a different auth token and a different `BotTaskType` or a parallel endpoint.
 
-### Parcel scanner: bot failure-result endpoint for SCAN_PARCEL
+### Parcel scanner: bot failure-result endpoint for SCAN_PARCEL -- RESOLVED (2026-05-24)
 - **From:** Parcel scanner spec `2026-05-23-parcel-scanner-design.md` §7 / Task 7 code review
 - **Why:** There is no explicit `POST .../scan-result` failure path. A failed scan leaves the `SCAN_PARCEL` task IN_PROGRESS until the in-progress timeout sweeps it (configured via `slpa.bot-task.in-progress-timeout`, default `PT20M`). This is acceptable for a non-gating feature but means a crashed bot leaves a stale row for the configured window. A lightweight failure-report body (`{ "error": "ACCESS_DENIED" }`) would let the bot close the task immediately.
 - **When:** Indefinite — only if stale IN_PROGRESS rows become operationally noisy.
 - **Notes:** The simplest form is a 204 endpoint that accepts any body and marks the task FAILED with the supplied reason string.
+- **Resolution (2026-05-24):** Implemented during the terrain-race bugfix
+  (`fix/parcel-scan-terrain-race`). New `POST /api/v1/bot/tasks/{taskId}/scan-failed`
+  endpoint on `BotTaskController`; backed by `ParcelScanService.markScanFailed`
+  and `BotTaskService.markFailed`. The bot's `ScanParcelHandler` now posts
+  `TERRAIN_NOT_LOADED` on partial terrain-patch arrival instead of relying
+  on the in-progress timeout sweep.
 
 ### Minor: `ParcelScanService.applyScanResult` uses `OffsetDateTime.now()` without injected Clock
 - **From:** Parcel scanner spec `2026-05-23-parcel-scanner-design.md` / Task 8 docs sweep


### PR DESCRIPTION
Promotes dev to main. One body of work: the parcel-scan terrain-race bugfix (#406), already reviewed and merged into dev.

## Bugfix (#406)
Heightmaps in prod were uniformly zero because LibreMetaverse's STORE_LAND_PATCHES was false (discarding all incoming terrain patches; TerrainHeightAtPoint always returned false). Fix flips the flag, adds a WaitForRegionTerrainAsync (256 patches or 30s timeout), and fails the scan with TERRAIN_NOT_LOADED if any cell remains unloaded after the wait. Diagnostic warning distinguishes 'all loaded but min==max' (code bug) from 'cells failed to load' (timing race) for the next prod scan.

Also adds the previously-deferred POST /api/v1/bot/tasks/{taskId}/scan-failed endpoint so the bot can report failures explicitly instead of relying on the in-progress timeout sweep.

## Deploys triggered
- Backend: GitHub Actions deploy-backend (backend/** changed) - new /scan-failed endpoint + service hooks.
- Bot: GitHub Actions deploy-bot (bot/** changed) - the actual root-cause fix lives here.
- Frontend: Amplify webhook (no frontend changes this release).

## Re-scanning existing bad data
NOT addressed by this PR; user is handling separately after deploy.