### PR TITLE
fix(bot): diagnostic logging on TeleportAsync

### DIFF
--- a/bot/src/Slpa.Bot/Sl/LibreMetaverseBotSession.cs
+++ b/bot/src/Slpa.Bot/Sl/LibreMetaverseBotSession.cs
@@ -330,6 +330,12 @@ public sealed class LibreMetaverseBotSession : IBotSession
         EventHandler<TeleportEventArgs>? handler = null;
         handler = (_, e) =>
         {
+            // Diagnostic: log every TeleportProgress event we observe. Before
+            // this was added, intermediate statuses (Start, Progress, Resolving,
+            // etc.) were silently discarded, making timeout failures opaque.
+            _log.LogInformation(
+                "TeleportProgress: status={Status} message={Message} target={Region}",
+                e.Status, e.Message ?? "<null>", regionName);
             if (e.Status is TeleportStatus.Finished
                 or TeleportStatus.Failed
                 or TeleportStatus.Cancelled)
@@ -356,10 +362,24 @@ public sealed class LibreMetaverseBotSession : IBotSession
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         timeoutCts.CancelAfter(TimeSpan.FromSeconds(30));
         var registration = timeoutCts.Token.Register(() =>
-            tcs.TrySetResult(TeleportResult.Fail(TeleportFailureKind.Timeout)));
+        {
+            // Diagnostic: explicit warn at the moment the timeout fires, so
+            // log timelines distinguish "timeout fired with zero progress
+            // events" from "timeout fired despite progress events streaming".
+            _log.LogWarning(
+                "Teleport timeout fired (target={Region}, currentSim={Sim})",
+                regionName, _client.Network.CurrentSim?.Name ?? "<null>");
+            tcs.TrySetResult(TeleportResult.Fail(TeleportFailureKind.Timeout));
+        });
         try
         {
             _seatedBelief = false; // a real teleport stands the avatar up
+            // Diagnostic: log the source sim + target before issuing the call,
+            // so we can correlate the LibreMetaverse "Requesting teleport to
+            // region handle ..." line with our side's intent.
+            _log.LogInformation(
+                "Issuing teleport: from={From} to={To} pos=({X},{Y},{Z})",
+                _client.Network.CurrentSim?.Name ?? "<null>", regionName, x, y, z);
             _client.Self.Teleport(regionName, new Vector3((float)x, (float)y, (float)z));
             return await tcs.Task.ConfigureAwait(false);
         }


### PR DESCRIPTION
SCAN_PARCEL teleports keep timing out with zero visibility into the 30s window. Adds three diagnostic log lines around `Self.Teleport`:

- pre-call: source sim name + target + pos
- inside the `TeleportProgress` handler: every observed event
- on 30s timeout firing: explicit warn with currentSim

No behavioral change. Lets the next failure tell us whether (a) zero progress events fire (LM accepts the call but produces nothing), (b) progress events fire but never reach Finished (sim-handoff hang), or (c) Finished fires but the handler misses it.

Tests: 117/117 pass; build clean. This is a live-prod diagnostic — merging to main once dev lands so it actually reaches the bots.