### PR TITLE
fix(frontend): restore 3D toggle to original floating canvas position

### DIFF
--- a/frontend/src/components/auction/ParcelMap3D.tsx
+++ b/frontend/src/components/auction/ParcelMap3D.tsx
@@ -189,13 +189,15 @@ export default function ParcelMap3D({
             />
           )}
         </Canvas>
+        <div className="absolute top-2 right-2">
+          <ParcelMap3DColorModeToggle mode={colorMode} onChange={setColorMode} />
+        </div>
       </div>
-      <div className="flex flex-col gap-1 w-full max-w-[320px]">
+      <div className="w-full max-w-[320px]">
         <ParcelMap3DLegend
           mode={colorMode}
           maxDelta={bounds.rMax - stats.parcelMin}
         />
-        <ParcelMap3DColorModeToggle mode={colorMode} onChange={setColorMode} />
       </div>
     </div>
   );


### PR DESCRIPTION
User reported the elevation/slope buttons aren't where they originally were. The chrome-restoration commit had moved the toggle below the canvas alongside the new legend; restoring the toggle to its original absolute top-2 right-2 floating position over the canvas. Legend stays below the canvas.