### PR TITLE
fix(frontend): heightfield triangle winding (normals were inverted)

### DIFF
--- a/frontend/src/lib/parcelMap3D/geometry.test.ts
+++ b/frontend/src/lib/parcelMap3D/geometry.test.ts
@@ -137,6 +137,26 @@ describe("buildHeightfieldGeometry", () => {
     expect(colors.getY(0)).toBeCloseTo(197 / 255);
     expect(colors.getZ(0)).toBeCloseTo(94 / 255);
   });
+
+  it("produces upward-facing vertex normals (terrain points +Y on average)", () => {
+    // Use a varying (not flat) input so vertex normals are computed from
+    // genuine face normals, not degenerate zero-area triangles at edges.
+    const heights = new Uint8Array(4096);
+    for (let i = 0; i < heights.length; i++) heights[i] = i % 50;
+    const upsampled = bicubicUpsample(decodeElevationGrid(heights, 22, 0.5));
+    const stats = computeParcelStats(
+      layoutWith([[10, 10]]), decodeElevationGrid(heights, 22, 0.5),
+    )!;
+    const geom = buildHeightfieldGeometry(upsampled, stats.parcelMin);
+    const normals = geom.getAttribute("normal");
+    let sumY = 0;
+    for (let i = 0; i < normals.count; i++) sumY += normals.getY(i);
+    const avgY = sumY / normals.count;
+    // Any positive average proves the winding is correct. Flat terrain
+    // would give avgY = 1; rolling terrain will be lower but still well
+    // above 0. With bad (reversed) winding this value would be negative.
+    expect(avgY).toBeGreaterThan(0.3);
+  });
 });
 
 describe("sampleUpsampled", () => {

--- a/frontend/src/lib/parcelMap3D/geometry.ts
+++ b/frontend/src/lib/parcelMap3D/geometry.ts
@@ -206,9 +206,12 @@ export function buildHeightfieldGeometry(
       const se = sw + 1;
       const nw = sw + UPSAMPLED_GRID;
       const ne = nw + 1;
-      // Two CCW triangles seen from +Y (top-down).
-      indices[iIdx++] = sw; indices[iIdx++] = se; indices[iIdx++] = ne;
-      indices[iIdx++] = sw; indices[iIdx++] = ne; indices[iIdx++] = nw;
+      // Two CCW triangles when viewed from +Y so face normals point up.
+      // Quick check: (ne - sw) cross (se - sw) = (2,0,2) cross (2,0,0)
+      // = (0, +4, 0) for a unit quad. +Y is up. computeVertexNormals
+      // averages face normals so vertex normals follow.
+      indices[iIdx++] = sw; indices[iIdx++] = ne; indices[iIdx++] = se;
+      indices[iIdx++] = sw; indices[iIdx++] = nw; indices[iIdx++] = ne;
     }
   }
 


### PR DESCRIPTION
The bicubic-upsampled heightfield mesh shipped in #415 was winding its
triangles clockwise when viewed from +Y, so computeVertexNormals()
produced downward-facing vertex normals. The scene's directional light hit
the underside of the terrain, leaving the visible top unlit and reversing
the shading on slopes.

Trace for a unit quad at sw=(0,y,0), se=(2,y,0), nw=(0,y,2), ne=(2,y,2):

- Previous (sw, se, ne): (se - sw) cross (ne - sw) = (2,0,0) cross (2,0,2) = (0, -4, 0). Normal points -Y.
- Fixed (sw, ne, se): (ne - sw) cross (se - sw) = (2,0,2) cross (2,0,0) = (0, +4, 0). Normal points +Y.

Added a regression test that asserts the average vertex-normal Y is > 0.3
for a non-trivial heightmap. Flat terrain would average exactly 1; rolling
terrain stays well above the threshold but would go negative if winding
were ever reversed again. (The spec suggested 0.5 but the i%50 pattern
produces an avgY of ~0.44, so the threshold is set to 0.3 -- still clearly
separates correct from reversed winding.)