### PR TITLE
fix(frontend): 3D canvas 320x320 size + matching legend layouts + descriptive text

### DIFF
--- a/frontend/src/components/auction/ParcelMap.tsx
+++ b/frontend/src/components/auction/ParcelMap.tsx
@@ -317,24 +317,29 @@ function clamp(v: number, lo: number, hi: number): number {
 }
 
 function ParcelMapLegend({ maxDelta }: { maxDelta: number }) {
-  // Linear gradient mirroring the 2-stop gradient used in colors.ts. Auto-
-  // scales to the region's actual relief (parcel low -> region high) so the
-  // visible transition is as soft as the data allows -- a cliff face on a
-  // mildly hilly region no longer renders as a hard band.
+  // Layout mirrors ParcelMap3DLegend: inline labels flank the gradient bar
+  // on one row, descriptive paragraph below. Auto-scales to the region's
+  // actual relief (parcel low -> region high) so the visible transition is
+  // as soft as the data allows -- a cliff face on a mildly hilly region no
+  // longer renders as a hard band.
   // RGB literals rather than #hex keep the no-hex-colors verify guard green.
   const stop = (c: { r: number; g: number; b: number }, pct: number) =>
     `rgb(${c.r}, ${c.g}, ${c.b}) ${pct}%`;
   const gradient = `linear-gradient(to right, ${stop(MAP_COLORS.green, 0)}, ${stop(MAP_COLORS.red, 100)})`;
   const rightLabel = `+${Math.round(maxDelta)} m`;
   return (
-    <div className="w-full max-w-[320px] flex flex-col gap-1">
-      <div
-        style={{ background: gradient }}
-        className="h-2 w-full border border-border-subtle"
-        aria-hidden="true"
-      />
-      <div className="flex justify-between text-[10px] text-fg-muted">
+    <div
+      role="group"
+      aria-label="2D map color scale"
+      className="w-full max-w-[320px] flex flex-col gap-1"
+    >
+      <div className="flex items-center gap-2 text-xs text-fg-muted">
         <span>0 m</span>
+        <div
+          style={{ background: gradient }}
+          className="h-2 flex-1 rounded-sm"
+          aria-hidden="true"
+        />
         <span>{rightLabel}</span>
       </div>
       <p className="text-[10px] text-fg-muted">

--- a/frontend/src/components/auction/ParcelMap3D.tsx
+++ b/frontend/src/components/auction/ParcelMap3D.tsx
@@ -157,9 +157,9 @@ export default function ParcelMap3D({
       <div
         role="img"
         aria-label="Interactive 3D region and parcel elevation map"
-        className="relative aspect-square w-full max-w-[320px] bg-bg-subtle border border-border-subtle"
+        className="relative aspect-square w-full max-w-[320px]"
       >
-        <Canvas>
+        <Canvas className="border border-border-subtle bg-bg-subtle">
           <PerspectiveCamera
             makeDefault
             fov={camera.fovDeg}

--- a/frontend/src/components/auction/ParcelMap3DLegend.tsx
+++ b/frontend/src/components/auction/ParcelMap3DLegend.tsx
@@ -9,11 +9,18 @@ export interface ParcelMap3DLegendProps {
   className?: string;
 }
 
+const ELEVATION_DESCRIPTION =
+  "Color = elevation above the parcel's lowest cell, scaled to the region's relief. Green is the parcel low; red is the region high. The SL terraforming raise/lower limit is 4 m; spread above 8 m can't be levelled.";
+
+const SLOPE_DESCRIPTION =
+  "Color = local slope angle, scaled to the 0° (flat, green) to 45° (steep, red) range. Slopes steeper than 45° saturate to red and are effectively unbuildable in SL.";
+
 /**
  * Gradient-bar legend for the 3D parcel-map. Renders a green->red CSS
- * gradient that matches the in-canvas vertex coloring + the mode-specific
- * end labels. Mirrors the existing 2D elevation legend in shape and uses
- * the same allowlisted inline-style pattern for the gradient bar.
+ * gradient that matches the in-canvas vertex coloring + mode-specific
+ * end labels + a descriptive paragraph. Mirrors the 2D elevation legend
+ * in shape and uses the same allowlisted inline-style pattern for the
+ * gradient bar.
  *
  * Spec: docs/superpowers/specs/2026-05-25-parcel-map-land-use-design.md
  */
@@ -21,24 +28,29 @@ export function ParcelMap3DLegend({ mode, maxDelta, className }: ParcelMap3DLege
   const leftLabel = mode === "elevation" ? "0 m" : "0°";
   const rightLabel =
     mode === "elevation" ? `+${Math.round(maxDelta)} m` : "45°";
+  const description =
+    mode === "elevation" ? ELEVATION_DESCRIPTION : SLOPE_DESCRIPTION;
 
   return (
     <div
       role="group"
       aria-label="3D map color scale"
-      className={cn("flex items-center gap-2 text-xs text-fg-muted", className)}
+      className={cn("flex flex-col gap-1", className)}
     >
-      <span>{leftLabel}</span>
-      <div
-        className="h-2 flex-1 rounded-sm"
-        // Inline style: gradient is data-driven, not a static theme color.
-        // Allowlisted in scripts/verify-no-inline-styles.sh.
-        style={{
-          background:
-            "linear-gradient(to right, rgb(34, 197, 94), rgb(239, 68, 68))",
-        }}
-      />
-      <span>{rightLabel}</span>
+      <div className="flex items-center gap-2 text-xs text-fg-muted">
+        <span>{leftLabel}</span>
+        <div
+          className="h-2 flex-1 rounded-sm"
+          // Inline style: gradient is data-driven, not a static theme color.
+          // Allowlisted in scripts/verify-no-inline-styles.sh.
+          style={{
+            background:
+              "linear-gradient(to right, rgb(34, 197, 94), rgb(239, 68, 68))",
+          }}
+        />
+        <span>{rightLabel}</span>
+      </div>
+      <p className="text-[10px] text-fg-muted">{description}</p>
     </div>
   );
 }


### PR DESCRIPTION
Three small UI fixes per user request:

**1. 3D canvas 320x320 outer.** User reported the 3D view measured 318.4x318.4 while the 2D measured 320x320. Cause: the 3D's border was on the outer wrapper div, which made the outer box 320x320 (border included) but the inner R3F canvas content area only 318x318. Moved border + bg from the wrapper to the R3F Canvas's className so the canvas wrapping div itself measures 320x320 outer with the border included - matching the 2D canvas element exactly.

**2. 3D legend gets mode-aware descriptive paragraph.** The 2D legend has an explanatory line about color = elevation + the SL terraforming 4 m / 8 m limits. The 3D legend now mirrors that, mode-aware:
- Elevation: same paragraph as 2D.
- Slope: 'Color = local slope angle, scaled to the 0° (flat, green) to 45° (steep, red) range. Slopes steeper than 45° saturate to red and are effectively unbuildable in SL.'

**3. 2D legend matches 3D inline layout.** The 2D legend used a stacked layout (full-width gradient bar on top, labels below). Restructured to match the 3D's inline shape: [0 m] [gradient bar flex-1] [+Nm] on one row, descriptive paragraph below. Added role=group + aria-label='2D map color scale' for a11y parity.

Tests: 96/96 ParcelMap tests pass; build + verify all green.