### PR TITLE
fix(parcel-map): SL world coords + parcel area on the map UI

### DIFF
--- a/frontend/src/components/auction/ParcelMap.test.tsx
+++ b/frontend/src/components/auction/ParcelMap.test.tsx
@@ -77,9 +77,9 @@ describe("ParcelMap", () => {
     );
     wrap(<ParcelMap publicId={publicId} />);
     expect(await screen.findByRole("application")).toBeInTheDocument();
-    const fig = screen.getByText(/Parcel covers 1 of 4096 cells/i);
+    const fig = screen.getByText(/Parcel covers 16 m/i);
     expect(fig).toBeInTheDocument();
-    expect(fig.textContent).toMatch(/Elevation range 22\.0 m to 22\.0 m/);
+    expect(fig.textContent).toMatch(/Elevation 22\.0 m to 22\.0 m/);
   });
 
   it("ArrowRight from initial focus (32, 32) moves to (32, 33) and updates the aria-live region", async () => {
@@ -93,7 +93,8 @@ describe("ParcelMap", () => {
     const live = screen
       .getAllByRole("status")
       .find((n) => n.getAttribute("aria-live") === "polite");
-    expect(live?.textContent).toMatch(/Cell 32, 33/);
+    // col 33 * 4 = 132 (x, east), row 32 * 4 = 128 (y, north)
+    expect(live?.textContent).toMatch(/Position 132, 128/);
     expect(live?.textContent).toMatch(/in parcel/);
   });
 });

--- a/frontend/src/components/auction/ParcelMap.tsx
+++ b/frontend/src/components/auction/ParcelMap.tsx
@@ -157,8 +157,8 @@ export function ParcelMap({ publicId, className }: Props) {
         }}
       />
       <figcaption className="text-xs text-fg-muted">
-        Parcel covers {stats.parcelCellCount} of 4096 cells. Elevation
-        range {stats.parcelMin.toFixed(1)} m to {stats.parcelMax.toFixed(1)} m.
+        Parcel covers {stats.parcelCellCount * 16} m². Elevation
+        {" "}{stats.parcelMin.toFixed(1)} m to {stats.parcelMax.toFixed(1)} m.
       </figcaption>
       {hover && <ParcelMapTooltip {...hover.cellInfo} pixelX={hover.pixelX} pixelY={hover.pixelY} />}
       <div role="status" aria-live="polite" className="sr-only">
@@ -287,7 +287,9 @@ function cellInfoFor(
 function announcementFor(info: CellInfo | null): string {
   if (!info) return "";
   const where = info.inParcel ? "in parcel" : "outside parcel";
-  return `Cell ${info.row}, ${info.col}. Elevation ${info.elevM.toFixed(1)} meters. ${where}.`;
+  // SL world coords for the SW corner of this 4 m cell. col -> x (east),
+  // row -> y (north); 4 m per cell, region is 0..256 m.
+  return `Position ${info.col * 4}, ${info.row * 4}. Elevation ${info.elevM.toFixed(1)} meters. ${where}.`;
 }
 
 function moveFocus(
@@ -315,7 +317,7 @@ function ParcelMapTooltip({ row, col, elevM, inParcel, pixelX, pixelY }: CellInf
       className="absolute pointer-events-none rounded-md border border-border-subtle bg-surface-raised px-2 py-1 text-xs text-fg shadow"
       role="presentation"
     >
-      <div>Cell ({row}, {col})</div>
+      <div>Pos: {col * 4}, {row * 4}</div>
       <div>Elevation {elevM.toFixed(1)} m</div>
       <div>{inParcel ? "In parcel" : "Outside parcel"}</div>
     </div>


### PR DESCRIPTION
Three UI tweaks per user feedback:

- **Tooltip:** `Cell (row, col)` -> `Pos: x, y` where x/y are SL world coords (SW corner of the 4 m cell; col * 4 east, row * 4 north). Matches what sellers see in the SL viewer's coordinate readout.
- **Figcaption:** `Parcel covers N of 4096 cells` -> `Parcel covers N*16 m`. Users do not need the cell count; area in square meters is the natural read. Also dropped the redundant 'range' word: `Elevation range X m to Y m` -> `Elevation X m to Y m`.
- **aria-live announcement:** `Cell row, col. Elevation...` -> `Position x, y. Elevation...` matching the tooltip wording.

## Test plan
- [x] ParcelMap.test.tsx 4/4 green (two assertions updated for the new strings)
- [x] npm run build clean
- [x] npm run verify all 4 guards green