### PR TITLE
Release: bot LoginParams.Options fix + admin scan re-enqueue

### DIFF
--- a/backend/src/main/java/com/slparcelauctions/backend/auction/parcelscan/AdminParcelScanController.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/parcelscan/AdminParcelScanController.java
@@ -1,0 +1,67 @@
+package com.slparcelauctions.backend.auction.parcelscan;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.exception.AuctionNotFoundException;
+import com.slparcelauctions.backend.bot.BotTaskRepository;
+import com.slparcelauctions.backend.bot.BotTaskType;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Admin endpoints for the parcel-scan subsystem. Lives under
+ * {@code /api/v1/admin/} so the SecurityConfig {@code hasRole("ADMIN")} rule
+ * gates every method without any per-method {@code @PreAuthorize} annotation.
+ */
+@RestController
+@RequestMapping("/api/v1/admin/parcel-scan")
+@RequiredArgsConstructor
+public class AdminParcelScanController {
+
+    private final AuctionRepository auctionRepo;
+    private final AuctionParcelLayoutRepository layoutRepo;
+    private final AuctionParcelHeightMapRepository heightRepo;
+    private final BotTaskRepository botTaskRepo;
+    private final ParcelScanService parcelScanService;
+
+    /**
+     * Re-enqueue a SCAN_PARCEL task for an auction whose previous scan
+     * attempt was orphaned (e.g. bot crashed mid-task leaving the row
+     * IN_PROGRESS indefinitely). Steps:
+     * <ol>
+     *   <li>Load auction by publicId. 404 if not found.</li>
+     *   <li>Delete any existing {@code auction_parcel_layouts} row.</li>
+     *   <li>Delete any existing {@code auction_parcel_height_maps} row.</li>
+     *   <li>Delete any non-terminal (PENDING or IN_PROGRESS) SCAN_PARCEL
+     *       tasks so {@link ParcelScanService#enqueueIfEligible}'s
+     *       duplicate-guard does not block re-enqueue.</li>
+     *   <li>Call {@link ParcelScanService#enqueueIfEligible} to create
+     *       a fresh PENDING SCAN_PARCEL task.</li>
+     * </ol>
+     *
+     * @param publicId the auction's public UUID
+     * @return 204 No Content on success; 404 if the auction is not found
+     */
+    @PostMapping("/{publicId}/reenqueue")
+    @Transactional
+    public ResponseEntity<Void> reenqueue(@PathVariable("publicId") UUID publicId) {
+        Auction auction = auctionRepo.findByPublicId(publicId)
+                .orElseThrow(() -> new AuctionNotFoundException(publicId));
+
+        layoutRepo.deleteByAuctionId(auction.getId());
+        heightRepo.deleteByAuctionId(auction.getId());
+        botTaskRepo.deletePendingByAuctionIdAndType(auction.getId(), BotTaskType.SCAN_PARCEL);
+
+        parcelScanService.enqueueIfEligible(auction);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/parcelscan/AuctionParcelHeightMapRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/parcelscan/AuctionParcelHeightMapRepository.java
@@ -11,4 +11,6 @@ public interface AuctionParcelHeightMapRepository extends JpaRepository<AuctionP
     boolean existsByAuctionId(Long auctionId);
 
     Optional<AuctionParcelHeightMap> findByAuctionId(Long auctionId);
+
+    void deleteByAuctionId(Long auctionId);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/auction/parcelscan/AuctionParcelLayoutRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/auction/parcelscan/AuctionParcelLayoutRepository.java
@@ -11,4 +11,6 @@ public interface AuctionParcelLayoutRepository extends JpaRepository<AuctionParc
     boolean existsByAuctionId(Long auctionId);
 
     Optional<AuctionParcelLayout> findByAuctionId(Long auctionId);
+
+    void deleteByAuctionId(Long auctionId);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskRepository.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -74,4 +75,21 @@ public interface BotTaskRepository extends JpaRepository<BotTask, Long> {
            "com.slparcelauctions.backend.bot.BotTaskStatus.CANCELLED)")
     boolean existsPendingByAuctionIdAndType(@Param("auctionId") Long auctionId,
                                             @Param("type") BotTaskType type);
+
+    /**
+     * Deletes all non-terminal (PENDING or IN_PROGRESS) tasks of the given type
+     * for the given auction. Used by the admin re-enqueue path to clear any
+     * orphaned or in-flight task before calling
+     * {@link com.slparcelauctions.backend.auction.parcelscan.ParcelScanService#enqueueIfEligible}
+     * so the eligibility check in rule 3 does not block re-enqueue.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM BotTask t " +
+           "WHERE t.auction.id = :auctionId " +
+           "AND t.taskType = :type " +
+           "AND t.status NOT IN (com.slparcelauctions.backend.bot.BotTaskStatus.COMPLETED, " +
+           "com.slparcelauctions.backend.bot.BotTaskStatus.FAILED, " +
+           "com.slparcelauctions.backend.bot.BotTaskStatus.CANCELLED)")
+    void deletePendingByAuctionIdAndType(@Param("auctionId") Long auctionId,
+                                         @Param("type") BotTaskType type);
 }

--- a/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskStatus.java
+++ b/backend/src/main/java/com/slparcelauctions/backend/bot/BotTaskStatus.java
@@ -3,7 +3,13 @@ package com.slparcelauctions.backend.bot;
 public enum BotTaskStatus {
     /** Claimable (VERIFY) or due (MONITOR_* where next_run_at <= now). */
     PENDING,
-    /** Claimed; times out after slpa.bot-task.in-progress-timeout (default PT20M). */
+    /**
+     * Claimed by a bot. There is NO automatic timeout sweep; a bot that
+     * crashes or disconnects mid-task leaves its row IN_PROGRESS permanently.
+     * Use the admin re-enqueue endpoint (POST /api/v1/admin/parcel-scan/
+     * {publicId}/reenqueue for SCAN_PARCEL) to recover orphaned scans. The
+     * design is intentionally one-shot per scan; see the parcel-scanner spec.
+     */
     IN_PROGRESS,
     /** VERIFY SUCCESS terminal. MONITOR_* rows never reach this state. */
     COMPLETED,

--- a/backend/src/test/java/com/slparcelauctions/backend/auction/parcelscan/AdminParcelScanControllerTest.java
+++ b/backend/src/test/java/com/slparcelauctions/backend/auction/parcelscan/AdminParcelScanControllerTest.java
@@ -1,0 +1,278 @@
+package com.slparcelauctions.backend.auction.parcelscan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.slparcelauctions.backend.auction.Auction;
+import com.slparcelauctions.backend.auction.AuctionParcelSnapshot;
+import com.slparcelauctions.backend.auction.AuctionRepository;
+import com.slparcelauctions.backend.auction.AuctionStatus;
+import com.slparcelauctions.backend.auction.VerificationTier;
+import com.slparcelauctions.backend.auth.AuthPrincipal;
+import com.slparcelauctions.backend.auth.JwtService;
+import com.slparcelauctions.backend.bot.BotTask;
+import com.slparcelauctions.backend.bot.BotTaskRepository;
+import com.slparcelauctions.backend.bot.BotTaskStatus;
+import com.slparcelauctions.backend.bot.BotTaskType;
+import com.slparcelauctions.backend.user.Role;
+import com.slparcelauctions.backend.user.User;
+import com.slparcelauctions.backend.user.UserRepository;
+
+/**
+ * Full-stack integration test for
+ * {@code POST /api/v1/admin/parcel-scan/{publicId}/reenqueue}.
+ *
+ * <p>Uses {@code @SpringBootTest + @AutoConfigureMockMvc} so the full Spring
+ * Security filter chain (including the {@code hasRole("ADMIN")} gate on
+ * {@code /api/v1/admin/**}), JWT auth filter, and
+ * {@link AdminParcelScanController} all run.
+ *
+ * <p>Class-level {@code @Transactional} provides automatic rollback after each
+ * test so rows do not bleed across test cases.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "auth.cleanup.enabled=false",
+        "slpa.auction-end.enabled=false",
+        "slpa.ownership-monitor.enabled=false",
+        "slpa.escrow.ownership-monitor-job.enabled=false",
+        "slpa.escrow.timeout-job.enabled=false",
+        "slpa.escrow.command-dispatcher-job.enabled=false",
+        "slpa.review.scheduler.enabled=false",
+        "slpa.notifications.cleanup.enabled=false",
+        "slpa.notifications.sl-im.cleanup.enabled=false",
+        "slpa.realty.invitation-expiry.enabled=false"
+})
+@Transactional
+class AdminParcelScanControllerTest {
+
+    @Autowired MockMvc mvc;
+    @Autowired JwtService jwtService;
+    @Autowired UserRepository userRepo;
+    @Autowired AuctionRepository auctionRepo;
+    @Autowired AuctionParcelLayoutRepository layoutRepo;
+    @Autowired AuctionParcelHeightMapRepository heightRepo;
+    @Autowired BotTaskRepository botTaskRepo;
+
+    // --- token helpers ---
+
+    private String adminToken() {
+        User admin = userRepo.save(User.builder()
+                .username("u-" + UUID.randomUUID().toString().substring(0, 8))
+                .email("admin-parcel-scan-" + UUID.randomUUID() + "@x.com")
+                .passwordHash("$2a$10$dummy.hash.value.for.test.only.aaaaaaaaaaaaaaaaaaaa")
+                .displayName("Admin")
+                .role(Role.ADMIN)
+                .verified(true)
+                .build());
+        return jwtService.issueAccessToken(
+                new AuthPrincipal(admin.getId(), admin.getPublicId(),
+                        admin.getEmail(), 1L, Role.ADMIN));
+    }
+
+    private String userToken() {
+        User user = userRepo.save(User.builder()
+                .username("u-" + UUID.randomUUID().toString().substring(0, 8))
+                .email("user-parcel-scan-" + UUID.randomUUID() + "@x.com")
+                .passwordHash("$2a$10$dummy.hash.value.for.test.only.aaaaaaaaaaaaaaaaaaaa")
+                .displayName("User")
+                .role(Role.USER)
+                .verified(true)
+                .build());
+        return jwtService.issueAccessToken(
+                new AuthPrincipal(user.getId(), user.getPublicId(),
+                        user.getEmail(), 1L, Role.USER));
+    }
+
+    // --- fixture helpers ---
+
+    private Auction newAuction(User seller) {
+        UUID parcelUuid = UUID.randomUUID();
+        Auction a = Auction.builder()
+                .title("Parcel scan reenqueue test listing")
+                .slParcelUuid(parcelUuid)
+                .seller(seller)
+                .status(AuctionStatus.ACTIVE)
+                .verificationTier(VerificationTier.SCRIPT)
+                .startingBid(1_000L)
+                .durationHours(168)
+                .snipeProtect(false)
+                .listingFeePaid(true)
+                .currentBid(0L)
+                .bidCount(0)
+                .consecutiveWorldApiFailures(0)
+                .commissionRate(new BigDecimal("0.05"))
+                .parcelScanIncluded(true)
+                .build();
+        a.setParcelSnapshot(AuctionParcelSnapshot.builder()
+                .slParcelUuid(parcelUuid)
+                .ownerUuid(UUID.randomUUID())
+                .ownerType("agent")
+                .parcelName("Reenqueue Test Parcel")
+                .regionName("Test Region")
+                .regionMaturityRating("GENERAL")
+                .areaSqm(1024)
+                .positionX(128.0).positionY(64.0).positionZ(22.0)
+                .build());
+        return auctionRepo.save(a);
+    }
+
+    private User newSeller(String label) {
+        return userRepo.save(User.builder()
+                .username("u-" + UUID.randomUUID().toString().substring(0, 8))
+                .email(label + "-" + UUID.randomUUID() + "@example.com")
+                .passwordHash("$2a$10$dummy.hash.value.for.test.only.aaaaaaaaaaaaaaaaaaaa")
+                .displayName(label)
+                .verified(true)
+                .slAvatarUuid(UUID.randomUUID())
+                .build());
+    }
+
+    private AuctionParcelLayout seedLayout(Auction auction) {
+        return layoutRepo.save(AuctionParcelLayout.builder()
+                .auction(auction)
+                .gridSize(64)
+                .cellSizeMeters(4)
+                .cells(new byte[512])
+                .scannedAt(OffsetDateTime.now())
+                .build());
+    }
+
+    private AuctionParcelHeightMap seedHeightMap(Auction auction) {
+        return heightRepo.save(AuctionParcelHeightMap.builder()
+                .auction(auction)
+                .gridSize(64)
+                .cellSizeMeters(4)
+                .cells(new byte[4096])
+                .baseMeters(22.0f)
+                .stepMeters(0.5f)
+                .scannedAt(OffsetDateTime.now())
+                .build());
+    }
+
+    private BotTask seedInProgressTask(Auction auction) {
+        BotTask task = BotTask.builder()
+                .taskType(BotTaskType.SCAN_PARCEL)
+                .status(BotTaskStatus.IN_PROGRESS)
+                .auction(auction)
+                .parcelUuid(auction.getSlParcelUuid())
+                .regionName("Test Region")
+                .positionX(128.0)
+                .positionY(64.0)
+                .positionZ(22.0)
+                .sentinelPrice(0L)
+                .build();
+        return botTaskRepo.save(task);
+    }
+
+    // --- test cases ---
+
+    /**
+     * Happy path: auction has an existing layout, height map, and IN_PROGRESS task.
+     * POST reenqueue must:
+     *   - delete the layout row
+     *   - delete the height map row
+     *   - delete the old IN_PROGRESS task
+     *   - create exactly one new PENDING SCAN_PARCEL task
+     */
+    @Test
+    void reenqueue_happyPath_returns204_clearsOldRastersAndTask_createsNewPending() throws Exception {
+        User seller = newSeller("happy-seller");
+        Auction auction = newAuction(seller);
+        seedLayout(auction);
+        seedHeightMap(auction);
+        BotTask oldTask = seedInProgressTask(auction);
+        Long oldTaskId = oldTask.getId();
+
+        mvc.perform(post("/api/v1/admin/parcel-scan/{publicId}/reenqueue",
+                        auction.getPublicId())
+                        .header("Authorization", "Bearer " + adminToken()))
+                .andExpect(status().isNoContent());
+
+        // Layout and height map rows must be gone
+        assertThat(layoutRepo.existsByAuctionId(auction.getId())).isFalse();
+        assertThat(heightRepo.existsByAuctionId(auction.getId())).isFalse();
+
+        // Old task must be gone
+        assertThat(botTaskRepo.findById(oldTaskId)).isEmpty();
+
+        // Exactly one new PENDING SCAN_PARCEL task must exist
+        assertThat(botTaskRepo.existsPendingByAuctionIdAndType(
+                auction.getId(), BotTaskType.SCAN_PARCEL)).isTrue();
+    }
+
+    /**
+     * Unknown publicId must return 404.
+     */
+    @Test
+    void reenqueue_unknownPublicId_returns404() throws Exception {
+        UUID unknown = UUID.randomUUID();
+
+        mvc.perform(post("/api/v1/admin/parcel-scan/{publicId}/reenqueue", unknown)
+                        .header("Authorization", "Bearer " + adminToken()))
+                .andExpect(status().isNotFound());
+    }
+
+    /**
+     * Non-admin role must be rejected with 403.
+     */
+    @Test
+    void reenqueue_nonAdmin_returns403() throws Exception {
+        User seller = newSeller("non-admin-seller");
+        Auction auction = newAuction(seller);
+
+        mvc.perform(post("/api/v1/admin/parcel-scan/{publicId}/reenqueue",
+                        auction.getPublicId())
+                        .header("Authorization", "Bearer " + userToken()))
+                .andExpect(status().isForbidden());
+    }
+
+    /**
+     * Anonymous (no token) must be rejected with 401.
+     */
+    @Test
+    void reenqueue_anonymous_returns401() throws Exception {
+        User seller = newSeller("anon-seller");
+        Auction auction = newAuction(seller);
+
+        mvc.perform(post("/api/v1/admin/parcel-scan/{publicId}/reenqueue",
+                        auction.getPublicId()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    /**
+     * No existing raster rows and no pending task: endpoint must still return
+     * 204 and create exactly one new PENDING task.
+     */
+    @Test
+    void reenqueue_noExistingRastersOrTask_returns204_createsNewPending() throws Exception {
+        User seller = newSeller("no-rasters-seller");
+        Auction auction = newAuction(seller);
+
+        // No layout, no height map, no task seeded
+
+        mvc.perform(post("/api/v1/admin/parcel-scan/{publicId}/reenqueue",
+                        auction.getPublicId())
+                        .header("Authorization", "Bearer " + adminToken()))
+                .andExpect(status().isNoContent());
+
+        assertThat(botTaskRepo.existsPendingByAuctionIdAndType(
+                auction.getId(), BotTaskType.SCAN_PARCEL)).isTrue();
+    }
+}

--- a/bot/src/Slpa.Bot/Sl/LibreMetaverseBotSession.cs
+++ b/bot/src/Slpa.Bot/Sl/LibreMetaverseBotSession.cs
@@ -133,11 +133,7 @@ public sealed class LibreMetaverseBotSession : IBotSession
         while (!ct.IsCancellationRequested)
         {
             TransitionTo(SessionState.Starting);
-            var loginParams = _client.Network.DefaultLoginParams(
-                FirstName(), LastName(), _opts.Password,
-                "Slpa.Bot", "1.0");
-            loginParams.URI = LoginUri;
-            loginParams.Start = _opts.StartLocation;
+            var loginParams = BuildLoginParams(_client, _opts.Username, _opts.Password, _opts.StartLocation);
 
             bool loggedIn;
             try
@@ -656,5 +652,27 @@ public sealed class LibreMetaverseBotSession : IBotSession
     {
         var parts = _opts.Username.Split(' ', 2);
         return parts.Length > 1 ? parts[1] : "Resident";
+    }
+
+    /// <summary>
+    /// Builds the <see cref="LoginParams"/> that <see cref="RunLoop"/> passes to
+    /// <see cref="TryLoginAsync"/>. Extracted for unit-testability via
+    /// <c>InternalsVisibleTo("Slpa.Bot.Tests")</c>.
+    /// </summary>
+    internal static LoginParams BuildLoginParams(
+        GridClient client, string username, string password, string startLocation)
+    {
+        var parts = username.Split(' ', 2);
+        string firstName = parts.Length > 0 ? parts[0] : username;
+        string lastName  = parts.Length > 1 ? parts[1] : "Resident";
+
+        var p = client.Network.DefaultLoginParams(firstName, lastName, password, "Slpa.Bot", "1.0");
+        p.URI   = LoginUri;
+        p.Start = startLocation;
+        // Strip all optional payload requests. The scan bot needs only
+        // teleport + Parcels + Terrain; the default 16-option list has
+        // triggered InternalDictionary.Add duplicate-key crashes on reconnect.
+        p.Options = Array.Empty<string>();
+        return p;
     }
 }

--- a/bot/tests/Slpa.Bot.Tests/LibreMetaverseBotSessionTests.cs
+++ b/bot/tests/Slpa.Bot.Tests/LibreMetaverseBotSessionTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using OpenMetaverse;
 using Slpa.Bot.Sl;
 using Xunit;
 
@@ -61,6 +62,28 @@ public sealed class LibreMetaverseBotSessionTests
         call.Y.Should().Be(66);
         call.Z.Should().Be(25);
         call.ForceMove.Should().BeTrue();
+    }
+
+    // --- LoginParams configuration ---
+
+    /// <summary>
+    /// Regression guard: BuildLoginParams must clear the Options list.
+    /// The default 16-option list from DefaultLoginParams has caused
+    /// InternalDictionary.Add duplicate-key crashes on bot reconnect
+    /// (System.ArgumentException: An item with the same key has already
+    /// been added). An empty Options list avoids the payload entirely;
+    /// the scan bot needs only teleport + Parcels + Terrain runtime events.
+    /// </summary>
+    [Fact]
+    public void BuildLoginParams_ClearsOptions_EmptyList()
+    {
+        var client = new GridClient();
+        var p = LibreMetaverseBotSession.BuildLoginParams(
+            client, "Test Bot", "pw", "home");
+
+        p.Options.Should().BeEmpty(
+            "the scan bot strips all optional login payloads to avoid " +
+            "the InternalDictionary duplicate-key crash on reconnect");
     }
 
     [Fact]

--- a/docs/implementation/DEFERRED_WORK.md
+++ b/docs/implementation/DEFERRED_WORK.md
@@ -218,6 +218,13 @@ When finishing a sub-spec that completes a deferred item, remove the entry.
 - **Why:** There is no explicit `POST .../scan-result` failure path. A failed scan leaves the `SCAN_PARCEL` task IN_PROGRESS until the in-progress timeout sweeps it (configured via `slpa.bot-task.in-progress-timeout`, default `PT20M`). This is acceptable for a non-gating feature but means a crashed bot leaves a stale row for the configured window. A lightweight failure-report body (`{ "error": "ACCESS_DENIED" }`) would let the bot close the task immediately.
 - **When:** Indefinite — only if stale IN_PROGRESS rows become operationally noisy.
 - **Notes:** The simplest form is a 204 endpoint that accepts any body and marks the task FAILED with the supplied reason string.
+- **Correction (2026-05-24, second pass):** No in-progress timeout sweep
+  exists in the codebase. The earlier description was based on a stale
+  aspirational comment in `BotTaskStatus.java` that has now been
+  corrected. The design is intentionally one-shot per scan. Orphaned
+  IN_PROGRESS rows from bot crashes are recovered via the admin
+  re-enqueue endpoint added in this PR (POST /api/v1/admin/parcel-scan/
+  {publicId}/reenqueue).
 
 ### Minor: `ParcelScanService.applyScanResult` uses `OffsetDateTime.now()` without injected Clock
 - **From:** Parcel scanner spec `2026-05-23-parcel-scanner-design.md` / Task 8 docs sweep


### PR DESCRIPTION
Promotes dev to main. Single body of work this release:

## PR #408
Strips LoginParams.Options to fix the LibreMetaverse InternalDictionary dup-key crash that was killing both bots on every reconnect (and orphaning in-flight SCAN_PARCEL tasks). Adds POST /api/v1/admin/parcel-scan/{publicId}/reenqueue so we can recover dead scans like tasks 13 + 14. Corrects the stale BotTaskStatus.java and DEFERRED_WORK claims about a non-existent in-progress timeout sweep.

## Deploys
- Backend: deploy-backend (new admin endpoint)
- Bot: deploy-bot (the actual login-options fix)
- Frontend: Amplify rebuild (no FE changes this release)

## Post-deploy
I'll call the new admin endpoint for tasks 13 + 14 once the bot stabilizes.