### PR TITLE
fix(frontend): restore two-phase mount for useParcelMapView SSR

### DIFF
--- a/frontend/src/hooks/useParcelMapView.ts
+++ b/frontend/src/hooks/useParcelMapView.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export type ParcelMapView = "2d" | "3d";
 
@@ -23,17 +23,28 @@ function readStoredView(): ParcelMapView {
  * localStorage-backed tab choice for the parcel-map view switcher. Returns
  * the current view and a setter that mirrors writes to localStorage.
  *
- * SSR-safe: the lazy initializer returns DEFAULT_VIEW on the server pass
- * (typeof window === "undefined") and reads from localStorage on the client
- * pass, avoiding a hydration mismatch while still restoring the user's
- * preference without a layout-effect flash. Junk values in storage (anything
- * other than "2d" or "3d") fall back to the default without throwing.
+ * SSR-safe via a two-phase mount: the initial render returns DEFAULT_VIEW on
+ * BOTH the server pass and the client hydration pass, so the markup matches
+ * and React does not warn about a hydration mismatch. After hydration the
+ * useEffect runs, reads the stored value, and re-renders if it differs. A
+ * naive useState lazy initializer would read localStorage during the client
+ * hydration pass and produce different HTML than the server, causing a
+ * mismatch warning whenever a returning visitor has "3d" stored.
  */
 export function useParcelMapView(): [
   ParcelMapView,
   (next: ParcelMapView) => void,
 ] {
-  const [view, setView] = useState<ParcelMapView>(readStoredView);
+  const [view, setView] = useState<ParcelMapView>(DEFAULT_VIEW);
+
+  // Deliberate two-phase mount: see JSDoc above. Lint rules that flag
+  // setState-in-effect do not model SSR hydration, so the suppression is
+  // load-bearing here.
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    setView(readStoredView());
+  }, []);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const update = useCallback((next: ParcelMapView) => {
     setView(next);


### PR DESCRIPTION
The lazy useState initializer introduced in the parcel-map-3d feature
(#415) causes a React hydration mismatch for any returning visitor with
\`\"3d\"\` stored in localStorage:

- Server render: \`readStoredView()\` returns \`\"2d\"\` (no \`window\`); server HTML
  marks the 2D tab active.
- Client hydration: \`readStoredView()\` runs again, reads localStorage,
  returns \`\"3d\"\`; client first render marks the 3D tab active.
- Hydration mismatch warning + brief visible tab flicker.

This restores the deliberate two-phase mount pattern (constant default ->
useEffect read) that the original implementation used. Server and client both
initialize to \`\"2d\"\`, hydration is clean, then useEffect swaps to the stored
value via a normal re-render. The \`react-hooks/set-state-in-effect\` lint rule
does not model SSR semantics, so a block-level eslint-disable with an
explanatory comment is the right suppression here.

\`ParcelMap3D.tsx\`'s \`reducedMotion\` lazy initializer is untouched: that
component is loaded via \`dynamic({ ssr: false })\` and never SSRs.

## Verification

- \`npm run lint\` clean (0 errors).
- \`npm run build\` green.
- \`npm run verify\` green.
- \`useParcelMapView.test.tsx\` 5/5 pass.