### PR TITLE
feat(frontend): 3D parcel map slope mode + solid look

### DIFF
--- a/docs/superpowers/plans/2026-05-24-parcel-map-3d-slope-and-solid-plan.md
+++ b/docs/superpowers/plans/2026-05-24-parcel-map-3d-slope-and-solid-plan.md
@@ -1,0 +1,1710 @@
+# Parcel Map 3D Slope Mode + Solid Look Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an inline slope-shaded color mode (flat = green, 45° = red) toggleable inside the 3D parcel map, plus extruded region walls and a floor plane so the terrain reads as a solid chunk of land. Simplify the shared green/red gradient from 3-stop to 2-stop across both 2D and 3D views.
+
+**Architecture:** New localStorage-backed `useParcelMapColorMode` hook and `ParcelMap3DColorModeToggle` presentational component drive a color mode (`"elevation" | "slope"`) into `buildHeightfieldGeometry`. The geometry helper gains a slope grid computed via closed-form finite-difference, plus extruded region-perimeter walls and a bottom floor quad. The shared `colors.ts` helper rewrites `gradientColor` as a 2-stop lerp and adds `slopeColor`; the 2D `ParcelMapLegend` updates in lockstep.
+
+**Tech Stack:** Next.js 16 (App Router) + React 19 + TypeScript 5 + Tailwind CSS 4 + Three.js + `@react-three/fiber` + `@react-three/drei` + Vitest.
+
+**Branch:** `feat/parcel-map-3d-slope-and-solid` (off latest `dev`, HEAD `3c9cdc9b` is the spec commit).
+
+**Spec:** `docs/superpowers/specs/2026-05-24-parcel-map-3d-slope-and-solid-design.md`
+
+**Partially addresses:** GitHub issue #414 (adds region walls; the parcel-specific walls + water plane + snapshot ground texture remain out of scope).
+
+---
+
+## Conventions every task must honor
+
+- No emojis anywhere.
+- No AI/Claude/Anthropic attribution in commits or PR bodies (no `Co-Authored-By` trailers, no AI footers).
+- No em-dashes in user-visible copy, commit messages, PR titles, or PR bodies.
+- Push commits before requesting review.
+- Use `Edit` not `Write` for existing files.
+- Per-task verification: `npm test` AND `npm run build` AND `npm run verify` (Vitest does not type-check; `npm run build` is the tsc gate).
+- Semantic Tailwind tokens only. No `dark:` variants. No `#hex` literals in className strings (use `rgb(...)` or semantic tokens). `rgb(...)` inside JSX prop values is fine.
+- READ `frontend/AGENTS.md` before touching any frontend code (Next.js 16 / React 19 differ from older versions).
+- Existing helpers used by both 2D and 3D views (`useParcelScan`, `encoding.ts`, the surviving parts of `colors.ts`) must NOT be duplicated.
+- `useParcelMapView.ts`, `ParcelMapTabs.tsx`, `ParcelMap3DSkeleton.tsx`, and all backend code are NOT touched by this plan.
+
+---
+
+## File map
+
+**New files:**
+
+| File | Responsibility |
+|---|---|
+| `frontend/src/hooks/useParcelMapColorMode.ts` | localStorage-backed `"elevation" \| "slope"` state, two-phase mount. |
+| `frontend/src/hooks/useParcelMapColorMode.test.tsx` | Default, persistence, junk filter, SSR safety. |
+| `frontend/src/components/auction/ParcelMap3DColorModeToggle.tsx` | Pure presentational inline button group, ARIA radio group. |
+| `frontend/src/components/auction/ParcelMap3DColorModeToggle.test.tsx` | ARIA roles, aria-checked, click handler, arrow-key cycle. |
+
+**Modified files:**
+
+| File | Change |
+|---|---|
+| `frontend/src/lib/parcelMap/colors.ts` | Drop `MAP_COLORS.yellow`; rewrite `gradientColor` as 2-stop; add `slopeColor`; export `lerp` so external callers (test fixtures) can verify midpoints if needed (or leave inline — see Task 1). |
+| `frontend/src/lib/parcelMap/colors.test.ts` | Update existing 3-stop test cases to 2-stop midpoints; add `slopeColor` cases. |
+| `frontend/src/components/auction/ParcelMap.tsx` | `ParcelMapLegend`: 2-stop CSS gradient; drop the `+4 m` middle axis label. Explainer text stays. |
+| `frontend/src/lib/parcelMap3D/geometry.ts` | Add `computeSlopeGrid`; extend `buildHeightfieldGeometry(upsampled, parcelMin, floorY, mode, slopeGrid)`; emit walls + floor inline. |
+| `frontend/src/lib/parcelMap3D/geometry.test.ts` | Update existing `buildHeightfieldGeometry` tests for new signature; add slope-grid + wall/floor + mode-swap tests. |
+| `frontend/src/components/auction/ParcelMap3D.tsx` | Call `useParcelMapColorMode`; thread `colorMode`, `floorY`, `slopeGrid` into `buildHeightfieldGeometry` memo; render `<ParcelMap3DColorModeToggle>` inside scene wrapper gated on data loaded. |
+| `frontend/src/components/auction/ParcelMap3D.test.tsx` | Add case: toggling color mode rebuilds geometry with the new mode. |
+
+**Untouched:** `useParcelMapView.ts`, `ParcelMapTabs.tsx`, `ParcelMap3DSkeleton.tsx`, all backend code, all bot code, all LSL.
+
+---
+
+## Pre-resolved gotchas (do NOT let a reviewer "correct" these back)
+
+1. **2-stop gradient is shared across 2D and 3D.** `gradientColor(deltaMeters)` is `lerp(green, red, clamp(deltaMeters / 8, 0, 1))`. No yellow stop. The 2D map's legend bar simplifies to 2 stops, and the `+4 m` label is removed. `MAP_COLORS.yellow` is deleted. The user explicitly confirmed the shared-helper change applies to both 2D and 3D.
+
+2. **`computeParcelStats` still consumes the RAW 64x64 grid**, not the upsampled grid. Unchanged from the prior 3D PR. Don't let this get "fixed."
+
+3. **Slope from finite difference, NOT from `computeVertexNormals` output.** `computeSlopeGrid(upsampled)` is a closed-form finite-difference helper, deterministic, returns `Float32Array(UPSAMPLED_GRID²)`. Edges use clamp-to-edge one-sided differences.
+
+4. **45° not 90° for slope-red saturation.** `t = clamp(slopeRad / (Math.PI / 4), 0, 1)`. The 0..π/2 range was explicitly rejected.
+
+5. **Walls use OWN vertices**, NOT shared with the top mesh. Sharing would cause `computeVertexNormals` to average top-face and wall-face normals at the perimeter, producing weird normals at the edge. Each wall gets 2 × 129 = 258 fresh vertices per side (top edge + bottom edge), 4 sides = 1,032 wall vertices.
+
+6. **Wall coloring matches the top vertex at the same X/Z, multiplied by 0.55**, for BOTH top and bottom edges of the wall. The wall reads as a vertically-uniform dimmed strip of the same material. When colorMode flips, walls recolor in lockstep with the top surface.
+
+7. **Triangle winding (CRITICAL):**
+   - Top mesh: CCW from +Y so normals point +Y. (Already correct post-normals-fix PR.)
+   - Walls: CCW from OUTSIDE the region. North wall normal = `+Z`, south = `-Z`, east = `+X`, west = `-X`.
+   - Floor: CCW from BELOW (-Y looking +Y) so face normal points `-Y`.
+   - Tests assert the average face normal per wall and the floor normal.
+
+8. **Floor color is a fixed earth tone `rgb(60, 50, 40)`**, not derived from terrain. Defensive coverage for low-orbit visibility.
+
+9. **ARIA radio-group pattern (NOT tabs).** Toggle is `role="radiogroup"` + 2× `role="radio"` + `aria-checked` + `aria-label="Color by"`. Not `role="tablist"`. The user is choosing how to color the same scene, not which scene to render.
+
+10. **localStorage key + default:** `slpa:parcel-map:3d-color`, default `"elevation"`. Two-phase mount (constant default initial state + `useEffect` read) — same pattern as `useParcelMapView`, do NOT use a lazy `useState` initializer (would cause hydration mismatch). Use the `/* eslint-disable react-hooks/set-state-in-effect */` block to suppress the lint rule (as in `useParcelMapView.ts`).
+
+11. **Toggle hidden during skeleton state.** `<ParcelMap3DColorModeToggle>` only renders in the success-path render branch (data loaded, WebGL available). Not during skeleton, not during fallback, not on `data === null`.
+
+12. **`buildHeightfieldGeometry` signature changes to FIVE args**: `(upsampled, parcelMin, floorY, mode, slopeGrid)`. `slopeGrid` is always required even for elevation mode — keeps the call site predictable, avoids optional-arg ambiguity, slope computation is cheap.
+
+---
+
+## Task 1: colors.ts rewrite + ParcelMapLegend update
+
+This task ships an atomic 2D change: the color helper switches from 3-stop to 2-stop, and the 2D map's legend reflects the new gradient. Both sides of the change land in one commit so the 2D map never renders olive tones with a "yellow at +4 m" label.
+
+**Files:**
+- Modify: `frontend/src/lib/parcelMap/colors.ts`
+- Modify: `frontend/src/lib/parcelMap/colors.test.ts`
+- Modify: `frontend/src/components/auction/ParcelMap.tsx` (`ParcelMapLegend` only)
+
+- [ ] **Step 1: Read `frontend/AGENTS.md`**
+
+Quick scan to confirm Next.js 16 caveat is fresh.
+
+- [ ] **Step 2: Update the failing tests in `colors.test.ts`**
+
+Replace the contents of `frontend/src/lib/parcelMap/colors.test.ts` with:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { gradientColor, slopeColor, dimOutside, MAP_COLORS } from "./colors";
+
+describe("gradientColor (2-stop green->red)", () => {
+  it("returns solid green when delta <= 0", () => {
+    expect(gradientColor(-2)).toEqual(MAP_COLORS.green);
+    expect(gradientColor(0)).toEqual(MAP_COLORS.green);
+  });
+
+  it("returns solid red when delta >= 8", () => {
+    expect(gradientColor(8)).toEqual(MAP_COLORS.red);
+    expect(gradientColor(12)).toEqual(MAP_COLORS.red);
+  });
+
+  it("lerps green->red linearly at the midpoint (delta = 4 m)", () => {
+    const g = MAP_COLORS.green;
+    const r = MAP_COLORS.red;
+    const mid = gradientColor(4);
+    expect(mid.r).toBeCloseTo((g.r + r.r) / 2, 0);
+    expect(mid.g).toBeCloseTo((g.g + r.g) / 2, 0);
+    expect(mid.b).toBeCloseTo((g.b + r.b) / 2, 0);
+  });
+
+  it("lerps green->red at delta = 2 m (25% of the way)", () => {
+    const g = MAP_COLORS.green;
+    const r = MAP_COLORS.red;
+    const t = 0.25;
+    const c = gradientColor(2);
+    expect(c.r).toBeCloseTo(g.r + (r.r - g.r) * t, 0);
+    expect(c.g).toBeCloseTo(g.g + (r.g - g.g) * t, 0);
+    expect(c.b).toBeCloseTo(g.b + (r.b - g.b) * t, 0);
+  });
+
+  it("lerps green->red at delta = 6 m (75% of the way)", () => {
+    const g = MAP_COLORS.green;
+    const r = MAP_COLORS.red;
+    const t = 0.75;
+    const c = gradientColor(6);
+    expect(c.r).toBeCloseTo(g.r + (r.r - g.r) * t, 0);
+    expect(c.g).toBeCloseTo(g.g + (r.g - g.g) * t, 0);
+    expect(c.b).toBeCloseTo(g.b + (r.b - g.b) * t, 0);
+  });
+});
+
+describe("slopeColor (2-stop green->red, 0..45 deg)", () => {
+  it("returns solid green at flat (0 rad)", () => {
+    expect(slopeColor(0)).toEqual(MAP_COLORS.green);
+  });
+
+  it("returns solid red at 45 deg (Math.PI / 4 rad)", () => {
+    expect(slopeColor(Math.PI / 4)).toEqual(MAP_COLORS.red);
+  });
+
+  it("saturates at red for slopes above 45 deg", () => {
+    expect(slopeColor(Math.PI / 2)).toEqual(MAP_COLORS.red);
+    expect(slopeColor(Math.PI)).toEqual(MAP_COLORS.red);
+  });
+
+  it("clamps to green for negative slopes (defensive)", () => {
+    expect(slopeColor(-0.1)).toEqual(MAP_COLORS.green);
+  });
+
+  it("lerps green->red linearly at half scale (22.5 deg = Math.PI / 8)", () => {
+    const g = MAP_COLORS.green;
+    const r = MAP_COLORS.red;
+    const c = slopeColor(Math.PI / 8);
+    expect(c.r).toBeCloseTo((g.r + r.r) / 2, 0);
+    expect(c.g).toBeCloseTo((g.g + r.g) / 2, 0);
+    expect(c.b).toBeCloseTo((g.b + r.b) / 2, 0);
+  });
+});
+
+describe("dimOutside", () => {
+  it("lerps a given rgb 60% toward neutral gray (120, 120, 120)", () => {
+    const dimmed = dimOutside({ r: 34, g: 197, b: 94 });
+    expect(dimmed.r).toBe(Math.round(34 * 0.4 + 120 * 0.6));
+    expect(dimmed.g).toBe(Math.round(197 * 0.4 + 120 * 0.6));
+    expect(dimmed.b).toBe(Math.round(94 * 0.4 + 120 * 0.6));
+  });
+
+  it("returns gray for any gray input (no-op)", () => {
+    const dimmed = dimOutside({ r: 120, g: 120, b: 120 });
+    expect(dimmed).toEqual({ r: 120, g: 120, b: 120 });
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+cd frontend && npx vitest run src/lib/parcelMap/colors.test.ts
+```
+
+Expected: failures referencing the removed `MAP_COLORS.yellow` and the missing `slopeColor` export.
+
+- [ ] **Step 4: Rewrite `colors.ts`**
+
+Replace `frontend/src/lib/parcelMap/colors.ts` contents with:
+
+```ts
+/**
+ * Pure gradient + dim math for the parcel map. No DOM, no React.
+ *
+ * Two color helpers feed the heatmap rendering:
+ *
+ *   gradientColor(deltaMeters)
+ *     Elevation above the parcel's lowest cell. 2-stop lerp:
+ *       delta <= 0   -> green
+ *       delta >= 8m  -> red (un-flattenable spread)
+ *       in between, smooth linear interpolation through olive/khaki tones.
+ *
+ *   slopeColor(slopeRad)
+ *     Local terrain slope in radians. 2-stop lerp:
+ *       0 rad           -> green (flat)
+ *       Math.PI / 4 rad -> red (45 deg, practical SL unbuildable threshold)
+ *       steeper still reads red.
+ *
+ * Outside-parcel cells in the 2D view are dimmed toward neutral gray (60%
+ * toward gray) so the parcel pops visually.
+ *
+ * Colors are rgb triples (not hex) to keep the no-hex-colors verify guard
+ * happy. The RGB values reference Tailwind's green-500 / red-500 / cyan-400
+ * for visual consistency with the rest of the app.
+ */
+export interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+export const MAP_COLORS = {
+  green: { r: 34, g: 197, b: 94 }, // Tailwind green-500
+  red: { r: 239, g: 68, b: 68 }, // Tailwind red-500
+  cyan: { r: 34, g: 211, b: 238 }, // Tailwind cyan-400 (boundary outline)
+  neutral: { r: 120, g: 120, b: 120 }, // dim target
+} as const;
+
+const SLOPE_RED_RAD = Math.PI / 4; // 45 deg saturation point
+const ELEVATION_RED_M = 8; // 8m above parcel min saturates to red
+
+/** Per-cell color from an elevation delta (cell elevation - parcel min). */
+export function gradientColor(deltaMeters: number): Rgb {
+  if (deltaMeters <= 0) return { ...MAP_COLORS.green };
+  if (deltaMeters >= ELEVATION_RED_M) return { ...MAP_COLORS.red };
+  const t = deltaMeters / ELEVATION_RED_M;
+  return lerp(MAP_COLORS.green, MAP_COLORS.red, t);
+}
+
+/** Per-vertex color from a local slope angle in radians (0..pi/2). */
+export function slopeColor(slopeRad: number): Rgb {
+  if (slopeRad <= 0) return { ...MAP_COLORS.green };
+  if (slopeRad >= SLOPE_RED_RAD) return { ...MAP_COLORS.red };
+  const t = slopeRad / SLOPE_RED_RAD;
+  return lerp(MAP_COLORS.green, MAP_COLORS.red, t);
+}
+
+/** Dim a per-cell color 60% toward neutral gray. */
+export function dimOutside(color: Rgb): Rgb {
+  const raw = lerp(color, MAP_COLORS.neutral, 0.6);
+  return {
+    r: Math.round(raw.r),
+    g: Math.round(raw.g),
+    b: Math.round(raw.b),
+  };
+}
+
+function lerp(a: Rgb, b: Rgb, t: number): Rgb {
+  return {
+    r: a.r + (b.r - a.r) * t,
+    g: a.g + (b.g - a.g) * t,
+    b: a.b + (b.b - a.b) * t,
+  };
+}
+```
+
+Use Edit (the file exists). The change: remove `MAP_COLORS.yellow`; replace `gradientColor` body; add `slopeColor`; expand the file header comment.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+cd frontend && npx vitest run src/lib/parcelMap/colors.test.ts
+```
+
+Expected: all `gradientColor`, `slopeColor`, and `dimOutside` cases pass.
+
+- [ ] **Step 6: Update `ParcelMapLegend` in `ParcelMap.tsx`**
+
+Edit the `ParcelMapLegend` function in `frontend/src/components/auction/ParcelMap.tsx` (currently lines 314-342). Replace the entire function body with the 2-stop version:
+
+```tsx
+function ParcelMapLegend() {
+  // Linear gradient mirroring the 2-stop gradient used in colors.ts:
+  //   green at delta=0 (parcel low point)
+  //   red at delta=8+ m (un-flattenable spread)
+  // RGB literals rather than #hex keep the no-hex-colors verify guard green.
+  const stop = (c: { r: number; g: number; b: number }, pct: number) =>
+    `rgb(${c.r}, ${c.g}, ${c.b}) ${pct}%`;
+  const gradient = `linear-gradient(to right, ${stop(MAP_COLORS.green, 0)}, ${stop(MAP_COLORS.red, 100)})`;
+  return (
+    <div className="w-full max-w-[320px] flex flex-col gap-1">
+      <div
+        style={{ background: gradient }}
+        className="h-2 w-full border border-border-subtle"
+        aria-hidden="true"
+      />
+      <div className="flex justify-between text-[10px] text-fg-muted">
+        <span>0 m</span>
+        <span>+8 m+</span>
+      </div>
+      <p className="text-[10px] text-fg-muted">
+        Color = elevation above the parcel&apos;s lowest cell.
+        +4 m is the SL terraforming raise/lower limit; +8 m+ is
+        un-flattenable spread.
+      </p>
+    </div>
+  );
+}
+```
+
+Use Edit. Changes: `gradient` string is two stops instead of three; the axis-labels row drops the middle `<span>+4 m</span>`. The explainer text is unchanged — it still mentions the SL terraforming threshold for context.
+
+- [ ] **Step 7: Per-task verification**
+
+```bash
+cd frontend && npm run build && npm test && npm run verify
+```
+
+Expected: build green; full suite green (the `ParcelMap.test.tsx` doesn't assert on legend internals, so no test changes needed there); all four verify guards green.
+
+If the `verify:no-hex-colors` guard flags anything, the `rgb(...)` calls inside the gradient string are already accepted by the guard (it targets `#xxxxxx`).
+
+- [ ] **Step 8: Commit and push**
+
+```bash
+git add frontend/src/lib/parcelMap/colors.ts frontend/src/lib/parcelMap/colors.test.ts frontend/src/components/auction/ParcelMap.tsx
+git commit -m "feat(frontend): 2-stop green/red gradient + legend update"
+git push
+```
+
+---
+
+## Task 2: useParcelMapColorMode hook
+
+Mirrors `useParcelMapView` structure exactly: localStorage-backed, two-phase mount, lint suppression on the deliberate `setState-in-effect` pattern.
+
+**Files:**
+- Create: `frontend/src/hooks/useParcelMapColorMode.ts`
+- Test: `frontend/src/hooks/useParcelMapColorMode.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/hooks/useParcelMapColorMode.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useParcelMapColorMode } from "./useParcelMapColorMode";
+
+const STORAGE_KEY = "slpa:parcel-map:3d-color";
+
+describe("useParcelMapColorMode", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns 'elevation' when localStorage is empty", () => {
+    const { result } = renderHook(() => useParcelMapColorMode());
+    expect(result.current[0]).toBe("elevation");
+  });
+
+  it("returns 'slope' when localStorage already holds 'slope'", () => {
+    window.localStorage.setItem(STORAGE_KEY, "slope");
+    const { result } = renderHook(() => useParcelMapColorMode());
+    expect(result.current[0]).toBe("slope");
+  });
+
+  it("ignores junk values and falls back to 'elevation'", () => {
+    window.localStorage.setItem(STORAGE_KEY, "asdf");
+    const { result } = renderHook(() => useParcelMapColorMode());
+    expect(result.current[0]).toBe("elevation");
+  });
+
+  it("setMode writes to localStorage and updates returned state", () => {
+    const { result } = renderHook(() => useParcelMapColorMode());
+    act(() => result.current[1]("slope"));
+    expect(result.current[0]).toBe("slope");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("slope");
+  });
+
+  it("setMode back to 'elevation' updates both state and storage", () => {
+    window.localStorage.setItem(STORAGE_KEY, "slope");
+    const { result } = renderHook(() => useParcelMapColorMode());
+    act(() => result.current[1]("elevation"));
+    expect(result.current[0]).toBe("elevation");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("elevation");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd frontend && npx vitest run src/hooks/useParcelMapColorMode.test.tsx
+```
+
+Expected: all 5 tests fail with `Cannot find module './useParcelMapColorMode'`.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `frontend/src/hooks/useParcelMapColorMode.ts`:
+
+```ts
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export type ParcelMap3DColorMode = "elevation" | "slope";
+
+const STORAGE_KEY = "slpa:parcel-map:3d-color";
+const DEFAULT_MODE: ParcelMap3DColorMode = "elevation";
+
+function readStoredMode(): ParcelMap3DColorMode {
+  if (typeof window === "undefined") return DEFAULT_MODE;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === "elevation" || raw === "slope") return raw;
+    return DEFAULT_MODE;
+  } catch {
+    // localStorage can throw in privacy modes or quota-exceeded scenarios.
+    return DEFAULT_MODE;
+  }
+}
+
+/**
+ * localStorage-backed color-mode choice for the parcel-map 3D view. Returns
+ * the current mode and a setter that mirrors writes to localStorage.
+ *
+ * SSR-safe via a two-phase mount: the initial render returns DEFAULT_MODE on
+ * BOTH the server pass and the client hydration pass, so the markup matches
+ * and React does not warn about a hydration mismatch. After hydration the
+ * useEffect runs, reads the stored value, and re-renders if it differs. A
+ * naive useState lazy initializer would read localStorage during the client
+ * hydration pass and produce different HTML than the server, causing a
+ * mismatch warning whenever a returning visitor has "slope" stored. Mirrors
+ * {@link useParcelMapView}.
+ */
+export function useParcelMapColorMode(): [
+  ParcelMap3DColorMode,
+  (next: ParcelMap3DColorMode) => void,
+] {
+  const [mode, setMode] = useState<ParcelMap3DColorMode>(DEFAULT_MODE);
+
+  // Deliberate two-phase mount: see JSDoc above. Lint rules that flag
+  // setState-in-effect do not model SSR hydration, so the suppression is
+  // load-bearing here.
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    setMode(readStoredMode());
+  }, []);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  const update = useCallback((next: ParcelMap3DColorMode) => {
+    setMode(next);
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // localStorage write can throw under quota or privacy modes; swallow
+      // so the in-session mode change still takes effect.
+    }
+  }, []);
+
+  return [mode, update];
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd frontend && npx vitest run src/hooks/useParcelMapColorMode.test.tsx
+```
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 5: Per-task verification**
+
+```bash
+cd frontend && npm run build && npm test && npm run verify
+```
+
+Expected: build green, full suite green, verify green.
+
+- [ ] **Step 6: Commit and push**
+
+```bash
+git add frontend/src/hooks/useParcelMapColorMode.ts frontend/src/hooks/useParcelMapColorMode.test.tsx
+git commit -m "feat(frontend): useParcelMapColorMode hook"
+git push
+```
+
+---
+
+## Task 3: computeSlopeGrid + buildHeightfieldGeometry walls/floor extension
+
+The largest task. Adds the pure slope helper, extends the geometry builder's signature to include `floorY`, `mode`, and `slopeGrid`, and emits the wall/floor geometry inline.
+
+**Files:**
+- Modify: `frontend/src/lib/parcelMap3D/geometry.ts`
+- Modify: `frontend/src/lib/parcelMap3D/geometry.test.ts`
+
+- [ ] **Step 1: Update the failing geometry test**
+
+Replace the contents of `frontend/src/lib/parcelMap3D/geometry.test.ts` with the version below. The changes from the current file:
+
+- Add `computeSlopeGrid` imports and a new describe block.
+- Update every `buildHeightfieldGeometry(upsampled, parcelMin)` call site to the new 5-arg form `(upsampled, parcelMin, floorY, "elevation", slopeGrid)`.
+- Update the existing "produces UPSAMPLED_GRID^2 vertices ..." test to reflect the new total vertex / index counts (now including walls + floor).
+- Add new describe blocks for wall geometry, wall colors, floor geometry, mode swap.
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  UPSAMPLE_FACTOR,
+  UPSAMPLED_GRID,
+  bicubicUpsample,
+  buildHeightfieldGeometry,
+  buildPerimeterPoints,
+  computeCameraDefaults,
+  computeParcelStats,
+  computeRegionBounds,
+  computeSlopeGrid,
+  decodeElevationGrid,
+  isWebGLAvailable,
+  sampleUpsampled,
+} from "./geometry";
+
+const TOP_VERTS = UPSAMPLED_GRID * UPSAMPLED_GRID;          // 16641
+const TOP_INDICES = (UPSAMPLED_GRID - 1) * (UPSAMPLED_GRID - 1) * 6; // 98304
+const WALL_VERTS = 4 * 2 * UPSAMPLED_GRID;                  // 1032
+const WALL_INDICES = 4 * (UPSAMPLED_GRID - 1) * 6;          // 3072
+const FLOOR_VERTS = 4;
+const FLOOR_INDICES = 6;
+const TOTAL_VERTS = TOP_VERTS + WALL_VERTS + FLOOR_VERTS;   // 17677
+const TOTAL_INDICES = TOP_INDICES + WALL_INDICES + FLOOR_INDICES; // 101382
+
+function layoutWith(setCells: Array<[number, number]>): Uint8Array {
+  const bytes = new Uint8Array(512);
+  for (const [row, col] of setCells) {
+    const bitIndex = row * 64 + col;
+    bytes[bitIndex >> 3] |= 1 << (7 - (bitIndex & 7));
+  }
+  return bytes;
+}
+
+function heightsAll(value: number): Uint8Array {
+  const b = new Uint8Array(4096);
+  b.fill(value);
+  return b;
+}
+
+function flatScene() {
+  const upsampled = bicubicUpsample(decodeElevationGrid(heightsAll(0), 22, 0.5));
+  const slope = computeSlopeGrid(upsampled);
+  return { upsampled, slope, parcelMin: 22, floorY: 14 };
+}
+
+describe("decodeElevationGrid", () => {
+  it("decodes a flat heightmap to all baseMeters", () => {
+    const grid = decodeElevationGrid(heightsAll(0), 22, 0.5);
+    expect(grid.length).toBe(64 * 64);
+    expect(grid[0]).toBeCloseTo(22.0);
+    expect(grid[4095]).toBeCloseTo(22.0);
+  });
+
+  it("decodes a varying heightmap with stepMeters scaling", () => {
+    const h = new Uint8Array(4096);
+    h[10] = 100;
+    const grid = decodeElevationGrid(h, 22, 0.5);
+    expect(grid[10]).toBeCloseTo(22.0 + 100 * 0.5);
+  });
+});
+
+describe("bicubicUpsample", () => {
+  it("returns a flat grid for a flat input (interpolation does not invent variation)", () => {
+    const input = new Float32Array(64 * 64).fill(25);
+    const out = bicubicUpsample(input);
+    expect(out.length).toBe(UPSAMPLED_GRID * UPSAMPLED_GRID);
+    for (const y of out) expect(y).toBeCloseTo(25, 4);
+  });
+
+  it("preserves sample values at upsampled vertices that coincide with original samples", () => {
+    const input = new Float32Array(64 * 64);
+    input[10 * 64 + 20] = 100;
+    const out = bicubicUpsample(input);
+    expect(out[20 * UPSAMPLED_GRID + 40]).toBeCloseTo(100, 4);
+  });
+
+  it("smoothly interpolates between two adjacent samples", () => {
+    const input = new Float32Array(64 * 64);
+    input[10 * 64 + 5] = 0;
+    input[10 * 64 + 6] = 10;
+    const out = bicubicUpsample(input);
+    const mid = out[20 * UPSAMPLED_GRID + 11];
+    expect(mid).toBeGreaterThan(2);
+    expect(mid).toBeLessThan(8);
+  });
+});
+
+describe("computeRegionBounds", () => {
+  it("returns base..base when all cells are zero", () => {
+    const b = computeRegionBounds(decodeElevationGrid(heightsAll(0), 22, 0.5));
+    expect(b).toEqual({ rMin: 22.0, rMax: 22.0 });
+  });
+
+  it("returns base..base+255*step when cells span the full uint8 range", () => {
+    const h = new Uint8Array(4096);
+    h[0] = 0;
+    h[1] = 255;
+    const b = computeRegionBounds(decodeElevationGrid(h, 22, 0.5));
+    expect(b.rMin).toBeCloseTo(22.0);
+    expect(b.rMax).toBeCloseTo(22.0 + 255 * 0.5);
+  });
+});
+
+describe("computeParcelStats", () => {
+  it("returns null when the parcel has no cells", () => {
+    const stats = computeParcelStats(
+      new Uint8Array(512), decodeElevationGrid(heightsAll(0), 22, 0.5),
+    );
+    expect(stats).toBeNull();
+  });
+
+  it("min/max/count over only the parcel cells", () => {
+    const h = new Uint8Array(4096);
+    h[10 * 64 + 10] = 0;
+    h[10 * 64 + 11] = 10;
+    h[20 * 64 + 20] = 100;
+    const layout = layoutWith([[10, 10], [10, 11]]);
+    const stats = computeParcelStats(layout, decodeElevationGrid(h, 22, 0.5))!;
+    expect(stats.parcelCellCount).toBe(2);
+    expect(stats.parcelMin).toBeCloseTo(22.0);
+    expect(stats.parcelMax).toBeCloseTo(27.0);
+  });
+});
+
+describe("computeSlopeGrid", () => {
+  it("returns a Float32Array of length UPSAMPLED_GRID^2", () => {
+    const upsampled = bicubicUpsample(decodeElevationGrid(heightsAll(0), 22, 0.5));
+    const slope = computeSlopeGrid(upsampled);
+    expect(slope).toBeInstanceOf(Float32Array);
+    expect(slope.length).toBe(UPSAMPLED_GRID * UPSAMPLED_GRID);
+  });
+
+  it("returns all zeros for a flat input", () => {
+    const upsampled = new Float32Array(UPSAMPLED_GRID * UPSAMPLED_GRID).fill(25);
+    const slope = computeSlopeGrid(upsampled);
+    for (const s of slope) expect(s).toBeCloseTo(0, 6);
+  });
+
+  it("returns a uniform non-zero slope for a constant ramp in X", () => {
+    // h(x, z) = x / 4 -> dh/dx = 0.25, dh/dz = 0 -> slope = atan(0.25)
+    const upsampled = new Float32Array(UPSAMPLED_GRID * UPSAMPLED_GRID);
+    for (let uRow = 0; uRow < UPSAMPLED_GRID; uRow++) {
+      for (let uCol = 0; uCol < UPSAMPLED_GRID; uCol++) {
+        upsampled[uRow * UPSAMPLED_GRID + uCol] = (uCol * 2) / 4;
+      }
+    }
+    const slope = computeSlopeGrid(upsampled);
+    // Inspect an interior vertex (uRow=64, uCol=64) -- avoids the one-sided
+    // edge fallback.
+    const interior = slope[64 * UPSAMPLED_GRID + 64];
+    expect(interior).toBeCloseTo(Math.atan(0.25), 4);
+  });
+
+  it("uses clamp-to-edge one-sided differences at the boundary (no NaN)", () => {
+    const upsampled = new Float32Array(UPSAMPLED_GRID * UPSAMPLED_GRID);
+    for (let i = 0; i < upsampled.length; i++) upsampled[i] = i % 7;
+    const slope = computeSlopeGrid(upsampled);
+    for (const s of slope) {
+      expect(Number.isFinite(s)).toBe(true);
+      expect(s).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe("sampleUpsampled", () => {
+  it("samples upsampled grid at world (x, z) coordinates with bilinear fallback", () => {
+    const upsampled = new Float32Array(UPSAMPLED_GRID * UPSAMPLED_GRID).fill(30);
+    expect(sampleUpsampled(upsampled, 40, 40)).toBeCloseTo(30);
+  });
+});
+
+describe("buildPerimeterPoints", () => {
+  it("returns 8 endpoints (4 edges * 2 endpoints) for a single isolated parcel cell", () => {
+    const upsampled = bicubicUpsample(decodeElevationGrid(heightsAll(0), 22, 0.5));
+    const points = buildPerimeterPoints(layoutWith([[10, 10]]), upsampled);
+    expect(points.length).toBe(8);
+    expect(points[0]).toHaveLength(3);
+  });
+
+  it("interior parcel cell with all four neighbors in-parcel emits zero edges", () => {
+    const layout = layoutWith([
+      [10, 10],
+      [9, 10], [11, 10], [10, 9], [10, 11],
+    ]);
+    const upsampled = bicubicUpsample(decodeElevationGrid(heightsAll(0), 22, 0.5));
+    const allPoints = buildPerimeterPoints(layout, upsampled);
+    expect(allPoints.length).toBe(24);
+  });
+
+  it("returns an empty array when the parcel has zero cells", () => {
+    const upsampled = bicubicUpsample(decodeElevationGrid(heightsAll(0), 22, 0.5));
+    expect(buildPerimeterPoints(new Uint8Array(512), upsampled)).toEqual([]);
+  });
+});
+
+describe("computeCameraDefaults", () => {
+  it("targets the geometric center at the mid elevation", () => {
+    const cam = computeCameraDefaults({ rMin: 20, rMax: 40 });
+    expect(cam.target).toEqual([128, 30, 128]);
+    expect(cam.fovDeg).toBe(50);
+  });
+
+  it("camera sits at 45 deg azimuth, 30 deg elevation above the target", () => {
+    const cam = computeCameraDefaults({ rMin: 0, rMax: 0 });
+    const [cx, cy, cz] = cam.position;
+    expect(cy).toBeGreaterThan(0);
+    expect(cx - 128).toBeCloseTo(cz - 128);
+    expect(cx - 128).toBeGreaterThan(0);
+  });
+});
+
+describe("UPSAMPLE_FACTOR", () => {
+  it("is exactly 2, so cell-edge coords align with upsampled vertices", () => {
+    expect(UPSAMPLE_FACTOR).toBe(2);
+    expect(UPSAMPLED_GRID).toBe(64 * 2 + 1);
+  });
+});
+
+describe("isWebGLAvailable", () => {
+  it("returns a boolean without throwing", () => {
+    expect(typeof isWebGLAvailable()).toBe("boolean");
+  });
+});
+
+describe("buildHeightfieldGeometry (top + walls + floor)", () => {
+  it("produces TOTAL_VERTS vertices and TOTAL_INDICES indices", () => {
+    const { upsampled, slope, parcelMin, floorY } = flatScene();
+    const geom = buildHeightfieldGeometry(
+      upsampled, parcelMin, floorY, "elevation", slope,
+    );
+    expect(geom.getAttribute("position").count).toBe(TOTAL_VERTS);
+    expect(geom.getAttribute("color").count).toBe(TOTAL_VERTS);
+    expect(geom.index!.count).toBe(TOTAL_INDICES);
+  });
+
+  it("vertex 0 (SW corner of top mesh) sits at world (0, baseMeters, 0)", () => {
+    const { upsampled, slope, parcelMin, floorY } = flatScene();
+    const geom = buildHeightfieldGeometry(
+      upsampled, parcelMin, floorY, "elevation", slope,
+    );
+    const pos = geom.getAttribute("position");
+    expect(pos.getX(0)).toBe(0);
+    expect(pos.getY(0)).toBeCloseTo(22.0);
+    expect(pos.getZ(0)).toBe(0);
+  });
+
+  it("colors top vertex 0 with green-500 when elevation equals parcelMin", () => {
+    const { upsampled, slope, parcelMin, floorY } = flatScene();
+    const geom = buildHeightfieldGeometry(
+      upsampled, parcelMin, floorY, "elevation", slope,
+    );
+    const colors = geom.getAttribute("color");
+    expect(colors.getX(0)).toBeCloseTo(34 / 255);
+    expect(colors.getY(0)).toBeCloseTo(197 / 255);
+    expect(colors.getZ(0)).toBeCloseTo(94 / 255);
+  });
+
+  it("top mesh produces upward-facing vertex normals (avg Y > 0.3)", () => {
+    const heights = new Uint8Array(4096);
+    for (let i = 0; i < heights.length; i++) heights[i] = i % 50;
+    const raw = decodeElevationGrid(heights, 22, 0.5);
+    const upsampled = bicubicUpsample(raw);
+    const slope = computeSlopeGrid(upsampled);
+    const stats = computeParcelStats(layoutWith([[10, 10]]), raw)!;
+    const bounds = computeRegionBounds(upsampled);
+    const geom = buildHeightfieldGeometry(
+      upsampled, stats.parcelMin, bounds.rMin - 8, "elevation", slope,
+    );
+    const normals = geom.getAttribute("normal");
+    // Average over the TOP mesh vertices only (first TOP_VERTS entries).
+    let sumY = 0;
+    for (let i = 0; i < TOP_VERTS; i++) sumY += normals.getY(i);
+    expect(sumY / TOP_VERTS).toBeGreaterThan(0.3);
+  });
+
+  it("each wall's face normal points outward from region center", () => {
+    const { upsampled, slope, parcelMin, floorY } = flatScene();
+    const geom = buildHeightfieldGeometry(
+      upsampled, parcelMin, floorY, "elevation", slope,
+    );
+    const normals = geom.getAttribute("normal");
+    // Walls live at vertex indices [TOP_VERTS, TOP_VERTS + WALL_VERTS).
+    // Wall vertex order: south (-Z), north (+Z), west (-X), east (+X), each
+    // contributing 2 * UPSAMPLED_GRID vertices.
+    const PER_WALL = 2 * UPSAMPLED_GRID;
+    function avgNormal(startVtx: number) {
+      let x = 0, y = 0, z = 0;
+      for (let i = 0; i < PER_WALL; i++) {
+        x += normals.getX(startVtx + i);
+        y += normals.getY(startVtx + i);
+        z += normals.getZ(startVtx + i);
+      }
+      return [x / PER_WALL, y / PER_WALL, z / PER_WALL];
+    }
+    const southAvg = avgNormal(TOP_VERTS + 0 * PER_WALL);
+    const northAvg = avgNormal(TOP_VERTS + 1 * PER_WALL);
+    const westAvg = avgNormal(TOP_VERTS + 2 * PER_WALL);
+    const eastAvg = avgNormal(TOP_VERTS + 3 * PER_WALL);
+    expect(southAvg[2]).toBeLessThan(-0.5);  // points -Z
+    expect(northAvg[2]).toBeGreaterThan(0.5); // points +Z
+    expect(westAvg[0]).toBeLessThan(-0.5);   // points -X
+    expect(eastAvg[0]).toBeGreaterThan(0.5);  // points +X
+  });
+
+  it("floor face normal points -Y (downward)", () => {
+    const { upsampled, slope, parcelMin, floorY } = flatScene();
+    const geom = buildHeightfieldGeometry(
+      upsampled, parcelMin, floorY, "elevation", slope,
+    );
+    const normals = geom.getAttribute("normal");
+    const floorStart = TOP_VERTS + WALL_VERTS;
+    let sumY = 0;
+    for (let i = 0; i < FLOOR_VERTS; i++) sumY += normals.getY(floorStart + i);
+    expect(sumY / FLOOR_VERTS).toBeCloseTo(-1, 1);
+  });
+
+  it("wall vertex color = top vertex color at same X/Z, multiplied by 0.55 (top + bottom edge match)", () => {
+    const { upsampled, slope, parcelMin, floorY } = flatScene();
+    const geom = buildHeightfieldGeometry(
+      upsampled, parcelMin, floorY, "elevation", slope,
+    );
+    const colors = geom.getAttribute("color");
+    // Top mesh vertex (0, 0) sits at color = green / 255 (since flat input).
+    const topR = colors.getX(0);
+    const topG = colors.getY(0);
+    const topB = colors.getZ(0);
+    // South wall starts immediately after the top mesh. The first 2 wall
+    // vertices are the top-edge and bottom-edge at (uCol=0, uRow=0).
+    const southStart = TOP_VERTS;
+    const wallTopR = colors.getX(southStart);
+    const wallBottomR = colors.getX(southStart + 1);
+    expect(wallTopR).toBeCloseTo(topR * 0.55, 4);
+    expect(wallBottomR).toBeCloseTo(topR * 0.55, 4);
+    expect(colors.getY(southStart)).toBeCloseTo(topG * 0.55, 4);
+    expect(colors.getZ(southStart)).toBeCloseTo(topB * 0.55, 4);
+  });
+
+  it("floor vertex color is the fixed earth tone rgb(60, 50, 40)", () => {
+    const { upsampled, slope, parcelMin, floorY } = flatScene();
+    const geom = buildHeightfieldGeometry(
+      upsampled, parcelMin, floorY, "elevation", slope,
+    );
+    const colors = geom.getAttribute("color");
+    const floorStart = TOP_VERTS + WALL_VERTS;
+    expect(colors.getX(floorStart)).toBeCloseTo(60 / 255, 4);
+    expect(colors.getY(floorStart)).toBeCloseTo(50 / 255, 4);
+    expect(colors.getZ(floorStart)).toBeCloseTo(40 / 255, 4);
+  });
+
+  it("mode swap (elevation -> slope) produces different top colors on a sloped input", () => {
+    // Ramp input: cells climb in X. In elevation mode the SW corner is
+    // parcelMin -> green. In slope mode the SW corner sits on a non-zero
+    // slope -> green-shifted-toward-red color (not pure green).
+    const h = new Uint8Array(4096);
+    for (let row = 0; row < 64; row++) {
+      for (let col = 0; col < 64; col++) {
+        h[row * 64 + col] = col * 2;
+      }
+    }
+    const raw = decodeElevationGrid(h, 22, 0.5);
+    const upsampled = bicubicUpsample(raw);
+    const slope = computeSlopeGrid(upsampled);
+    const stats = computeParcelStats(layoutWith([[0, 0]]), raw)!;
+    const bounds = computeRegionBounds(upsampled);
+    const floorY = bounds.rMin - 8;
+    const elevGeom = buildHeightfieldGeometry(
+      upsampled, stats.parcelMin, floorY, "elevation", slope,
+    );
+    const slopeGeom = buildHeightfieldGeometry(
+      upsampled, stats.parcelMin, floorY, "slope", slope,
+    );
+    const elevColor0 = elevGeom.getAttribute("color");
+    const slopeColor0 = slopeGeom.getAttribute("color");
+    // The SW corner top vertex should differ between the two modes.
+    const elevR = elevColor0.getX(0);
+    const slopeR = slopeColor0.getX(0);
+    expect(slopeR).not.toBeCloseTo(elevR, 2);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd frontend && npx vitest run src/lib/parcelMap3D/geometry.test.ts
+```
+
+Expected: the existing tests fail because `computeSlopeGrid` doesn't exist; the new wall/floor tests fail because the new signature isn't in place.
+
+- [ ] **Step 3: Add `computeSlopeGrid` to `geometry.ts`**
+
+Insert this helper into `frontend/src/lib/parcelMap3D/geometry.ts` after `bicubicUpsample` and before `computeRegionBounds`. Use Edit.
+
+```ts
+/**
+ * Closed-form finite-difference slope at every upsampled vertex. Returns a
+ * {@link UPSAMPLED_GRID} squared Float32Array of slope angles in radians
+ * (0 = flat, pi/2 = vertical). Edges use one-sided differences (clamp-to-edge);
+ * interior vertices use centered differences.
+ *
+ *   dhdx = (h[uRow,   uCol+1] - h[uRow,   uCol-1]) / (2 * UPSAMPLED_SPACING_M)
+ *   dhdz = (h[uRow+1, uCol  ] - h[uRow-1, uCol  ]) / (2 * UPSAMPLED_SPACING_M)
+ *   slope = atan(sqrt(dhdx*dhdx + dhdz*dhdz))
+ *
+ * Pure math; safe to memoize via {@code useMemo}.
+ */
+export function computeSlopeGrid(upsampled: Float32Array): Float32Array {
+  const out = new Float32Array(UPSAMPLED_GRID * UPSAMPLED_GRID);
+  const inv2 = 1 / (2 * UPSAMPLED_SPACING_M);
+  const invEdge = 1 / UPSAMPLED_SPACING_M;
+  for (let uRow = 0; uRow < UPSAMPLED_GRID; uRow++) {
+    const rowNorth = Math.min(UPSAMPLED_GRID - 1, uRow + 1);
+    const rowSouth = Math.max(0, uRow - 1);
+    const rowSpanIsCentered = rowNorth - rowSouth === 2;
+    for (let uCol = 0; uCol < UPSAMPLED_GRID; uCol++) {
+      const colEast = Math.min(UPSAMPLED_GRID - 1, uCol + 1);
+      const colWest = Math.max(0, uCol - 1);
+      const colSpanIsCentered = colEast - colWest === 2;
+      const dhdx =
+        (upsampled[uRow * UPSAMPLED_GRID + colEast] -
+          upsampled[uRow * UPSAMPLED_GRID + colWest]) *
+        (colSpanIsCentered ? inv2 : invEdge);
+      const dhdz =
+        (upsampled[rowNorth * UPSAMPLED_GRID + uCol] -
+          upsampled[rowSouth * UPSAMPLED_GRID + uCol]) *
+        (rowSpanIsCentered ? inv2 : invEdge);
+      out[uRow * UPSAMPLED_GRID + uCol] = Math.atan(Math.sqrt(dhdx * dhdx + dhdz * dhdz));
+    }
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Rewrite `buildHeightfieldGeometry` to the new signature and emit walls + floor**
+
+Replace the existing `buildHeightfieldGeometry` function in `geometry.ts` (currently lines 175-224) with the version below. Also import `slopeColor` from `colors.ts` at the top of the file. Use Edit.
+
+First, update the colors import at the top:
+
+```ts
+import { gradientColor, slopeColor } from "@/lib/parcelMap/colors";
+```
+
+Then replace the function:
+
+```ts
+/**
+ * Build the heightfield mesh as a single indexed {@link BufferGeometry}.
+ * Includes the top surface (129x129 vertices, smooth heightfield), four
+ * extruded perimeter walls reaching down to {@code floorY}, and a bottom
+ * floor quad at {@code floorY}. Vertex colors come from one of two helpers
+ * depending on {@code mode}: elevation (delta from parcelMin) or slope (rad).
+ * Walls reuse the perimeter top color multiplied by {@link WALL_DIM}; both
+ * top and bottom edges of each wall share the same color. Floor uses a
+ * fixed neutral earth tone.
+ *
+ * Vertex layout (used by tests asserting positions/colors/normals by index):
+ *   [0 .. TOP_VERTS)              top mesh, row-major (uRow * UPSAMPLED_GRID + uCol)
+ *   [TOP_VERTS .. +PER_WALL)      south wall, pairs of (top-edge, bottom-edge) by uCol
+ *   [+PER_WALL .. +2*PER_WALL)    north wall, same pair ordering by uCol
+ *   [+2*PER_WALL .. +3*PER_WALL)  west wall, pairs by uRow
+ *   [+3*PER_WALL .. +4*PER_WALL)  east wall, pairs by uRow
+ *   [TOP_VERTS + WALL_VERTS ..)   floor (4 vertices, SW SE NW NE)
+ *
+ * Wall triangle winding is CCW from outside the region so face normals
+ * point outward (south=-Z, north=+Z, west=-X, east=+X). Floor winding is
+ * CCW from below so face normal points -Y.
+ */
+export function buildHeightfieldGeometry(
+  upsampled: Float32Array,
+  parcelMin: number,
+  floorY: number,
+  mode: "elevation" | "slope",
+  slopeGrid: Float32Array,
+): BufferGeometry {
+  const TOP_VERTS = UPSAMPLED_GRID * UPSAMPLED_GRID;
+  const QUAD_COUNT = (UPSAMPLED_GRID - 1) * (UPSAMPLED_GRID - 1);
+  const TOP_INDICES = QUAD_COUNT * 6;
+  const PER_WALL_VERTS = 2 * UPSAMPLED_GRID;
+  const PER_WALL_INDICES = (UPSAMPLED_GRID - 1) * 6;
+  const WALL_VERTS = 4 * PER_WALL_VERTS;
+  const WALL_INDICES = 4 * PER_WALL_INDICES;
+  const FLOOR_VERTS = 4;
+  const FLOOR_INDICES = 6;
+
+  const totalVerts = TOP_VERTS + WALL_VERTS + FLOOR_VERTS;
+  const totalIndices = TOP_INDICES + WALL_INDICES + FLOOR_INDICES;
+
+  const positions = new Float32Array(totalVerts * 3);
+  const colors = new Float32Array(totalVerts * 3);
+  const indices = new Uint32Array(totalIndices);
+
+  // ---- 1. Top surface ----
+  for (let uRow = 0; uRow < UPSAMPLED_GRID; uRow++) {
+    for (let uCol = 0; uCol < UPSAMPLED_GRID; uCol++) {
+      const vIdx = uRow * UPSAMPLED_GRID + uCol;
+      const y = upsampled[vIdx];
+      const x = uCol * UPSAMPLED_SPACING_M;
+      const z = uRow * UPSAMPLED_SPACING_M;
+      positions[vIdx * 3 + 0] = x;
+      positions[vIdx * 3 + 1] = y;
+      positions[vIdx * 3 + 2] = z;
+      const c = topColorAt(uRow, uCol, upsampled, slopeGrid, parcelMin, mode);
+      colors[vIdx * 3 + 0] = c.r / 255;
+      colors[vIdx * 3 + 1] = c.g / 255;
+      colors[vIdx * 3 + 2] = c.b / 255;
+    }
+  }
+  let iIdx = 0;
+  for (let uRow = 0; uRow < UPSAMPLED_GRID - 1; uRow++) {
+    for (let uCol = 0; uCol < UPSAMPLED_GRID - 1; uCol++) {
+      const sw = uRow * UPSAMPLED_GRID + uCol;
+      const se = sw + 1;
+      const nw = sw + UPSAMPLED_GRID;
+      const ne = nw + 1;
+      indices[iIdx++] = sw; indices[iIdx++] = ne; indices[iIdx++] = se;
+      indices[iIdx++] = sw; indices[iIdx++] = nw; indices[iIdx++] = ne;
+    }
+  }
+
+  // ---- 2. Walls (south, north, west, east in this order) ----
+  let vCursor = TOP_VERTS;
+
+  // South wall (z=0, faces -Z). Pairs ordered by uCol: top vertex, then bottom.
+  vCursor = emitWall({
+    perimeterIndex: (uCol) => 0 * UPSAMPLED_GRID + uCol,
+    perimeterX: (uCol) => uCol * UPSAMPLED_SPACING_M,
+    perimeterZ: () => 0,
+    perimeterCount: UPSAMPLED_GRID,
+    // Winding for outward -Z: see test "each wall's face normal points outward".
+    quadIndices: (baseTopA, baseBottomA, baseTopB, baseBottomB) => [
+      baseTopA, baseBottomA, baseBottomB,
+      baseTopA, baseBottomB, baseTopB,
+    ],
+    isVertical: false,
+  });
+  // North wall (z=256, faces +Z).
+  vCursor = emitWall({
+    perimeterIndex: (uCol) => (UPSAMPLED_GRID - 1) * UPSAMPLED_GRID + uCol,
+    perimeterX: (uCol) => uCol * UPSAMPLED_SPACING_M,
+    perimeterZ: () => (UPSAMPLED_GRID - 1) * UPSAMPLED_SPACING_M,
+    perimeterCount: UPSAMPLED_GRID,
+    // Reverse winding so normal flips to +Z.
+    quadIndices: (baseTopA, baseBottomA, baseTopB, baseBottomB) => [
+      baseTopA, baseTopB, baseBottomB,
+      baseTopA, baseBottomB, baseBottomA,
+    ],
+    isVertical: false,
+  });
+  // West wall (x=0, faces -X). Iterate by uRow.
+  vCursor = emitWall({
+    perimeterIndex: (uRow) => uRow * UPSAMPLED_GRID + 0,
+    perimeterX: () => 0,
+    perimeterZ: (uRow) => uRow * UPSAMPLED_SPACING_M,
+    perimeterCount: UPSAMPLED_GRID,
+    // Outward -X.
+    quadIndices: (baseTopA, baseBottomA, baseTopB, baseBottomB) => [
+      baseTopA, baseTopB, baseBottomB,
+      baseTopA, baseBottomB, baseBottomA,
+    ],
+    isVertical: true,
+  });
+  // East wall (x=256, faces +X).
+  vCursor = emitWall({
+    perimeterIndex: (uRow) => uRow * UPSAMPLED_GRID + (UPSAMPLED_GRID - 1),
+    perimeterX: () => (UPSAMPLED_GRID - 1) * UPSAMPLED_SPACING_M,
+    perimeterZ: (uRow) => uRow * UPSAMPLED_SPACING_M,
+    perimeterCount: UPSAMPLED_GRID,
+    // Reverse winding so normal flips to +X.
+    quadIndices: (baseTopA, baseBottomA, baseTopB, baseBottomB) => [
+      baseTopA, baseBottomA, baseBottomB,
+      baseTopA, baseBottomB, baseTopB,
+    ],
+    isVertical: true,
+  });
+
+  function emitWall(opts: {
+    perimeterIndex: (i: number) => number;
+    perimeterX: (i: number) => number;
+    perimeterZ: (i: number) => number;
+    perimeterCount: number;
+    quadIndices: (baseTopA: number, baseBottomA: number, baseTopB: number, baseBottomB: number) => number[];
+    isVertical: boolean;
+  }): number {
+    const walVertStart = vCursor;
+    for (let i = 0; i < opts.perimeterCount; i++) {
+      const topIdx = opts.perimeterIndex(i);
+      const x = opts.perimeterX(i);
+      const z = opts.perimeterZ(i);
+      const topY = upsampled[topIdx];
+
+      // Top-edge wall vertex
+      positions[vCursor * 3 + 0] = x;
+      positions[vCursor * 3 + 1] = topY;
+      positions[vCursor * 3 + 2] = z;
+      // Bottom-edge wall vertex (same X/Z, at floorY)
+      positions[(vCursor + 1) * 3 + 0] = x;
+      positions[(vCursor + 1) * 3 + 1] = floorY;
+      positions[(vCursor + 1) * 3 + 2] = z;
+
+      // Color: top mesh color at this perimeter vertex, multiplied by WALL_DIM.
+      // Same color for both top and bottom edge of the wall.
+      const topR = colors[topIdx * 3 + 0];
+      const topG = colors[topIdx * 3 + 1];
+      const topB = colors[topIdx * 3 + 2];
+      colors[vCursor * 3 + 0] = topR * WALL_DIM;
+      colors[vCursor * 3 + 1] = topG * WALL_DIM;
+      colors[vCursor * 3 + 2] = topB * WALL_DIM;
+      colors[(vCursor + 1) * 3 + 0] = topR * WALL_DIM;
+      colors[(vCursor + 1) * 3 + 1] = topG * WALL_DIM;
+      colors[(vCursor + 1) * 3 + 2] = topB * WALL_DIM;
+
+      vCursor += 2;
+    }
+    for (let i = 0; i < opts.perimeterCount - 1; i++) {
+      const baseTopA = walVertStart + i * 2;
+      const baseBottomA = baseTopA + 1;
+      const baseTopB = walVertStart + (i + 1) * 2;
+      const baseBottomB = baseTopB + 1;
+      const tri = opts.quadIndices(baseTopA, baseBottomA, baseTopB, baseBottomB);
+      for (let t = 0; t < tri.length; t++) indices[iIdx++] = tri[t];
+    }
+    return vCursor;
+  }
+
+  // ---- 3. Floor ----
+  const floorStart = TOP_VERTS + WALL_VERTS;
+  const REGION_END = (UPSAMPLED_GRID - 1) * UPSAMPLED_SPACING_M; // 256
+  const floorCorners: Array<[number, number, number]> = [
+    [0, floorY, 0],                     // sw
+    [REGION_END, floorY, 0],            // se
+    [0, floorY, REGION_END],            // nw
+    [REGION_END, floorY, REGION_END],   // ne
+  ];
+  for (let i = 0; i < 4; i++) {
+    const [fx, fy, fz] = floorCorners[i];
+    positions[(floorStart + i) * 3 + 0] = fx;
+    positions[(floorStart + i) * 3 + 1] = fy;
+    positions[(floorStart + i) * 3 + 2] = fz;
+    colors[(floorStart + i) * 3 + 0] = FLOOR_COLOR.r / 255;
+    colors[(floorStart + i) * 3 + 1] = FLOOR_COLOR.g / 255;
+    colors[(floorStart + i) * 3 + 2] = FLOOR_COLOR.b / 255;
+  }
+  // Two CCW triangles seen from -Y (below) so face normal points -Y.
+  // SW(0), SE(1), NW(2), NE(3). Looking from -Y: (sw, nw, ne) + (sw, ne, se).
+  indices[iIdx++] = floorStart + 0; indices[iIdx++] = floorStart + 2; indices[iIdx++] = floorStart + 3;
+  indices[iIdx++] = floorStart + 0; indices[iIdx++] = floorStart + 3; indices[iIdx++] = floorStart + 1;
+
+  const geometry = new BufferGeometry();
+  geometry.setAttribute("position", new Float32BufferAttribute(positions, 3));
+  geometry.setAttribute("color", new Float32BufferAttribute(colors, 3));
+  geometry.setIndex(new BufferAttribute(indices, 1));
+  geometry.computeVertexNormals();
+  return geometry;
+}
+
+/** Wall vertex color = top color * WALL_DIM (darker shaded side). */
+const WALL_DIM = 0.55;
+/** Floor face color (defensive coverage for low-orbit visibility). */
+const FLOOR_COLOR = { r: 60, g: 50, b: 40 };
+
+function topColorAt(
+  uRow: number,
+  uCol: number,
+  upsampled: Float32Array,
+  slopeGrid: Float32Array,
+  parcelMin: number,
+  mode: "elevation" | "slope",
+) {
+  const idx = uRow * UPSAMPLED_GRID + uCol;
+  if (mode === "elevation") {
+    return gradientColor(upsampled[idx] - parcelMin);
+  }
+  return slopeColor(slopeGrid[idx]);
+}
+```
+
+Use Edit. The function body grows substantially (from ~50 lines to ~150). The signature changes are: new params `floorY`, `mode`, `slopeGrid`; the body now emits walls and a floor in addition to the top mesh. The two new module-level constants (`WALL_DIM`, `FLOOR_COLOR`) and the inline helper `topColorAt` come below the function.
+
+- [ ] **Step 5: Run all geometry tests to verify they pass**
+
+```bash
+cd frontend && npx vitest run src/lib/parcelMap3D/geometry.test.ts
+```
+
+Expected: all tests pass. The total count should be ~31 (existing ~22 plus new computeSlopeGrid + new wall/floor + new mode-swap cases).
+
+If a wall-normal test fails, the winding for that wall is reversed — toggle the order of the two triangles in `quadIndices` for the affected wall (or swap pairs within a triangle). The test pinpoints which wall (`southAvg`, `northAvg`, `westAvg`, `eastAvg`) is wrong.
+
+- [ ] **Step 6: Per-task verification**
+
+```bash
+cd frontend && npm run build && npm test && npm run verify
+```
+
+Expected: build green (the new signature compiles, callers in `ParcelMap3D.tsx` will break — that's fixed in Task 5; for now, this task's verification skips Task 5's file by running the smaller per-file test first then the full suite which WILL surface a type error if anything else is wrong).
+
+If `npm test` reports `ParcelMap3D.test.tsx` failing because the 2-arg call to `buildHeightfieldGeometry` is now invalid, accept that failure — Task 5 fixes it. Document it in the per-task report. Do NOT update `ParcelMap3D.tsx` here.
+
+Actually: this DOES affect the build (tsc will fail on the 2-arg call site in `ParcelMap3D.tsx`). To keep this task atomically passing on its own, **temporarily update `ParcelMap3D.tsx`** to pass placeholder args:
+
+```tsx
+// Temporary, replaced cleanly in Task 5:
+return buildHeightfieldGeometry(
+  upsampledGrid, stats.parcelMin, bounds.rMin - 8, "elevation",
+  // Placeholder slope grid - Task 5 wires the real computeSlopeGrid memo.
+  new Float32Array(UPSAMPLED_GRID * UPSAMPLED_GRID),
+);
+```
+
+Where `UPSAMPLED_GRID` is imported alongside the existing imports. This keeps build green; Task 5 swaps the placeholder for the real `slopeGrid` memo + adds the color-mode toggle wiring.
+
+Use Edit on `ParcelMap3D.tsx` for this transitional change. Document it in the commit.
+
+- [ ] **Step 7: Commit and push**
+
+```bash
+git add frontend/src/lib/parcelMap3D/geometry.ts frontend/src/lib/parcelMap3D/geometry.test.ts frontend/src/components/auction/ParcelMap3D.tsx
+git commit -m "feat(frontend): heightfield walls + floor + slope grid helper"
+git push
+```
+
+The commit body should note: "ParcelMap3D temporarily passes elevation mode + placeholder slope grid; full wiring follows in the toggle task."
+
+---
+
+## Task 4: ParcelMap3DColorModeToggle component
+
+Pure presentational ARIA radio group. No localStorage, no state — the owning component wires `mode` and `onChange` from the hook.
+
+**Files:**
+- Create: `frontend/src/components/auction/ParcelMap3DColorModeToggle.tsx`
+- Test: `frontend/src/components/auction/ParcelMap3DColorModeToggle.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/components/auction/ParcelMap3DColorModeToggle.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ParcelMap3DColorModeToggle } from "./ParcelMap3DColorModeToggle";
+
+describe("ParcelMap3DColorModeToggle", () => {
+  it("renders an ARIA radio group with the correct aria-label", () => {
+    render(<ParcelMap3DColorModeToggle mode="elevation" onChange={() => {}} />);
+    const group = screen.getByRole("radiogroup", { name: "Color by" });
+    expect(group).toBeInTheDocument();
+  });
+
+  it("renders two radio buttons labelled Elevation and Slope", () => {
+    render(<ParcelMap3DColorModeToggle mode="elevation" onChange={() => {}} />);
+    expect(screen.getByRole("radio", { name: "Elevation" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Slope" })).toBeInTheDocument();
+  });
+
+  it("aria-checked reflects the current mode prop", () => {
+    const { rerender } = render(
+      <ParcelMap3DColorModeToggle mode="elevation" onChange={() => {}} />,
+    );
+    expect(screen.getByRole("radio", { name: "Elevation" })).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByRole("radio", { name: "Slope" })).toHaveAttribute("aria-checked", "false");
+    rerender(<ParcelMap3DColorModeToggle mode="slope" onChange={() => {}} />);
+    expect(screen.getByRole("radio", { name: "Elevation" })).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByRole("radio", { name: "Slope" })).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("clicking a radio fires onChange with the corresponding mode value", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<ParcelMap3DColorModeToggle mode="elevation" onChange={onChange} />);
+    await user.click(screen.getByRole("radio", { name: "Slope" }));
+    expect(onChange).toHaveBeenCalledWith("slope");
+  });
+
+  it("Arrow-Right from Elevation moves focus and selection to Slope", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<ParcelMap3DColorModeToggle mode="elevation" onChange={onChange} />);
+    const elev = screen.getByRole("radio", { name: "Elevation" });
+    elev.focus();
+    await user.keyboard("{ArrowRight}");
+    expect(onChange).toHaveBeenCalledWith("slope");
+  });
+
+  it("Arrow-Left from Slope wraps focus + selection back to Elevation", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<ParcelMap3DColorModeToggle mode="slope" onChange={onChange} />);
+    const slope = screen.getByRole("radio", { name: "Slope" });
+    slope.focus();
+    await user.keyboard("{ArrowLeft}");
+    expect(onChange).toHaveBeenCalledWith("elevation");
+  });
+
+  it("the active radio has tabIndex 0 and the inactive radio has tabIndex -1 (roving)", () => {
+    render(<ParcelMap3DColorModeToggle mode="elevation" onChange={() => {}} />);
+    expect(screen.getByRole("radio", { name: "Elevation" })).toHaveAttribute("tabindex", "0");
+    expect(screen.getByRole("radio", { name: "Slope" })).toHaveAttribute("tabindex", "-1");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd frontend && npx vitest run src/components/auction/ParcelMap3DColorModeToggle.test.tsx
+```
+
+Expected: all 7 tests fail with `Cannot find module './ParcelMap3DColorModeToggle'`.
+
+- [ ] **Step 3: Implement the toggle**
+
+Create `frontend/src/components/auction/ParcelMap3DColorModeToggle.tsx`:
+
+```tsx
+"use client";
+
+import { type KeyboardEvent } from "react";
+
+import { cn } from "@/lib/cn";
+import { type ParcelMap3DColorMode } from "@/hooks/useParcelMapColorMode";
+
+interface Props {
+  mode: ParcelMap3DColorMode;
+  onChange: (next: ParcelMap3DColorMode) => void;
+  className?: string;
+}
+
+const MODES: ReadonlyArray<{ value: ParcelMap3DColorMode; label: string }> = [
+  { value: "elevation", label: "Elevation" },
+  { value: "slope", label: "Slope" },
+];
+
+/**
+ * Inline button group for the 3D parcel-map color mode. ARIA radio group
+ * pattern (not tabs) -- the user is picking how to color the same scene, not
+ * which scene to render. Pure presentational; the owning component wires
+ * {@code mode} and {@code onChange} to {@link useParcelMapColorMode}.
+ *
+ * Spec: docs/superpowers/specs/2026-05-24-parcel-map-3d-slope-and-solid-design.md
+ */
+export function ParcelMap3DColorModeToggle({ mode, onChange, className }: Props) {
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+    const idx = MODES.findIndex((m) => m.value === mode);
+    if (idx === -1) return;
+    const delta = e.key === "ArrowRight" ? 1 : -1;
+    const next = MODES[(idx + delta + MODES.length) % MODES.length];
+    onChange(next.value);
+    // Focus follows selection so Arrow keys cycle continuously.
+    const group = e.currentTarget.parentElement;
+    group?.querySelector<HTMLButtonElement>(`button[data-mode="${next.value}"]`)?.focus();
+  };
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Color by"
+      className={cn(
+        "inline-flex gap-1 rounded-md border border-border-subtle bg-surface-raised p-1",
+        className,
+      )}
+    >
+      {MODES.map((m) => {
+        const selected = mode === m.value;
+        return (
+          <button
+            key={m.value}
+            type="button"
+            role="radio"
+            data-mode={m.value}
+            aria-checked={selected}
+            tabIndex={selected ? 0 : -1}
+            onClick={() => onChange(m.value)}
+            onKeyDown={handleKeyDown}
+            className={cn(
+              "px-2 py-1 text-xs font-medium transition-colors",
+              selected
+                ? "text-brand"
+                : "text-fg-muted hover:text-fg",
+            )}
+          >
+            {m.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd frontend && npx vitest run src/components/auction/ParcelMap3DColorModeToggle.test.tsx
+```
+
+Expected: all 7 tests pass.
+
+- [ ] **Step 5: Per-task verification**
+
+```bash
+cd frontend && npm run build && npm test && npm run verify
+```
+
+Expected: build green, full suite green, verify green.
+
+- [ ] **Step 6: Commit and push**
+
+```bash
+git add frontend/src/components/auction/ParcelMap3DColorModeToggle.tsx frontend/src/components/auction/ParcelMap3DColorModeToggle.test.tsx
+git commit -m "feat(frontend): parcel map 3D color mode toggle"
+git push
+```
+
+---
+
+## Task 5: Wire ParcelMap3D + open PR + merge
+
+Final task: wires the hook + toggle into `ParcelMap3D`, replaces the Task 3 placeholder slope grid with a real `useMemo`, opens and merges the PR.
+
+**Files:**
+- Modify: `frontend/src/components/auction/ParcelMap3D.tsx`
+- Modify: `frontend/src/components/auction/ParcelMap3D.test.tsx`
+
+- [ ] **Step 1: Update the failing test in `ParcelMap3D.test.tsx`**
+
+Open `frontend/src/components/auction/ParcelMap3D.test.tsx` and add a new case at the bottom of the `describe("ParcelMap3D", ...)` block. Use Edit. The new case asserts the toggle renders when scan data is available and that clicking it persists the new mode to localStorage:
+
+```tsx
+it("renders the color mode toggle once scan data is loaded, defaulting to elevation", async () => {
+  vi.spyOn(parcelScanApi, "getParcelScan").mockResolvedValue(scanPayload());
+  vi.spyOn(geometryModule, "isWebGLAvailable").mockReturnValue(true);
+  wrap(<ParcelMap3D publicId={publicId} />);
+  const group = await screen.findByRole("radiogroup", { name: "Color by" });
+  expect(group).toBeInTheDocument();
+  expect(screen.getByRole("radio", { name: "Elevation" })).toHaveAttribute("aria-checked", "true");
+  expect(screen.getByRole("radio", { name: "Slope" })).toHaveAttribute("aria-checked", "false");
+});
+
+it("hides the color mode toggle during the loading skeleton state", () => {
+  vi.spyOn(parcelScanApi, "getParcelScan").mockImplementation(() => new Promise(() => {}));
+  vi.spyOn(geometryModule, "isWebGLAvailable").mockReturnValue(true);
+  wrap(<ParcelMap3D publicId={publicId} />);
+  expect(screen.queryByRole("radiogroup", { name: "Color by" })).toBeNull();
+});
+
+it("clicking the Slope radio writes 'slope' to localStorage", async () => {
+  const user = userEvent.setup();
+  window.localStorage.clear();
+  vi.spyOn(parcelScanApi, "getParcelScan").mockResolvedValue(scanPayload());
+  vi.spyOn(geometryModule, "isWebGLAvailable").mockReturnValue(true);
+  wrap(<ParcelMap3D publicId={publicId} />);
+  const slope = await screen.findByRole("radio", { name: "Slope" });
+  await user.click(slope);
+  expect(window.localStorage.getItem("slpa:parcel-map:3d-color")).toBe("slope");
+});
+```
+
+If the test file does not already import `userEvent`, add this near the top:
+
+```tsx
+import userEvent from "@testing-library/user-event";
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd frontend && npx vitest run src/components/auction/ParcelMap3D.test.tsx
+```
+
+Expected: the three new cases fail (no radiogroup yet); the existing cases still pass.
+
+- [ ] **Step 3: Wire `useParcelMapColorMode` + slope grid + toggle into `ParcelMap3D.tsx`**
+
+Edit `frontend/src/components/auction/ParcelMap3D.tsx`:
+
+3a. Add imports near the existing imports block:
+
+```tsx
+import { useParcelMapColorMode } from "@/hooks/useParcelMapColorMode";
+import { ParcelMap3DColorModeToggle } from "./ParcelMap3DColorModeToggle";
+import {
+  // ... existing imports kept
+  computeSlopeGrid,
+} from "@/lib/parcelMap3D/geometry";
+```
+
+3b. Inside the component body, near the other hook calls (`useParcelScan`, etc.), add:
+
+```tsx
+const [colorMode, setColorMode] = useParcelMapColorMode();
+```
+
+3c. Add a memo for the slope grid right after the `upsampledGrid` memo:
+
+```tsx
+const slopeGrid = useMemo(() => {
+  if (!upsampledGrid) return null;
+  return computeSlopeGrid(upsampledGrid);
+}, [upsampledGrid]);
+```
+
+3d. Update the `meshGeometry` memo to use the real `slopeGrid`, the real `floorY`, and the current `colorMode`:
+
+```tsx
+const meshGeometry = useMemo(() => {
+  if (!upsampledGrid || !stats || !bounds || !slopeGrid) return null;
+  return buildHeightfieldGeometry(
+    upsampledGrid,
+    stats.parcelMin,
+    bounds.rMin - 8,
+    colorMode,
+    slopeGrid,
+  );
+}, [upsampledGrid, stats, bounds, colorMode, slopeGrid]);
+```
+
+3e. Add `slopeGrid` to the early-return check (the existing guard that rejects rendering when any memo is null):
+
+```tsx
+if (
+  isError || !data || !decoded || !stats || !bounds
+  || !meshGeometry || !perimeterPoints || !camera || !slopeGrid
+) {
+  return null;
+}
+```
+
+3f. Remove any `UPSAMPLED_GRID` import that was added in Task 3 for the placeholder — it's no longer needed.
+
+3g. Inside the wrapping `<div>` of the success-path render branch (the one with `role="img"`), add the toggle absolute-positioned top-right. Wrap the `<Canvas>` and the toggle in a relative container if not already:
+
+```tsx
+return (
+  <div
+    role="img"
+    aria-label="Interactive 3D region and parcel elevation map"
+    className={cn(
+      "relative aspect-square w-full max-w-[320px] bg-bg-subtle border border-border-subtle",
+      className,
+    )}
+  >
+    <Canvas>
+      {/* unchanged */}
+    </Canvas>
+    <div className="absolute top-2 right-2">
+      <ParcelMap3DColorModeToggle mode={colorMode} onChange={setColorMode} />
+    </div>
+  </div>
+);
+```
+
+The `relative` className is added to the wrapping `<div>` so the absolute-positioned toggle is positioned against it. If the wrapper already has positioning context, skip the `relative` addition.
+
+Use Edit for all sub-steps.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd frontend && npx vitest run src/components/auction/ParcelMap3D.test.tsx
+```
+
+Expected: all tests pass — the new toggle cases plus all the existing ones.
+
+- [ ] **Step 5: Full frontend verification**
+
+```bash
+cd frontend && npm run build && npm test && npm run lint && npm run verify
+```
+
+Expected: build green, full Vitest suite green (count grows by the new cases), ESLint clean, all four verify guards green.
+
+- [ ] **Step 6: Commit and push**
+
+```bash
+git add frontend/src/components/auction/ParcelMap3D.tsx frontend/src/components/auction/ParcelMap3D.test.tsx
+git commit -m "feat(frontend): wire color mode toggle + slope grid into ParcelMap3D"
+git push
+```
+
+- [ ] **Step 7: Open the PR `feat/parcel-map-3d-slope-and-solid` -> `dev`**
+
+```bash
+gh pr create --base dev --head feat/parcel-map-3d-slope-and-solid \
+  --title "feat(frontend): 3D parcel map slope mode + solid look" \
+  --body @- <<'EOF'
+Two enhancements to the parcel-map 3D view, plus a cascading color simplification.
+
+## What ships
+
+- **Slope-shaded color mode.** Inline button group inside the 3D view toggles between Elevation (existing) and Slope (new). Slope colors come from a closed-form finite-difference helper: flat = green, 45deg = red. Preference persists via localStorage (`slpa:parcel-map:3d-color`).
+- **Solid look.** Four extruded perimeter walls reach 8m below the lowest cell, wall color = terrain color * 0.55 (recolors in lockstep with the mode), bottom plane at `regionMin - 8m` in a neutral earth tone. Adds ~1k triangles to the existing ~33k.
+- **2-stop gradient.** Shared `gradientColor` helper switches from 3-stop (green/yellow/red) to smooth 2-stop (green/red). Both 2D map and 3D modes use the new gradient; the 2D legend simplifies to two stops and the `+4 m` axis label is removed.
+
+## Out of scope (tracked in #414)
+
+- Water plane at SL sea level.
+- Snapshot-as-ground-texture using `parcel.snapshotUrl`.
+- Parcel-specific walls (this PR adds REGION walls, not the listed-parcel-only walls noted in #414).
+
+## Verification
+
+- `npm run build && npm test && npm run lint && npm run verify` green locally.
+
+## Spec / plan
+
+- Spec: `docs/superpowers/specs/2026-05-24-parcel-map-3d-slope-and-solid-design.md`
+- Plan: `docs/superpowers/plans/2026-05-24-parcel-map-3d-slope-and-solid-plan.md`
+EOF
+```
+
+- [ ] **Step 8: Merge the PR into `dev`**
+
+```bash
+gh pr merge --merge feat/parcel-map-3d-slope-and-solid
+git checkout dev && git pull --ff-only
+```
+
+Do NOT touch the `dev` -> `main` PR — the user merges that themselves.
+
+---
+
+## Self-review
+
+**1. Spec coverage**
+
+| Spec section | Task(s) |
+|---|---|
+| §3.1 Inline button group placement | Task 4 (component), Task 5 (placement inside scene wrapper) |
+| §3.2 ARIA radio group | Task 4 (component implementation + tests) |
+| §3.3 localStorage persistence (`slpa:parcel-map:3d-color`, default "elevation", two-phase mount) | Task 2 (hook) |
+| §3.4 Toggle visibility gating | Task 5 (toggle only rendered in success-path branch + Step 1 test) |
+| §4.1 Shared 2-stop helper | Task 1 (colors.ts rewrite) |
+| §4.2 Elevation mode 2-stop gradient | Task 1 |
+| §4.3 Slope mode 2-stop gradient | Task 1 (slopeColor helper) |
+| §4.4 Slope value computation via finite difference | Task 3 (computeSlopeGrid) |
+| §4.5 2D map legend cascading update | Task 1 (ParcelMapLegend) |
+| §5.1 Floor depth (regionMin - 8m) | Task 3 (buildHeightfieldGeometry takes floorY; Task 5 passes `bounds.rMin - 8`) |
+| §5.2 Walls (4 sides, 128 quads each, top edge follows terrain, outward normals) | Task 3 (emitWall helper + tests) |
+| §5.3 Floor (4 verts, downward normal, fixed earth tone) | Task 3 (floor block + tests) |
+| §5.4 Geometry overhead | Task 3 (test asserts total vertex + index counts) |
+| §6 File list | Task list above matches 1:1 |
+| §7 Testing | Each task ships its own tests |
+| §8 Out of scope | PR body references #414 |
+| §10 Decision log | Implicit in implementation |
+
+All spec sections covered.
+
+**2. Placeholder scan**
+
+No `TBD`, `TODO`, `implement later`, or vague directives. Every step has an exact command or code block. The "temporarily pass placeholder slope grid" in Task 3 Step 6 is intentional scaffolding with a defined removal point in Task 5 Step 3f.
+
+**3. Type consistency**
+
+- `useParcelMapColorMode()` returns `[ParcelMap3DColorMode, (next: ParcelMap3DColorMode) => void]` in Task 2 implementation, Task 2 test, Task 4 import, and Task 5 wiring.
+- `ParcelMap3DColorMode = "elevation" | "slope"` consistent across hook, toggle, geometry.
+- `buildHeightfieldGeometry(upsampled, parcelMin, floorY, mode, slopeGrid)` signature consistent in Task 3 implementation, Task 3 test, Task 3 Step 6 placeholder, and Task 5 real wiring.
+- `computeSlopeGrid(upsampled): Float32Array` signature consistent in Task 3 implementation, Task 3 test, Task 5 memo.
+- `STORAGE_KEY = "slpa:parcel-map:3d-color"` consistent across hook, hook test, ParcelMap3D test.
+- Wall vertex layout (south, north, west, east in that order, pair ordering by perimeter index) consistent between Task 3 implementation comment block and Task 3 test wall-normal assertions.
+
+No drift.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-24-parcel-map-3d-slope-and-solid-plan.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-24-parcel-map-3d-slope-and-solid-design.md
+++ b/docs/superpowers/specs/2026-05-24-parcel-map-3d-slope-and-solid-design.md
@@ -1,0 +1,310 @@
+# Parcel Map 3D View - Slope Mode + Solid Look
+
+**Date:** 2026-05-24
+**Status:** Awaiting user review.
+**Builds on:** `docs/superpowers/specs/2026-05-24-parcel-map-3d-design.md` (the initial 3D view spec, now shipped).
+**Touches:** `docs/superpowers/specs/2026-05-24-parcel-map-frontend-design.md` (the shared 2D/3D color helper changes apply to both views).
+**Partially addresses:** [Issue #414](https://github.com/TheCodeLlama/slparcelauctions/issues/414) — adds region walls (not the parcel-specific walls originally noted there; those remain a separate enhancement).
+
+## 1. Goal
+
+Two related improvements to the parcel-map 3D view that address feedback from a visitor looking at a real listing:
+
+1. **Slope-shaded color mode.** Today the terrain is colored by elevation above the parcel's lowest point. A near-vertical cliff face sitting near the parcel's low point shows green, hiding the fact that it's unbuildable. Add an alternative color mode that colors by local slope angle (flat = green, 45° vertical = red), and let the visitor toggle between the two modes inline.
+
+2. **Solid look.** The terrain currently renders as a single top sheet, which looks like floating geometry. Add downward-extruded region walls and a bottom plane so the terrain reads as a solid chunk of land.
+
+Cascading change: the 2-stop simplification of the green-red gradient (no yellow midpoint) applies to both the 2D map and the 3D view, since they share `frontend/src/lib/parcelMap/colors.ts`.
+
+## 2. Architecture
+
+```
+ParcelMap3D (existing, "use client", default export)
+  uses:
+    useParcelScan(publicId)          (existing)
+    useParcelMapColorMode()          (NEW; localStorage-backed)
+  renders:
+    <Canvas>
+      <PerspectiveCamera ...>
+      <OrbitControls ...>
+      <ambientLight />
+      <directionalLight />
+      <mesh geometry={meshGeometry}>   <-- now includes top + walls + floor
+        <meshStandardMaterial vertexColors />
+      </mesh>
+      {perimeterPoints.length > 0 && (
+        <Line color="white" lineWidth={2} ... />    (existing parcel wireframe)
+      )}
+    </Canvas>
+    <ParcelMap3DColorModeToggle .../>  <-- NEW, top-right absolute, ARIA radio group
+```
+
+Backend is untouched. No new API calls. The same `useParcelScan` payload feeds both color modes.
+
+## 3. Color mode toggle (UI + persistence)
+
+### 3.1 Placement
+
+An inline button group floats top-right inside the 3D canvas wrapping `<div>`. Two buttons: `[Elevation] [Slope]`. The button group is hidden during the loading skeleton state and shown once scan data is available.
+
+```
++-- 3D canvas wrapper ---------------------------+
+|                                  [Elev][Slp]   |
+|                                                |
+|     [orbitable 3D terrain]                     |
+|                                                |
++------------------------------------------------+
+```
+
+### 3.2 ARIA pattern
+
+`role="radiogroup"` with `aria-label="Color by"`. Two child buttons with `role="radio"` and `aria-checked={true|false}`. This is NOT a tabs pattern — the user is choosing how to color the same scene, not which scene to render, so the tabs pattern (which requires a separate `role="tabpanel"` per option) is wrong. The radio-group pattern correctly models "pick one of N for an attribute of the current view."
+
+Keyboard nav: standard radio-group behavior — Tab focuses the group, Arrow keys cycle the selected option. Selecting via Arrow keys is enough; no separate Enter/Space activation needed (unlike tabs).
+
+### 3.3 Persistence
+
+- **Hook:** new `useParcelMapColorMode` in `frontend/src/hooks/useParcelMapColorMode.ts`. Mirrors `useParcelMapView` exactly.
+- **Storage key:** `slpa:parcel-map:3d-color`
+- **Values:** `"elevation" | "slope"`
+- **Default:** `"elevation"`
+- **Two-phase mount:** initial render returns the default on both server and client; `useEffect` reads the stored value on mount. Avoids hydration mismatch (the same lesson the original 3D PR learned the hard way; see `useParcelMapView.ts`'s JSDoc).
+- Junk values fall back to default.
+- localStorage errors are swallowed silently.
+- The setter writes through on every change.
+
+### 3.4 Visibility
+
+The toggle is mounted inside `ParcelMap3D`'s success-path render branch (the same branch that renders the `<Canvas>`). It's not rendered during:
+
+- The pending/skeleton state (no toggle to act on when there's no terrain).
+- The WebGL-fallback state (no 3D scene at all in that branch).
+- The `data === null` state (no scan available).
+
+## 4. Color mapping (both modes)
+
+### 4.1 Shared 2-stop helper
+
+`frontend/src/lib/parcelMap/colors.ts` swaps its 3-stop gradient for a 2-stop `lerp(green, red, t)` builder. Both `gradientColor` (existing, elevation mode) and `slopeColor` (new, slope mode) use it. `MAP_COLORS.yellow` is removed (it was only referenced by the now-deleted 3-stop logic).
+
+### 4.2 Elevation mode
+
+`gradientColor(deltaMeters)` becomes:
+
+```ts
+export function gradientColor(deltaMeters: number): Rgb {
+  const t = Math.min(1, Math.max(0, deltaMeters / 8));
+  return lerp(MAP_COLORS.green, MAP_COLORS.red, t);
+}
+```
+
+- `delta ≤ 0` -> green (parcel low point or below it)
+- `delta ≥ 8m` -> red (saturates; the "un-flattenable spread" SL terraforming limit)
+- In between: smooth lerp through olive/khaki tones (e.g. `delta = 4m` -> `rgb(~137, ~133, ~81)`)
+
+The visible result on the 2D map and the 3D view: same overall meaning (green = low, red = high) but no hard horizontal band at the 4m yellow midpoint.
+
+### 4.3 Slope mode
+
+```ts
+export function slopeColor(slopeRad: number): Rgb {
+  const t = Math.min(1, Math.max(0, slopeRad / (Math.PI / 4)));
+  return lerp(MAP_COLORS.green, MAP_COLORS.red, t);
+}
+```
+
+- `0` rad (flat) -> green
+- `π/4` rad (45°) -> red (saturates)
+- Steeper still reads red; the gradient doesn't waste range on theoretical 45-90° terrain that almost never occurs in SL
+
+45° is the practical "unbuildable" threshold in SL (houses and roads stop working comfortably above this). The user-meaningful cliff/walkable distinction lands cleanly in the gradient's bright transition zone.
+
+### 4.4 Slope-value computation
+
+Slope values come from a closed-form finite difference on the upsampled height grid, NOT from `computeVertexNormals` output. For each upsampled vertex `(uRow, uCol)`:
+
+```
+dhdx = (h[uRow,   uCol+1] - h[uRow,   uCol-1]) / (2 * UPSAMPLED_SPACING_M)
+dhdz = (h[uRow+1, uCol  ] - h[uRow-1, uCol  ]) / (2 * UPSAMPLED_SPACING_M)
+slopeRad = atan(sqrt(dhdx*dhdx + dhdz*dhdz))
+```
+
+Edges use one-sided differences (clamp-to-edge). The result is a 129x129 `Float32Array` of slope angles in radians, same indexing as the upsampled height grid.
+
+**Why finite-difference, not normals?** It's deterministic and easy to unit-test in isolation. It also decouples slope computation from the BufferGeometry lifecycle — we can compute slopes before building geometry, memoize them, and feed both top and wall coloring without juggling normal attributes.
+
+**New pure helper:** `computeSlopeGrid(upsampled: Float32Array): Float32Array` in `frontend/src/lib/parcelMap3D/geometry.ts`.
+
+### 4.5 2D map cascade
+
+`frontend/src/components/auction/ParcelMap.tsx` consumes `gradientColor` via the canvas paint pass and via the `ParcelMapLegend` subcomponent's CSS gradient. The cascading changes:
+
+- The canvas paint pass produces smooth green-to-red tones, no yellow band.
+- `ParcelMapLegend`'s CSS gradient becomes two stops (green at 0%, red at 100%) instead of three.
+- The `+4 m` midpoint label is removed from the legend's axis labels.
+- The legend explainer text remains — it still mentions the SL 4m terraforming raise/lower limit for context, just without a dedicated visual marker.
+
+The 2D map's dim-outside treatment, hover tooltip, focus cursor, and SW-first row flip are all unchanged.
+
+## 5. Solid mesh (walls + floor)
+
+### 5.1 Floor depth
+
+`floorY = regionMin - 8`, where `regionMin` comes from `computeRegionBounds(upsampled)` (the upsampled grid's min, not the raw grid). Eight meters below the lowest cell means a flat region still presents as a visible slab and a hilly region presents as a tall block, with predictable visual mass across listings.
+
+### 5.2 Walls
+
+Four perimeter walls, one per region edge:
+
+- **North wall** at `z = 256` (uRow = 128 row of upsampled grid)
+- **South wall** at `z = 0` (uRow = 0)
+- **East wall** at `x = 256` (uCol = 128)
+- **West wall** at `x = 0` (uCol = 0)
+
+Each wall is a strip of 128 quads, one between every pair of adjacent upsampled perimeter vertices. Top edge sits at the actual perimeter heightfield elevation (so the wall follows the terrain's bumpiness at its top edge — no fake flat band). Bottom edge sits at `floorY`. Geometry is added inline in `buildHeightfieldGeometry`.
+
+**Triangle winding:** each wall's triangles are wound so face normals point OUTWARD from the region center. Concretely:
+
+- North wall: face normal points `+Z`.
+- South wall: face normal points `-Z`.
+- East wall: face normal points `+X`.
+- West wall: face normal points `-X`.
+
+The regression test asserts the average face-normal direction per wall matches its expected outward axis.
+
+**Vertices:** the wall uses its own vertex entries (separate from the top mesh) so the per-wall vertex normals come out clean from `computeVertexNormals` without averaging into the top mesh's normals. The wall is visually flat-shaded along its vertical extent.
+
+**Per-vertex color:** at each perimeter point, the color is `terrainColorAt(uRow, uCol, mode) * 0.55`. Both top and bottom edge of the wall at that perimeter point share the same color, so the wall reads as a uniformly dimmed strip of the terrain material. When the user flips between elevation and slope mode, the wall recolors in lockstep with the top mesh.
+
+**Wall geometry totals:** 4 sides * 128 quads * 2 tris = 1,024 wall triangles, 4 sides * 2 (top + bottom) * 129 (vertices per perimeter row) = 1,032 wall vertices.
+
+### 5.3 Floor
+
+A single quad spanning the full region at `floorY`:
+
+- Vertices: `(0, floorY, 0)`, `(256, floorY, 0)`, `(0, floorY, 256)`, `(256, floorY, 256)`.
+- **Triangle winding:** CCW when viewed from below (`-Y` looking `+Y`), so the face normal points `-Y` (downward). The lit side faces down; only visible if the visitor orbits below the region (rare but supported by drei's OrbitControls).
+- **Color:** a fixed earth tone `rgb(60, 50, 40)`. The floor is rarely visible; this is defensive coverage for the low-orbit case.
+- 2 triangles, 4 vertices.
+
+### 5.4 Total geometry overhead
+
+Adds 1,026 triangles and 1,036 vertices to the existing ~33k-tri heightfield. Negligible on any modern GPU.
+
+## 6. Files
+
+**New:**
+
+| File | Responsibility |
+|---|---|
+| `frontend/src/hooks/useParcelMapColorMode.ts` | localStorage-backed color-mode state, two-phase mount. |
+| `frontend/src/hooks/useParcelMapColorMode.test.tsx` | Default, persistence, junk filter, SSR safety. |
+| `frontend/src/components/auction/ParcelMap3DColorModeToggle.tsx` | Inline button group, ARIA radio group, pure presentational. |
+| `frontend/src/components/auction/ParcelMap3DColorModeToggle.test.tsx` | Radio-group ARIA, click handling, keyboard nav. |
+
+**Modified:**
+
+| File | Change |
+|---|---|
+| `frontend/src/lib/parcelMap/colors.ts` | 3-stop -> 2-stop `gradientColor`; new `slopeColor`; drop `MAP_COLORS.yellow`. |
+| `frontend/src/lib/parcelMap/colors.test.ts` | Update midpoint expectations; add `slopeColor` cases. |
+| `frontend/src/lib/parcelMap3D/geometry.ts` | New `computeSlopeGrid`; extend `buildHeightfieldGeometry(upsampled, parcelMin, floorY, mode)`; emit walls + floor. |
+| `frontend/src/lib/parcelMap3D/geometry.test.ts` | New `computeSlopeGrid` tests; assert wall/floor vertex + index counts; assert wall outward normals; assert floor downward normal; assert mode swap produces different colors at the same vertex. |
+| `frontend/src/components/auction/ParcelMap.tsx` | `ParcelMapLegend` becomes 2-stop CSS gradient; drop `+4 m` mid label. |
+| `frontend/src/components/auction/ParcelMap3D.tsx` | Call `useParcelMapColorMode`; thread `colorMode` + `floorY` into `buildHeightfieldGeometry` memo; render `<ParcelMap3DColorModeToggle>` inside the scene wrapper. |
+| `frontend/src/components/auction/ParcelMap3D.test.tsx` | New case: toggling color mode rebuilds geometry / passes the new mode to the helper. |
+
+**Untouched:**
+
+- `frontend/src/components/auction/ParcelMapTabs.tsx` (the 2D/3D tab wrapper, separate concern).
+- `frontend/src/components/auction/ParcelMap3DSkeleton.tsx`.
+- `frontend/src/hooks/useParcelMapView.ts`.
+- All backend code.
+
+## 7. Testing
+
+### 7.1 colors
+
+- `gradientColor(0)` -> exact green.
+- `gradientColor(8)` -> exact red.
+- `gradientColor(4)` -> midpoint olive `rgb(~137, ~133, ~81)`.
+- `gradientColor(-1)` -> clamps to green.
+- `gradientColor(20)` -> clamps to red.
+- `slopeColor(0)` -> exact green.
+- `slopeColor(Math.PI / 4)` -> exact red.
+- `slopeColor(Math.PI / 8)` -> midpoint olive.
+- `slopeColor(Math.PI / 2)` -> clamps to red.
+
+### 7.2 computeSlopeGrid
+
+- Flat input (all elevations equal) -> all zeros.
+- Linear ramp in X (dh/dx = constant, dh/dz = 0) -> uniform `atan(dh/dx)` everywhere except a small tolerance at the edges from the one-sided difference.
+- Returns a `Float32Array` of length `UPSAMPLED_GRID * UPSAMPLED_GRID`.
+- Edge cells (uRow=0, uRow=128, uCol=0, uCol=128) use clamp-to-edge one-sided differences (no NaN, no out-of-bounds reads).
+
+### 7.3 buildHeightfieldGeometry (extended)
+
+Existing tests stay; the signature gains `floorY` and `mode` (`elevation` | `slope`):
+
+- Total vertex count = `UPSAMPLED_GRID^2 + 4 * 2 * UPSAMPLED_GRID + 4 = 17,677`. Total index count = `(UPSAMPLED_GRID - 1)^2 * 6 + 4 * (UPSAMPLED_GRID - 1) * 6 + 6 = 101,382`.
+- `mode = "elevation"` with flat input -> vertex 0 is green (existing assertion still holds; the 2-stop midpoint change doesn't move the green endpoint).
+- `mode = "slope"` with flat input -> vertex 0 is also green (zero slope).
+- Wall vertex at perimeter vertex (0, 0): both top and bottom share the same color, which equals the top mesh's vertex (0, 0) color * 0.55 (use `toBeCloseTo` on each rgb channel).
+- Wall outward normals: assert the average face-normal direction per wall is approximately the expected outward axis.
+- Floor face normal: assert the average is `(0, -1, 0)`.
+
+### 7.4 useParcelMapColorMode
+
+Mirrors `useParcelMapView.test.tsx` structure:
+
+- Returns `"elevation"` when localStorage is empty.
+- Returns `"slope"` when localStorage has `"slope"`.
+- Ignores junk -> falls back to `"elevation"`.
+- `setMode` writes to localStorage and updates returned state.
+- Two-phase mount: server-side `useState` initializer returns default; client `useEffect` reads stored value.
+
+### 7.5 ParcelMap3DColorModeToggle
+
+- Renders `role="radiogroup"` with `aria-label="Color by"`.
+- Both buttons have `role="radio"` and correct `aria-checked` for the current `mode` prop.
+- Clicking either button fires `onChange` with the right value.
+- Arrow-key navigation cycles `aria-checked` between the two options.
+
+### 7.6 ParcelMap3D
+
+Existing tests stay. Add:
+
+- When `colorMode` is `"slope"`, `buildHeightfieldGeometry` is called with `mode = "slope"` (mock the helper or assert via a wrapping spy).
+- Toggling the radio group via the rendered `<ParcelMap3DColorModeToggle>` triggers a re-render with the new mode.
+
+### 7.7 Manual
+
+- Switch between elevation and slope on a real parcel that has a visible cliff vs flat top. Slope mode should color the cliff red and the flat top green; elevation mode does the opposite for the same geometry.
+- Orbit below the region. The floor should be visible (lit) and the wall undersides should not show through.
+- Refresh between auctions: the saved color mode persists.
+
+## 8. Out of scope
+
+Tracked in [Issue #414](https://github.com/TheCodeLlama/slparcelauctions/issues/414):
+
+- **Water plane** at SL sea level (Y=20).
+- **Snapshot-as-ground-texture** using `parcel.snapshotUrl`.
+- **Parcel-specific walls** (extruding just the listed parcel's perimeter to the ground). This spec adds REGION walls, which addresses the "floating geometry" concern; parcel-specific walls remain a separate enhancement on the issue.
+
+Also explicitly not in this spec:
+
+- Saving the color mode per-auction or per-user (lives in localStorage; same shape as the 2D/3D tab choice).
+- Hover/click slope readout in the 3D view (still no per-vertex tooltip in 3D; the 2D view continues to own per-cell readouts).
+- Custom slope thresholds beyond the fixed 0-45° mapping.
+- Animated transitions between color modes.
+
+## 9. Decision log (2026-05-24)
+
+- **Toggle UI: inline button group.** Picked over extending the existing 2D/3D tab row because the slope/elevation choice is an attribute of the 3D view, not a separate view. Picked over a dropdown because two options don't need a select widget and the inline buttons are always visible during interaction.
+- **Slope scale: 0-45°.** Picked over 0-90° because most SL terrain falls in 0-45° and the 45° threshold is the practical "unbuildable" line. Picked over auto-scale because cross-parcel comparability matters.
+- **Wall coloring: darker variant of terrain * 0.55.** Picked over solid earth tone because the gradient continuity across top and walls reinforces "this is a chunk of the same material" without making real cliffs visually identical to the region cut edge.
+- **Floor depth: regionMin - 8m.** Picked over auto-proportional and sea-level because predictable visual mass across listings beats sculpted-but-inconsistent.
+- **Slope from finite difference, not normals.** Picked over reading `computeVertexNormals` output because finite difference is deterministic, easy to unit-test, and decouples slope computation from the BufferGeometry lifecycle.
+- **2-stop gradient (no yellow).** Applied to both 2D and 3D via the shared `colors.ts` helper. Picked over keeping the 3-stop for the 2D map because a single source of truth beats divergent behavior between views and the user explicitly asked for a smoother gradient.
+- **Color mode persistence: localStorage, key `slpa:parcel-map:3d-color`.** Same pattern as `slpa:parcel-map:view`. Default `"elevation"`.
+- **Region walls, not parcel walls.** The parcel-specific walls noted in issue #414 are a different effect (extruding just the listed parcel's perimeter); this spec addresses the "floating geometry" concern with the broader region-level extrusion. Parcel walls remain on the issue.

--- a/frontend/src/components/auction/ParcelMap.tsx
+++ b/frontend/src/components/auction/ParcelMap.tsx
@@ -312,14 +312,13 @@ function clamp(v: number, lo: number, hi: number): number {
 }
 
 function ParcelMapLegend() {
-  // Linear gradient mirroring the 3-stop gradient used in colors.ts:
+  // Linear gradient mirroring the 2-stop gradient used in colors.ts:
   //   green at delta=0 (parcel low point)
-  //   yellow at delta=4 m (SL terraforming raise/lower limit)
   //   red at delta=8+ m (un-flattenable spread)
   // RGB literals rather than #hex keep the no-hex-colors verify guard green.
   const stop = (c: { r: number; g: number; b: number }, pct: number) =>
     `rgb(${c.r}, ${c.g}, ${c.b}) ${pct}%`;
-  const gradient = `linear-gradient(to right, ${stop(MAP_COLORS.green, 0)}, ${stop(MAP_COLORS.yellow, 50)}, ${stop(MAP_COLORS.red, 100)})`;
+  const gradient = `linear-gradient(to right, ${stop(MAP_COLORS.green, 0)}, ${stop(MAP_COLORS.red, 100)})`;
   return (
     <div className="w-full max-w-[320px] flex flex-col gap-1">
       <div
@@ -329,7 +328,6 @@ function ParcelMapLegend() {
       />
       <div className="flex justify-between text-[10px] text-fg-muted">
         <span>0 m</span>
-        <span>+4 m</span>
         <span>+8 m+</span>
       </div>
       <p className="text-[10px] text-fg-muted">

--- a/frontend/src/components/auction/ParcelMap.tsx
+++ b/frontend/src/components/auction/ParcelMap.tsx
@@ -331,9 +331,9 @@ function ParcelMapLegend() {
         <span>+8 m+</span>
       </div>
       <p className="text-[10px] text-fg-muted">
-        Color = elevation above the parcel&apos;s lowest cell.
-        +4 m is the SL terraforming raise/lower limit; +8 m+ is
-        un-flattenable spread.
+        Color = elevation above the parcel&apos;s lowest cell. The gradient runs
+        from flat (0 m) to un-flattenable spread (8 m+); the SL terraforming
+        raise/lower limit is 4 m.
       </p>
     </div>
   );

--- a/frontend/src/components/auction/ParcelMap3D.test.tsx
+++ b/frontend/src/components/auction/ParcelMap3D.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
@@ -117,5 +118,33 @@ describe("ParcelMap3D", () => {
     expect(
       screen.getByRole("img", { name: /Interactive 3D region and parcel elevation map/ }),
     ).toBeInTheDocument();
+  });
+
+  it("renders the color mode toggle once scan data is loaded, defaulting to elevation", async () => {
+    vi.spyOn(parcelScanApi, "getParcelScan").mockResolvedValue(scanPayload());
+    vi.spyOn(geometryModule, "isWebGLAvailable").mockReturnValue(true);
+    wrap(<ParcelMap3D publicId={publicId} />);
+    const group = await screen.findByRole("radiogroup", { name: "Color by" });
+    expect(group).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Elevation" })).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByRole("radio", { name: "Slope" })).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("hides the color mode toggle during the loading skeleton state", () => {
+    vi.spyOn(parcelScanApi, "getParcelScan").mockImplementation(() => new Promise(() => {}));
+    vi.spyOn(geometryModule, "isWebGLAvailable").mockReturnValue(true);
+    wrap(<ParcelMap3D publicId={publicId} />);
+    expect(screen.queryByRole("radiogroup", { name: "Color by" })).toBeNull();
+  });
+
+  it("clicking the Slope radio writes 'slope' to localStorage", async () => {
+    const user = userEvent.setup();
+    window.localStorage.clear();
+    vi.spyOn(parcelScanApi, "getParcelScan").mockResolvedValue(scanPayload());
+    vi.spyOn(geometryModule, "isWebGLAvailable").mockReturnValue(true);
+    wrap(<ParcelMap3D publicId={publicId} />);
+    const slope = await screen.findByRole("radio", { name: "Slope" });
+    await user.click(slope);
+    expect(window.localStorage.getItem("slpa:parcel-map:3d-color")).toBe("slope");
   });
 });

--- a/frontend/src/components/auction/ParcelMap3D.tsx
+++ b/frontend/src/components/auction/ParcelMap3D.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/cn";
 import { useParcelScan } from "@/hooks/useParcelScan";
 import { decodeBase64ToBytes } from "@/lib/parcelMap/encoding";
 import {
+  UPSAMPLED_GRID,
   bicubicUpsample,
   buildHeightfieldGeometry,
   buildPerimeterPoints,
@@ -93,9 +94,17 @@ export default function ParcelMap3D({
   }, [upsampledGrid]);
 
   const meshGeometry = useMemo(() => {
-    if (!upsampledGrid || !stats) return null;
-    return buildHeightfieldGeometry(upsampledGrid, stats.parcelMin);
-  }, [upsampledGrid, stats]);
+    if (!upsampledGrid || !stats || !bounds) return null;
+    // Transitional placeholder. Task 5 wires the real slopeGrid memo and
+    // colorMode hook, replacing the empty array + hardcoded "elevation".
+    return buildHeightfieldGeometry(
+      upsampledGrid,
+      stats.parcelMin,
+      bounds.rMin - 8,
+      "elevation",
+      new Float32Array(UPSAMPLED_GRID * UPSAMPLED_GRID),
+    );
+  }, [upsampledGrid, stats, bounds]);
 
   // Dispose GPU-side BufferGeometry when it changes or the component unmounts
   // to prevent memory leaks.

--- a/frontend/src/components/auction/ParcelMap3D.tsx
+++ b/frontend/src/components/auction/ParcelMap3D.tsx
@@ -6,19 +6,21 @@ import { Line, OrbitControls, PerspectiveCamera } from "@react-three/drei";
 
 import { cn } from "@/lib/cn";
 import { useParcelScan } from "@/hooks/useParcelScan";
+import { useParcelMapColorMode } from "@/hooks/useParcelMapColorMode";
 import { decodeBase64ToBytes } from "@/lib/parcelMap/encoding";
 import {
-  UPSAMPLED_GRID,
   bicubicUpsample,
   buildHeightfieldGeometry,
   buildPerimeterPoints,
   computeCameraDefaults,
   computeParcelStats,
   computeRegionBounds,
+  computeSlopeGrid,
   decodeElevationGrid,
   isWebGLAvailable,
 } from "@/lib/parcelMap3D/geometry";
 import { ParcelMap3DSkeleton } from "./ParcelMap3DSkeleton";
+import { ParcelMap3DColorModeToggle } from "./ParcelMap3DColorModeToggle";
 
 interface Props {
   publicId: string;
@@ -56,6 +58,7 @@ export default function ParcelMap3D({
       typeof window !== "undefined" &&
       window.matchMedia("(prefers-reduced-motion: reduce)").matches,
   );
+  const [colorMode, setColorMode] = useParcelMapColorMode();
 
   useEffect(() => {
     if (!webglOk) onWebGLUnavailable?.();
@@ -83,6 +86,11 @@ export default function ParcelMap3D({
     return bicubicUpsample(rawGrid);
   }, [rawGrid]);
 
+  const slopeGrid = useMemo(() => {
+    if (!upsampledGrid) return null;
+    return computeSlopeGrid(upsampledGrid);
+  }, [upsampledGrid]);
+
   const stats = useMemo(() => {
     if (!decoded || !rawGrid) return null;
     return computeParcelStats(decoded.layoutCells, rawGrid);
@@ -94,17 +102,15 @@ export default function ParcelMap3D({
   }, [upsampledGrid]);
 
   const meshGeometry = useMemo(() => {
-    if (!upsampledGrid || !stats || !bounds) return null;
-    // Transitional placeholder. Task 5 wires the real slopeGrid memo and
-    // colorMode hook, replacing the empty array + hardcoded "elevation".
+    if (!upsampledGrid || !stats || !bounds || !slopeGrid) return null;
     return buildHeightfieldGeometry(
       upsampledGrid,
       stats.parcelMin,
       bounds.rMin - 8,
-      "elevation",
-      new Float32Array(UPSAMPLED_GRID * UPSAMPLED_GRID),
+      colorMode,
+      slopeGrid,
     );
-  }, [upsampledGrid, stats, bounds]);
+  }, [upsampledGrid, stats, bounds, colorMode, slopeGrid]);
 
   // Dispose GPU-side BufferGeometry when it changes or the component unmounts
   // to prevent memory leaks.
@@ -139,7 +145,7 @@ export default function ParcelMap3D({
   if (isPending) return <ParcelMap3DSkeleton className={className} />;
   if (
     isError || !data || !decoded || !stats || !bounds
-    || !meshGeometry || !perimeterPoints || !camera
+    || !meshGeometry || !perimeterPoints || !camera || !slopeGrid
   ) {
     return null;
   }
@@ -149,7 +155,7 @@ export default function ParcelMap3D({
       role="img"
       aria-label="Interactive 3D region and parcel elevation map"
       className={cn(
-        "aspect-square w-full max-w-[320px] bg-bg-subtle border border-border-subtle",
+        "relative aspect-square w-full max-w-[320px] bg-bg-subtle border border-border-subtle",
         className,
       )}
     >
@@ -183,6 +189,9 @@ export default function ParcelMap3D({
           />
         )}
       </Canvas>
+      <div className="absolute top-2 right-2">
+        <ParcelMap3DColorModeToggle mode={colorMode} onChange={setColorMode} />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/auction/ParcelMap3DColorModeToggle.test.tsx
+++ b/frontend/src/components/auction/ParcelMap3DColorModeToggle.test.tsx
@@ -44,6 +44,7 @@ describe("ParcelMap3DColorModeToggle", () => {
     elev.focus();
     await user.keyboard("{ArrowRight}");
     expect(onChange).toHaveBeenCalledWith("slope");
+    expect(screen.getByRole("radio", { name: "Slope" })).toHaveFocus();
   });
 
   it("Arrow-Left from Slope wraps focus + selection back to Elevation", async () => {
@@ -54,6 +55,7 @@ describe("ParcelMap3DColorModeToggle", () => {
     slope.focus();
     await user.keyboard("{ArrowLeft}");
     expect(onChange).toHaveBeenCalledWith("elevation");
+    expect(screen.getByRole("radio", { name: "Elevation" })).toHaveFocus();
   });
 
   it("the active radio has tabIndex 0 and the inactive radio has tabIndex -1 (roving)", () => {

--- a/frontend/src/components/auction/ParcelMap3DColorModeToggle.test.tsx
+++ b/frontend/src/components/auction/ParcelMap3DColorModeToggle.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ParcelMap3DColorModeToggle } from "./ParcelMap3DColorModeToggle";
+
+describe("ParcelMap3DColorModeToggle", () => {
+  it("renders an ARIA radio group with the correct aria-label", () => {
+    render(<ParcelMap3DColorModeToggle mode="elevation" onChange={() => {}} />);
+    const group = screen.getByRole("radiogroup", { name: "Color by" });
+    expect(group).toBeInTheDocument();
+  });
+
+  it("renders two radio buttons labelled Elevation and Slope", () => {
+    render(<ParcelMap3DColorModeToggle mode="elevation" onChange={() => {}} />);
+    expect(screen.getByRole("radio", { name: "Elevation" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Slope" })).toBeInTheDocument();
+  });
+
+  it("aria-checked reflects the current mode prop", () => {
+    const { rerender } = render(
+      <ParcelMap3DColorModeToggle mode="elevation" onChange={() => {}} />,
+    );
+    expect(screen.getByRole("radio", { name: "Elevation" })).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByRole("radio", { name: "Slope" })).toHaveAttribute("aria-checked", "false");
+    rerender(<ParcelMap3DColorModeToggle mode="slope" onChange={() => {}} />);
+    expect(screen.getByRole("radio", { name: "Elevation" })).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByRole("radio", { name: "Slope" })).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("clicking a radio fires onChange with the corresponding mode value", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<ParcelMap3DColorModeToggle mode="elevation" onChange={onChange} />);
+    await user.click(screen.getByRole("radio", { name: "Slope" }));
+    expect(onChange).toHaveBeenCalledWith("slope");
+  });
+
+  it("Arrow-Right from Elevation moves focus and selection to Slope", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<ParcelMap3DColorModeToggle mode="elevation" onChange={onChange} />);
+    const elev = screen.getByRole("radio", { name: "Elevation" });
+    elev.focus();
+    await user.keyboard("{ArrowRight}");
+    expect(onChange).toHaveBeenCalledWith("slope");
+  });
+
+  it("Arrow-Left from Slope wraps focus + selection back to Elevation", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<ParcelMap3DColorModeToggle mode="slope" onChange={onChange} />);
+    const slope = screen.getByRole("radio", { name: "Slope" });
+    slope.focus();
+    await user.keyboard("{ArrowLeft}");
+    expect(onChange).toHaveBeenCalledWith("elevation");
+  });
+
+  it("the active radio has tabIndex 0 and the inactive radio has tabIndex -1 (roving)", () => {
+    render(<ParcelMap3DColorModeToggle mode="elevation" onChange={() => {}} />);
+    expect(screen.getByRole("radio", { name: "Elevation" })).toHaveAttribute("tabindex", "0");
+    expect(screen.getByRole("radio", { name: "Slope" })).toHaveAttribute("tabindex", "-1");
+  });
+});

--- a/frontend/src/components/auction/ParcelMap3DColorModeToggle.tsx
+++ b/frontend/src/components/auction/ParcelMap3DColorModeToggle.tsx
@@ -5,7 +5,7 @@ import { type KeyboardEvent } from "react";
 import { cn } from "@/lib/cn";
 import { type ParcelMap3DColorMode } from "@/hooks/useParcelMapColorMode";
 
-interface Props {
+export interface ParcelMap3DColorModeToggleProps {
   mode: ParcelMap3DColorMode;
   onChange: (next: ParcelMap3DColorMode) => void;
   className?: string;
@@ -24,7 +24,7 @@ const MODES: ReadonlyArray<{ value: ParcelMap3DColorMode; label: string }> = [
  *
  * Spec: docs/superpowers/specs/2026-05-24-parcel-map-3d-slope-and-solid-design.md
  */
-export function ParcelMap3DColorModeToggle({ mode, onChange, className }: Props) {
+export function ParcelMap3DColorModeToggle({ mode, onChange, className }: ParcelMap3DColorModeToggleProps) {
   const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
     if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
     e.preventDefault();
@@ -60,7 +60,8 @@ export function ParcelMap3DColorModeToggle({ mode, onChange, className }: Props)
             onClick={() => onChange(m.value)}
             onKeyDown={handleKeyDown}
             className={cn(
-              "px-2 py-1 text-xs font-medium transition-colors",
+              "px-2 py-1 text-xs font-medium transition-colors rounded",
+              "focus:outline-none focus-visible:ring-1 focus-visible:ring-brand",
               selected
                 ? "text-brand"
                 : "text-fg-muted hover:text-fg",

--- a/frontend/src/components/auction/ParcelMap3DColorModeToggle.tsx
+++ b/frontend/src/components/auction/ParcelMap3DColorModeToggle.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { type KeyboardEvent } from "react";
+
+import { cn } from "@/lib/cn";
+import { type ParcelMap3DColorMode } from "@/hooks/useParcelMapColorMode";
+
+interface Props {
+  mode: ParcelMap3DColorMode;
+  onChange: (next: ParcelMap3DColorMode) => void;
+  className?: string;
+}
+
+const MODES: ReadonlyArray<{ value: ParcelMap3DColorMode; label: string }> = [
+  { value: "elevation", label: "Elevation" },
+  { value: "slope", label: "Slope" },
+];
+
+/**
+ * Inline button group for the 3D parcel-map color mode. ARIA radio group
+ * pattern (not tabs) -- the user is picking how to color the same scene, not
+ * which scene to render. Pure presentational; the owning component wires
+ * {@code mode} and {@code onChange} to {@link useParcelMapColorMode}.
+ *
+ * Spec: docs/superpowers/specs/2026-05-24-parcel-map-3d-slope-and-solid-design.md
+ */
+export function ParcelMap3DColorModeToggle({ mode, onChange, className }: Props) {
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+    const idx = MODES.findIndex((m) => m.value === mode);
+    if (idx === -1) return;
+    const delta = e.key === "ArrowRight" ? 1 : -1;
+    const next = MODES[(idx + delta + MODES.length) % MODES.length];
+    onChange(next.value);
+    // Focus follows selection so Arrow keys cycle continuously.
+    const group = e.currentTarget.parentElement;
+    group?.querySelector<HTMLButtonElement>(`button[data-mode="${next.value}"]`)?.focus();
+  };
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Color by"
+      className={cn(
+        "inline-flex gap-1 rounded-md border border-border-subtle bg-surface-raised p-1",
+        className,
+      )}
+    >
+      {MODES.map((m) => {
+        const selected = mode === m.value;
+        return (
+          <button
+            key={m.value}
+            type="button"
+            role="radio"
+            data-mode={m.value}
+            aria-checked={selected}
+            tabIndex={selected ? 0 : -1}
+            onClick={() => onChange(m.value)}
+            onKeyDown={handleKeyDown}
+            className={cn(
+              "px-2 py-1 text-xs font-medium transition-colors",
+              selected
+                ? "text-brand"
+                : "text-fg-muted hover:text-fg",
+            )}
+          >
+            {m.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useParcelMapColorMode.test.tsx
+++ b/frontend/src/hooks/useParcelMapColorMode.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useParcelMapColorMode } from "./useParcelMapColorMode";
+
+const STORAGE_KEY = "slpa:parcel-map:3d-color";
+
+describe("useParcelMapColorMode", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns 'elevation' when localStorage is empty", () => {
+    const { result } = renderHook(() => useParcelMapColorMode());
+    expect(result.current[0]).toBe("elevation");
+  });
+
+  it("returns 'slope' when localStorage already holds 'slope'", () => {
+    window.localStorage.setItem(STORAGE_KEY, "slope");
+    const { result } = renderHook(() => useParcelMapColorMode());
+    expect(result.current[0]).toBe("slope");
+  });
+
+  it("ignores junk values and falls back to 'elevation'", () => {
+    window.localStorage.setItem(STORAGE_KEY, "asdf");
+    const { result } = renderHook(() => useParcelMapColorMode());
+    expect(result.current[0]).toBe("elevation");
+  });
+
+  it("setMode writes to localStorage and updates returned state", () => {
+    const { result } = renderHook(() => useParcelMapColorMode());
+    act(() => result.current[1]("slope"));
+    expect(result.current[0]).toBe("slope");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("slope");
+  });
+
+  it("setMode back to 'elevation' updates both state and storage", () => {
+    window.localStorage.setItem(STORAGE_KEY, "slope");
+    const { result } = renderHook(() => useParcelMapColorMode());
+    act(() => result.current[1]("elevation"));
+    expect(result.current[0]).toBe("elevation");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("elevation");
+  });
+});

--- a/frontend/src/hooks/useParcelMapColorMode.ts
+++ b/frontend/src/hooks/useParcelMapColorMode.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export type ParcelMap3DColorMode = "elevation" | "slope";
+
+const STORAGE_KEY = "slpa:parcel-map:3d-color";
+const DEFAULT_MODE: ParcelMap3DColorMode = "elevation";
+
+function readStoredMode(): ParcelMap3DColorMode {
+  if (typeof window === "undefined") return DEFAULT_MODE;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === "elevation" || raw === "slope") return raw;
+    return DEFAULT_MODE;
+  } catch {
+    // localStorage can throw in privacy modes or quota-exceeded scenarios.
+    return DEFAULT_MODE;
+  }
+}
+
+/**
+ * localStorage-backed color-mode choice for the parcel-map 3D view. Returns
+ * the current mode and a setter that mirrors writes to localStorage.
+ *
+ * SSR-safe via a two-phase mount: the initial render returns DEFAULT_MODE on
+ * BOTH the server pass and the client hydration pass, so the markup matches
+ * and React does not warn about a hydration mismatch. After hydration the
+ * useEffect runs, reads the stored value, and re-renders if it differs. A
+ * naive useState lazy initializer would read localStorage during the client
+ * hydration pass and produce different HTML than the server, causing a
+ * mismatch warning whenever a returning visitor has "slope" stored. Mirrors
+ * {@link useParcelMapView}.
+ */
+export function useParcelMapColorMode(): [
+  ParcelMap3DColorMode,
+  (next: ParcelMap3DColorMode) => void,
+] {
+  const [mode, setMode] = useState<ParcelMap3DColorMode>(DEFAULT_MODE);
+
+  // Deliberate two-phase mount: see JSDoc above. Lint rules that flag
+  // setState-in-effect do not model SSR hydration, so the suppression is
+  // load-bearing here.
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    setMode(readStoredMode());
+  }, []);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  const update = useCallback((next: ParcelMap3DColorMode) => {
+    setMode(next);
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // localStorage write can throw under quota or privacy modes; swallow
+      // so the in-session mode change still takes effect.
+    }
+  }, []);
+
+  return [mode, update];
+}

--- a/frontend/src/lib/parcelMap/colors.test.ts
+++ b/frontend/src/lib/parcelMap/colors.test.ts
@@ -1,40 +1,72 @@
 import { describe, it, expect } from "vitest";
-import { gradientColor, dimOutside, MAP_COLORS } from "./colors";
+import { gradientColor, slopeColor, dimOutside, MAP_COLORS } from "./colors";
 
-describe("gradientColor", () => {
+describe("gradientColor (2-stop green->red)", () => {
   it("returns solid green when delta <= 0", () => {
     expect(gradientColor(-2)).toEqual(MAP_COLORS.green);
     expect(gradientColor(0)).toEqual(MAP_COLORS.green);
   });
 
-  it("returns yellow at delta = 4 (terraforming limit)", () => {
-    expect(gradientColor(4)).toEqual(MAP_COLORS.yellow);
-  });
-
-  it("returns red at delta = 8 (un-flattenable spread)", () => {
+  it("returns solid red when delta >= 8", () => {
     expect(gradientColor(8)).toEqual(MAP_COLORS.red);
-  });
-
-  it("returns solid red when delta > 8", () => {
     expect(gradientColor(12)).toEqual(MAP_COLORS.red);
   });
 
-  it("lerps green->yellow at delta = 2 (midpoint of first segment)", () => {
+  it("lerps green->red linearly at the midpoint (delta = 4 m)", () => {
     const g = MAP_COLORS.green;
-    const y = MAP_COLORS.yellow;
-    const mid = gradientColor(2);
-    expect(mid.r).toBeCloseTo((g.r + y.r) / 2, 0);
-    expect(mid.g).toBeCloseTo((g.g + y.g) / 2, 0);
-    expect(mid.b).toBeCloseTo((g.b + y.b) / 2, 0);
+    const r = MAP_COLORS.red;
+    const mid = gradientColor(4);
+    expect(mid.r).toBeCloseTo((g.r + r.r) / 2, 0);
+    expect(mid.g).toBeCloseTo((g.g + r.g) / 2, 0);
+    expect(mid.b).toBeCloseTo((g.b + r.b) / 2, 0);
   });
 
-  it("lerps yellow->red at delta = 6 (midpoint of second segment)", () => {
-    const y = MAP_COLORS.yellow;
+  it("lerps green->red at delta = 2 m (25% of the way)", () => {
+    const g = MAP_COLORS.green;
     const r = MAP_COLORS.red;
-    const mid = gradientColor(6);
-    expect(mid.r).toBeCloseTo((y.r + r.r) / 2, 0);
-    expect(mid.g).toBeCloseTo((y.g + r.g) / 2, 0);
-    expect(mid.b).toBeCloseTo((y.b + r.b) / 2, 0);
+    const t = 0.25;
+    const c = gradientColor(2);
+    expect(c.r).toBeCloseTo(g.r + (r.r - g.r) * t, 0);
+    expect(c.g).toBeCloseTo(g.g + (r.g - g.g) * t, 0);
+    expect(c.b).toBeCloseTo(g.b + (r.b - g.b) * t, 0);
+  });
+
+  it("lerps green->red at delta = 6 m (75% of the way)", () => {
+    const g = MAP_COLORS.green;
+    const r = MAP_COLORS.red;
+    const t = 0.75;
+    const c = gradientColor(6);
+    expect(c.r).toBeCloseTo(g.r + (r.r - g.r) * t, 0);
+    expect(c.g).toBeCloseTo(g.g + (r.g - g.g) * t, 0);
+    expect(c.b).toBeCloseTo(g.b + (r.b - g.b) * t, 0);
+  });
+});
+
+describe("slopeColor (2-stop green->red, 0..45 deg)", () => {
+  it("returns solid green at flat (0 rad)", () => {
+    expect(slopeColor(0)).toEqual(MAP_COLORS.green);
+  });
+
+  it("returns solid red at 45 deg (Math.PI / 4 rad)", () => {
+    expect(slopeColor(Math.PI / 4)).toEqual(MAP_COLORS.red);
+  });
+
+  it("saturates at red for slopes above 45 deg", () => {
+    expect(slopeColor(Math.PI / 2)).toEqual(MAP_COLORS.red);
+    expect(slopeColor(Math.PI)).toEqual(MAP_COLORS.red);
+  });
+
+  it("clamps to green for negative slopes (defensive)", () => {
+    expect(slopeColor(-0.1)).toEqual(MAP_COLORS.green);
+  });
+
+  it("lerps green->red linearly at half scale (22.5 deg = Math.PI / 8)", () => {
+    const g = MAP_COLORS.green;
+    const r = MAP_COLORS.red;
+    const c = slopeColor(Math.PI / 8);
+    expect(c.r).toBeCloseTo((g.r + r.r) / 2, 0);
+    expect(c.g).toBeCloseTo((g.g + r.g) / 2, 0);
+    expect(c.b).toBeCloseTo((g.b + r.b) / 2, 0);
   });
 });
 

--- a/frontend/src/lib/parcelMap/colors.ts
+++ b/frontend/src/lib/parcelMap/colors.ts
@@ -46,7 +46,11 @@ export function gradientColor(deltaMeters: number): Rgb {
   return lerp(MAP_COLORS.green, MAP_COLORS.red, t);
 }
 
-/** Per-vertex color from a local slope angle in radians (0..pi/2). */
+/**
+ * Per-vertex color from a local slope angle in radians. Gradient maps the
+ * 0..pi/4 (0..45 deg) range; inputs above pi/4 saturate to red, inputs
+ * below 0 clamp to green.
+ */
 export function slopeColor(slopeRad: number): Rgb {
   if (slopeRad <= 0) return { ...MAP_COLORS.green };
   if (slopeRad >= SLOPE_RED_RAD) return { ...MAP_COLORS.red };

--- a/frontend/src/lib/parcelMap/colors.ts
+++ b/frontend/src/lib/parcelMap/colors.ts
@@ -1,18 +1,26 @@
 /**
  * Pure gradient + dim math for the parcel map. No DOM, no React.
  *
- * Gradient anchors are pinned to SL terraforming semantics:
- *   delta = 0         green   - the parcel's lowest cell (the reference)
- *   delta = 4 m       yellow  - the per-parcel raise/lower limit
- *   delta = 8 m       red     - un-flattenable spread (>8 m can't be levelled)
- *   delta > 8 m       red     - saturated
+ * Two color helpers feed the heatmap rendering:
  *
- * Linear lerp between anchors. Outside-the-parcel cells are dimmed toward
- * neutral gray (60% toward gray) so the parcel pops visually.
+ *   gradientColor(deltaMeters)
+ *     Elevation above the parcel's lowest cell. 2-stop lerp:
+ *       delta <= 0   -> green
+ *       delta >= 8m  -> red (un-flattenable spread)
+ *       in between, smooth linear interpolation through olive/khaki tones.
+ *
+ *   slopeColor(slopeRad)
+ *     Local terrain slope in radians. 2-stop lerp:
+ *       0 rad           -> green (flat)
+ *       Math.PI / 4 rad -> red (45 deg, practical SL unbuildable threshold)
+ *       steeper still reads red.
+ *
+ * Outside-parcel cells in the 2D view are dimmed toward neutral gray (60%
+ * toward gray) so the parcel pops visually.
  *
  * Colors are rgb triples (not hex) to keep the no-hex-colors verify guard
- * happy. The RGB values reference Tailwind's green-500 / yellow-500 / red-500
- * / cyan-400 for visual consistency with the rest of the app.
+ * happy. The RGB values reference Tailwind's green-500 / red-500 / cyan-400
+ * for visual consistency with the rest of the app.
  */
 export interface Rgb {
   r: number;
@@ -22,22 +30,28 @@ export interface Rgb {
 
 export const MAP_COLORS = {
   green: { r: 34, g: 197, b: 94 }, // Tailwind green-500
-  yellow: { r: 234, g: 179, b: 8 }, // Tailwind yellow-500
   red: { r: 239, g: 68, b: 68 }, // Tailwind red-500
   cyan: { r: 34, g: 211, b: 238 }, // Tailwind cyan-400 (boundary outline)
   neutral: { r: 120, g: 120, b: 120 }, // dim target
 } as const;
 
+const SLOPE_RED_RAD = Math.PI / 4; // 45 deg saturation point
+const ELEVATION_RED_M = 8; // 8m above parcel min saturates to red
+
 /** Per-cell color from an elevation delta (cell elevation - parcel min). */
 export function gradientColor(deltaMeters: number): Rgb {
   if (deltaMeters <= 0) return { ...MAP_COLORS.green };
-  if (deltaMeters >= 8) return { ...MAP_COLORS.red };
-  if (deltaMeters <= 4) {
-    const t = deltaMeters / 4;
-    return lerp(MAP_COLORS.green, MAP_COLORS.yellow, t);
-  }
-  const t = (deltaMeters - 4) / 4;
-  return lerp(MAP_COLORS.yellow, MAP_COLORS.red, t);
+  if (deltaMeters >= ELEVATION_RED_M) return { ...MAP_COLORS.red };
+  const t = deltaMeters / ELEVATION_RED_M;
+  return lerp(MAP_COLORS.green, MAP_COLORS.red, t);
+}
+
+/** Per-vertex color from a local slope angle in radians (0..pi/2). */
+export function slopeColor(slopeRad: number): Rgb {
+  if (slopeRad <= 0) return { ...MAP_COLORS.green };
+  if (slopeRad >= SLOPE_RED_RAD) return { ...MAP_COLORS.red };
+  const t = slopeRad / SLOPE_RED_RAD;
+  return lerp(MAP_COLORS.green, MAP_COLORS.red, t);
 }
 
 /** Dim a per-cell color 60% toward neutral gray. */

--- a/frontend/src/lib/parcelMap3D/geometry.test.ts
+++ b/frontend/src/lib/parcelMap3D/geometry.test.ts
@@ -8,10 +8,20 @@ import {
   computeCameraDefaults,
   computeParcelStats,
   computeRegionBounds,
+  computeSlopeGrid,
   decodeElevationGrid,
   isWebGLAvailable,
   sampleUpsampled,
 } from "./geometry";
+
+const TOP_VERTS = UPSAMPLED_GRID * UPSAMPLED_GRID;
+const TOP_INDICES = (UPSAMPLED_GRID - 1) * (UPSAMPLED_GRID - 1) * 6;
+const WALL_VERTS = 4 * 2 * UPSAMPLED_GRID;
+const WALL_INDICES = 4 * (UPSAMPLED_GRID - 1) * 6;
+const FLOOR_VERTS = 4;
+const FLOOR_INDICES = 6;
+const TOTAL_VERTS = TOP_VERTS + WALL_VERTS + FLOOR_VERTS;
+const TOTAL_INDICES = TOP_INDICES + WALL_INDICES + FLOOR_INDICES;
 
 function layoutWith(setCells: Array<[number, number]>): Uint8Array {
   const bytes = new Uint8Array(512);
@@ -26,6 +36,12 @@ function heightsAll(value: number): Uint8Array {
   const b = new Uint8Array(4096);
   b.fill(value);
   return b;
+}
+
+function flatScene() {
+  const upsampled = bicubicUpsample(decodeElevationGrid(heightsAll(0), 22, 0.5));
+  const slope = computeSlopeGrid(upsampled);
+  return { upsampled, slope, parcelMin: 22, floorY: 14 };
 }
 
 describe("decodeElevationGrid", () => {
@@ -53,7 +69,6 @@ describe("bicubicUpsample", () => {
   });
 
   it("preserves sample values at upsampled vertices that coincide with original samples", () => {
-    // At 2x upsample, original (row, col) maps to upsampled (2*row, 2*col).
     const input = new Float32Array(64 * 64);
     input[10 * 64 + 20] = 100;
     const out = bicubicUpsample(input);
@@ -62,12 +77,9 @@ describe("bicubicUpsample", () => {
 
   it("smoothly interpolates between two adjacent samples", () => {
     const input = new Float32Array(64 * 64);
-    // Step: row 10 col 5 = 0, row 10 col 6 = 10.
     input[10 * 64 + 5] = 0;
     input[10 * 64 + 6] = 10;
     const out = bicubicUpsample(input);
-    // Midpoint between cols 5 and 6 in upsampled space is col index 11
-    // (2*5 + 1). With Catmull-Rom it should be roughly 5 (smooth midpoint).
     const mid = out[20 * UPSAMPLED_GRID + 11];
     expect(mid).toBeGreaterThan(2);
     expect(mid).toBeLessThan(8);
@@ -102,7 +114,7 @@ describe("computeParcelStats", () => {
     const h = new Uint8Array(4096);
     h[10 * 64 + 10] = 0;
     h[10 * 64 + 11] = 10;
-    h[20 * 64 + 20] = 100; // outside parcel
+    h[20 * 64 + 20] = 100;
     const layout = layoutWith([[10, 10], [10, 11]]);
     const stats = computeParcelStats(layout, decodeElevationGrid(h, 22, 0.5))!;
     expect(stats.parcelCellCount).toBe(2);
@@ -111,58 +123,47 @@ describe("computeParcelStats", () => {
   });
 });
 
-describe("buildHeightfieldGeometry", () => {
-  it("produces UPSAMPLED_GRID^2 vertices and (UPSAMPLED_GRID-1)^2 * 2 triangles", () => {
+describe("computeSlopeGrid", () => {
+  it("returns a Float32Array of length UPSAMPLED_GRID^2", () => {
     const upsampled = bicubicUpsample(decodeElevationGrid(heightsAll(0), 22, 0.5));
-    const geom = buildHeightfieldGeometry(upsampled, 22);
-    expect(geom.getAttribute("position").count).toBe(UPSAMPLED_GRID * UPSAMPLED_GRID);
-    expect(geom.getAttribute("color").count).toBe(UPSAMPLED_GRID * UPSAMPLED_GRID);
-    expect(geom.index!.count).toBe((UPSAMPLED_GRID - 1) * (UPSAMPLED_GRID - 1) * 6);
+    const slope = computeSlopeGrid(upsampled);
+    expect(slope).toBeInstanceOf(Float32Array);
+    expect(slope.length).toBe(UPSAMPLED_GRID * UPSAMPLED_GRID);
   });
 
-  it("vertex 0 (SW corner) sits at world (0, baseMeters, 0)", () => {
-    const upsampled = bicubicUpsample(decodeElevationGrid(heightsAll(0), 22, 0.5));
-    const geom = buildHeightfieldGeometry(upsampled, 22);
-    const pos = geom.getAttribute("position");
-    expect(pos.getX(0)).toBe(0);
-    expect(pos.getY(0)).toBeCloseTo(22.0);
-    expect(pos.getZ(0)).toBe(0);
+  it("returns all zeros for a flat input", () => {
+    const upsampled = new Float32Array(UPSAMPLED_GRID * UPSAMPLED_GRID).fill(25);
+    const slope = computeSlopeGrid(upsampled);
+    for (const s of slope) expect(s).toBeCloseTo(0, 6);
   });
 
-  it("colors vertex 0 with green-500 when its elevation equals parcelMin", () => {
-    const upsampled = bicubicUpsample(decodeElevationGrid(heightsAll(0), 22, 0.5));
-    const geom = buildHeightfieldGeometry(upsampled, 22);
-    const colors = geom.getAttribute("color");
-    expect(colors.getX(0)).toBeCloseTo(34 / 255);
-    expect(colors.getY(0)).toBeCloseTo(197 / 255);
-    expect(colors.getZ(0)).toBeCloseTo(94 / 255);
+  it("returns a uniform non-zero slope for a constant ramp in X", () => {
+    // h(x, z) = x / 4 -> dh/dx = 0.25, dh/dz = 0 -> slope = atan(0.25)
+    const upsampled = new Float32Array(UPSAMPLED_GRID * UPSAMPLED_GRID);
+    for (let uRow = 0; uRow < UPSAMPLED_GRID; uRow++) {
+      for (let uCol = 0; uCol < UPSAMPLED_GRID; uCol++) {
+        upsampled[uRow * UPSAMPLED_GRID + uCol] = (uCol * 2) / 4;
+      }
+    }
+    const slope = computeSlopeGrid(upsampled);
+    const interior = slope[64 * UPSAMPLED_GRID + 64];
+    expect(interior).toBeCloseTo(Math.atan(0.25), 4);
   });
 
-  it("produces upward-facing vertex normals (terrain points +Y on average)", () => {
-    // Use a varying (not flat) input so vertex normals are computed from
-    // genuine face normals, not degenerate zero-area triangles at edges.
-    const heights = new Uint8Array(4096);
-    for (let i = 0; i < heights.length; i++) heights[i] = i % 50;
-    const upsampled = bicubicUpsample(decodeElevationGrid(heights, 22, 0.5));
-    const stats = computeParcelStats(
-      layoutWith([[10, 10]]), decodeElevationGrid(heights, 22, 0.5),
-    )!;
-    const geom = buildHeightfieldGeometry(upsampled, stats.parcelMin);
-    const normals = geom.getAttribute("normal");
-    let sumY = 0;
-    for (let i = 0; i < normals.count; i++) sumY += normals.getY(i);
-    const avgY = sumY / normals.count;
-    // Any positive average proves the winding is correct. Flat terrain
-    // would give avgY = 1; rolling terrain will be lower but still well
-    // above 0. With bad (reversed) winding this value would be negative.
-    expect(avgY).toBeGreaterThan(0.3);
+  it("uses clamp-to-edge one-sided differences at the boundary (no NaN)", () => {
+    const upsampled = new Float32Array(UPSAMPLED_GRID * UPSAMPLED_GRID);
+    for (let i = 0; i < upsampled.length; i++) upsampled[i] = i % 7;
+    const slope = computeSlopeGrid(upsampled);
+    for (const s of slope) {
+      expect(Number.isFinite(s)).toBe(true);
+      expect(s).toBeGreaterThanOrEqual(0);
+    }
   });
 });
 
 describe("sampleUpsampled", () => {
   it("samples upsampled grid at world (x, z) coordinates with bilinear fallback", () => {
     const upsampled = new Float32Array(UPSAMPLED_GRID * UPSAMPLED_GRID).fill(30);
-    // World cell-edge (col=10) sits at x = 40m, which maps to upsampled col 20.
     expect(sampleUpsampled(upsampled, 40, 40)).toBeCloseTo(30);
   });
 });
@@ -170,9 +171,7 @@ describe("sampleUpsampled", () => {
 describe("buildPerimeterPoints", () => {
   it("returns 8 endpoints (4 edges * 2 endpoints) for a single isolated parcel cell", () => {
     const upsampled = bicubicUpsample(decodeElevationGrid(heightsAll(0), 22, 0.5));
-    const points = buildPerimeterPoints(
-      layoutWith([[10, 10]]), upsampled,
-    );
+    const points = buildPerimeterPoints(layoutWith([[10, 10]]), upsampled);
     expect(points.length).toBe(8);
     expect(points[0]).toHaveLength(3);
   });
@@ -184,7 +183,6 @@ describe("buildPerimeterPoints", () => {
     ]);
     const upsampled = bicubicUpsample(decodeElevationGrid(heightsAll(0), 22, 0.5));
     const allPoints = buildPerimeterPoints(layout, upsampled);
-    // 4 outer cells each have 3 outward edges; center has 0. Total endpoints = 24.
     expect(allPoints.length).toBe(24);
   });
 
@@ -220,5 +218,150 @@ describe("UPSAMPLE_FACTOR", () => {
 describe("isWebGLAvailable", () => {
   it("returns a boolean without throwing", () => {
     expect(typeof isWebGLAvailable()).toBe("boolean");
+  });
+});
+
+describe("buildHeightfieldGeometry (top + walls + floor)", () => {
+  it("produces TOTAL_VERTS vertices and TOTAL_INDICES indices", () => {
+    const { upsampled, slope, parcelMin, floorY } = flatScene();
+    const geom = buildHeightfieldGeometry(
+      upsampled, parcelMin, floorY, "elevation", slope,
+    );
+    expect(geom.getAttribute("position").count).toBe(TOTAL_VERTS);
+    expect(geom.getAttribute("color").count).toBe(TOTAL_VERTS);
+    expect(geom.index!.count).toBe(TOTAL_INDICES);
+  });
+
+  it("vertex 0 (SW corner of top mesh) sits at world (0, baseMeters, 0)", () => {
+    const { upsampled, slope, parcelMin, floorY } = flatScene();
+    const geom = buildHeightfieldGeometry(
+      upsampled, parcelMin, floorY, "elevation", slope,
+    );
+    const pos = geom.getAttribute("position");
+    expect(pos.getX(0)).toBe(0);
+    expect(pos.getY(0)).toBeCloseTo(22.0);
+    expect(pos.getZ(0)).toBe(0);
+  });
+
+  it("colors top vertex 0 with green-500 when elevation equals parcelMin", () => {
+    const { upsampled, slope, parcelMin, floorY } = flatScene();
+    const geom = buildHeightfieldGeometry(
+      upsampled, parcelMin, floorY, "elevation", slope,
+    );
+    const colors = geom.getAttribute("color");
+    expect(colors.getX(0)).toBeCloseTo(34 / 255);
+    expect(colors.getY(0)).toBeCloseTo(197 / 255);
+    expect(colors.getZ(0)).toBeCloseTo(94 / 255);
+  });
+
+  it("top mesh produces upward-facing vertex normals (avg Y > 0.3)", () => {
+    const heights = new Uint8Array(4096);
+    for (let i = 0; i < heights.length; i++) heights[i] = i % 50;
+    const raw = decodeElevationGrid(heights, 22, 0.5);
+    const upsampled = bicubicUpsample(raw);
+    const slope = computeSlopeGrid(upsampled);
+    const stats = computeParcelStats(layoutWith([[10, 10]]), raw)!;
+    const bounds = computeRegionBounds(upsampled);
+    const geom = buildHeightfieldGeometry(
+      upsampled, stats.parcelMin, bounds.rMin - 8, "elevation", slope,
+    );
+    const normals = geom.getAttribute("normal");
+    let sumY = 0;
+    for (let i = 0; i < TOP_VERTS; i++) sumY += normals.getY(i);
+    expect(sumY / TOP_VERTS).toBeGreaterThan(0.3);
+  });
+
+  it("each wall's face normal points outward from region center", () => {
+    const { upsampled, slope, parcelMin, floorY } = flatScene();
+    const geom = buildHeightfieldGeometry(
+      upsampled, parcelMin, floorY, "elevation", slope,
+    );
+    const normals = geom.getAttribute("normal");
+    const PER_WALL = 2 * UPSAMPLED_GRID;
+    function avgNormal(startVtx: number) {
+      let x = 0, y = 0, z = 0;
+      for (let i = 0; i < PER_WALL; i++) {
+        x += normals.getX(startVtx + i);
+        y += normals.getY(startVtx + i);
+        z += normals.getZ(startVtx + i);
+      }
+      return [x / PER_WALL, y / PER_WALL, z / PER_WALL];
+    }
+    const southAvg = avgNormal(TOP_VERTS + 0 * PER_WALL);
+    const northAvg = avgNormal(TOP_VERTS + 1 * PER_WALL);
+    const westAvg = avgNormal(TOP_VERTS + 2 * PER_WALL);
+    const eastAvg = avgNormal(TOP_VERTS + 3 * PER_WALL);
+    expect(southAvg[2]).toBeLessThan(-0.5);
+    expect(northAvg[2]).toBeGreaterThan(0.5);
+    expect(westAvg[0]).toBeLessThan(-0.5);
+    expect(eastAvg[0]).toBeGreaterThan(0.5);
+  });
+
+  it("floor face normal points -Y (downward)", () => {
+    const { upsampled, slope, parcelMin, floorY } = flatScene();
+    const geom = buildHeightfieldGeometry(
+      upsampled, parcelMin, floorY, "elevation", slope,
+    );
+    const normals = geom.getAttribute("normal");
+    const floorStart = TOP_VERTS + WALL_VERTS;
+    let sumY = 0;
+    for (let i = 0; i < FLOOR_VERTS; i++) sumY += normals.getY(floorStart + i);
+    expect(sumY / FLOOR_VERTS).toBeCloseTo(-1, 1);
+  });
+
+  it("wall vertex color = top vertex color at same X/Z, multiplied by 0.55 (top + bottom edge match)", () => {
+    const { upsampled, slope, parcelMin, floorY } = flatScene();
+    const geom = buildHeightfieldGeometry(
+      upsampled, parcelMin, floorY, "elevation", slope,
+    );
+    const colors = geom.getAttribute("color");
+    const topR = colors.getX(0);
+    const topG = colors.getY(0);
+    const topB = colors.getZ(0);
+    const southStart = TOP_VERTS;
+    const wallTopR = colors.getX(southStart);
+    const wallBottomR = colors.getX(southStart + 1);
+    expect(wallTopR).toBeCloseTo(topR * 0.55, 4);
+    expect(wallBottomR).toBeCloseTo(topR * 0.55, 4);
+    expect(colors.getY(southStart)).toBeCloseTo(topG * 0.55, 4);
+    expect(colors.getZ(southStart)).toBeCloseTo(topB * 0.55, 4);
+  });
+
+  it("floor vertex color is the fixed earth tone rgb(60, 50, 40)", () => {
+    const { upsampled, slope, parcelMin, floorY } = flatScene();
+    const geom = buildHeightfieldGeometry(
+      upsampled, parcelMin, floorY, "elevation", slope,
+    );
+    const colors = geom.getAttribute("color");
+    const floorStart = TOP_VERTS + WALL_VERTS;
+    expect(colors.getX(floorStart)).toBeCloseTo(60 / 255, 4);
+    expect(colors.getY(floorStart)).toBeCloseTo(50 / 255, 4);
+    expect(colors.getZ(floorStart)).toBeCloseTo(40 / 255, 4);
+  });
+
+  it("mode swap (elevation -> slope) produces different top colors on a sloped input", () => {
+    const h = new Uint8Array(4096);
+    for (let row = 0; row < 64; row++) {
+      for (let col = 0; col < 64; col++) {
+        h[row * 64 + col] = col * 2;
+      }
+    }
+    const raw = decodeElevationGrid(h, 22, 0.5);
+    const upsampled = bicubicUpsample(raw);
+    const slope = computeSlopeGrid(upsampled);
+    const stats = computeParcelStats(layoutWith([[0, 0]]), raw)!;
+    const bounds = computeRegionBounds(upsampled);
+    const floorY = bounds.rMin - 8;
+    const elevGeom = buildHeightfieldGeometry(
+      upsampled, stats.parcelMin, floorY, "elevation", slope,
+    );
+    const slopeGeom = buildHeightfieldGeometry(
+      upsampled, stats.parcelMin, floorY, "slope", slope,
+    );
+    const elevColor0 = elevGeom.getAttribute("color");
+    const slopeColor0 = slopeGeom.getAttribute("color");
+    const elevR = elevColor0.getX(0);
+    const slopeR = slopeColor0.getX(0);
+    expect(slopeR).not.toBeCloseTo(elevR, 2);
   });
 });

--- a/frontend/src/lib/parcelMap3D/geometry.ts
+++ b/frontend/src/lib/parcelMap3D/geometry.ts
@@ -4,7 +4,7 @@ import {
   Float32BufferAttribute,
 } from "three";
 
-import { gradientColor } from "@/lib/parcelMap/colors";
+import { gradientColor, slopeColor } from "@/lib/parcelMap/colors";
 import { isCellInParcel } from "@/lib/parcelMap/encoding";
 
 const GRID = 64;
@@ -123,6 +123,44 @@ export function bicubicUpsample(grid: Float32Array): Float32Array {
   return out;
 }
 
+/**
+ * Closed-form finite-difference slope at every upsampled vertex. Returns a
+ * {@link UPSAMPLED_GRID} squared Float32Array of slope angles in radians
+ * (0 = flat, pi/2 = vertical). Edges use one-sided differences (clamp-to-edge);
+ * interior vertices use centered differences.
+ *
+ *   dhdx = (h[uRow,   uCol+1] - h[uRow,   uCol-1]) / (2 * UPSAMPLED_SPACING_M)
+ *   dhdz = (h[uRow+1, uCol  ] - h[uRow-1, uCol  ]) / (2 * UPSAMPLED_SPACING_M)
+ *   slope = atan(sqrt(dhdx*dhdx + dhdz*dhdz))
+ *
+ * Pure math; safe to memoize via {@code useMemo}.
+ */
+export function computeSlopeGrid(upsampled: Float32Array): Float32Array {
+  const out = new Float32Array(UPSAMPLED_GRID * UPSAMPLED_GRID);
+  const inv2 = 1 / (2 * UPSAMPLED_SPACING_M);
+  const invEdge = 1 / UPSAMPLED_SPACING_M;
+  for (let uRow = 0; uRow < UPSAMPLED_GRID; uRow++) {
+    const rowNorth = Math.min(UPSAMPLED_GRID - 1, uRow + 1);
+    const rowSouth = Math.max(0, uRow - 1);
+    const rowSpanIsCentered = rowNorth - rowSouth === 2;
+    for (let uCol = 0; uCol < UPSAMPLED_GRID; uCol++) {
+      const colEast = Math.min(UPSAMPLED_GRID - 1, uCol + 1);
+      const colWest = Math.max(0, uCol - 1);
+      const colSpanIsCentered = colEast - colWest === 2;
+      const dhdx =
+        (upsampled[uRow * UPSAMPLED_GRID + colEast] -
+          upsampled[uRow * UPSAMPLED_GRID + colWest]) *
+        (colSpanIsCentered ? inv2 : invEdge);
+      const dhdz =
+        (upsampled[rowNorth * UPSAMPLED_GRID + uCol] -
+          upsampled[rowSouth * UPSAMPLED_GRID + uCol]) *
+        (rowSpanIsCentered ? inv2 : invEdge);
+      out[uRow * UPSAMPLED_GRID + uCol] = Math.atan(Math.sqrt(dhdx * dhdx + dhdz * dhdz));
+    }
+  }
+  return out;
+}
+
 /** Min and max elevation across the (raw or upsampled) elevation grid. */
 export function computeRegionBounds(grid: Float32Array): RegionBounds {
   let min = Number.POSITIVE_INFINITY;
@@ -162,27 +200,51 @@ export function computeParcelStats(
 
 /**
  * Build the heightfield mesh as a single indexed {@link BufferGeometry}.
- * 129x129 vertices on a regular grid, two CCW triangles per quad. Vertex
- * colors come from {@code gradientColor(elev - parcelMin)} so the gradient
- * interpolates smoothly across triangle interiors. No walls -- the terrain
- * is a continuous surface.
+ * Includes the top surface (129x129 vertices, smooth heightfield), four
+ * extruded perimeter walls reaching down to {@code floorY}, and a bottom
+ * floor quad at {@code floorY}. Vertex colors come from one of two helpers
+ * depending on {@code mode}: elevation (delta from parcelMin) or slope (rad).
+ * Walls reuse the perimeter top color multiplied by {@link WALL_DIM}; both
+ * top and bottom edges of each wall share the same color. Floor uses a
+ * fixed neutral earth tone.
  *
- * Coordinate system:
- *   X = uCol * UPSAMPLED_SPACING_M (east, +X)
- *   Y = upsampled[uRow * UPSAMPLED_GRID + uCol]
- *   Z = uRow * UPSAMPLED_SPACING_M (north, +Z, "north is +Z")
+ * Vertex layout (used by tests asserting positions/colors/normals by index):
+ *   [0 .. TOP_VERTS)              top mesh, row-major (uRow * UPSAMPLED_GRID + uCol)
+ *   [TOP_VERTS .. +PER_WALL)      south wall, pairs of (top-edge, bottom-edge) by uCol
+ *   [+PER_WALL .. +2*PER_WALL)    north wall, same pair ordering by uCol
+ *   [+2*PER_WALL .. +3*PER_WALL)  west wall, pairs by uRow
+ *   [+3*PER_WALL .. +4*PER_WALL)  east wall, pairs by uRow
+ *   [TOP_VERTS + WALL_VERTS ..)   floor (4 vertices, SW SE NW NE)
+ *
+ * Wall triangle winding is CCW from outside the region so face normals
+ * point outward (south=-Z, north=+Z, west=-X, east=+X). Floor winding is
+ * CCW from below so face normal points -Y.
  */
 export function buildHeightfieldGeometry(
   upsampled: Float32Array,
   parcelMin: number,
+  floorY: number,
+  mode: "elevation" | "slope",
+  slopeGrid: Float32Array,
 ): BufferGeometry {
-  const vertexCount = UPSAMPLED_GRID * UPSAMPLED_GRID;
-  const quadCount = (UPSAMPLED_GRID - 1) * (UPSAMPLED_GRID - 1);
+  const TOP_VERTS = UPSAMPLED_GRID * UPSAMPLED_GRID;
+  const QUAD_COUNT = (UPSAMPLED_GRID - 1) * (UPSAMPLED_GRID - 1);
+  const TOP_INDICES = QUAD_COUNT * 6;
+  const PER_WALL_VERTS = 2 * UPSAMPLED_GRID;
+  const PER_WALL_INDICES = (UPSAMPLED_GRID - 1) * 6;
+  const WALL_VERTS = 4 * PER_WALL_VERTS;
+  const WALL_INDICES = 4 * PER_WALL_INDICES;
+  const FLOOR_VERTS = 4;
+  const FLOOR_INDICES = 6;
 
-  const positions = new Float32Array(vertexCount * 3);
-  const colors = new Float32Array(vertexCount * 3);
-  const indices = new Uint32Array(quadCount * 6);
+  const totalVerts = TOP_VERTS + WALL_VERTS + FLOOR_VERTS;
+  const totalIndices = TOP_INDICES + WALL_INDICES + FLOOR_INDICES;
 
+  const positions = new Float32Array(totalVerts * 3);
+  const colors = new Float32Array(totalVerts * 3);
+  const indices = new Uint32Array(totalIndices);
+
+  // ---- 1. Top surface ----
   for (let uRow = 0; uRow < UPSAMPLED_GRID; uRow++) {
     for (let uCol = 0; uCol < UPSAMPLED_GRID; uCol++) {
       const vIdx = uRow * UPSAMPLED_GRID + uCol;
@@ -192,13 +254,12 @@ export function buildHeightfieldGeometry(
       positions[vIdx * 3 + 0] = x;
       positions[vIdx * 3 + 1] = y;
       positions[vIdx * 3 + 2] = z;
-      const c = gradientColor(y - parcelMin);
+      const c = topColorAt(uRow, uCol, upsampled, slopeGrid, parcelMin, mode);
       colors[vIdx * 3 + 0] = c.r / 255;
       colors[vIdx * 3 + 1] = c.g / 255;
       colors[vIdx * 3 + 2] = c.b / 255;
     }
   }
-
   let iIdx = 0;
   for (let uRow = 0; uRow < UPSAMPLED_GRID - 1; uRow++) {
     for (let uCol = 0; uCol < UPSAMPLED_GRID - 1; uCol++) {
@@ -206,14 +267,133 @@ export function buildHeightfieldGeometry(
       const se = sw + 1;
       const nw = sw + UPSAMPLED_GRID;
       const ne = nw + 1;
-      // Two CCW triangles when viewed from +Y so face normals point up.
-      // Quick check: (ne - sw) cross (se - sw) = (2,0,2) cross (2,0,0)
-      // = (0, +4, 0) for a unit quad. +Y is up. computeVertexNormals
-      // averages face normals so vertex normals follow.
       indices[iIdx++] = sw; indices[iIdx++] = ne; indices[iIdx++] = se;
       indices[iIdx++] = sw; indices[iIdx++] = nw; indices[iIdx++] = ne;
     }
   }
+
+  // ---- 2. Walls (south, north, west, east in this order) ----
+  let vCursor = TOP_VERTS;
+
+  function emitWall(opts: {
+    perimeterIndex: (i: number) => number;
+    perimeterX: (i: number) => number;
+    perimeterZ: (i: number) => number;
+    perimeterCount: number;
+    quadIndices: (
+      baseTopA: number, baseBottomA: number,
+      baseTopB: number, baseBottomB: number,
+    ) => number[];
+  }): number {
+    const wallVertStart = vCursor;
+    for (let i = 0; i < opts.perimeterCount; i++) {
+      const topIdx = opts.perimeterIndex(i);
+      const x = opts.perimeterX(i);
+      const z = opts.perimeterZ(i);
+      const topY = upsampled[topIdx];
+
+      positions[vCursor * 3 + 0] = x;
+      positions[vCursor * 3 + 1] = topY;
+      positions[vCursor * 3 + 2] = z;
+      positions[(vCursor + 1) * 3 + 0] = x;
+      positions[(vCursor + 1) * 3 + 1] = floorY;
+      positions[(vCursor + 1) * 3 + 2] = z;
+
+      const topR = colors[topIdx * 3 + 0];
+      const topG = colors[topIdx * 3 + 1];
+      const topB = colors[topIdx * 3 + 2];
+      colors[vCursor * 3 + 0] = topR * WALL_DIM;
+      colors[vCursor * 3 + 1] = topG * WALL_DIM;
+      colors[vCursor * 3 + 2] = topB * WALL_DIM;
+      colors[(vCursor + 1) * 3 + 0] = topR * WALL_DIM;
+      colors[(vCursor + 1) * 3 + 1] = topG * WALL_DIM;
+      colors[(vCursor + 1) * 3 + 2] = topB * WALL_DIM;
+
+      vCursor += 2;
+    }
+    for (let i = 0; i < opts.perimeterCount - 1; i++) {
+      const baseTopA = wallVertStart + i * 2;
+      const baseBottomA = baseTopA + 1;
+      const baseTopB = wallVertStart + (i + 1) * 2;
+      const baseBottomB = baseTopB + 1;
+      const tri = opts.quadIndices(baseTopA, baseBottomA, baseTopB, baseBottomB);
+      for (let t = 0; t < tri.length; t++) indices[iIdx++] = tri[t];
+    }
+    return vCursor;
+  }
+
+  // South wall: uRow = 0, z = 0. CCW from outside (-Z side) -> normal = -Z.
+  // Viewed from -Z: uCol increases left to right. For -Z normal, each quad's
+  // CCW winding (from -Z perspective) = topA, topB, bottomB, topA, bottomB, bottomA.
+  vCursor = emitWall({
+    perimeterIndex: (uCol) => 0 * UPSAMPLED_GRID + uCol,
+    perimeterX: (uCol) => uCol * UPSAMPLED_SPACING_M,
+    perimeterZ: () => 0,
+    perimeterCount: UPSAMPLED_GRID,
+    quadIndices: (baseTopA, baseBottomA, baseTopB, baseBottomB) => [
+      baseTopA, baseTopB, baseBottomB,
+      baseTopA, baseBottomB, baseBottomA,
+    ],
+  });
+
+  // North wall: uRow = UPSAMPLED_GRID-1, z = max. CCW from outside (+Z side) -> normal = +Z.
+  vCursor = emitWall({
+    perimeterIndex: (uCol) => (UPSAMPLED_GRID - 1) * UPSAMPLED_GRID + uCol,
+    perimeterX: (uCol) => uCol * UPSAMPLED_SPACING_M,
+    perimeterZ: () => (UPSAMPLED_GRID - 1) * UPSAMPLED_SPACING_M,
+    perimeterCount: UPSAMPLED_GRID,
+    quadIndices: (baseTopA, baseBottomA, baseTopB, baseBottomB) => [
+      baseTopA, baseBottomA, baseBottomB,
+      baseTopA, baseBottomB, baseTopB,
+    ],
+  });
+
+  // West wall: uCol = 0, x = 0. CCW from outside (-X side) -> normal = -X.
+  vCursor = emitWall({
+    perimeterIndex: (uRow) => uRow * UPSAMPLED_GRID + 0,
+    perimeterX: () => 0,
+    perimeterZ: (uRow) => uRow * UPSAMPLED_SPACING_M,
+    perimeterCount: UPSAMPLED_GRID,
+    quadIndices: (baseTopA, baseBottomA, baseTopB, baseBottomB) => [
+      baseTopA, baseBottomA, baseBottomB,
+      baseTopA, baseBottomB, baseTopB,
+    ],
+  });
+
+  // East wall: uCol = UPSAMPLED_GRID-1, x = max. CCW from outside (+X side) -> normal = +X.
+  vCursor = emitWall({
+    perimeterIndex: (uRow) => uRow * UPSAMPLED_GRID + (UPSAMPLED_GRID - 1),
+    perimeterX: () => (UPSAMPLED_GRID - 1) * UPSAMPLED_SPACING_M,
+    perimeterZ: (uRow) => uRow * UPSAMPLED_SPACING_M,
+    perimeterCount: UPSAMPLED_GRID,
+    quadIndices: (baseTopA, baseBottomA, baseTopB, baseBottomB) => [
+      baseTopA, baseTopB, baseBottomB,
+      baseTopA, baseBottomB, baseBottomA,
+    ],
+  });
+
+  // ---- 3. Floor ----
+  const floorStart = TOP_VERTS + WALL_VERTS;
+  const REGION_END = (UPSAMPLED_GRID - 1) * UPSAMPLED_SPACING_M;
+  const floorCorners: Array<[number, number, number]> = [
+    [0, floorY, 0],
+    [REGION_END, floorY, 0],
+    [0, floorY, REGION_END],
+    [REGION_END, floorY, REGION_END],
+  ];
+  for (let i = 0; i < 4; i++) {
+    const [fx, fy, fz] = floorCorners[i];
+    positions[(floorStart + i) * 3 + 0] = fx;
+    positions[(floorStart + i) * 3 + 1] = fy;
+    positions[(floorStart + i) * 3 + 2] = fz;
+    colors[(floorStart + i) * 3 + 0] = FLOOR_COLOR.r / 255;
+    colors[(floorStart + i) * 3 + 1] = FLOOR_COLOR.g / 255;
+    colors[(floorStart + i) * 3 + 2] = FLOOR_COLOR.b / 255;
+  }
+  // Two CCW triangles seen from -Y (below) so face normal points -Y.
+  // SW=0, SE=1, NW=2, NE=3. Clockwise from above = CCW from below -> -Y normal.
+  indices[iIdx++] = floorStart + 0; indices[iIdx++] = floorStart + 3; indices[iIdx++] = floorStart + 2;
+  indices[iIdx++] = floorStart + 0; indices[iIdx++] = floorStart + 1; indices[iIdx++] = floorStart + 3;
 
   const geometry = new BufferGeometry();
   geometry.setAttribute("position", new Float32BufferAttribute(positions, 3));
@@ -221,6 +401,26 @@ export function buildHeightfieldGeometry(
   geometry.setIndex(new BufferAttribute(indices, 1));
   geometry.computeVertexNormals();
   return geometry;
+}
+
+/** Wall vertex color = top color * WALL_DIM (darker shaded side). */
+const WALL_DIM = 0.55;
+/** Floor face color (defensive coverage for low-orbit visibility). */
+const FLOOR_COLOR = { r: 60, g: 50, b: 40 };
+
+function topColorAt(
+  uRow: number,
+  uCol: number,
+  upsampled: Float32Array,
+  slopeGrid: Float32Array,
+  parcelMin: number,
+  mode: "elevation" | "slope",
+) {
+  const idx = uRow * UPSAMPLED_GRID + uCol;
+  if (mode === "elevation") {
+    return gradientColor(upsampled[idx] - parcelMin);
+  }
+  return slopeColor(slopeGrid[idx]);
 }
 
 /**

--- a/frontend/src/lib/parcelMap3D/geometry.ts
+++ b/frontend/src/lib/parcelMap3D/geometry.ts
@@ -18,6 +18,42 @@ export const UPSAMPLED_GRID = GRID * UPSAMPLE_FACTOR + 1;
 /** Spacing between upsampled vertices in meters (REGION_M / (UPSAMPLED_GRID - 1)). */
 export const UPSAMPLED_SPACING_M = REGION_M / (UPSAMPLED_GRID - 1);
 
+/**
+ * Wall-vertex color multiplier vs the top-surface color at the same X/Z.
+ * 0.55 was chosen during brainstorming as the visual weight of a "darker
+ * shaded side" -- clearly distinct from the top while still recognizable
+ * as the same terrain material. Both top and bottom edges of every wall
+ * vertex use this multiplier so the wall reads as a uniformly-dimmed strip.
+ */
+const WALL_DIM = 0.55;
+/**
+ * Bottom-plane face color. Fixed neutral earth tone, not derived from the
+ * terrain. The floor is rarely visible (only on aggressive low-angle orbit
+ * that gets the camera below the region), so this is defensive coverage to
+ * avoid a transparent void rather than a primary visual element.
+ */
+const FLOOR_COLOR = { r: 60, g: 50, b: 40 };
+
+/**
+ * Vertex color for a top-surface vertex, dispatched by color mode. Returns
+ * {@link gradientColor}'s elevation-delta hue in {@code "elevation"} mode
+ * or {@link slopeColor}'s slope-angle hue in {@code "slope"} mode.
+ */
+function topColorAt(
+  uRow: number,
+  uCol: number,
+  upsampled: Float32Array,
+  slopeGrid: Float32Array,
+  parcelMin: number,
+  mode: "elevation" | "slope",
+) {
+  const idx = uRow * UPSAMPLED_GRID + uCol;
+  if (mode === "elevation") {
+    return gradientColor(upsampled[idx] - parcelMin);
+  }
+  return slopeColor(slopeGrid[idx]);
+}
+
 export interface RegionBounds {
   rMin: number;
   rMax: number;
@@ -209,12 +245,12 @@ export function computeParcelStats(
  * fixed neutral earth tone.
  *
  * Vertex layout (used by tests asserting positions/colors/normals by index):
- *   [0 .. TOP_VERTS)              top mesh, row-major (uRow * UPSAMPLED_GRID + uCol)
- *   [TOP_VERTS .. +PER_WALL)      south wall, pairs of (top-edge, bottom-edge) by uCol
- *   [+PER_WALL .. +2*PER_WALL)    north wall, same pair ordering by uCol
- *   [+2*PER_WALL .. +3*PER_WALL)  west wall, pairs by uRow
- *   [+3*PER_WALL .. +4*PER_WALL)  east wall, pairs by uRow
- *   [TOP_VERTS + WALL_VERTS ..)   floor (4 vertices, SW SE NW NE)
+ *   [0 .. TOP_VERTS)                          top mesh, row-major (uRow * UPSAMPLED_GRID + uCol)
+ *   [TOP_VERTS .. +PER_WALL_VERTS)            south wall, pairs of (top-edge, bottom-edge) by uCol
+ *   [+PER_WALL_VERTS .. +2*PER_WALL_VERTS)    north wall, same pair ordering by uCol
+ *   [+2*PER_WALL_VERTS .. +3*PER_WALL_VERTS)  west wall, pairs by uRow
+ *   [+3*PER_WALL_VERTS .. +4*PER_WALL_VERTS)  east wall, pairs by uRow
+ *   [TOP_VERTS + WALL_VERTS ..)               floor (4 vertices, SW SE NW NE)
  *
  * Wall triangle winding is CCW from outside the region so face normals
  * point outward (south=-Z, north=+Z, west=-X, east=+X). Floor winding is
@@ -275,6 +311,14 @@ export function buildHeightfieldGeometry(
   // ---- 2. Walls (south, north, west, east in this order) ----
   let vCursor = TOP_VERTS;
 
+  // Emit one wall strip. Each call writes `perimeterCount` vertex-pairs
+  // (top-edge + bottom-edge at each perimeter point) and `perimeterCount - 1`
+  // quads. The `quadIndices` callback maps the four base vertex offsets for
+  // each quad (top-edge-A, bottom-edge-A, top-edge-B, bottom-edge-B) to 6
+  // CCW triangle indices; winding direction differs per wall so face normals
+  // point OUTWARD from the region center (south=-Z, north=+Z, west=-X,
+  // east=+X). Wall color = top-surface color at the same perimeter X/Z,
+  // multiplied by WALL_DIM for both the top and bottom edge of the wall.
   function emitWall(opts: {
     perimeterIndex: (i: number) => number;
     perimeterX: (i: number) => number;
@@ -350,7 +394,7 @@ export function buildHeightfieldGeometry(
 
   // West wall: uCol = 0, x = 0. CCW from outside (-X side) -> normal = -X.
   vCursor = emitWall({
-    perimeterIndex: (uRow) => uRow * UPSAMPLED_GRID + 0,
+    perimeterIndex: (uRow) => uRow * UPSAMPLED_GRID,
     perimeterX: () => 0,
     perimeterZ: (uRow) => uRow * UPSAMPLED_SPACING_M,
     perimeterCount: UPSAMPLED_GRID,
@@ -374,7 +418,7 @@ export function buildHeightfieldGeometry(
 
   // ---- 3. Floor ----
   const floorStart = TOP_VERTS + WALL_VERTS;
-  const REGION_END = (UPSAMPLED_GRID - 1) * UPSAMPLED_SPACING_M;
+  const REGION_END = (UPSAMPLED_GRID - 1) * UPSAMPLED_SPACING_M; // = REGION_M (256 m)
   const floorCorners: Array<[number, number, number]> = [
     [0, floorY, 0],
     [REGION_END, floorY, 0],
@@ -403,25 +447,6 @@ export function buildHeightfieldGeometry(
   return geometry;
 }
 
-/** Wall vertex color = top color * WALL_DIM (darker shaded side). */
-const WALL_DIM = 0.55;
-/** Floor face color (defensive coverage for low-orbit visibility). */
-const FLOOR_COLOR = { r: 60, g: 50, b: 40 };
-
-function topColorAt(
-  uRow: number,
-  uCol: number,
-  upsampled: Float32Array,
-  slopeGrid: Float32Array,
-  parcelMin: number,
-  mode: "elevation" | "slope",
-) {
-  const idx = uRow * UPSAMPLED_GRID + uCol;
-  if (mode === "elevation") {
-    return gradientColor(upsampled[idx] - parcelMin);
-  }
-  return slopeColor(slopeGrid[idx]);
-}
 
 /**
  * Sample the upsampled grid at world (x, z) coordinates in meters. With


### PR DESCRIPTION
Two enhancements to the parcel-map 3D view, plus a cascading color simplification.

## What ships

- **Slope-shaded color mode.** Inline button group inside the 3D view toggles between Elevation (existing) and Slope (new). Slope colors come from a closed-form finite-difference helper: flat = green, 45deg = red. Preference persists via localStorage (`slpa:parcel-map:3d-color`).
- **Solid look.** Four extruded perimeter walls reach 8m below the lowest cell, wall color = terrain color * 0.55 (recolors in lockstep with the mode), bottom plane at `regionMin - 8m` in a neutral earth tone. Adds ~1k triangles to the existing ~33k.
- **2-stop gradient.** Shared `gradientColor` helper switches from 3-stop (green/yellow/red) to smooth 2-stop (green/red). Both 2D map and 3D modes use the new gradient; the 2D legend simplifies to two stops and the `+4 m` axis label is removed.

## Out of scope (tracked in #414)

- Water plane at SL sea level.
- Snapshot-as-ground-texture using `parcel.snapshotUrl`.
- Parcel-specific walls (this PR adds REGION walls, not the listed-parcel-only walls noted in #414).

## Verification

- `npm run build && npm test && npm run lint && npm run verify` green locally.

## Spec / plan

- Spec: `docs/superpowers/specs/2026-05-24-parcel-map-3d-slope-and-solid-design.md`
- Plan: `docs/superpowers/plans/2026-05-24-parcel-map-3d-slope-and-solid-plan.md`